### PR TITLE
Update scripts to run RISC-V emulator using LIT

### DIFF
--- a/.github/workflows/TestBuild.yml
+++ b/.github/workflows/TestBuild.yml
@@ -27,5 +27,7 @@ jobs:
         with:
           path: llvm
           key: build-${{ steps.llvm-build-dir.outputs.commit }}
+      - name: Build RVV enviroment
+        run: bash ./thirdparty/build-rvv-env.sh
       - name: Test build
         run: bash ./tests/Actions/TestBuild.sh  llvm/build-${{ steps.llvm-build-dir.outputs.commit }}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,16 @@
 add_subdirectory(Interface)
 
+set(RISCV_GNU_TOOLCHAIN_SYSROOT "${BUDDY_SOURCE_DIR}/thirdparty/build-riscv-gnu-toolchain/sysroot")
+set(QEMU_BINARY_DIR "${BUDDY_SOURCE_DIR}/thirdparty/qemu/build/riscv64-linux-user")
+set(CROSS_MLIR_RUNNER_UTILS "${BUDDY_SOURCE_DIR}/thirdparty/build-cross-mlir/lib")
+set(CROSS_LLI_BIN "${BUDDY_SOURCE_DIR}/thirdparty/build-cross-clang/bin/lli")
+
+if (NOT EXISTS ${RISCV_GNU_TOOLCHAIN_SYSROOT}
+    OR NOT EXISTS ${CROSS_MLIR_RUNNER_UTILS}
+    OR NOT EXISTS ${CROSS_LLI_BIN})
+    message(WARNING "RISC-V envinroment is not set up. RVV tests will fail."
+                    "For more info how to set up the envinroment, please refer to documention.")
+endif()
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/tests/Dialect/RVV/vector-load.mlir
+++ b/tests/Dialect/RVV/vector-load.mlir
@@ -1,0 +1,43 @@
+//
+// x86
+//
+// RUN: mlir-opt %s --convert-vector-to-scf --lower-affine --convert-scf-to-cf --convert-vector-to-llvm \
+// RUN: --convert-memref-to-llvm --convert-func-to-llvm --reconcile-unrealized-casts  \
+// RUN: | mlir-cpu-runner -O0 -e main -entry-point-result=i32 \
+// RUN: -shared-libs=%mlir_runner_utils_dir/libmlir_runner_utils%shlibext,%mlir_runner_utils_dir/libmlir_c_runner_utils%shlibext \
+// RUN: | FileCheck %s
+//
+// RVV
+//
+// RUN: mlir-opt %s --convert-vector-to-scf --lower-affine --convert-scf-to-cf --convert-vector-to-llvm \
+// RUN:             --convert-memref-to-llvm --convert-func-to-llvm --reconcile-unrealized-casts \
+// RUN: | mlir-translate --mlir-to-llvmir \
+// RUN: | qemu-riscv64 -L %riscv_gnu_toolchain_sysroot -cpu rv64,x-v=true,vlen=128 \
+// RUN: %cross_lli_bin --march=riscv64 -mattr=+m,+d,+v -jit-linker=jitlink -relocation-model=pic \
+// RUN: --dlopen=%cross_mlir_runner_utils/libmlir_c_runner_utils.so | FileCheck %s
+
+memref.global "private" @gv : memref<4x4xf32> = dense<[[0. , 1. , 2. , 3. ],
+                                                       [10., 11., 12., 13.],
+                                                       [20., 21., 22., 23.],
+                                                       [30., 31., 32., 33.]]>
+
+func.func @main() -> i32 {
+  %mem = memref.get_global @gv : memref<4x4xf32>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  // Load 1-D vector from memref.
+  %vec_1d = vector.load %mem[%c0, %c0] : memref<4x4xf32>, vector<4xf32>
+  vector.print %vec_1d : vector<4xf32>
+// CHECK: ( 0, 1, 2, 3 )
+  // Load 2-D vector from memref.
+  %f0 = arith.constant 0.0 : f32
+  %vec_2d = vector.transfer_read %mem[%c2, %c0], %f0
+      {permutation_map = affine_map<(d0, d1) -> (d0, d1)>} :
+    memref<4x4xf32>, vector<2x4xf32>
+  vector.print %vec_2d : vector<2x4xf32>
+// CHECK: ( ( 20, 21, 22, 23 ), ( 30, 31, 32, 33 ) )
+
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -45,23 +45,28 @@ config.excludes = ['Inputs', 'Examples', 'CMakeLists.txt', 'README.txt', 'LICENS
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
 
-# test_exec_root: The root path where tests should be run.
-config.test_exec_root = os.path.join(config.buddy_obj_root, 'tests')
+# tools_dir: tool directories to be used when testing
 config.buddy_tools_dir = os.path.join(config.buddy_obj_root, 'bin')
+config.qemu_tools_dir = "/home/artemy/workspace/repos/buddy-mlir/thirdparty/qemu/build/riscv64-linux-user"
 
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
 
-tool_dirs = [config.buddy_tools_dir, config.llvm_tools_dir]
+tool_dirs = [config.buddy_tools_dir, config.llvm_tools_dir, config.qemu_tools_dir]
 tools = [
     'buddy-opt',
     'buddy-translate',
     'buddy-container-test',
     'buddy-audio-container-test',
+    'mlir-opt',
     'mlir-cpu-runner',
+    'qemu-riscv64'
 ]
 tools.extend([
     ToolSubst('%mlir_runner_utils_dir', config.mlir_runner_utils_dir, unresolved='ignore'),
+    ToolSubst('%riscv_gnu_toolchain_sysroot', config.riscv_gnu_toolchain_sysroot, unresolved='ignore'),
+    ToolSubst('%cross_mlir_runner_utils', config.cross_mlir_runner_utils, unresolved='ignore'),
+    ToolSubst('%cross_lli_bin', config.cross_lli_bin, unresolved='ignore'),
 ])
 
 if config.buddy_enable_opencv == "ON":

--- a/tests/lit.site.cfg.py.in
+++ b/tests/lit.site.cfg.py.in
@@ -33,6 +33,10 @@ config.buddy_src_root = "@CMAKE_SOURCE_DIR@"
 config.buddy_obj_root = "@CMAKE_BINARY_DIR@"
 config.buddy_enable_opencv = "@BUDDY_ENABLE_OPENCV@"
 config.mlir_runner_utils_dir = "@LLVM_LIBS_DIR@"
+config.riscv_gnu_toolchain_sysroot = "@RISCV_GNU_TOOLCHAIN_SYSROOT@"
+config.cross_mlir_runner_utils = "@CROSS_MLIR_RUNNER_UTILS@"
+config.cross_lli_bin = "@CROSS_LLI_BIN@"
+config.qemu_tools_dir = "@QEMU_BINARY_DIR@"
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.

--- a/thirdparty/build-rvv-env.sh
+++ b/thirdparty/build-rvv-env.sh
@@ -10,7 +10,7 @@ fi
 
 if [ ! -d "riscv-gnu-toolchain" ]
 then
-  git clone git@github.com:riscv-collab/riscv-gnu-toolchain.git
+  git clone https://github.com/riscv-collab/riscv-gnu-toolchain.git
   cd riscv-gnu-toolchain
   git checkout rvv-next
   git submodule update --init --recursive
@@ -49,7 +49,7 @@ fi
 
 if [ ! -d "qemu" ]
 then
-  git clone git@github.com:sifive/qemu.git
+  git clone https://github.com/riscv-collab/riscv-gnu-toolchain.git
   cd qemu
   git checkout 856da0e94f
   mkdir build


### PR DESCRIPTION
# Motivation
Many of the examples from `MLIRVector`, `RVVExperiment` can be used as regression tests. It will help to test them regularly and will save the cost of maintenance.

# Opens
* Not ready to be integrated in CI since RISC-V environment is time-consuming to set up. Would need to have https://github.com/buddy-compiler/buddy-mlir/issues/19 resolved and use the same approach for the environment.
* Currently, if there is no RISC-V environment, the corresponding tests will fail. We could make those tests optional and do not run them if the environment is not available.