### PR TITLE
Remove a confusing instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ $ cmake -G Ninja ../llvm \
     -DLLVM_TARGETS_TO_BUILD="host;RISCV" \
     -DLLVM_ENABLE_ASSERTIONS=ON \
     -DCMAKE_BUILD_TYPE=RELEASE
-$ ninja
 $ ninja check-mlir
 ```
 

--- a/examples/BudDialect/TestInlineInterface.mlir
+++ b/examples/BudDialect/TestInlineInterface.mlir
@@ -1,0 +1,16 @@
+memref.global "private" @gv : memref<4x4xf32> = dense<[[0. , 1. , 2. , 3. ],
+                                                       [10., 11., 12., 13.],
+                                                       [20., 21., 22., 23.],
+                                                       [30., 31., 32., 33.]]>
+
+func.func private @example(%arg0: memref<4x4xf32>) -> (f32) {
+  %res = bud.test_array_attr %arg0 {coordinate = [0, 1]} : memref<4x4xf32>, f32
+  return %res : f32
+}
+
+func.func @main() {
+  %mem = memref.get_global @gv : memref<4x4xf32>
+  %1 = func.call @example(%mem) : (memref<4x4xf32>) -> (f32)
+  vector.print %1 : f32 
+  return
+}

--- a/examples/BudDialect/makefile
+++ b/examples/BudDialect/makefile
@@ -16,3 +16,7 @@ bud-print-lower:
 bud-str-attr-lower:
 	@${BUDDY_OPT} ./TestStrAttr.mlir \
 		--lower-bud -o ./log.mlir
+
+bud-inline-interface-run:
+	@${BUDDY_OPT} ./TestInlineInterface.mlir \
+		--inline -o ./log.mlir

--- a/lib/Dialect/Bud/BudDialect.cpp
+++ b/lib/Dialect/Bud/BudDialect.cpp
@@ -30,6 +30,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Type.h"
 #include "llvm/Support/SourceMgr.h"
+#include "mlir/Transforms/InliningUtils.h"
 
 #include "Bud/BudDialect.h"
 #include "Bud/BudOps.h"
@@ -38,6 +39,28 @@ using namespace mlir;
 using namespace buddy::bud;
 
 #include "Bud/BudOpsDialect.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// BudDialect Interfaces
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct BudInlinerInterface : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+  // We don't have any special restrictions on what can be inlined into
+  // destination regions (e.g. while/conditional bodies). Always allow it.
+  bool isLegalToInline(Region *dest, Region *src, bool wouldBeCloned,
+                       BlockAndValueMapping &valueMapping) const final {
+    return true;
+  }
+  // Operations in bud dialect are always legal to inline since they are
+  // pure.
+  bool isLegalToInline(Operation *, Region *, bool,
+                       BlockAndValueMapping &) const final {
+    return true;
+  }
+};
+} // namespace
 
 //===----------------------------------------------------------------------===//
 // Bud dialect.
@@ -52,6 +75,7 @@ void BudDialect::initialize() {
 #define GET_ATTRDEF_LIST
 #include "Bud/BudOpsAttributes.cpp.inc"
       >();
+  addInterfaces<BudInlinerInterface>();
 }
 
 #include "Bud/BudOpsEnums.cpp.inc"


### PR DESCRIPTION
Build LLVM submodule with "ninja check-mlir" instead of "ninja".