### PR TITLE
Remove a confusing instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ $ cmake -G Ninja ../llvm \
     -DLLVM_TARGETS_TO_BUILD="host;RISCV" \
     -DLLVM_ENABLE_ASSERTIONS=ON \
     -DCMAKE_BUILD_TYPE=RELEASE
-$ ninja
 $ ninja check-mlir
 ```
 


### PR DESCRIPTION
Build LLVM submodule with "ninja check-mlir" instead of "ninja".