### PR TITLE
Improve DIP dialect interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ $ cd buddy-mlir/build
 $ cmake -G Ninja .. -DBUDDY_EXAMPLES=ON -DBUDDY_DIP_OPT_STRIP_MINING=256
 $ ninja correlation2D
 $ cd bin
-$ ./correlation2D ../../examples/ConvOpt/images/YuTu.png result-dip.png
+$ ./correlation2D ../../examples/ConvOpt/images/YuTu.png result-dip-replicate-padding.png result-dip-constant-padding.png
 ```
 
 *Note: Maximum allowed value of `BUDDY_DIP_OPT_STRIP_MINING` for producing correct result is equal to image width.*

--- a/examples/DIPDialect/corr2d.mlir
+++ b/examples/DIPDialect/corr2d.mlir
@@ -1,5 +1,11 @@
-func @corr_2d(%inputImage : memref<?x?xf32>, %kernel : memref<?x?xf32>, %outputImage : memref<?x?xf32>, %centerX : index, %centerY : index, %boundaryOption : index)
+func @corr_2d_constant_padding(%inputImage : memref<?x?xf32>, %kernel : memref<?x?xf32>, %outputImage : memref<?x?xf32>, %centerX : index, %centerY : index, %constantValue : f32)
 {
-  dip.corr_2d %inputImage, %kernel, %outputImage, %centerX, %centerY, %boundaryOption : memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>, index, index, index
+  dip.corr_2d %inputImage, %kernel, %outputImage, %centerX, %centerY, %constantValue {boundary_option = "CONSTANT_PADDING"} : memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>, index, index, f32
+  return
+}
+
+func @corr_2d_replicate_padding(%inputImage : memref<?x?xf32>, %kernel : memref<?x?xf32>, %outputImage : memref<?x?xf32>, %centerX : index, %centerY : index, %constantValue : f32)
+{
+  dip.corr_2d %inputImage, %kernel, %outputImage, %centerX, %centerY , %constantValue {boundary_option = "REPLICATE_PADDING"} : memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>, index, index, f32
   return
 }

--- a/examples/DIPDialect/correlation2D.cpp
+++ b/examples/DIPDialect/correlation2D.cpp
@@ -15,42 +15,10 @@
 
 #include <iostream>
 #include <time.h>
+#include <dip.hpp>
 
 using namespace cv;
 using namespace std;
-
-// Define Memref Descriptor.
-typedef struct MemRef_descriptor_ *MemRef_descriptor;
-typedef struct MemRef_descriptor_ {
-  float *allocated;
-  float *aligned;
-  intptr_t offset;
-  intptr_t sizes[2];
-  intptr_t strides[2];
-} Memref;
-
-// Constructor
-MemRef_descriptor MemRef_Descriptor(float *allocated, float *aligned,
-                                    intptr_t offset, intptr_t sizes[2],
-                                    intptr_t strides[2]) {
-  MemRef_descriptor n = (MemRef_descriptor)malloc(sizeof(*n));
-  n->allocated = allocated;
-  n->aligned = aligned;
-  n->offset = offset;
-  for (int i = 0; i < 2; i++)
-    n->sizes[i] = sizes[i];
-  for (int j = 0; j < 2; j++)
-    n->strides[j] = strides[j];
-
-  return n;
-}
-
-// Declare the Corr2D C interface.
-extern "C" {
-void _mlir_ciface_corr_2d(MemRef_descriptor input, MemRef_descriptor kernel,
-                          MemRef_descriptor output, unsigned int centerX,
-                          unsigned int centerY, int boundaryOption);
-}
 
 bool testImages(cv::Mat img1, cv::Mat img2) {
   if (img1.rows != img2.rows || img1.cols != img2.cols) {
@@ -126,7 +94,7 @@ bool testImplementation(int argc, char *argv[], std::ptrdiff_t x,
   Mat kernel1 = Mat(3, 3, CV_32FC1, laplacianKernelAlign);
 
   // Call the MLIR Corr2D function.
-  _mlir_ciface_corr_2d(input, kernel, output, x, y, 0);
+  dip::Corr2D(input, kernel, output, x, y, dip::BOUNDARY_OPTION::REPLICATE_PADDING);
 
   // Define a cv::Mat with the output of the conv2d.
   Mat outputImage(outputRows, outputCols, CV_32FC1, output->aligned);

--- a/examples/DIPDialect/correlation2D.cpp
+++ b/examples/DIPDialect/correlation2D.cpp
@@ -13,9 +13,9 @@
 
 #include "../ConvOpt/kernels.h"
 
+#include <dip.hpp>
 #include <iostream>
 #include <time.h>
-#include <dip.hpp>
 
 using namespace cv;
 using namespace std;
@@ -94,7 +94,8 @@ bool testImplementation(int argc, char *argv[], std::ptrdiff_t x,
   Mat kernel1 = Mat(3, 3, CV_32FC1, laplacianKernelAlign);
 
   // Call the MLIR Corr2D function.
-  dip::Corr2D(input, kernel, output, x, y, dip::BOUNDARY_OPTION::REPLICATE_PADDING);
+  dip::Corr2D(input, kernel, output, x, y,
+              dip::BOUNDARY_OPTION::REPLICATE_PADDING);
 
   // Define a cv::Mat with the output of the conv2d.
   Mat outputImage(outputRows, outputCols, CV_32FC1, output->aligned);

--- a/examples/DIPDialect/correlation2D.cpp
+++ b/examples/DIPDialect/correlation2D.cpp
@@ -124,9 +124,9 @@ bool testImplementation(int argc, char *argv[], std::ptrdiff_t x,
   // Define a cv::Mat with the output of Corr2D.
   Mat outputImageConstantPadding(outputRows, outputCols, CV_32FC1,
                                  output->aligned);
-  imwrite(argv[2], outputImageConstantPadding);
+  imwrite(argv[3], outputImageConstantPadding);
 
-  Mat o2 = imread(argv[2], IMREAD_GRAYSCALE);
+  Mat o2 = imread(argv[3], IMREAD_GRAYSCALE);
   filter2D(image, opencvConstantPadding, CV_8UC1, kernel1, cv::Point(x, y), 0.0,
            cv::BORDER_CONSTANT);
 

--- a/include/Dialect/DIP/DIPOps.h
+++ b/include/Dialect/DIP/DIPOps.h
@@ -25,6 +25,7 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 
 #define GET_OP_CLASSES
 #include "DIP/DIPOps.h.inc"

--- a/include/Dialect/DIP/DIPOps.td
+++ b/include/Dialect/DIP/DIPOps.td
@@ -22,7 +22,20 @@
 #define DIP_DIPOPS_TD
 
 include "DIPDialect.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+
+def DIP_ConstantPadding : StrEnumAttrCase<"ConstantPadding", -1, "CONSTANT_PADDING">;
+def DIP_ReplicatePadding : StrEnumAttrCase<"ReplicatePadding", -1, "REPLICATE_PADDING">;
+
+def DIP_BoundaryOptionAttr : StrEnumAttr<"BoundaryOptionAttr",
+    "Specifies desired method of boundary extrapolation during image processing.",
+    [
+      DIP_ConstantPadding,
+      DIP_ReplicatePadding
+    ]>{
+  let cppNamespace = "::buddy::dip";
+}
 
 def DIP_Corr2DOp : DIP_Op<"corr_2d">
 {
@@ -42,8 +55,9 @@ def DIP_Corr2DOp : DIP_Op<"corr_2d">
   For example: 
 
   ```mlir
-    dip.corr_2d %inputImage, %kernel, %output, %centerX, %centerY, %boundaryOption : 
-                memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>, index, index, index
+    dip.corr_2d %inputImage, %kernel, %output, %centerX, %centerY, %constantValue
+                {boundary_option = "CONSTANT_PADDING"} : memref<?x?xf32>, memref<?x?xf32>,
+                memref<?x?xf32>, index, index, index
   ```
   }];
 
@@ -53,11 +67,11 @@ def DIP_Corr2DOp : DIP_Op<"corr_2d">
                            [MemRead]>:$memrefK,
                        Arg<AnyRankedOrUnrankedMemRef, "outputMemref",
                            [MemRead]>:$memrefCO,
-                       Index : $centerX, Index : $centerY, 
-                       Index : $boundaryOption);
+                       Index : $centerX, Index : $centerY, F32 : $constantValue,
+                       DIP_BoundaryOptionAttr:$boundary_option);
 
   let assemblyFormat = [{
-    $memrefI `,` $memrefK `,` $memrefCO `,` $centerX `,` $centerY `,` $boundaryOption attr-dict `:` type($memrefI) `,` type($memrefK) `,` type($memrefCO) `,` type($centerX) `,` type($centerY) `,` type($boundaryOption)
+    $memrefI `,` $memrefK `,` $memrefCO `,` $centerX `,` $centerY `,` $constantValue attr-dict `:` type($memrefI) `,` type($memrefK) `,` type($memrefCO) `,` type($centerX) `,` type($centerY) `,` type($constantValue)
   }];
 }
 

--- a/include/Interface/buddy/dip/dip.h
+++ b/include/Interface/buddy/dip/dip.h
@@ -1,4 +1,4 @@
-//===- dip.hpp --------------------------------------------------------===//
+//===- dip.h --------------------------------------------------------===//
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,36 +21,12 @@
 #ifndef INCLUDE_DIP
 #define INCLUDE_DIP
 
-// Define Memref Descriptor.
-typedef struct MemRef_descriptor_ *MemRef_descriptor;
-typedef struct MemRef_descriptor_ {
-  float *allocated;
-  float *aligned;
-  intptr_t offset;
-  intptr_t sizes[2];
-  intptr_t strides[2];
-} Memref;
-
-// Constructor
-MemRef_descriptor MemRef_Descriptor(float *allocated, float *aligned,
-                                    intptr_t offset, intptr_t sizes[2],
-                                    intptr_t strides[2]) {
-  MemRef_descriptor n = (MemRef_descriptor)malloc(sizeof(*n));
-  n->allocated = allocated;
-  n->aligned = aligned;
-  n->offset = offset;
-  for (int i = 0; i < 2; i++)
-    n->sizes[i] = sizes[i];
-  for (int j = 0; j < 2; j++)
-    n->strides[j] = strides[j];
-
-  return n;
-}
+#include <Interface/buddy/dip/memref.h>
 
 namespace dip {
 namespace detail {
 // Functions present inside dip::detail are not meant to be called by users
-// directly. 
+// directly.
 // Declare the Corr2D C interface.
 extern "C" {
 void _mlir_ciface_corr_2d_constant_padding(

--- a/include/Interface/buddy/dip/memref.h
+++ b/include/Interface/buddy/dip/memref.h
@@ -1,0 +1,53 @@
+//===- memref.h --------------------------------------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+//
+// Header file for MemRef specific entities.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_MEMREF
+#define INCLUDE_MEMREF
+
+// ToDo : Port improved implementation of MemRef_descriptor_ from
+// buddy-benchmark in this file.
+
+// Define Memref Descriptor.
+typedef struct MemRef_descriptor_ *MemRef_descriptor;
+typedef struct MemRef_descriptor_ {
+  float *allocated;
+  float *aligned;
+  intptr_t offset;
+  intptr_t sizes[2];
+  intptr_t strides[2];
+} Memref;
+
+// Constructor
+MemRef_descriptor MemRef_Descriptor(float *allocated, float *aligned,
+                                    intptr_t offset, intptr_t sizes[2],
+                                    intptr_t strides[2]) {
+  MemRef_descriptor n = (MemRef_descriptor)malloc(sizeof(*n));
+  n->allocated = allocated;
+  n->aligned = aligned;
+  n->offset = offset;
+  for (int i = 0; i < 2; i++)
+    n->sizes[i] = sizes[i];
+  for (int j = 0; j < 2; j++)
+    n->strides[j] = strides[j];
+
+  return n;
+}
+
+#endif

--- a/include/dip.hpp
+++ b/include/dip.hpp
@@ -1,0 +1,86 @@
+//===- dip.hpp --------------------------------------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+//
+// Header file for DIP dialect specific operations and other entities.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_DIP
+#define INCLUDE_DIP
+
+// Define Memref Descriptor.
+typedef struct MemRef_descriptor_ *MemRef_descriptor;
+typedef struct MemRef_descriptor_ {
+  float *allocated;
+  float *aligned;
+  intptr_t offset;
+  intptr_t sizes[2];
+  intptr_t strides[2];
+} Memref;
+
+// Constructor
+MemRef_descriptor MemRef_Descriptor(float *allocated, float *aligned,
+                                    intptr_t offset, intptr_t sizes[2],
+                                    intptr_t strides[2]) {
+  MemRef_descriptor n = (MemRef_descriptor)malloc(sizeof(*n));
+  n->allocated = allocated;
+  n->aligned = aligned;
+  n->offset = offset;
+  for (int i = 0; i < 2; i++)
+    n->sizes[i] = sizes[i];
+  for (int j = 0; j < 2; j++)
+    n->strides[j] = strides[j];
+
+  return n;
+}
+
+namespace dip {
+  namespace detail {
+  // Functions present inside dip::detail are not meant to be called by users directly.
+  // Declare the Corr2D C interface.
+  extern "C" {
+  void _mlir_ciface_corr_2d_constant_padding(MemRef_descriptor input, MemRef_descriptor kernel,
+                          MemRef_descriptor output, unsigned int centerX,
+                          unsigned int centerY, float constantValue);
+
+  void _mlir_ciface_corr_2d_replicate_padding(MemRef_descriptor input, MemRef_descriptor kernel,
+                          MemRef_descriptor output, unsigned int centerX,
+                          unsigned int centerY, float constantValue);
+  }
+  }
+
+
+  enum class BOUNDARY_OPTION{
+  CONSTANT_PADDING, 
+  REPLICATE_PADDING
+  };
+
+  void Corr2D(MemRef_descriptor input, MemRef_descriptor kernel, MemRef_descriptor output, 
+              unsigned int centerX, unsigned int centerY, BOUNDARY_OPTION option, 
+              float constantValue = 0)
+  {
+    if (option == BOUNDARY_OPTION::CONSTANT_PADDING)
+    {
+      detail::_mlir_ciface_corr_2d_constant_padding(input, kernel, output, centerX, centerY, constantValue);
+    }
+    else if (option == BOUNDARY_OPTION::REPLICATE_PADDING)
+    {
+      detail::_mlir_ciface_corr_2d_replicate_padding(input, kernel, output, centerX, centerY, 0);
+    }
+  }
+}
+
+#endif

--- a/include/dip.hpp
+++ b/include/dip.hpp
@@ -48,39 +48,35 @@ MemRef_descriptor MemRef_Descriptor(float *allocated, float *aligned,
 }
 
 namespace dip {
-  namespace detail {
-  // Functions present inside dip::detail are not meant to be called by users directly.
-  // Declare the Corr2D C interface.
-  extern "C" {
-  void _mlir_ciface_corr_2d_constant_padding(MemRef_descriptor input, MemRef_descriptor kernel,
-                          MemRef_descriptor output, unsigned int centerX,
-                          unsigned int centerY, float constantValue);
+namespace detail {
+// Functions present inside dip::detail are not meant to be called by users
+// directly. 
+// Declare the Corr2D C interface.
+extern "C" {
+void _mlir_ciface_corr_2d_constant_padding(
+    MemRef_descriptor input, MemRef_descriptor kernel, MemRef_descriptor output,
+    unsigned int centerX, unsigned int centerY, float constantValue);
 
-  void _mlir_ciface_corr_2d_replicate_padding(MemRef_descriptor input, MemRef_descriptor kernel,
-                          MemRef_descriptor output, unsigned int centerX,
-                          unsigned int centerY, float constantValue);
-  }
-  }
+void _mlir_ciface_corr_2d_replicate_padding(
+    MemRef_descriptor input, MemRef_descriptor kernel, MemRef_descriptor output,
+    unsigned int centerX, unsigned int centerY, float constantValue);
+}
+} // namespace detail
 
+enum class BOUNDARY_OPTION { CONSTANT_PADDING, REPLICATE_PADDING };
 
-  enum class BOUNDARY_OPTION{
-  CONSTANT_PADDING, 
-  REPLICATE_PADDING
-  };
-
-  void Corr2D(MemRef_descriptor input, MemRef_descriptor kernel, MemRef_descriptor output, 
-              unsigned int centerX, unsigned int centerY, BOUNDARY_OPTION option, 
-              float constantValue = 0)
-  {
-    if (option == BOUNDARY_OPTION::CONSTANT_PADDING)
-    {
-      detail::_mlir_ciface_corr_2d_constant_padding(input, kernel, output, centerX, centerY, constantValue);
-    }
-    else if (option == BOUNDARY_OPTION::REPLICATE_PADDING)
-    {
-      detail::_mlir_ciface_corr_2d_replicate_padding(input, kernel, output, centerX, centerY, 0);
-    }
+void Corr2D(MemRef_descriptor input, MemRef_descriptor kernel,
+            MemRef_descriptor output, unsigned int centerX,
+            unsigned int centerY, BOUNDARY_OPTION option,
+            float constantValue = 0) {
+  if (option == BOUNDARY_OPTION::CONSTANT_PADDING) {
+    detail::_mlir_ciface_corr_2d_constant_padding(
+        input, kernel, output, centerX, centerY, constantValue);
+  } else if (option == BOUNDARY_OPTION::REPLICATE_PADDING) {
+    detail::_mlir_ciface_corr_2d_replicate_padding(input, kernel, output,
+                                                   centerX, centerY, 0);
   }
 }
+} // namespace dip
 
 #endif

--- a/lib/Conversion/LowerDIP/LowerDIPPass.cpp
+++ b/lib/Conversion/LowerDIP/LowerDIPPass.cpp
@@ -139,9 +139,8 @@ public:
     Value output = op->getOperand(2);
     Value centerX = op->getOperand(3);
     Value centerY = op->getOperand(4);
-    // Value boundaryOptionVal = op->getOperand(5);
-    unsigned int boundaryOption = 1;
-    // ToDo : Make boundaryOption an attribute.
+    Value constantValue = op->getOperand(5);
+    auto boundaryOptionAttr = op.boundary_option();
     Value strideVal = rewriter.create<ConstantIndexOp>(loc, stride);
 
     FloatType f32 = FloatType::getF32(ctx);
@@ -165,7 +164,6 @@ public:
     VectorType vectorTy32 = VectorType::get({stride}, f32);
     VectorType vectorMaskTy = VectorType::get({stride}, i1);
 
-    // Improve this flow for constant padding option.
     Value zeroPaddingElem =
         rewriter.create<ConstantFloatOp>(loc, (APFloat)(float)0, f32);
     Value zeroPadding =
@@ -205,9 +203,9 @@ public:
               loc, rowUpCond,
               [&](OpBuilder &builder, Location loc) {
                 // rowUp
-                if (!boundaryOption) {
+                if (boundaryOptionAttr == (llvm::StringRef)"CONSTANT_PADDING") {
                   Value inputVec = builder.create<BroadcastOp>(loc, vectorTy32,
-                                                               zeroPaddingElem);
+                                                               constantValue);
 
                   calcAndStoreFMAwoTailProcessing(builder, loc, vectorTy32,
                                                   inputVec, kernelVec, output,
@@ -227,7 +225,7 @@ public:
                             createInvertedMask(builder, loc, strideVal,
                                                vectorMaskTy, leftMaskElem);
 
-                        if (boundaryOption == 1) {
+                        if (boundaryOptionAttr == (llvm::StringRef)"REPLICATE_PADDING") {
                           Value paddingVal = builder.create<memref::LoadOp>(
                               loc, input, ValueRange{c0, c0});
                           Value padding = builder.create<BroadcastOp>(
@@ -256,7 +254,7 @@ public:
                             [&](OpBuilder &builder, Location loc) {
                               // colMid & rowUp
                               Value inputVec;
-                              if (boundaryOption == 1) {
+                              if (boundaryOptionAttr == (llvm::StringRef)"REPLICATE_PADDING") {
                                 inputVec = builder.create<LoadOp>(
                                     loc, vectorTy32, input,
                                     ValueRange{c0, imCol});
@@ -277,7 +275,7 @@ public:
                               Value rightMask = builder.create<CreateMaskOp>(
                                   loc, vectorMaskTy, rightMaskElem);
 
-                              if (boundaryOption == 1) {
+                              if (boundaryOptionAttr == (llvm::StringRef)"REPLICATE_PADDING") {
                                 Value rightRange =
                                     builder.create<SubIOp>(loc, inputCol, c1);
                                 Value paddingVal =
@@ -328,9 +326,9 @@ public:
                                 createInvertedMask(builder, loc, strideVal,
                                                    vectorMaskTy, leftMaskElem);
 
-                            if (!boundaryOption) {
+                            if (boundaryOptionAttr == (llvm::StringRef)"CONSTANT_PADDING") {
                               Value padding = builder.create<BroadcastOp>(
-                                  loc, vectorTy32, zeroPaddingElem);
+                                  loc, vectorTy32, constantValue);
 
                               Value leftPaddingOffset =
                                   builder.create<SubIOp>(loc, c0, leftMaskElem);
@@ -338,7 +336,7 @@ public:
                                   loc, vectorTy32, input,
                                   ValueRange{imRow, leftPaddingOffset},
                                   leftMask, padding);
-                            } else if (boundaryOption == 1) {
+                            } else if (boundaryOptionAttr == (llvm::StringRef)"REPLICATE_PADDING") {
                               Value paddingVal = builder.create<memref::LoadOp>(
                                   loc, input, ValueRange{imRow, c0});
                               Value padding = builder.create<BroadcastOp>(
@@ -388,15 +386,15 @@ public:
                                       builder.create<CreateMaskOp>(
                                           loc, vectorMaskTy, rightMaskElem);
 
-                                  if (!boundaryOption) {
+                                  if (boundaryOptionAttr == (llvm::StringRef)"CONSTANT_PADDING") {
                                     Value padding = builder.create<BroadcastOp>(
-                                        loc, vectorTy32, zeroPaddingElem);
+                                        loc, vectorTy32, constantValue);
 
                                     inputVec = builder.create<MaskedLoadOp>(
                                         loc, vectorTy32, input,
                                         ValueRange{imRow, imCol}, rightMask,
                                         padding);
-                                  } else if (boundaryOption == 1) {
+                                  } else if (boundaryOptionAttr == (llvm::StringRef)"REPLICATE_PADDING") {
                                     Value rightRange = builder.create<SubIOp>(
                                         loc, inputCol, c1);
                                     Value paddingVal =
@@ -428,9 +426,9 @@ public:
                     },
                     [&](OpBuilder &builder, Location loc) {
                       // rowDown
-                      if (!boundaryOption) {
+                      if (boundaryOptionAttr == (llvm::StringRef)"CONSTANT_PADDING") {
                         Value inputVec = builder.create<BroadcastOp>(
-                            loc, vectorTy32, zeroPaddingElem);
+                            loc, vectorTy32, constantValue);
 
                         calcAndStoreFMAwoTailProcessing(
                             builder, loc, vectorTy32, inputVec, kernelVec,
@@ -452,7 +450,7 @@ public:
                                   builder, loc, strideVal, vectorMaskTy,
                                   leftMaskElem);
 
-                              if (boundaryOption == 1) {
+                              if (boundaryOptionAttr == (llvm::StringRef)"REPLICATE_PADDING") {
                                 Value paddingVal =
                                     builder.create<memref::LoadOp>(
                                         loc, input, ValueRange{downRange, c0});
@@ -486,7 +484,7 @@ public:
                                     Value inputVec;
                                     Value downRange = builder.create<SubIOp>(
                                         loc, inputRow, c1);
-                                    if (boundaryOption == 1) {
+                                    if (boundaryOptionAttr == (llvm::StringRef)"REPLICATE_PADDING") {
                                       inputVec = builder.create<LoadOp>(
                                           loc, vectorTy32, input,
                                           ValueRange{downRange, imCol});
@@ -515,7 +513,7 @@ public:
                                     Value rightRange = builder.create<SubIOp>(
                                         loc, inputCol, c1);
 
-                                    if (boundaryOption == 1) {
+                                    if (boundaryOptionAttr == (llvm::StringRef)"REPLICATE_PADDING") {
                                       Value paddingVal =
                                           builder.create<memref::LoadOp>(
                                               loc, input,

--- a/lib/Conversion/LowerDIP/LowerDIPPass.cpp
+++ b/lib/Conversion/LowerDIP/LowerDIPPass.cpp
@@ -19,12 +19,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Bufferization/Transforms/Bufferize.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Pass/Pass.h"
-#include "mlir/Dialect/Bufferization/Transforms/Bufferize.h"
 
 #include "DIP/DIPDialect.h"
 #include "DIP/DIPOps.h"
@@ -203,7 +203,8 @@ public:
               loc, rowUpCond,
               [&](OpBuilder &builder, Location loc) {
                 // rowUp
-                if (boundaryOptionAttr == (llvm::StringRef)"CONSTANT_PADDING") {
+                if (boundaryOptionAttr ==
+                    (llvm::StringRef) "CONSTANT_PADDING") {
                   Value inputVec = builder.create<BroadcastOp>(loc, vectorTy32,
                                                                constantValue);
 
@@ -225,7 +226,8 @@ public:
                             createInvertedMask(builder, loc, strideVal,
                                                vectorMaskTy, leftMaskElem);
 
-                        if (boundaryOptionAttr == (llvm::StringRef)"REPLICATE_PADDING") {
+                        if (boundaryOptionAttr ==
+                            (llvm::StringRef) "REPLICATE_PADDING") {
                           Value paddingVal = builder.create<memref::LoadOp>(
                               loc, input, ValueRange{c0, c0});
                           Value padding = builder.create<BroadcastOp>(
@@ -254,7 +256,8 @@ public:
                             [&](OpBuilder &builder, Location loc) {
                               // colMid & rowUp
                               Value inputVec;
-                              if (boundaryOptionAttr == (llvm::StringRef)"REPLICATE_PADDING") {
+                              if (boundaryOptionAttr ==
+                                  (llvm::StringRef) "REPLICATE_PADDING") {
                                 inputVec = builder.create<LoadOp>(
                                     loc, vectorTy32, input,
                                     ValueRange{c0, imCol});
@@ -275,7 +278,8 @@ public:
                               Value rightMask = builder.create<CreateMaskOp>(
                                   loc, vectorMaskTy, rightMaskElem);
 
-                              if (boundaryOptionAttr == (llvm::StringRef)"REPLICATE_PADDING") {
+                              if (boundaryOptionAttr ==
+                                  (llvm::StringRef) "REPLICATE_PADDING") {
                                 Value rightRange =
                                     builder.create<SubIOp>(loc, inputCol, c1);
                                 Value paddingVal =
@@ -326,7 +330,8 @@ public:
                                 createInvertedMask(builder, loc, strideVal,
                                                    vectorMaskTy, leftMaskElem);
 
-                            if (boundaryOptionAttr == (llvm::StringRef)"CONSTANT_PADDING") {
+                            if (boundaryOptionAttr ==
+                                (llvm::StringRef) "CONSTANT_PADDING") {
                               Value padding = builder.create<BroadcastOp>(
                                   loc, vectorTy32, constantValue);
 
@@ -336,7 +341,8 @@ public:
                                   loc, vectorTy32, input,
                                   ValueRange{imRow, leftPaddingOffset},
                                   leftMask, padding);
-                            } else if (boundaryOptionAttr == (llvm::StringRef)"REPLICATE_PADDING") {
+                            } else if (boundaryOptionAttr ==
+                                       (llvm::StringRef) "REPLICATE_PADDING") {
                               Value paddingVal = builder.create<memref::LoadOp>(
                                   loc, input, ValueRange{imRow, c0});
                               Value padding = builder.create<BroadcastOp>(
@@ -386,7 +392,8 @@ public:
                                       builder.create<CreateMaskOp>(
                                           loc, vectorMaskTy, rightMaskElem);
 
-                                  if (boundaryOptionAttr == (llvm::StringRef)"CONSTANT_PADDING") {
+                                  if (boundaryOptionAttr ==
+                                      (llvm::StringRef) "CONSTANT_PADDING") {
                                     Value padding = builder.create<BroadcastOp>(
                                         loc, vectorTy32, constantValue);
 
@@ -394,7 +401,9 @@ public:
                                         loc, vectorTy32, input,
                                         ValueRange{imRow, imCol}, rightMask,
                                         padding);
-                                  } else if (boundaryOptionAttr == (llvm::StringRef)"REPLICATE_PADDING") {
+                                  } else if (boundaryOptionAttr ==
+                                             (llvm::StringRef) "REPLICATE_"
+                                                               "PADDING") {
                                     Value rightRange = builder.create<SubIOp>(
                                         loc, inputCol, c1);
                                     Value paddingVal =
@@ -426,7 +435,8 @@ public:
                     },
                     [&](OpBuilder &builder, Location loc) {
                       // rowDown
-                      if (boundaryOptionAttr == (llvm::StringRef)"CONSTANT_PADDING") {
+                      if (boundaryOptionAttr ==
+                          (llvm::StringRef) "CONSTANT_PADDING") {
                         Value inputVec = builder.create<BroadcastOp>(
                             loc, vectorTy32, constantValue);
 
@@ -450,7 +460,8 @@ public:
                                   builder, loc, strideVal, vectorMaskTy,
                                   leftMaskElem);
 
-                              if (boundaryOptionAttr == (llvm::StringRef)"REPLICATE_PADDING") {
+                              if (boundaryOptionAttr ==
+                                  (llvm::StringRef) "REPLICATE_PADDING") {
                                 Value paddingVal =
                                     builder.create<memref::LoadOp>(
                                         loc, input, ValueRange{downRange, c0});
@@ -484,7 +495,8 @@ public:
                                     Value inputVec;
                                     Value downRange = builder.create<SubIOp>(
                                         loc, inputRow, c1);
-                                    if (boundaryOptionAttr == (llvm::StringRef)"REPLICATE_PADDING") {
+                                    if (boundaryOptionAttr ==
+                                        (llvm::StringRef) "REPLICATE_PADDING") {
                                       inputVec = builder.create<LoadOp>(
                                           loc, vectorTy32, input,
                                           ValueRange{downRange, imCol});
@@ -513,7 +525,8 @@ public:
                                     Value rightRange = builder.create<SubIOp>(
                                         loc, inputCol, c1);
 
-                                    if (boundaryOptionAttr == (llvm::StringRef)"REPLICATE_PADDING") {
+                                    if (boundaryOptionAttr ==
+                                        (llvm::StringRef) "REPLICATE_PADDING") {
                                       Value paddingVal =
                                           builder.create<memref::LoadOp>(
                                               loc, input,


### PR DESCRIPTION
DIP dialect specific functions/entities were defined/declared in a separate header file named `dip.hpp`. Proposed C++ interface for `dip.corr_2d` provides complete control over its functionalities to the user. A sample depicting its usage is : 
```
dip::Corr2D(input, kernel, output, centerX, centerY, boundary_option, constantValue(optional));
``` 
where 
```
input : Input image memref

kernel : Kernel memref

output : Output image memref

centerX : X co-ordinate of anchor point

centerY : Y co-ordinate of anchor point

boundary_option : Desired method of boundary extrapolation. 
Available options are dip::BOUNDARY_OPTION::CONSTANT_PADDING and dip::BOUNDARY_OPTION::REPLICATE_PADDING. 

constantValue : Optional argument which is expected to be provided with dip::BOUNDARY_OPTION::CONSTANT_PADDING. Its default value is zero.
```

Note : I did not include `Memref_descriptor` and related things in `namespace dip {}` because its implementation is not yet finalised. I will make necessary changes once `Memref_descriptor` container is successfully ported from buddy_benchmark repository. 

