### PR TITLE
add pwconv to gemm pass

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,17 @@
+# This file is used by clang-format to autoformat buddy-compiler source code
+#
+# The clang-format is part of llvm toolchain.
+# It need to install llvm and clang to format source code style.
+#
+# The basic usage is,
+#   clang-format -i -style=file PATH/TO/SOURCE/CODE
+#
+# The -style=file implicit use ".clang-format" file located in one of 
+# parent directory. 
+# The -i means inplace change.
+#
+# The document of clang-format is 
+#   http://clang.llvm.org/docs/ClangFormat.html
+#   http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+BasedOnStyle:  LLVM

--- a/examples/ConvOpt/pointwise_conv2d_nhwc_filter_hwcf.mlir
+++ b/examples/ConvOpt/pointwise_conv2d_nhwc_filter_hwcf.mlir
@@ -1,0 +1,9 @@
+// Generated from Mobilenet.mlir file
+func @conv_2d_1x1(%input: tensor<1x4x5x2xf32>, %filter: tensor<1x1x2x7xf32>) -> tensor<1x4x5x7xf32> {
+    %0 = linalg.init_tensor [1, 4, 5, 7] : tensor<1x4x5x7xf32>
+    %1 = linalg.conv_2d_nhwc_hwcf {
+        dilations = dense<1> : tensor<2xi64>,
+        strides = dense<1> : tensor<2xi64>
+    } ins(%input, %filter : tensor<1x4x5x2xf32>, tensor<1x1x2x7xf32>) outs(%0 : tensor<1x4x5x7xf32>) -> tensor<1x4x5x7xf32>
+    return %1 : tensor<1x4x5x7xf32>
+}

--- a/lib/Conversion/ConvVectorization/CMakeLists.txt
+++ b/lib/Conversion/ConvVectorization/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_mlir_library(CBConvVectorization
   CBConvVectorization.cpp
+  GEMMPointwiseConv2DNhwcHwcf.cpp
   )

--- a/lib/Conversion/ConvVectorization/GEMMPointwiseConv2DNhwcHwcf.cpp
+++ b/lib/Conversion/ConvVectorization/GEMMPointwiseConv2DNhwcHwcf.cpp
@@ -1,0 +1,149 @@
+//===- GEMMPointwiseConv.cpp - transfer Convolution to GEMM-===//
+//
+// This file implements the algorithm to transfer Pointwise Convolution to GEMM.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+
+#include "mlir/Pass/Pass.h"
+
+#include <iostream>
+
+using namespace mlir;
+using namespace vector;
+
+//===----------------------------------------------------------------------===//
+// Rewrite Pattern
+//===----------------------------------------------------------------------===//
+
+namespace {
+class GEMMPointwiseConvPattern : public ConversionPattern {
+public:
+  explicit GEMMPointwiseConvPattern(MLIRContext *context,
+                                                 int64_t strideParam)
+      : ConversionPattern(linalg::Conv2DNhwcHwcfOp::getOperationName(), 1,
+                          context) {}
+
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op->getLoc();
+
+    // Get input, kernel and output.
+    Value input = op->getOperand(0);
+    Value kernel = op->getOperand(1);
+    Value output = op->getOperand(2);
+    // Get shape of input and output
+    ShapedType inputShapeType = input.getType().cast<ShapedType>();
+    ShapedType filterShapeType = kernel.getType().cast<ShapedType>();
+    ShapedType outputShapeType = output.getType().cast<ShapedType>();
+
+    auto inputShape = inputShapeType.getShape();
+    auto filterShape = filterShapeType.getShape();
+    auto outputShape = outputShapeType.getShape();
+    // Assertions
+    if (filterShape[0] != 1 || filterShape[1] != 1)
+      return failure();
+
+    // TODO(Joe): Support conversion to linalg.batch_matmul.
+    if (inputShape[0] != 1)
+      return failure();
+
+    auto convOp = dyn_cast<linalg::Conv2DNhwcHwcfOp>(op);
+
+    if (!llvm::all_of(convOp.strides(), [](APInt element) {
+          return element.getSExtValue() == 1;
+        }))
+      return failure();
+
+    if (!llvm::all_of(convOp.dilations(), [](APInt element) {
+          return element.getSExtValue() == 1;
+        }))
+      return failure();
+
+    // start arrange
+    SmallVector<ReassociationIndices, 4> reassociationIndices = {{0, 1, 2},
+                                                                 {3}};
+
+    auto reshapedInputType =
+        RankedTensorType::get({inputShape[1] * inputShape[2], inputShape[3]},
+                              inputShapeType.getElementType());
+    auto reshapedFilterType = RankedTensorType::get(
+        {filterShape[2], filterShape[3]}, filterShapeType.getElementType());
+
+    auto reshapedOutputType =
+        RankedTensorType::get({outputShape[1] * outputShape[2], outputShape[3]},
+                              outputShapeType.getElementType());
+
+    Value reshapedInput = rewriter.create<tensor::CollapseShapeOp>(
+        loc, reshapedInputType, input, reassociationIndices);
+    Value reshapedFilter = rewriter.create<tensor::CollapseShapeOp>(
+        loc, reshapedFilterType, kernel, reassociationIndices);
+    Value reshapedOutput = rewriter.create<tensor::CollapseShapeOp>(
+        loc, reshapedOutputType, output, reassociationIndices);
+
+    // Create MutmulOp
+    auto matmulResult = rewriter.create<linalg::MatmulOp>(
+        loc, reshapedOutputType, ArrayRef<Value>{reshapedInput, reshapedFilter},
+        ArrayRef<Value>{reshapedOutput});
+
+    auto reshapedResult = rewriter.create<tensor::ExpandShapeOp>(
+        loc, outputShapeType, matmulResult.getResults()[0],
+        reassociationIndices);
+
+    // Remove the origin convolution operation.
+    rewriter.replaceOp(op, ArrayRef<Value>{reshapedResult});
+    // rewriter.eraseOp(op);
+    return success();
+  }
+};
+} // end anonymous namespace
+
+//===----------------------------------------------------------------------===//
+// PointwiseConvToGemmPass
+//===----------------------------------------------------------------------===//
+
+namespace {
+class PointwiseConvToGemmPass
+    : public PassWrapper<PointwiseConvToGemmPass,
+                         OperationPass<ModuleOp>> {
+public:
+  StringRef getArgument() const final { return "pointwise-conv-to-gemm"; }
+  StringRef getDescription() const final {
+    return "Pointwise Convolution to Gemm.";
+  }
+  PointwiseConvToGemmPass() = default;
+  PointwiseConvToGemmPass(const PointwiseConvToGemmPass &) {}
+
+  void runOnOperation() override;
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect, tensor::TensorDialect,
+                    scf::SCFDialect, func::FuncDialect>();
+  }
+};
+} // end anonymous namespace.
+
+void PointwiseConvToGemmPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+
+  ConversionTarget target(*context);
+  target.addLegalDialect<arith::ArithmeticDialect, scf::SCFDialect,
+                         func::FuncDialect, memref::MemRefDialect,
+                         tensor::TensorDialect>();
+  target.addLegalOp<ModuleOp, FuncOp, func::ReturnOp>();
+  target.addLegalOp<linalg::FillOp, tensor::CollapseShapeOp, linalg::MatmulOp,
+                    tensor::ExpandShapeOp>();
+}
+
+namespace mlir {
+namespace buddy {
+void registerPointwiseConvToGemmPass() {
+  PassRegistration<PointwiseConvToGemmPass>();
+}
+} // namespace buddy
+} // namespace mlir

--- a/tools/buddy-opt/buddy-opt.cpp
+++ b/tools/buddy-opt/buddy-opt.cpp
@@ -26,6 +26,7 @@
 namespace mlir {
 namespace buddy {
 void registerConvVectorizationPass();
+void registerPointwiseConvToGemmPass();
 void registerLowerBudPass();
 void registerLowerDIPPass();
 void registerLowerRVVPass();
@@ -35,6 +36,7 @@ void registerLowerRVVPass();
 int main(int argc, char **argv) {
   // Register all MLIR passes.
   mlir::registerAllPasses();
+  mlir::buddy::registerPointwiseConvToGemmPass();
   // Register Vectorization of Convolution.
   mlir::buddy::registerConvVectorizationPass();
   mlir::buddy::registerLowerBudPass();


### PR DESCRIPTION
Add Draft version of pointwise optimization pass
- add pass
- add example pointwise_conv.mlir

Usage and flag:
```
./bin/buddy-opt ../examples/ConvOpt/pointwise_conv2d_nhwc_filter_hwcf.mlir -pointwise-conv-to-gemm --print-ir-before-all
// -----// IR Dump Before {anonymous}::PointwiseConvVectorizationPass //----- //
module  {
  func @conv_2d_1x1(%arg0: tensor<1x4x5x2xf32>, %arg1: tensor<1x1x2x7xf32>) -> tensor<1x4x5x7xf32> {
    %0 = linalg.init_tensor [1, 4, 5, 7] : tensor<1x4x5x7xf32>
    %1 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1 : tensor<1x4x5x2xf32>, tensor<1x1x2x7xf32>) outs(%0 : tensor<1x4x5x7xf32>) -> tensor<1x4x5x7xf32>
    return %1 : tensor<1x4x5x7xf32>
  }
}


module  {
  func @conv_2d_1x1(%arg0: tensor<1x4x5x2xf32>, %arg1: tensor<1x1x2x7xf32>) -> tensor<1x4x5x7xf32> {
    %0 = linalg.init_tensor [1, 4, 5, 7] : tensor<1x4x5x7xf32>
    %1 = tensor.collapse_shape %arg0 [[0, 1, 2], [3]] : tensor<1x4x5x2xf32> into tensor<20x2xf32>
    %2 = tensor.collapse_shape %arg1 [[0, 1, 2], [3]] : tensor<1x1x2x7xf32> into tensor<2x7xf32>
    %3 = tensor.collapse_shape %0 [[0, 1, 2], [3]] : tensor<1x4x5x7xf32> into tensor<20x7xf32>
    %4 = linalg.matmul ins(%1, %2 : tensor<20x2xf32>, tensor<2x7xf32>) outs(%3 : tensor<20x7xf32>) -> tensor<20x7xf32>
    %5 = tensor.expand_shape %4 [[0, 1, 2], [3]] : tensor<20x7xf32> into tensor<1x4x5x7xf32>
    return %5 : tensor<1x4x5x7xf32>
  }
}
```