### PR TITLE
add `-fsanitize=address` in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ project(buddy-mlir LANGUAGES CXX C)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+
 #-------------------------------------------------------------------------------
 # Options and settings
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
I cannot compile this project on neither macOS nor ArchLinux until I explicitly add `-fsanitize=address` in CMakeLists.txt. Although this may due to my local compile env setup, I find that llvm-project has added it. So I think this setup may be included in CMakeLists.txt rather than in local env setup.