### PR TITLE
Improve CBConvVectorization Lowering pass

### DIFF
--- a/include/Utils/DIPUtils.h
+++ b/include/Utils/DIPUtils.h
@@ -163,10 +163,6 @@ void BilinearInterpolationResizing(
     Value inputRowLastElemF32, Value inputColLastElemF32, VectorType vectorTy32,
     int64_t stride, Value c0, Value c0F32, Value c1F32);
 
-// Function to test whether a value is equivalent to zero or not.
-Value zeroCond(OpBuilder &builder, Location loc, Type elemType, Value value,
-               Value zeroElem);
-
 // Util function for morphological transformations ; compares two vectors and
 // returns a mask
 Value createCompVecMorph(OpBuilder &builder, Location loc, VectorType type,

--- a/include/Utils/Utils.h
+++ b/include/Utils/Utils.h
@@ -26,35 +26,34 @@ using namespace mlir;
 namespace buddy {
 
 // Function to test whether a value is equivalent to zero or not.
-inline Value zeroCond(OpBuilder &builder, Location loc, Type elemType,
-                      Value value, Value zeroElem);
+Value zeroCond(OpBuilder &builder, Location loc, Type elemType, Value value,
+               Value zeroElem);
 
 // Create an inverted mask having all 1's shifted to right side.
-inline Value createInvertedMask(OpBuilder &builder, Location loc,
-                                Value strideVal, VectorType vectorMaskTy,
-                                Value leftIndex);
+Value createInvertedMask(OpBuilder &builder, Location loc, Value strideVal,
+                         VectorType vectorMaskTy, Value leftIndex);
 
 // Cast a value from index type to f32 type.
-inline Value indexToF32(OpBuilder &builder, Location loc, Value val);
+Value indexToF32(OpBuilder &builder, Location loc, Value val);
 
 // Cast a value from f32 type to index type.
-inline Value F32ToIndex(OpBuilder &builder, Location loc, Value val);
+Value F32ToIndex(OpBuilder &builder, Location loc, Value val);
 
 // Round off floating point value to nearest integer type value.
-inline Value roundOff(OpBuilder &builder, Location loc, Value val);
+Value roundOff(OpBuilder &builder, Location loc, Value val);
 
 // Bound values to permissible range of allocatable values w.r.t output image.
-inline Value valBound(OpBuilder &builder, Location loc, Value val,
-                      Value lastElemF32, Value c0F32);
+Value valBound(OpBuilder &builder, Location loc, Value val, Value lastElemF32,
+               Value c0F32);
 
 // Equivalent of std::iota.
-inline Value iotaVec(OpBuilder &builder, Location loc, MLIRContext *ctx,
-                     Value indexStart, Value strideVal, VectorType vecType,
-                     Value c0, int64_t stride);
+Value iotaVec(OpBuilder &builder, Location loc, MLIRContext *ctx,
+              Value indexStart, Value strideVal, VectorType vecType, Value c0,
+              int64_t stride);
 
 // Cast index type value to f32 type and then expand it in a vector.
-inline Value castAndExpand(OpBuilder &builder, Location loc, Value val,
-                           VectorType vecType);
+Value castAndExpand(OpBuilder &builder, Location loc, Value val,
+                    VectorType vecType);
 
 } // namespace buddy
 

--- a/include/Utils/Utils.h
+++ b/include/Utils/Utils.h
@@ -25,30 +25,34 @@ using namespace mlir;
 using namespace arith;
 using namespace vector;
 
+// Function to test whether a value is equivalent to zero or not.
+inline Value zeroCond(OpBuilder &builder, Location loc, Type elemType, Value value,
+               Value zeroElem);
+
 // Create an inverted mask having all 1's shifted to right side.
-Value createInvertedMask(OpBuilder &builder, Location loc, Value strideVal,
+inline Value createInvertedMask(OpBuilder &builder, Location loc, Value strideVal,
                          VectorType vectorMaskTy, Value leftIndex);
 
 // Cast a value from index type to f32 type.
-Value indexToF32(OpBuilder &builder, Location loc, Value val);
+inline Value indexToF32(OpBuilder &builder, Location loc, Value val);
 
 // Cast a value from f32 type to index type.
-Value F32ToIndex(OpBuilder &builder, Location loc, Value val);
+inline Value F32ToIndex(OpBuilder &builder, Location loc, Value val);
 
 // Round off floating point value to nearest integer type value.
-Value roundOff(OpBuilder &builder, Location loc, Value val);
+inline Value roundOff(OpBuilder &builder, Location loc, Value val);
 
 // Bound values to permissible range of allocatable values w.r.t output image.
-Value valBound(OpBuilder &builder, Location loc, Value val, Value lastElemF32,
+inline Value valBound(OpBuilder &builder, Location loc, Value val, Value lastElemF32,
                Value c0F32);
 
 // Equivalent of std::iota.
-Value iotaVec(OpBuilder &builder, Location loc, MLIRContext *ctx,
+inline Value iotaVec(OpBuilder &builder, Location loc, MLIRContext *ctx,
               Value indexStart, Value strideVal, VectorType vecType, Value c0,
               int64_t stride);
 
 // Cast index type value to f32 type and then expand it in a vector.
-Value castAndExpand(OpBuilder &builder, Location loc, Value val,
+inline Value castAndExpand(OpBuilder &builder, Location loc, Value val,
                     VectorType vecType);
 
 #include "Utils/Utils.cpp"

--- a/include/Utils/Utils.h
+++ b/include/Utils/Utils.h
@@ -26,12 +26,13 @@ using namespace arith;
 using namespace vector;
 
 // Function to test whether a value is equivalent to zero or not.
-inline Value zeroCond(OpBuilder &builder, Location loc, Type elemType, Value value,
-               Value zeroElem);
+inline Value zeroCond(OpBuilder &builder, Location loc, Type elemType,
+                      Value value, Value zeroElem);
 
 // Create an inverted mask having all 1's shifted to right side.
-inline Value createInvertedMask(OpBuilder &builder, Location loc, Value strideVal,
-                         VectorType vectorMaskTy, Value leftIndex);
+inline Value createInvertedMask(OpBuilder &builder, Location loc,
+                                Value strideVal, VectorType vectorMaskTy,
+                                Value leftIndex);
 
 // Cast a value from index type to f32 type.
 inline Value indexToF32(OpBuilder &builder, Location loc, Value val);
@@ -43,17 +44,17 @@ inline Value F32ToIndex(OpBuilder &builder, Location loc, Value val);
 inline Value roundOff(OpBuilder &builder, Location loc, Value val);
 
 // Bound values to permissible range of allocatable values w.r.t output image.
-inline Value valBound(OpBuilder &builder, Location loc, Value val, Value lastElemF32,
-               Value c0F32);
+inline Value valBound(OpBuilder &builder, Location loc, Value val,
+                      Value lastElemF32, Value c0F32);
 
 // Equivalent of std::iota.
 inline Value iotaVec(OpBuilder &builder, Location loc, MLIRContext *ctx,
-              Value indexStart, Value strideVal, VectorType vecType, Value c0,
-              int64_t stride);
+                     Value indexStart, Value strideVal, VectorType vecType,
+                     Value c0, int64_t stride);
 
 // Cast index type value to f32 type and then expand it in a vector.
 inline Value castAndExpand(OpBuilder &builder, Location loc, Value val,
-                    VectorType vecType);
+                           VectorType vecType);
 
 #include "Utils/Utils.cpp"
 

--- a/lib/Conversion/ConvVectorization/CBConvVectorization.cpp
+++ b/lib/Conversion/ConvVectorization/CBConvVectorization.cpp
@@ -86,8 +86,9 @@ void populateCBSplitingPattern(Operation *op, int64_t stride,
               // Broadcast element of the kernel.
               Value kernelValue = builder.create<memref::LoadOp>(
                   loc, kernel, ValueRange{ivs[1], ivs[2]});
-              Value kernelNonZeroCond = zeroCond(builder, loc, f32, kernelValue,
-                                                 indexToF32(builder, loc, c0));
+              Value kernelNonZeroCond =
+                  buddy::zeroCond(builder, loc, f32, kernelValue,
+                                  buddy::indexToF32(builder, loc, c0));
               builder.create<scf::IfOp>(
                   loc, kernelNonZeroCond,
                   [&](OpBuilder &builder, Location loc) {

--- a/lib/Conversion/ConvVectorization/CMakeLists.txt
+++ b/lib/Conversion/ConvVectorization/CMakeLists.txt
@@ -2,4 +2,7 @@ add_mlir_library(CBConvVectorization
   CBConvVectorization.cpp
   GEMMPointwiseConv2DNhwcHwcf.cpp
   PoolingVectorization.cpp
+  
+  LINK_LIBS PUBLIC
+  Utils
   )

--- a/lib/Utils/DIPUtils.cpp
+++ b/lib/Utils/DIPUtils.cpp
@@ -652,19 +652,6 @@ void BilinearInterpolationResizing(
       });
 }
 
-// Function to test whether a value is equivalent to zero or not.
-Value zeroCond(OpBuilder &builder, Location loc, Type elemType, Value value,
-               Value zeroElem) {
-  Value cond;
-  auto bitWidth = elemType.getIntOrFloatBitWidth();
-  if (elemType.isF32() || elemType.isF64()) {
-    cond = builder.create<CmpFOp>(loc, CmpFPredicate::ONE, value, zeroElem);
-  } else if (elemType.isInteger(bitWidth)) {
-    cond = builder.create<CmpIOp>(loc, CmpIPredicate::ne, value, zeroElem);
-  }
-  return cond;
-}
-
 // Util function for morphological transformations ; compares two vectors and
 // returns a mask
 Value createCompVecMorph(OpBuilder &builder, Location loc, VectorType type,

--- a/lib/Utils/DIPUtils.cpp
+++ b/lib/Utils/DIPUtils.cpp
@@ -22,32 +22,49 @@
 #ifndef UTILS_DIPUTILS_DEF
 #define UTILS_DIPUTILS_DEF
 
-#include <stdarg.h>
+#include <mlir/Dialect/Affine/IR/AffineOps.h>
+#include <mlir/Dialect/Affine/IR/AffineValueMap.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Math/IR/Math.h>
+#include <mlir/Dialect/MemRef/IR/MemRef.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Dialect/Vector/IR/VectorOps.h>
+#include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/Value.h>
 
+#include "DIP/DIPDialect.h"
+#include "DIP/DIPOps.h"
 #include "Utils/DIPUtils.h"
+#include "Utils/Utils.h"
 
-// Inserts a constant op with value 0 into a location `loc` based on type
-// `type`. Supported types are : f32, f64, integer types.
-Value insertZeroConstantOp(MLIRContext *ctx, OpBuilder &builder, Location loc,
-                           Type elemTy) {
-  Value op = {};
-  auto bitWidth = elemTy.getIntOrFloatBitWidth();
-  if (elemTy.isF32() || elemTy.isF64()) {
-    FloatType type =
-        elemTy.isF32() ? FloatType::getF32(ctx) : FloatType::getF64(ctx);
-    auto zero = APFloat::getZero(type.getFloatSemantics());
-    op = builder.create<ConstantFloatOp>(loc, zero, type);
-  } else if (elemTy.isInteger(bitWidth)) {
-    IntegerType type = IntegerType::get(ctx, bitWidth);
-    op = builder.create<ConstantIntOp>(loc, 0, type);
-  }
+using namespace mlir;
 
-  return op;
-}
+namespace buddy {
+namespace dip {
+template DIP_ERROR checkDIPCommonTypes<dip::Corr2DOp>(dip::Corr2DOp, size_t,
+                                                      ...);
+template DIP_ERROR checkDIPCommonTypes<dip::Rotate2DOp>(dip::Rotate2DOp, size_t,
+                                                        ...);
+template DIP_ERROR checkDIPCommonTypes<dip::Resize2DOp>(dip::Resize2DOp, size_t,
+                                                        ...);
+template DIP_ERROR checkDIPCommonTypes<dip::Erosion2DOp>(dip::Erosion2DOp,
+                                                         size_t, ...);
+template DIP_ERROR checkDIPCommonTypes<dip::Dilation2DOp>(dip::Dilation2DOp,
+                                                          size_t, ...);
+template DIP_ERROR checkDIPCommonTypes<dip::Opening2DOp>(dip::Opening2DOp,
+                                                         size_t, ...);
+template DIP_ERROR checkDIPCommonTypes<dip::Closing2DOp>(dip::Closing2DOp,
+                                                         size_t, ...);
+template DIP_ERROR checkDIPCommonTypes<dip::TopHat2DOp>(dip::TopHat2DOp, size_t,
+                                                        ...);
+template DIP_ERROR checkDIPCommonTypes<dip::BottomHat2DOp>(dip::BottomHat2DOp,
+                                                           size_t, ...);
+template DIP_ERROR checkDIPCommonTypes<dip::MorphGrad2DOp>(dip::MorphGrad2DOp,
+                                                           size_t, ...);
 
 // Function for applying type check mechanisms for all DIP dialect operations.
 template <typename DIPOP>
-auto checkDIPCommonTypes(DIPOP op, size_t numArgs, ...) {
+DIP_ERROR checkDIPCommonTypes(DIPOP op, size_t numArgs, ...) {
   if (op->getName().stripDialect() == "corr_2d") {
     // Define variable arguments list.
     va_list vaList;
@@ -208,6 +225,25 @@ auto checkDIPCommonTypes(DIPOP op, size_t numArgs, ...) {
   return DIP_ERROR::NO_ERROR;
 }
 
+// Inserts a constant op with value 0 into a location `loc` based on type
+// `type`. Supported types are : f32, f64, integer types.
+Value insertZeroConstantOp(MLIRContext *ctx, OpBuilder &builder, Location loc,
+                           Type elemTy) {
+  Value op = {};
+  auto bitWidth = elemTy.getIntOrFloatBitWidth();
+  if (elemTy.isF32() || elemTy.isF64()) {
+    FloatType type =
+        elemTy.isF32() ? FloatType::getF32(ctx) : FloatType::getF64(ctx);
+    auto zero = APFloat::getZero(type.getFloatSemantics());
+    op = builder.create<arith::ConstantFloatOp>(loc, zero, type);
+  } else if (elemTy.isInteger(bitWidth)) {
+    IntegerType type = IntegerType::get(ctx, bitWidth);
+    op = builder.create<arith::ConstantIntOp>(loc, 0, type);
+  }
+
+  return op;
+}
+
 // Inserts FMA operation into a given location `loc` based on type `type`.
 // Note: FMA is done by Multiply and Add for integer types, because there is no
 // dedicated FMA operation for them.
@@ -233,11 +269,12 @@ void calcAndStoreFMAwoTailProcessing(OpBuilder &builder, Location loc,
                                      VectorType vecType, Value inputVec,
                                      Value kernelVec, Value output,
                                      Value beginIdx, Value endIdx) {
-  Value outputVec = builder.create<LoadOp>(loc, vecType, output,
-                                           ValueRange{beginIdx, endIdx});
+  Value outputVec = builder.create<vector::LoadOp>(
+      loc, vecType, output, ValueRange{beginIdx, endIdx});
   Value resVec =
       insertFMAOp(builder, loc, vecType, inputVec, kernelVec, outputVec);
-  builder.create<StoreOp>(loc, resVec, output, ValueRange{beginIdx, endIdx});
+  builder.create<vector::StoreOp>(loc, resVec, output,
+                                  ValueRange{beginIdx, endIdx});
 }
 
 // Checks if we encountered a tail (columns remaining after processing in
@@ -247,18 +284,19 @@ Value tailChecker(OpBuilder &builder, Location loc, AffineMap calcHelper,
                   Value colPivot) {
   Value tailChecker = builder.create<AffineApplyOp>(
       loc, calcHelper, ValueRange{strideVal, kernelSize, c1});
-  Value colEndDistance = builder.create<SubIOp>(loc, pseudoCol, colPivot);
-  Value tailCond = builder.create<CmpIOp>(loc, CmpIPredicate::sge,
-                                          colEndDistance, tailChecker);
+  Value colEndDistance =
+      builder.create<arith::SubIOp>(loc, pseudoCol, colPivot);
+  Value tailCond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sge,
+                                                 colEndDistance, tailChecker);
   return tailCond;
 }
 
 // Creates the required mask which is to be used for tail processing.
 Value tailMaskCreator(OpBuilder &builder, Location loc, Value inputCol,
                       Value colPivot, VectorType vectorMaskTy) {
-  Value extraElemCount = builder.create<SubIOp>(loc, inputCol, colPivot);
+  Value extraElemCount = builder.create<arith::SubIOp>(loc, inputCol, colPivot);
   Value tailMask =
-      builder.create<CreateMaskOp>(loc, vectorMaskTy, extraElemCount);
+      builder.create<vector::CreateMaskOp>(loc, vectorMaskTy, extraElemCount);
   return tailMask;
 }
 
@@ -273,25 +311,25 @@ void calcAndStoreFMAwTailProcessing(OpBuilder &builder, Location loc,
   builder.create<scf::IfOp>(
       loc, tailCond,
       [&](OpBuilder &builder, Location loc) {
-        Value outputVec = builder.create<LoadOp>(loc, vecType, output,
-                                                 ValueRange{beginIdx, endIdx});
+        Value outputVec = builder.create<vector::LoadOp>(
+            loc, vecType, output, ValueRange{beginIdx, endIdx});
         Value resVec =
             insertFMAOp(builder, loc, vecType, inputVec, kernelVec, outputVec);
-        builder.create<StoreOp>(loc, resVec, output,
-                                ValueRange{beginIdx, endIdx});
+        builder.create<vector::StoreOp>(loc, resVec, output,
+                                        ValueRange{beginIdx, endIdx});
 
         builder.create<scf::YieldOp>(loc);
       },
       [&](OpBuilder &builder, Location loc) {
         Value extraElemMask =
             tailMaskCreator(builder, loc, inputCol, endIdx, vectorMaskTy);
-        Value outputVec = builder.create<MaskedLoadOp>(
+        Value outputVec = builder.create<vector::MaskedLoadOp>(
             loc, vecType, output, ValueRange{beginIdx, endIdx}, extraElemMask,
             zeroPadding);
         Value resVec =
             insertFMAOp(builder, loc, vecType, inputVec, kernelVec, outputVec);
-        builder.create<MaskedStoreOp>(loc, output, ValueRange{beginIdx, endIdx},
-                                      extraElemMask, resVec);
+        builder.create<vector::MaskedStoreOp>(
+            loc, output, ValueRange{beginIdx, endIdx}, extraElemMask, resVec);
 
         builder.create<scf::YieldOp>(loc);
       });
@@ -335,10 +373,10 @@ std::vector<Value> standardRotate(OpBuilder &builder, Location loc,
 // Get center co-ordinates w.r.t given dimension.
 Value getCenter(OpBuilder &builder, Location loc, MLIRContext *ctx, Value dim) {
   Value dimF32 = indexToF32(builder, loc, dim);
-  Value c1f = builder.create<ConstantFloatOp>(loc, (llvm::APFloat)1.0f,
-                                              builder.getF32Type());
-  Value c2f = builder.create<ConstantFloatOp>(loc, (llvm::APFloat)2.0f,
-                                              builder.getF32Type());
+  Value c1f = builder.create<arith::ConstantFloatOp>(loc, (llvm::APFloat)1.0f,
+                                                     builder.getF32Type());
+  Value c2f = builder.create<arith::ConstantFloatOp>(loc, (llvm::APFloat)2.0f,
+                                                     builder.getF32Type());
 
   Value temp1 = builder.create<arith::AddFOp>(loc, dimF32, c1f);
   Value temp2 = builder.create<arith::DivFOp>(loc, temp1, c2f);
@@ -405,8 +443,8 @@ void fillPixels(OpBuilder &builder, Location loc, Value resXVec, Value resYVec,
 
 // Calculate tan(angle / 2) where angle is a function parameter.
 Value customTanVal(OpBuilder &builder, Location loc, Value angleVal) {
-  Value c2F32 = builder.create<ConstantFloatOp>(loc, (llvm::APFloat)2.0f,
-                                                builder.getF32Type());
+  Value c2F32 = builder.create<arith::ConstantFloatOp>(loc, (llvm::APFloat)2.0f,
+                                                       builder.getF32Type());
   Value angleVal_2 = builder.create<arith::DivFOp>(loc, angleVal, c2F32);
 
   Value sinVal = builder.create<math::SinOp>(loc, angleVal_2);
@@ -652,6 +690,21 @@ void BilinearInterpolationResizing(
       });
 }
 
+// Function to test whether a value is equivalent to zero or not.
+Value zeroCond(OpBuilder &builder, Location loc, Type elemType, Value value,
+               Value zeroElem) {
+  Value cond;
+  auto bitWidth = elemType.getIntOrFloatBitWidth();
+  if (elemType.isF32() || elemType.isF64()) {
+    cond = builder.create<arith::CmpFOp>(loc, arith::CmpFPredicate::ONE, value,
+                                         zeroElem);
+  } else if (elemType.isInteger(bitWidth)) {
+    cond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne, value,
+                                         zeroElem);
+  }
+  return cond;
+}
+
 // Util function for morphological transformations ; compares two vectors and
 // returns a mask
 Value createCompVecMorph(OpBuilder &builder, Location loc, VectorType type,
@@ -661,19 +714,19 @@ Value createCompVecMorph(OpBuilder &builder, Location loc, VectorType type,
   auto bitWidth = elemTy.getIntOrFloatBitWidth();
   if (elemTy.isF32() || elemTy.isF64()) {
     if (op == DIP_OP::EROSION_2D) {
-      compVec =
-          builder.create<CmpFOp>(loc, CmpFPredicate::OGE, inputVec, outputVec);
+      compVec = builder.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OGE,
+                                              inputVec, outputVec);
     } else if (op == DIP_OP::DILATION_2D) {
-      compVec =
-          builder.create<CmpFOp>(loc, CmpFPredicate::OLE, inputVec, outputVec);
+      compVec = builder.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OLE,
+                                              inputVec, outputVec);
     }
   } else if (elemTy.isInteger(bitWidth)) {
     if (op == DIP_OP::EROSION_2D) {
-      compVec =
-          builder.create<CmpIOp>(loc, CmpIPredicate::sge, inputVec, outputVec);
+      compVec = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sge,
+                                              inputVec, outputVec);
     } else if (op == DIP_OP::DILATION_2D) {
-      compVec =
-          builder.create<CmpIOp>(loc, CmpIPredicate::sle, inputVec, outputVec);
+      compVec = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sle,
+                                              inputVec, outputVec);
     }
   }
   return compVec;
@@ -685,8 +738,8 @@ void calcAndStorewoTailProcessingMorph(
     Value kernelVec, Value output, Value beginIdx, Value endIdx,
     Value zeroPadding, Value inputCol, VectorType vectorMaskTy, Type elemTy,
     Value kernelValue, Value zeroPaddingElem, DIP_OP op) {
-  Value outputVec = builder.create<LoadOp>(loc, vecType, output,
-                                           ValueRange{beginIdx, endIdx});
+  Value outputVec = builder.create<vector::LoadOp>(
+      loc, vecType, output, ValueRange{beginIdx, endIdx});
   Value compVec = {};
   if (op == DIP_OP::EROSION_2D) {
     compVec = createCompVecMorph(builder, loc, vecType, inputVec, outputVec,
@@ -696,10 +749,11 @@ void calcAndStorewoTailProcessingMorph(
                                  DIP_OP::DILATION_2D);
   }
 
-  Value resVec = builder.create<MaskedLoadOp>(
+  Value resVec = builder.create<vector::MaskedLoadOp>(
       loc, vecType, output, ValueRange{beginIdx, endIdx}, compVec, inputVec);
 
-  builder.create<StoreOp>(loc, resVec, output, ValueRange{beginIdx, endIdx});
+  builder.create<vector::StoreOp>(loc, resVec, output,
+                                  ValueRange{beginIdx, endIdx});
 }
 
 // Utility function for morphological transformations, can handle tail
@@ -712,8 +766,8 @@ void calcAndStorewTailProcessingMorph(
   builder.create<scf::IfOp>(
       loc, tailCond,
       [&](OpBuilder &builder, Location loc) {
-        Value outputVec = builder.create<LoadOp>(loc, vecType, output,
-                                                 ValueRange{beginIdx, endIdx});
+        Value outputVec = builder.create<vector::LoadOp>(
+            loc, vecType, output, ValueRange{beginIdx, endIdx});
 
         Value compVec = {};
         if (op == DIP_OP::EROSION_2D) {
@@ -724,12 +778,12 @@ void calcAndStorewTailProcessingMorph(
                                        outputVec, DIP_OP::DILATION_2D);
         }
 
-        Value resVec = builder.create<MaskedLoadOp>(
+        Value resVec = builder.create<vector::MaskedLoadOp>(
             loc, vecType, output, ValueRange{beginIdx, endIdx}, compVec,
             inputVec);
 
-        builder.create<StoreOp>(loc, resVec, output,
-                                ValueRange{beginIdx, endIdx});
+        builder.create<vector::StoreOp>(loc, resVec, output,
+                                        ValueRange{beginIdx, endIdx});
 
         builder.create<scf::YieldOp>(loc);
       },
@@ -737,7 +791,7 @@ void calcAndStorewTailProcessingMorph(
         Value extraElemMask =
             tailMaskCreator(builder, loc, inputCol, endIdx, vectorMaskTy);
 
-        Value outputVec = builder.create<MaskedLoadOp>(
+        Value outputVec = builder.create<vector::MaskedLoadOp>(
             loc, vecType, output, ValueRange{beginIdx, endIdx}, extraElemMask,
             zeroPadding);
 
@@ -750,12 +804,12 @@ void calcAndStorewTailProcessingMorph(
                                        outputVec, DIP_OP::DILATION_2D);
         }
 
-        Value resVec = builder.create<MaskedLoadOp>(
+        Value resVec = builder.create<vector::MaskedLoadOp>(
             loc, vecType, output, ValueRange{beginIdx, endIdx}, compVec,
             inputVec);
 
-        builder.create<MaskedStoreOp>(loc, output, ValueRange{beginIdx, endIdx},
-                                      extraElemMask, resVec);
+        builder.create<vector::MaskedStoreOp>(
+            loc, output, ValueRange{beginIdx, endIdx}, extraElemMask, resVec);
 
         builder.create<scf::YieldOp>(loc);
       });
@@ -767,8 +821,8 @@ void traverseImagewBoundaryExtrapolation(
     Value constantValue, Value strideVal, Type elemTy,
     buddy::dip::BoundaryOption boundaryOptionAttr, int64_t stride, DIP_OP op) {
   // Create constant indices.
-  Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-  Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
+  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
 
   IntegerType i1 = IntegerType::get(ctx, 1);
 
@@ -779,8 +833,8 @@ void traverseImagewBoundaryExtrapolation(
 
   // Variables used for detecting rowMid, rowDown, colMid and colRight
   // regions.
-  Value rowMidHelper = rewriter.create<AddIOp>(loc, inputRow, centerY);
-  Value colMidHelper = rewriter.create<AddIOp>(loc, inputCol, centerX);
+  Value rowMidHelper = rewriter.create<arith::AddIOp>(loc, inputRow, centerY);
+  Value colMidHelper = rewriter.create<arith::AddIOp>(loc, inputCol, centerX);
 
   SmallVector<Value, 8> lowerBounds(4, c0);
   SmallVector<Value, 8> uperBounds{inputRow, kernelSize, inputCol, kernelSize};
@@ -791,7 +845,7 @@ void traverseImagewBoundaryExtrapolation(
 
   Value zeroPaddingElem = insertZeroConstantOp(ctx, rewriter, loc, elemTy);
   Value zeroPadding =
-      rewriter.create<BroadcastOp>(loc, vectorTy32, zeroPaddingElem);
+      rewriter.create<vector::BroadcastOp>(loc, vectorTy32, zeroPaddingElem);
 
   AffineExpr a, b, c;
   bindDims(ctx, a, b, c);
@@ -805,23 +859,24 @@ void traverseImagewBoundaryExtrapolation(
       [&](OpBuilder &builder, Location loc, ValueRange ivs) {
         // Indices of current pixel with respect to pseudo image containing
         // extrapolated boundaries.
-        Value currRow = builder.create<AddIOp>(loc, ivs[0], ivs[1]);
-        Value currCol = builder.create<AddIOp>(loc, ivs[2], ivs[3]);
+        Value currRow = builder.create<arith::AddIOp>(loc, ivs[0], ivs[1]);
+        Value currCol = builder.create<arith::AddIOp>(loc, ivs[2], ivs[3]);
 
         Value kernelValue = builder.create<memref::LoadOp>(
             loc, kernel, ValueRange{ivs[1], ivs[3]});
         Value kernelVec =
-            builder.create<BroadcastOp>(loc, vectorTy32, kernelValue);
+            builder.create<vector::BroadcastOp>(loc, vectorTy32, kernelValue);
 
         // Pixel indices with respect to the actual image.
-        Value imRow = builder.create<SubIOp>(loc, currRow, centerY);
-        Value imCol = builder.create<SubIOp>(loc, currCol, centerX);
+        Value imRow = builder.create<arith::SubIOp>(loc, currRow, centerY);
+        Value imCol = builder.create<arith::SubIOp>(loc, currCol, centerX);
 
         // Index of pixel used for determining right region.
-        Value colLastElem = builder.create<AddIOp>(loc, currCol, strideVal);
+        Value colLastElem =
+            builder.create<arith::AddIOp>(loc, currCol, strideVal);
 
-        Value rowUpCond =
-            builder.create<CmpIOp>(loc, CmpIPredicate::slt, currRow, centerY);
+        Value rowUpCond = builder.create<arith::CmpIOp>(
+            loc, arith::CmpIPredicate::slt, currRow, centerY);
 
         // Condition to check if the kernel value is a non-zero number.
         Value kernelNonZeroCond =
@@ -834,7 +889,7 @@ void traverseImagewBoundaryExtrapolation(
                     // rowUp
                     if (boundaryOptionAttr ==
                         buddy::dip::BoundaryOption::ConstantPadding) {
-                      Value inputVec = builder.create<BroadcastOp>(
+                      Value inputVec = builder.create<vector::BroadcastOp>(
                           loc, vectorTy32, constantValue);
                       if (op == DIP_OP::CORRELATION_2D) {
                         calcAndStoreFMAwoTailProcessing(
@@ -862,16 +917,16 @@ void traverseImagewBoundaryExtrapolation(
                             zeroPaddingElem, DIP_OP::EROSION_2D);
                       }
                     } else {
-                      Value colLeftCond = builder.create<CmpIOp>(
-                          loc, CmpIPredicate::slt, currCol, centerX);
+                      Value colLeftCond = builder.create<arith::CmpIOp>(
+                          loc, arith::CmpIPredicate::slt, currCol, centerX);
 
                       builder.create<scf::IfOp>(
                           loc, colLeftCond,
                           [&](OpBuilder &builder, Location loc) {
                             // colLeft & rowUp
                             Value inputVec;
-                            Value leftMaskElem =
-                                builder.create<SubIOp>(loc, centerX, currCol);
+                            Value leftMaskElem = builder.create<arith::SubIOp>(
+                                loc, centerX, currCol);
                             Value leftMask =
                                 createInvertedMask(builder, loc, strideVal,
                                                    vectorMaskTy, leftMaskElem);
@@ -880,11 +935,13 @@ void traverseImagewBoundaryExtrapolation(
                                 buddy::dip::BoundaryOption::ReplicatePadding) {
                               Value paddingVal = builder.create<memref::LoadOp>(
                                   loc, input, ValueRange{c0, c0});
-                              Value padding = builder.create<BroadcastOp>(
-                                  loc, vectorTy32, paddingVal);
+                              Value padding =
+                                  builder.create<vector::BroadcastOp>(
+                                      loc, vectorTy32, paddingVal);
 
                               Value leftPaddingOffset =
-                                  builder.create<SubIOp>(loc, c0, leftMaskElem);
+                                  builder.create<arith::SubIOp>(loc, c0,
+                                                                leftMaskElem);
                               inputVec = builder.create<vector::MaskedLoadOp>(
                                   loc, vectorTy32, input,
                                   ValueRange{c0, leftPaddingOffset}, leftMask,
@@ -913,8 +970,8 @@ void traverseImagewBoundaryExtrapolation(
                           },
                           [&](OpBuilder &builder, Location loc) {
                             // (colMid or colRight) & rowUp
-                            Value colMidCond = builder.create<CmpIOp>(
-                                loc, CmpIPredicate::slt, colLastElem,
+                            Value colMidCond = builder.create<arith::CmpIOp>(
+                                loc, arith::CmpIPredicate::slt, colLastElem,
                                 colMidHelper);
 
                             builder.create<scf::IfOp>(
@@ -925,7 +982,7 @@ void traverseImagewBoundaryExtrapolation(
                                   if (boundaryOptionAttr ==
                                       buddy::dip::BoundaryOption::
                                           ReplicatePadding) {
-                                    inputVec = builder.create<LoadOp>(
+                                    inputVec = builder.create<vector::LoadOp>(
                                         loc, vectorTy32, input,
                                         ValueRange{c0, imCol});
                                   }
@@ -955,30 +1012,34 @@ void traverseImagewBoundaryExtrapolation(
                                   // colRight & rowUp
                                   Value inputVec;
                                   Value rightMaskHelper =
-                                      builder.create<SubIOp>(loc, colLastElem,
-                                                             colMidHelper);
-                                  Value rightMaskElem = builder.create<SubIOp>(
-                                      loc, strideVal, rightMaskHelper);
+                                      builder.create<arith::SubIOp>(
+                                          loc, colLastElem, colMidHelper);
+                                  Value rightMaskElem =
+                                      builder.create<arith::SubIOp>(
+                                          loc, strideVal, rightMaskHelper);
                                   Value rightMask =
-                                      builder.create<CreateMaskOp>(
+                                      builder.create<vector::CreateMaskOp>(
                                           loc, vectorMaskTy, rightMaskElem);
 
                                   if (boundaryOptionAttr ==
                                       buddy::dip::BoundaryOption::
                                           ReplicatePadding) {
-                                    Value rightRange = builder.create<SubIOp>(
-                                        loc, inputCol, c1);
+                                    Value rightRange =
+                                        builder.create<arith::SubIOp>(
+                                            loc, inputCol, c1);
                                     Value paddingVal =
                                         builder.create<memref::LoadOp>(
                                             loc, input,
                                             ValueRange{c0, rightRange});
-                                    Value padding = builder.create<BroadcastOp>(
-                                        loc, vectorTy32, paddingVal);
+                                    Value padding =
+                                        builder.create<vector::BroadcastOp>(
+                                            loc, vectorTy32, paddingVal);
 
-                                    inputVec = builder.create<MaskedLoadOp>(
-                                        loc, vectorTy32, input,
-                                        ValueRange{c0, imCol}, rightMask,
-                                        padding);
+                                    inputVec =
+                                        builder.create<vector::MaskedLoadOp>(
+                                            loc, vectorTy32, input,
+                                            ValueRange{c0, imCol}, rightMask,
+                                            padding);
                                   }
                                   Value tailCond = tailChecker(
                                       builder, loc, calcHelper, strideVal,
@@ -1015,23 +1076,24 @@ void traverseImagewBoundaryExtrapolation(
                   },
                   [&](OpBuilder &builder, Location loc) {
                     // rowMid or rowDown
-                    Value rowMidCond = builder.create<CmpIOp>(
-                        loc, CmpIPredicate::slt, currRow, rowMidHelper);
+                    Value rowMidCond = builder.create<arith::CmpIOp>(
+                        loc, arith::CmpIPredicate::slt, currRow, rowMidHelper);
 
                     builder.create<scf::IfOp>(
                         loc, rowMidCond,
                         [&](OpBuilder &builder, Location loc) {
                           // rowMid
-                          Value colLeftCond = builder.create<CmpIOp>(
-                              loc, CmpIPredicate::slt, currCol, centerX);
+                          Value colLeftCond = builder.create<arith::CmpIOp>(
+                              loc, arith::CmpIPredicate::slt, currCol, centerX);
 
                           builder.create<scf::IfOp>(
                               loc, colLeftCond,
                               [&](OpBuilder &builder, Location loc) {
                                 // colLeft & rowMid
                                 Value inputVec;
-                                Value leftMaskElem = builder.create<SubIOp>(
-                                    loc, centerX, currCol);
+                                Value leftMaskElem =
+                                    builder.create<arith::SubIOp>(loc, centerX,
+                                                                  currCol);
                                 Value leftMask = createInvertedMask(
                                     builder, loc, strideVal, vectorMaskTy,
                                     leftMaskElem);
@@ -1039,32 +1101,36 @@ void traverseImagewBoundaryExtrapolation(
                                 if (boundaryOptionAttr ==
                                     buddy::dip::BoundaryOption::
                                         ConstantPadding) {
-                                  Value padding = builder.create<BroadcastOp>(
-                                      loc, vectorTy32, constantValue);
+                                  Value padding =
+                                      builder.create<vector::BroadcastOp>(
+                                          loc, vectorTy32, constantValue);
 
                                   Value leftPaddingOffset =
-                                      builder.create<SubIOp>(loc, c0,
-                                                             leftMaskElem);
-                                  inputVec = builder.create<MaskedLoadOp>(
-                                      loc, vectorTy32, input,
-                                      ValueRange{imRow, leftPaddingOffset},
-                                      leftMask, padding);
+                                      builder.create<arith::SubIOp>(
+                                          loc, c0, leftMaskElem);
+                                  inputVec =
+                                      builder.create<vector::MaskedLoadOp>(
+                                          loc, vectorTy32, input,
+                                          ValueRange{imRow, leftPaddingOffset},
+                                          leftMask, padding);
                                 } else if (boundaryOptionAttr ==
                                            buddy::dip::BoundaryOption::
                                                ReplicatePadding) {
                                   Value paddingVal =
                                       builder.create<memref::LoadOp>(
                                           loc, input, ValueRange{imRow, c0});
-                                  Value padding = builder.create<BroadcastOp>(
-                                      loc, vectorTy32, paddingVal);
+                                  Value padding =
+                                      builder.create<vector::BroadcastOp>(
+                                          loc, vectorTy32, paddingVal);
 
                                   Value leftPaddingOffset =
-                                      builder.create<SubIOp>(loc, c0,
-                                                             leftMaskElem);
-                                  inputVec = builder.create<MaskedLoadOp>(
-                                      loc, vectorTy32, input,
-                                      ValueRange{imRow, leftPaddingOffset},
-                                      leftMask, padding);
+                                      builder.create<arith::SubIOp>(
+                                          loc, c0, leftMaskElem);
+                                  inputVec =
+                                      builder.create<vector::MaskedLoadOp>(
+                                          loc, vectorTy32, input,
+                                          ValueRange{imRow, leftPaddingOffset},
+                                          leftMask, padding);
                                 }
 
                                 if (op == DIP_OP::CORRELATION_2D) {
@@ -1091,17 +1157,19 @@ void traverseImagewBoundaryExtrapolation(
                               },
                               [&](OpBuilder &builder, Location loc) {
                                 // (colMid or colRight) & rowMid
-                                Value colMidCond = builder.create<CmpIOp>(
-                                    loc, CmpIPredicate::slt, colLastElem,
-                                    colMidHelper);
+                                Value colMidCond =
+                                    builder.create<arith::CmpIOp>(
+                                        loc, arith::CmpIPredicate::slt,
+                                        colLastElem, colMidHelper);
 
                                 builder.create<scf::IfOp>(
                                     loc, colMidCond,
                                     [&](OpBuilder &builder, Location loc) {
                                       // colMid & rowMid
-                                      Value inputVec = builder.create<LoadOp>(
-                                          loc, vectorTy32, input,
-                                          ValueRange{imRow, imCol});
+                                      Value inputVec =
+                                          builder.create<vector::LoadOp>(
+                                              loc, vectorTy32, input,
+                                              ValueRange{imRow, imCol});
 
                                       if (op == DIP_OP::CORRELATION_2D) {
                                         calcAndStoreFMAwoTailProcessing(
@@ -1131,44 +1199,48 @@ void traverseImagewBoundaryExtrapolation(
                                       // colRight & rowMid
                                       Value inputVec;
                                       Value rightMaskHelper =
-                                          builder.create<SubIOp>(
+                                          builder.create<arith::SubIOp>(
                                               loc, colLastElem, colMidHelper);
                                       Value rightMaskElem =
-                                          builder.create<SubIOp>(
+                                          builder.create<arith::SubIOp>(
                                               loc, strideVal, rightMaskHelper);
                                       Value rightMask =
-                                          builder.create<CreateMaskOp>(
+                                          builder.create<vector::CreateMaskOp>(
                                               loc, vectorMaskTy, rightMaskElem);
 
                                       if (boundaryOptionAttr ==
                                           buddy::dip::BoundaryOption::
                                               ConstantPadding) {
                                         Value padding =
-                                            builder.create<BroadcastOp>(
+                                            builder.create<vector::BroadcastOp>(
                                                 loc, vectorTy32, constantValue);
 
-                                        inputVec = builder.create<MaskedLoadOp>(
-                                            loc, vectorTy32, input,
-                                            ValueRange{imRow, imCol}, rightMask,
-                                            padding);
+                                        inputVec =
+                                            builder
+                                                .create<vector::MaskedLoadOp>(
+                                                    loc, vectorTy32, input,
+                                                    ValueRange{imRow, imCol},
+                                                    rightMask, padding);
                                       } else if (boundaryOptionAttr ==
                                                  buddy::dip::BoundaryOption::
                                                      ReplicatePadding) {
                                         Value rightRange =
-                                            builder.create<SubIOp>(
+                                            builder.create<arith::SubIOp>(
                                                 loc, inputCol, c1);
                                         Value paddingVal =
                                             builder.create<memref::LoadOp>(
                                                 loc, input,
                                                 ValueRange{imRow, rightRange});
                                         Value padding =
-                                            builder.create<BroadcastOp>(
+                                            builder.create<vector::BroadcastOp>(
                                                 loc, vectorTy32, paddingVal);
 
-                                        inputVec = builder.create<MaskedLoadOp>(
-                                            loc, vectorTy32, input,
-                                            ValueRange{imRow, imCol}, rightMask,
-                                            padding);
+                                        inputVec =
+                                            builder
+                                                .create<vector::MaskedLoadOp>(
+                                                    loc, vectorTy32, input,
+                                                    ValueRange{imRow, imCol},
+                                                    rightMask, padding);
                                       }
                                       Value tailCond = tailChecker(
                                           builder, loc, calcHelper, strideVal,
@@ -1207,8 +1279,9 @@ void traverseImagewBoundaryExtrapolation(
                           // rowDown
                           if (boundaryOptionAttr ==
                               buddy::dip::BoundaryOption::ConstantPadding) {
-                            Value inputVec = builder.create<BroadcastOp>(
-                                loc, vectorTy32, constantValue);
+                            Value inputVec =
+                                builder.create<vector::BroadcastOp>(
+                                    loc, vectorTy32, constantValue);
 
                             if (op == DIP_OP::CORRELATION_2D) {
                               calcAndStoreFMAwoTailProcessing(
@@ -1228,8 +1301,9 @@ void traverseImagewBoundaryExtrapolation(
                                   zeroPaddingElem, DIP_OP::DILATION_2D);
                             }
                           } else {
-                            Value colLeftCond = builder.create<CmpIOp>(
-                                loc, CmpIPredicate::slt, currCol, centerX);
+                            Value colLeftCond = builder.create<arith::CmpIOp>(
+                                loc, arith::CmpIPredicate::slt, currCol,
+                                centerX);
 
                             builder.create<scf::IfOp>(
                                 loc, colLeftCond,
@@ -1237,9 +1311,11 @@ void traverseImagewBoundaryExtrapolation(
                                   // colLeft & rowDown
                                   Value inputVec;
                                   Value downRange =
-                                      builder.create<SubIOp>(loc, inputRow, c1);
-                                  Value leftMaskElem = builder.create<SubIOp>(
-                                      loc, centerX, currCol);
+                                      builder.create<arith::SubIOp>(
+                                          loc, inputRow, c1);
+                                  Value leftMaskElem =
+                                      builder.create<arith::SubIOp>(
+                                          loc, centerX, currCol);
                                   Value leftMask = createInvertedMask(
                                       builder, loc, strideVal, vectorMaskTy,
                                       leftMaskElem);
@@ -1251,17 +1327,19 @@ void traverseImagewBoundaryExtrapolation(
                                         builder.create<memref::LoadOp>(
                                             loc, input,
                                             ValueRange{downRange, c0});
-                                    Value padding = builder.create<BroadcastOp>(
-                                        loc, vectorTy32, paddingVal);
+                                    Value padding =
+                                        builder.create<vector::BroadcastOp>(
+                                            loc, vectorTy32, paddingVal);
 
                                     Value leftPaddingOffset =
-                                        builder.create<SubIOp>(loc, c0,
-                                                               leftMaskElem);
-                                    inputVec = builder.create<MaskedLoadOp>(
-                                        loc, vectorTy32, input,
-                                        ValueRange{downRange,
-                                                   leftPaddingOffset},
-                                        leftMask, padding);
+                                        builder.create<arith::SubIOp>(
+                                            loc, c0, leftMaskElem);
+                                    inputVec =
+                                        builder.create<vector::MaskedLoadOp>(
+                                            loc, vectorTy32, input,
+                                            ValueRange{downRange,
+                                                       leftPaddingOffset},
+                                            leftMask, padding);
                                   }
 
                                   if (op == DIP_OP::CORRELATION_2D) {
@@ -1288,9 +1366,10 @@ void traverseImagewBoundaryExtrapolation(
                                 },
                                 [&](OpBuilder &builder, Location loc) {
                                   // (colMid or colRight) & rowDown
-                                  Value colMidCond = builder.create<CmpIOp>(
-                                      loc, CmpIPredicate::slt, colLastElem,
-                                      colMidHelper);
+                                  Value colMidCond =
+                                      builder.create<arith::CmpIOp>(
+                                          loc, arith::CmpIPredicate::slt,
+                                          colLastElem, colMidHelper);
 
                                   builder.create<scf::IfOp>(
                                       loc, colMidCond,
@@ -1298,14 +1377,15 @@ void traverseImagewBoundaryExtrapolation(
                                         // colMid & rowDown
                                         Value inputVec;
                                         Value downRange =
-                                            builder.create<SubIOp>(
+                                            builder.create<arith::SubIOp>(
                                                 loc, inputRow, c1);
                                         if (boundaryOptionAttr ==
                                             buddy::dip::BoundaryOption::
                                                 ReplicatePadding) {
-                                          inputVec = builder.create<LoadOp>(
-                                              loc, vectorTy32, input,
-                                              ValueRange{downRange, imCol});
+                                          inputVec =
+                                              builder.create<vector::LoadOp>(
+                                                  loc, vectorTy32, input,
+                                                  ValueRange{downRange, imCol});
                                         }
 
                                         if (op == DIP_OP::CORRELATION_2D) {
@@ -1337,22 +1417,23 @@ void traverseImagewBoundaryExtrapolation(
                                         // colRight & rowDown
                                         Value inputVec;
                                         Value rightMaskHelper =
-                                            builder.create<SubIOp>(
+                                            builder.create<arith::SubIOp>(
                                                 loc, colLastElem, colMidHelper);
                                         Value rightMaskElem =
-                                            builder.create<SubIOp>(
+                                            builder.create<arith::SubIOp>(
                                                 loc, strideVal,
                                                 rightMaskHelper);
                                         Value rightMask =
-                                            builder.create<CreateMaskOp>(
-                                                loc, vectorMaskTy,
-                                                rightMaskElem);
+                                            builder
+                                                .create<vector::CreateMaskOp>(
+                                                    loc, vectorMaskTy,
+                                                    rightMaskElem);
 
                                         Value downRange =
-                                            builder.create<SubIOp>(
+                                            builder.create<arith::SubIOp>(
                                                 loc, inputRow, c1);
                                         Value rightRange =
-                                            builder.create<SubIOp>(
+                                            builder.create<arith::SubIOp>(
                                                 loc, inputCol, c1);
 
                                         if (boundaryOptionAttr ==
@@ -1371,10 +1452,12 @@ void traverseImagewBoundaryExtrapolation(
                                                       paddingVal);
 
                                           inputVec =
-                                              builder.create<MaskedLoadOp>(
-                                                  loc, vectorTy32, input,
-                                                  ValueRange{downRange, imCol},
-                                                  rightMask, padding);
+                                              builder
+                                                  .create<vector::MaskedLoadOp>(
+                                                      loc, vectorTy32, input,
+                                                      ValueRange{downRange,
+                                                                 imCol},
+                                                      rightMask, padding);
                                         }
                                         Value tailCond = tailChecker(
                                             builder, loc, calcHelper, strideVal,
@@ -1420,5 +1503,8 @@ void traverseImagewBoundaryExtrapolation(
             });
       });
 }
+
+} // namespace dip
+} // namespace buddy
 
 #endif // UTILS_DIPUTILS_DEF

--- a/lib/Utils/DIPUtils.cpp
+++ b/lib/Utils/DIPUtils.cpp
@@ -1,4 +1,4 @@
-//====- DIPUtils.h --------------------------------------------------------===//
+//====- DIPUtils.cpp ------------------------------------------------------===//
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/Utils/Utils.cpp
+++ b/lib/Utils/Utils.cpp
@@ -1,4 +1,4 @@
-//====- Utils.h -----------------------------------------------------------===//
+//====- Utils.cpp ---------------------------------------------------------===//
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/Utils/Utils.cpp
+++ b/lib/Utils/Utils.cpp
@@ -24,6 +24,19 @@
 
 #include "Utils/Utils.h"
 
+// Function to test whether a value is equivalent to zero or not.
+Value zeroCond(OpBuilder &builder, Location loc, Type elemType, Value value,
+               Value zeroElem) {
+  Value cond;
+  auto bitWidth = elemType.getIntOrFloatBitWidth();
+  if (elemType.isF32() || elemType.isF64()) {
+    cond = builder.create<CmpFOp>(loc, CmpFPredicate::ONE, value, zeroElem);
+  } else if (elemType.isInteger(bitWidth)) {
+    cond = builder.create<CmpIOp>(loc, CmpIPredicate::ne, value, zeroElem);
+  }
+  return cond;
+}
+
 // Create an inverted mask having all 1's shifted to right side.
 Value createInvertedMask(OpBuilder &builder, Location loc, Value strideVal,
                          VectorType vectorMaskTy, Value leftIndex) {

--- a/lib/Utils/Utils.cpp
+++ b/lib/Utils/Utils.cpp
@@ -42,9 +42,11 @@ Value zeroCond(OpBuilder &builder, Location loc, Type elemType, Value value,
   Value cond;
   auto bitWidth = elemType.getIntOrFloatBitWidth();
   if (elemType.isF32() || elemType.isF64()) {
-    cond = builder.create<CmpFOp>(loc, CmpFPredicate::ONE, value, zeroElem);
+    cond = builder.create<arith::CmpFOp>(loc, arith::CmpFPredicate::ONE, value,
+                                         zeroElem);
   } else if (elemType.isInteger(bitWidth)) {
-    cond = builder.create<CmpIOp>(loc, CmpIPredicate::ne, value, zeroElem);
+    cond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne, value,
+                                         zeroElem);
   }
   return cond;
 }


### PR DESCRIPTION
This PR intends to improve `CBConvVectorization` lowering pass by adding support for neglecting null kernel elements. This should save us some extra assembly instructions (for FMA calculation, tail processing, etc.) in cases where we encounter a null kernel element. 

I am attaching benchmark results with and without this modification to illustrate the above behaviour. 

Before modification : 649 iterations
![Screenshot from 2022-11-07 11-58-32](https://user-images.githubusercontent.com/63031630/200380616-ab5803e4-fee9-437d-94a7-1fd15ac137de.png)


After modification : 1509 iterations
![Screenshot from 2022-11-07 23-15-15](https://user-images.githubusercontent.com/63031630/200380776-b804f176-d48a-4115-a638-f6758c4450ad.png)

