### PR TITLE
[RVV] Add Rsqrt operation

### DIFF
--- a/examples/MLIRMath/makefile
+++ b/examples/MLIRMath/makefile
@@ -36,3 +36,39 @@ math-atan2-run:
 		-reconcile-unrealized-casts | \
 	${MLIR_CPU_RUNNER} ${OPT_FLAG} -e main -entry-point-result=void \
 		-shared-libs=${MLIR_RUNNER_UTILS} -shared-libs=${MLIR_C_RUNNER_UTILS}
+
+math-rsqrt-lower:
+	@${MLIR_OPT} ./math-rsqrt.mlir \
+		-convert-math-to-llvm -convert-func-to-llvm \
+		-o ./log.mlir
+
+math-rsqrt-translate:
+	@${MLIR_OPT} ./math-rsqrt.mlir \
+		-convert-math-to-llvm -convert-func-to-llvm | \
+	${MLIR_TRANSLATE} \
+		-mlir-to-llvmir -o log.ll
+
+math-rsqrt-lower-x86:
+	@${MLIR_OPT} ./math-rsqrt.mlir \
+		-test-math-polynomial-approximation=enable-avx2 \
+		-convert-vector-to-llvm="enable-x86vector" \
+		-convert-math-to-llvm -convert-func-to-llvm \
+		-o ./log.mlir
+
+math-rsqrt-translate-x86:
+	@${MLIR_OPT} ./math-rsqrt.mlir \
+		-test-math-polynomial-approximation=enable-avx2 \
+		-convert-vector-to-llvm="enable-x86vector" \
+		-convert-math-to-llvm -convert-func-to-llvm | \
+	${MLIR_TRANSLATE} \
+		-mlir-to-llvmir -o log.ll
+
+math-rsqrt-asm-x86:
+	@${MLIR_OPT} ./math-rsqrt.mlir \
+		-test-math-polynomial-approximation=enable-avx2 \
+		-convert-vector-to-llvm="enable-x86vector" \
+		-convert-math-to-llvm -convert-func-to-llvm | \
+	${MLIR_TRANSLATE} \
+		-mlir-to-llvmir | \
+	${LLC} ${OPT_FLAG} -mtriple=x86_64-unknown-linux-gnu -mattr=+avx512f \
+		--filetype=asm -o log.s

--- a/examples/MLIRMath/math-rsqrt.mlir
+++ b/examples/MLIRMath/math-rsqrt.mlir
@@ -1,0 +1,4 @@
+func.func @main(%arg0: vector<8xf32>) -> vector<8xf32> {
+  %0 = math.rsqrt %arg0 : vector<8xf32>
+  return %0 : vector<8xf32>
+}

--- a/examples/RVVDialect/.gitignore
+++ b/examples/RVVDialect/.gitignore
@@ -1,3 +1,5 @@
 log.mlir
 log.ll
 log.s
+log.o
+a.out

--- a/examples/RVVDialect/makefile
+++ b/examples/RVVDialect/makefile
@@ -4,6 +4,16 @@ BUDDY_TRANSLATE := ../../build/bin/buddy-translate
 LLC := ../../llvm/build/bin/llc
 OPT_FLAG := -O0
 
+RISCV_GNU_TOOLCHAIN := ../../thirdparty/build-riscv-gnu-toolchain
+RISCV_GNU_TOOLCHAIN_SYSROOT := ../../thirdparty/build-riscv-gnu-toolchain/sysroot
+QEMU := ../../thirdparty/qemu/build/riscv64-linux-user/qemu-riscv64
+LOCAL_CLANG := ../../thirdparty/build-local-clang/bin/clang
+CROSS_LLI := ../../thirdparty/build-cross-clang/bin/lli
+CROSS_MLIR_CPU_RUNNER := ../../thirdparty/build-cross-mlir/bin/mlir-cpu-runner
+CROSS_MLIR_C_RUNNER_UTILS := ../../thirdparty/build-cross-mlir/lib/libmlir_c_runner_utils.so
+CROSS_MLIR_RUNNER_UTILS := ../../thirdparty/build-cross-mlir/lib/libmlir_runner_utils.so
+CROSS_MLIR_LIB := ../../thirdparty/build-cross-mlir/lib
+
 rvv-setvl-lower:
 	@${BUDDY_OPT} ./rvv-setvl.mlir \
 		--lower-rvv --convert-func-to-llvm \
@@ -15,3 +25,32 @@ rvv-setvl-translate:
 		--lower-rvv --convert-func-to-llvm \
 		--reconcile-unrealized-casts | \
 	${BUDDY_TRANSLATE} --buddy-to-llvmir -o log.ll
+
+rvv-rsqrt-lower:
+	@${BUDDY_OPT} ./rvv-rsqrt.mlir \
+		--convert-scf-to-cf \
+		--convert-math-to-llvm \
+		--lower-rvv --convert-vector-to-llvm --convert-memref-to-llvm --convert-func-to-llvm \
+		--reconcile-unrealized-casts \
+		-o ./log.mlir
+
+rvv-rsqrt-translate:
+	@${BUDDY_OPT} ./rvv-rsqrt.mlir \
+		--convert-scf-to-cf \
+		--convert-math-to-llvm \
+		--lower-rvv --convert-vector-to-llvm --convert-memref-to-llvm --convert-func-to-llvm \
+		--reconcile-unrealized-casts | \
+		${BUDDY_TRANSLATE} --buddy-to-llvmir -o log.ll
+
+rvv-rsqrt-aot:
+	@${BUDDY_OPT} ./rvv-rsqrt.mlir \
+		-convert-scf-to-cf \
+		--convert-math-to-llvm \
+		--lower-rvv -convert-vector-to-llvm --convert-memref-to-llvm --convert-func-to-llvm\
+		--reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} --buddy-to-llvmir | \
+	${LLC} -mtriple riscv64 -target-abi lp64d -mattr=+m,+d,+v -riscv-v-vector-bits-min=128 --filetype=obj -o log.o
+	@${RISCV_GNU_TOOLCHAIN}/bin/riscv64-unknown-linux-gnu-gcc log.o -mabi=lp64d \
+		-L${CROSS_MLIR_LIB} -lmlir_runner_utils -lmlir_c_runner_utils \
+		-o a.out
+	@LD_LIBRARY_PATH=${CROSS_MLIR_LIB} ${QEMU} -L ${RISCV_GNU_TOOLCHAIN_SYSROOT} -cpu rv64,x-v=true,vlen=128 a.out

--- a/examples/RVVDialect/rvv-rsqrt.mlir
+++ b/examples/RVVDialect/rvv-rsqrt.mlir
@@ -1,0 +1,48 @@
+memref.global "private" @gv_f32 : memref<20xf32> = dense<[0. , 1. , 2. , 3. , 4. , 5. , 6. , 7. , 8. , 9. ,
+                                                          10., 11., 12., 13., 14., 15., 16., 17., 18., 19.]>
+
+func.func private @printMemrefF32(memref<*xf32>)
+
+func.func @alloc_mem_f32() -> memref<20xf32> {
+  %f0 = arith.constant 0.0 : f32
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %mem = memref.alloc() : memref<20xf32>
+  %dim = memref.dim %mem, %c0 : memref<20xf32>
+  scf.for %idx = %c0 to %dim step %c1 {
+    memref.store %f0, %mem[%idx] : memref<20xf32>
+  }
+  return %mem : memref<20xf32>
+}
+
+func.func @main() -> i32 {
+  %mem_f32 = memref.get_global @gv_f32 : memref<20xf32>
+  %c0 = arith.constant 0 : index
+  %c10 = arith.constant 10 : index
+
+  // Configure the register.
+  // SEW = 32
+  %sew = arith.constant 2 : index
+  // LMUL = 2
+  %lmul = arith.constant 1 : index
+  // AVL = 8
+  %avl8 = arith.constant 8 : index
+  // Load vl elements.
+  %vl8 = rvv.setvl %avl8, %sew, %lmul : index  
+
+  %load_vec_f32 = rvv.load %mem_f32[%c0], %vl8 : memref<20xf32>, vector<[8]xf32>, index
+  %res_rsqrt_mem = call @alloc_mem_f32() : () -> memref<20xf32>
+
+  // Test rsqrt in RVV Dialect.
+  %res_rvv = rvv.rsqrt %load_vec_f32, %vl8 : vector<[8]xf32>, index
+  rvv.store %res_rvv, %res_rsqrt_mem[%c0], %vl8 : vector<[8]xf32>, memref<20xf32>, index
+  // Test rsqrt in Math Dialect.
+  %res_math = math.rsqrt %load_vec_f32 : vector<[8]xf32>
+  rvv.store %res_math, %res_rsqrt_mem[%c10], %vl8 : vector<[8]xf32>, memref<20xf32>, index
+
+  %print_res_rsqrt= memref.cast %res_rsqrt_mem : memref<20xf32> to memref<*xf32>
+  call @printMemrefF32(%print_res_rsqrt) : (memref<*xf32>) -> ()
+
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/include/Dialect/RVV/RVV.td
+++ b/include/Dialect/RVV/RVV.td
@@ -111,6 +111,14 @@ def RVVStoreOp : RVV_Op<"store">,
     "`:` type($value) `,` type($base) `,`  type($length)";
 }
 
+def RsqrtOp : RVV_Op<"rsqrt", [Pure, AllTypesMatch<["src", "dst"]>]>,
+    Arguments<(ins ScalableVectorOf<[AnyType]>:$src, Index:$length)>,
+    Results<(outs ScalableVectorOf<[AnyType]>:$dst)> {
+  let summary = "Reciprocal of the square-root";
+  let description = "Floating-point reciprocal square-root estimated to 7 bits.";
+  let assemblyFormat = "$src `,` $length attr-dict `:` type($dst) `,`  type($length)";
+}
+
 //===----------------------------------------------------------------------===//
 // RVV intrinsic operation definitions
 //===----------------------------------------------------------------------===//
@@ -142,11 +150,22 @@ class RVV_USStore_IntrOp<string mnemonic, list<Trait> traits = []> :
                   /*list<Trait> traits=*/traits, 
                   /*int numResults=*/0>;
 
+class RVV_UnaryNoMask_IntrOp<string mnemonic, list<Trait> traits = []> :
+  LLVM_IntrOpBase</*Dialect dialect=*/RVV_Dialect,
+                  /*string opName=*/"intr." # mnemonic,
+                  /*string enumName=*/"riscv_" # !subst(".", "_", mnemonic),
+                  /*list<int> overloadedResults=*/[0], 
+                  /*list<int> overloadedOperands=*/[2], 
+                  /*list<Trait> traits=*/traits, 
+                  /*int numResults=*/1>;
+
 def RVVIntrSetVlIOp : RVV_VSetVlI_IntrOp<"vsetvli">,
   Arguments<(ins AnyInteger, AnyInteger, AnyInteger)>;
 def RVVIntrLoadEleOp : RVV_USLoad_IntrOp<"vle">,
   Arguments<(ins AnyScalableVector, LLVM_AnyPointer, AnyInteger)>;
 def RVVIntrStoreEleOp : RVV_USStore_IntrOp<"vse">,
   Arguments<(ins AnyScalableVector, LLVM_AnyPointer, AnyInteger)>;
+def IntrFrsqrt7Op : RVV_UnaryNoMask_IntrOp<"vfrsqrt7">,
+  Arguments<(ins AnyScalableVector, AnyScalableVector, AnyInteger)>;
 
 #endif // RVV_OPS


### PR DESCRIPTION
## Summary
1. Add Rsqrt operation for RVV Dialect.
2. Add Resqrt lowering example from Math Dialect to X86vector Dialect for testing and reference.

## Motivation
When expressing deep learning models in MLIR ecosystem, **Rsqrt operation** (Reciprocal of the square-root) frequently shows up to participate in the calculations of BN or LN(Batch or Layer Normalization) in the form of `tosa.rsqrt` or `math.rsqrt`. In normal lowering pipeline, they will be divided into two operations, `llvm.intr.sqrt` and `llvm.fdiv`. It is neither efficient nor elegant.  

To address the problem, x86vector dialect supports [x86vector.avx.rsqrt](https://mlir.llvm.org/docs/Dialects/X86Vector/#x86vectoravxrsqrt-mlirx86vectorrsqrtop) to directly target [specific AVX instruction](https://uops.info/html-instr/VRSQRTPS_XMM_XMM.html), but similar solution hasn't be found in RISC-V so far. RVV has instruction **`vfrsqrt7`** to specifically deal with the square-root reciprocal, so I think adding the related operation in RVV dialect can facilitate supports for deep learning and other mathematical models in RISC-V.

## Work
1. An unmasked version of rsqrt as well as its intrinsic operation is inplemented, naming 'RsqrtOp' and 'IntrFrsqrt7Op' in _RVV.td_ respectively('RVV' prefix is omited for simplicity). As for the masked version, I am digging out suitable potential usages.
2. Go back to `math.rsqrt`, it's already supported to be lowered to `x86vector.avx.rsqrt` with `test-math-polynomial-approximation` pass, so I add the related example here for testing and reference.

## Rsqrt Example in RVV Dialect

Define in RVV dialect: 
`%res_rvv = rvv.rsqrt %load_vec_f32, %vl8 : vector<[8]xf32>, index`

Lower to intrinsic operation:
`%31 = "rvv.intr.vfrsqrt7"(%30, %28, %23) : (vector<[8]xf32>, vector<[8]xf32>, i64) -> vector<[8]xf32>`

Translate to llvm IR:
`%7 = call <vscale x 8 x float> @llvm.sqrt.nxv8f32(<vscale x 8 x float> %2)`

Comile and run. A demo result is shown below while the first line represents the output of `rvv.rsqrt` and the second line represents that of `math.rsqrt` given the same input(with acceptable error).
```
[inf,  0.996094,  0.703125,  0.574219,  0.498047,  0.445312,  0.40625,  0.376953,  0,  0,  
inf,  1,  0.707107,  0.57735,  0.5,  0.447214,  0.408248,  0.377964,  0,  0]
```