### PR TITLE
Improve codes in CGModule

### DIFF
--- a/frontend/FrontendGen/include/AST.h
+++ b/frontend/FrontendGen/include/AST.h
@@ -60,7 +60,7 @@ public:
   llvm::SmallVector<llvm::StringRef, 4> getBuilderNames() {
     return this->builderNames;
   }
-  llvm::SmallVector<int> getbulderIdxs() { return this->builderIdxs; }
+  llvm::SmallVector<int> getBuilderIndices() { return this->builderIdxs; }
 };
 
 /// This class is used to mark the node in the generator as a rule, and can also

--- a/frontend/FrontendGen/include/CGModule.h
+++ b/frontend/FrontendGen/include/CGModule.h
@@ -22,17 +22,17 @@
 namespace frontendgen {
 
 /// TypeMap is used to store type maps.The cppMap is used to map c++ types,
-/// argumentsMap and resultsmap are used to map TableGen types.
+/// argumentsMap and resultsMap are used to map TableGen types.
 class TypeMap {
   llvm::StringMap<llvm::StringRef> cppMap;
-  llvm::StringMap<llvm::StringRef> argmentsMap;
+  llvm::StringMap<llvm::StringRef> argumentsMap;
   llvm::StringMap<llvm::StringRef> resultsMap;
 
 public:
   TypeMap() {
 #define CPPMAP(key, value) cppMap.insert(std::pair(key, value));
 #define RESULTSMAP(key, value) resultsMap.insert(std::pair(key, value));
-#define ARGUMENTSMAP(key, value) argmentsMap.insert(std::pair(key, value));
+#define ARGUMENTSMAP(key, value) argumentsMap.insert(std::pair(key, value));
 #include "TypeMap.def"
   }
   llvm::StringRef findCppMap(llvm::StringRef value);
@@ -64,7 +64,7 @@ public:
   void emitClass(llvm::StringRef grammarName);
   void emitRuleVisitor(llvm::StringRef grammarName, Rule *rule);
   void emitBuilders(Rule *rule);
-  void emitBuilder(llvm::StringRef buildrOp, int index);
+  void emitBuilder(llvm::StringRef builderOp, int index);
   Op *findOp(llvm::StringRef opName);
   void emitOp(Op *op, int index);
 };


### PR DESCRIPTION
# Improve codes in CGModule

This PR improves codes in `frontend/FrontendGen/lib/CGModule.cpp`.

## Fixed typos in this file:

A list of typos is below:

- `grammarNmae` -> `grammarName`
- `formuls` -> `formulas`
- `gramarName` -> `grammarName`
- `indexs` -> `indices`
- `opArgments` -> `opArguments`
- `resultsmap` -> `resultsMap`
- `argmentsMap` -> `argumentsMap`
- `buildrOp` -> `builderOp`
- `getbulderIdxs` -> `getBuilderIndices`

## Fixed wrong index type for storing the result of `string::find`

In lines `19` and `47`, `start` and `end` are used to store the result of `std::string::find`, which returns a `std::size_t`. The `std::string::npos` can never be stored in an `uint`, which causes the conditions (e.g. `start == std::string::npos`) below never satisfy.

## Fixed passing temporary string objects to StringRefs

In the original code, we have:

```cpp
llvm::SmallVector<llvm::StringRef> opArgments;

//...

os << "arg" << index << ";\n";
llvm::StringRef arg("arg" + std::to_string(index));
opArgments.push_back(arg);
```

Here comes a problem: expression `"arg" + std::to_string(index)` will create a temporary string object, which may be destroyed at the end of the expression. But, the StringRef in `opArgments` still keeps a pointer into this string's data, which will become a dangling pointer.

This PR introduced a new vector named `tmpStrings` to keep all the temporary strings, ensuring their lifetime is at least as long as `opArgments`.

An alternative approach is to change `opArgments` to a `SmallVector<std::string>`. But this may cause a performance problem because most of the elements in `opArgments` seem just a reference to other strings.

Because I am not familiar with this part of the code, there may be some other lifetime problems. A deeper review may be needed. 