### PR TITLE
[DIP] replace C-style variadic function with std::vector

### DIFF
--- a/include/Utils/DIPUtils.h
+++ b/include/Utils/DIPUtils.h
@@ -22,6 +22,7 @@
 #ifndef INCLUDE_UTILS_DIPUTILS_H
 #define INCLUDE_UTILS_DIPUTILS_H
 
+#include "DIP/DIPOps.h"
 #include "Utils/Utils.h"
 #include <stdarg.h>
 
@@ -197,7 +198,7 @@ void traverseImagewBoundaryExtrapolation(
 
 // Function for applying type check mechanisms for all DIP dialect operations.
 template <typename DIPOP>
-DIP_ERROR checkDIPCommonTypes(DIPOP op, size_t numArgs, ...);
+DIP_ERROR checkDIPCommonTypes(DIPOP op, const std::vector<Value> &args);
 } // namespace dip
 } // namespace buddy
 

--- a/include/Utils/DIPUtils.h
+++ b/include/Utils/DIPUtils.h
@@ -22,7 +22,6 @@
 #ifndef INCLUDE_UTILS_DIPUTILS_H
 #define INCLUDE_UTILS_DIPUTILS_H
 
-#include "DIP/DIPOps.h"
 #include "Utils/Utils.h"
 #include <stdarg.h>
 

--- a/lib/Conversion/LowerDIP/LowerDIPPass.cpp
+++ b/lib/Conversion/LowerDIP/LowerDIPPass.cpp
@@ -72,7 +72,7 @@ public:
 
     auto inElemTy = input.getType().cast<MemRefType>().getElementType();
     dip::DIP_ERROR error = dip::checkDIPCommonTypes<dip::Corr2DOp>(
-        op, 4, input, kernel, output, constantValue);
+        op, {input, kernel, output, constantValue});
 
     if (error == dip::DIP_ERROR::INCONSISTENT_TYPES) {
       return op->emitOpError() << "input, kernel, output and constant must "
@@ -116,7 +116,7 @@ public:
 
     auto inElemTy = input.getType().cast<MemRefType>().getElementType();
     dip::DIP_ERROR error =
-        dip::checkDIPCommonTypes<dip::Rotate2DOp>(op, 2, input, output);
+        dip::checkDIPCommonTypes<dip::Rotate2DOp>(op, {input, output});
 
     if (error == dip::DIP_ERROR::INCONSISTENT_TYPES) {
       return op->emitOpError()
@@ -295,7 +295,7 @@ public:
 
     auto inElemTy = input.getType().cast<MemRefType>().getElementType();
     dip::DIP_ERROR error =
-        dip::checkDIPCommonTypes<dip::Resize2DOp>(op, 2, input, output);
+        dip::checkDIPCommonTypes<dip::Resize2DOp>(op, {input, output});
 
     if (error == dip::DIP_ERROR::INCONSISTENT_TYPES) {
       return op->emitOpError()
@@ -423,7 +423,7 @@ public:
 
     auto inElemTy = input.getType().cast<MemRefType>().getElementType();
     dip::DIP_ERROR error = dip::checkDIPCommonTypes<dip::Erosion2DOp>(
-        op, 5, input, kernel, output, copymemref, constantValue);
+        op, {input, kernel, output, copymemref, constantValue});
 
     if (error == dip::DIP_ERROR::INCONSISTENT_TYPES) {
       return op->emitOpError()
@@ -496,7 +496,7 @@ public:
 
     auto inElemTy = input.getType().cast<MemRefType>().getElementType();
     dip::DIP_ERROR error = dip::checkDIPCommonTypes<dip::Dilation2DOp>(
-        op, 5, input, kernel, output, copymemref, constantValue);
+        op, {input, kernel, output, copymemref, constantValue});
 
     if (error == dip::DIP_ERROR::INCONSISTENT_TYPES) {
       return op->emitOpError()
@@ -569,8 +569,8 @@ public:
 
     auto inElemTy = input.getType().cast<MemRefType>().getElementType();
     dip::DIP_ERROR error = dip::checkDIPCommonTypes<dip::Opening2DOp>(
-        op, 7, input, kernel, output, output1, copymemref, copymemref1,
-        constantValue);
+        op, {input, kernel, output, output1, copymemref, copymemref1,
+             constantValue});
 
     if (error == dip::DIP_ERROR::INCONSISTENT_TYPES) {
       return op->emitOpError() << "input, kernel, output, output1, copymemref, "
@@ -664,8 +664,8 @@ public:
 
     auto inElemTy = input.getType().cast<MemRefType>().getElementType();
     dip::DIP_ERROR error = dip::checkDIPCommonTypes<dip::Closing2DOp>(
-        op, 7, input, kernel, output, output1, copymemref, copymemref1,
-        constantValue);
+        op, {input, kernel, output, output1, copymemref, copymemref1,
+             constantValue});
 
     if (error == dip::DIP_ERROR::INCONSISTENT_TYPES) {
       return op->emitOpError() << "input, kernel, output, output1, copymemref, "
@@ -766,8 +766,8 @@ public:
     auto inElemTy = input.getType().cast<MemRefType>().getElementType();
     auto bitWidth = inElemTy.getIntOrFloatBitWidth();
     dip::DIP_ERROR error = dip::checkDIPCommonTypes<dip::TopHat2DOp>(
-        op, 9, input, kernel, output, output1, output2, input1, copymemref,
-        copymemref1, constantValue);
+        op, {input, kernel, output, output1, output2, input1, copymemref,
+             copymemref1, constantValue});
 
     if (error == dip::DIP_ERROR::INCONSISTENT_TYPES) {
       return op->emitOpError()
@@ -971,8 +971,8 @@ public:
     auto inElemTy = input.getType().cast<MemRefType>().getElementType();
     auto bitWidth = inElemTy.getIntOrFloatBitWidth();
     dip::DIP_ERROR error = dip::checkDIPCommonTypes<dip::BottomHat2DOp>(
-        op, 9, input, kernel, output, output1, output2, input1, copymemref,
-        copymemref1, constantValue);
+        op, {input, kernel, output, output1, output2, input1, copymemref,
+             copymemref1, constantValue});
 
     if (error == dip::DIP_ERROR::INCONSISTENT_TYPES) {
       return op->emitOpError()
@@ -1170,8 +1170,8 @@ public:
     auto inElemTy = input.getType().cast<MemRefType>().getElementType();
     auto bitWidth = inElemTy.getIntOrFloatBitWidth();
     dip::DIP_ERROR error = dip::checkDIPCommonTypes<dip::MorphGrad2DOp>(
-        op, 9, input, kernel, output, output1, output2, input1, copymemref,
-        copymemref1, constantValue);
+        op, {input, kernel, output, output1, output2, input1, copymemref,
+             copymemref1, constantValue});
 
     if (error == dip::DIP_ERROR::INCONSISTENT_TYPES) {
       return op->emitOpError()


### PR DESCRIPTION
The `checkDIPCommonTypes` function uses C-style variadic arguments only for passing variadic numbers of the same type arguments, which should be avoided in C++. It is recommended to replace this usage with `std::initializer_list` or `std::vector`.

This PR also fixes the compilation failure in `clang++`, which will give a warning (as an error) for non-POD type `Value` in `va_arg`.