### PR TITLE
Caching for LLVM build in github actions

### DIFF
--- a/.github/workflows/TestBuild.yml
+++ b/.github/workflows/TestBuild.yml
@@ -22,10 +22,10 @@ jobs:
         id: llvm-build-dir
         run: |
           echo "::set-output name=commit::$(git submodule status | awk '{print $1;}')"
-      - name: Test build
-        run: bash ./tests/Actions/TestBuild.sh  llvm/build-${{ steps.llvm-build-dir.outputs.commit }}
       - name: Cache llvm build directory
         uses: actions/cache@v3
         with:
           path: llvm
           key: build-${{ steps.llvm-build-dir.outputs.commit }}
+      - name: Test build
+        run: bash ./tests/Actions/TestBuild.sh  llvm/build-${{ steps.llvm-build-dir.outputs.commit }}

--- a/.github/workflows/TestBuild.yml
+++ b/.github/workflows/TestBuild.yml
@@ -9,9 +9,21 @@ jobs:
 
     runs-on: ubuntu-latest
 
-# ToDo : Cache llvm build to reduce execution time on each run of virtual instance.
     steps:
-    - uses: actions/checkout@v2
-    - uses: seanmiddleditch/gha-setup-ninja@master
-    - name: test build
-      run: bash ./tests/Actions/TestBuild.sh
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+      - name: Set up ninja
+        uses: seanmiddleditch/gha-setup-ninja@master
+      - name: Prepare llvm build directory name
+        id: llvm-build-dir
+        run: |
+          echo "::set-output name=commit::$(git submodule status | awk '{print $1;}')"
+      - name: Test build
+        run: bash ./tests/Actions/TestBuild.sh  llvm/build-${{ steps.llvm-build-dir.outputs.commit }}
+      - name: Cache llvm build directory
+        uses: actions/cache@v3
+        with:
+          path: llvm
+          key: build-${{ steps.llvm-build-dir.outputs.commit }}

--- a/.github/workflows/TestBuild.yml
+++ b/.github/workflows/TestBuild.yml
@@ -3,6 +3,8 @@ name: test build process
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build:

--- a/tests/Actions/TestBuild.sh
+++ b/tests/Actions/TestBuild.sh
@@ -1,18 +1,32 @@
-git submodule update --init
-mkdir llvm/build
-cd llvm/build
-cmake -G Ninja ../llvm \
-    -DLLVM_ENABLE_PROJECTS="mlir" \
-    -DLLVM_TARGETS_TO_BUILD="host;RISCV" \
-    -DLLVM_ENABLE_ASSERTIONS=ON \
-    -DCMAKE_BUILD_TYPE=RELEASE
-ninja
+if [ -z "$1"]
+then
+  llvm_build_dir="llvm/build"
+else
+  llvm_build_dir="$1"
+fi
+if [ ! -d $llvm_build_dir ]
+then
+    mkdir $llvm_build_dir
+fi
+
+cd $llvm_build_dir
+# assuming if there is something in llvm_build_dir, it is a valid build,
+# so we won't build llvm
+if [ -z "$(ls -A ./)"]
+then
+    cmake -G Ninja ../llvm \
+        -DLLVM_ENABLE_PROJECTS="mlir" \
+        -DLLVM_TARGETS_TO_BUILD="host;RISCV" \
+        -DLLVM_ENABLE_ASSERTIONS=ON \
+        -DCMAKE_BUILD_TYPE=RELEASE
+    ninja
+fi
 cd ../..
 mkdir build
 cd build
 cmake -G Ninja .. \
-    -DMLIR_DIR=$PWD/../llvm/build/lib/cmake/mlir \
-    -DLLVM_DIR=$PWD/../llvm/build/lib/cmake/llvm \
+    -DMLIR_DIR=$PWD/../$llvm_build_dir/lib/cmake/mlir \
+    -DLLVM_DIR=$PWD/../$llvm_build_dir/lib/cmake/llvm \
     -DLLVM_ENABLE_ASSERTIONS=ON \
     -DCMAKE_BUILD_TYPE=RELEASE
 ninja check-buddy

--- a/tests/Actions/TestBuild.sh
+++ b/tests/Actions/TestBuild.sh
@@ -1,4 +1,4 @@
-if [ -z "$1"]
+if [ -z "$1" ]
 then
   llvm_build_dir="llvm/build"
 else
@@ -12,7 +12,7 @@ fi
 cd $llvm_build_dir
 # assuming if there is something in llvm_build_dir, it is a valid build,
 # so we won't build llvm
-if [ -z "$(ls -A ./)"]
+if [ -z "$(ls -A ./)" ]
 then
     cmake -G Ninja ../llvm \
         -DLLVM_ENABLE_PROJECTS="mlir" \


### PR DESCRIPTION
# Motivation

* Saving build time by caching LLVM build results
* Enabling github actions for pull requests to check changes more often and give a developer faster feedback
  * it takes a couple of minutes to run the pipeline if the llvvm build is cached
* Corresponding issue https://github.com/buddy-compiler/buddy-mlir/issues/19

# Details

* Update `TestBuild.yml` to use `actions/cache@v3` for caching
  * llvm-project submodule revision is chosen as a cache key
* Update `TestBuild.sh` to set a build name for llvm-project and skip building llvm if the build directory already exists
* Examples
  * Without caching ~ 1 hour 35 minutes: https://github.com/buddy-compiler/buddy-mlir/runs/7336914536?check_suite_focus=true 
  * With caching
    * 2m 56s https://github.com/buddy-compiler/buddy-mlir/runs/7338385660?check_suite_focus=true
    * 3m 29s https://github.com/buddy-compiler/buddy-mlir/runs/7338471382?check_suite_focus=true