### PR TITLE
Search for ANTLR only if samples compilation enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,23 +83,26 @@ check_toolchain()
 #-------------------------------------------------------------------------------
 # Antlr Configuration
 #-------------------------------------------------------------------------------
+# NB: currently, ANTLR is used in examples only,
+# however, there is a plan to use in the frontend,
+# so it is kept in the top-level cmake
+if(BUDDY_EXAMPLES)
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Antlr)
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Antlr)
+    # required if linking to static library
+    add_definitions(-DANTLR4CPP_STATIC)
 
-# required if linking to static library
-add_definitions(-DANTLR4CPP_STATIC)
+    # add external build for antlrcpp
+    include(ExternalAntlr4Cpp)
+    # add antrl4cpp artifacts to project environment
+    include_directories(${ANTLR4_INCLUDE_DIRS})
 
-# add external build for antlrcpp
-include(ExternalAntlr4Cpp)
-# add antrl4cpp artifacts to project environment
-include_directories(${ANTLR4_INCLUDE_DIRS})
-
-# set variable pointing to the antlr tool that supports C++
-# this is not required if the jar file can be found under PATH environment
-set(ANTLR_EXECUTABLE ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/antlr/antlr-4.10.1-complete.jar)
-# add macros to generate ANTLR Cpp code from grammar
-find_package(ANTLR REQUIRED)
-
+    # set variable pointing to the antlr tool that supports C++
+    # this is not required if the jar file can be found under PATH environment
+    set(ANTLR_EXECUTABLE ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/antlr/antlr-4.10.1-complete.jar)
+    # add macros to generate ANTLR Cpp code from grammar
+    find_package(ANTLR REQUIRED)
+endif()
 #-------------------------------------------------------------------------------
 # Directory setup
 #-------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,10 +83,10 @@ check_toolchain()
 #-------------------------------------------------------------------------------
 # Antlr Configuration
 #-------------------------------------------------------------------------------
-# NB: currently, ANTLR is used in examples only,
+# NB: currently, ANTLR is used in dsl examples only,
 # however, there is a plan to use in the frontend,
 # so it is kept in the top-level cmake
-if(BUDDY_EXAMPLES)
+if(BUDDY_DSL_EXAMPLES)
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Antlr)
 
     # required if linking to static library


### PR DESCRIPTION
## Motivation
Currently, developers do not need ANTLR if they build it with examples disabled.