### PR TITLE
[buddy-mlir Enhancement] Use better type for memref sizes

### DIFF
--- a/examples/ConvOpt/edge-detection.cpp
+++ b/examples/ConvOpt/edge-detection.cpp
@@ -62,9 +62,9 @@ int main(int argc, char *argv[]) {
   buddyKernelStart = clock();
   // Get the data, row, and column information of the kernel.
   float *kernelAlign = laplacianKernelAlign;
-  int kernelRows = laplacianKernelRows;
-  int kernelCols = laplacianKernelCols;
-  intptr_t sizesKernel[2] = {kernelRows, kernelCols};
+  size_t kernelRows = laplacianKernelRows;
+  size_t kernelCols = laplacianKernelCols;
+  size_t sizesKernel[2] = {kernelRows, kernelCols};
   // Define the kernel MemRef object.
   MemRef<float, 2> kernelMemRef(kernelAlign, sizesKernel);
   clock_t buddyKernelEnd;
@@ -77,9 +77,9 @@ int main(int argc, char *argv[]) {
   clock_t buddyOutputStart;
   buddyOutputStart = clock();
   // Define the output.
-  int outputRows = buddyInputMat.rows - kernelRows + 1;
-  int outputCols = buddyInputMat.cols - kernelCols + 1;
-  intptr_t sizesOutput[2] = {outputRows, outputCols};
+  size_t outputRows = buddyInputMat.rows - kernelRows + 1;
+  size_t outputCols = buddyInputMat.cols - kernelCols + 1;
+  size_t sizesOutput[2] = {outputRows, outputCols};
   MemRef<float, 2> outputMemRef(sizesOutput);
   clock_t buddyOutputEnd;
   buddyOutputEnd = clock();

--- a/examples/DAPDialect/biquad.cpp
+++ b/examples/DAPDialect/biquad.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[]) {
   cout << "Current specified path: \n";
   cout << "Load: " << fileName << endl;
   cout << "Save: " << saveFileName << endl;
-  intptr_t kernelSize = 6;
+  size_t kernelSize = 6;
   MemRef<float, 1> kernel(&kernelSize);
   dap::biquadLowpass<float, 1>(kernel, 0.3, -1.0);
   auto aud = dap::Audio<float, 1>(fileName);

--- a/examples/DAPDialect/firLowpass.cpp
+++ b/examples/DAPDialect/firLowpass.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[]) {
   cout << "Current specified path: \n";
   cout << "Load: " << fileName << endl;
   cout << "Save: " << saveFileName << endl;
-  intptr_t kernelSize = 100;
+  size_t kernelSize = 100;
   MemRef<float, 1> kernel(&kernelSize);
   dap::firLowpass<float, 1>(kernel, dap::WINDOW_TYPE::BLACKMANHARRIS7,
                             kernelSize, 0.3, nullptr);

--- a/examples/DAPDialect/iirLowpass.cpp
+++ b/examples/DAPDialect/iirLowpass.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[]) {
   cout << "Load: " << fileName << endl;
   cout << "Save: " << saveFileName << endl;
   int order = 8;
-  intptr_t kernelSize[2] = {int(order / 2), 6};
+  size_t kernelSize[2] = {int(order / 2), 6};
   MemRef<float, 2> kernel(kernelSize);
 
   dap::iirLowpass<float, 2>(kernel, dap::butterworth<float>(order), 1000,

--- a/examples/DIPDialect/correlation2D.cpp
+++ b/examples/DIPDialect/correlation2D.cpp
@@ -66,12 +66,12 @@ bool testImplementation(int argc, char *argv[], std::ptrdiff_t x,
 
   // Define the kernel.
   float *kernelAlign = laplacianKernelAlign;
-  int kernelRows = laplacianKernelRows;
-  int kernelCols = laplacianKernelCols;
+  size_t kernelRows = laplacianKernelRows;
+  size_t kernelCols = laplacianKernelCols;
 
   // Define sizes and strides.
-  intptr_t sizesKernel[2] = {kernelRows, kernelCols};
-  intptr_t sizesOutput[2] = {image.rows, image.cols};
+  size_t sizesKernel[2] = {kernelRows, kernelCols};
+  size_t sizesOutput[2] = {static_cast<size_t>(image.rows), static_cast<size_t>(image.cols)};
 
   // Define memref containers.
   Img<float, 2> input(image);

--- a/examples/DIPDialect/morph2D.cpp
+++ b/examples/DIPDialect/morph2D.cpp
@@ -64,12 +64,12 @@ bool testImplementation(int argc, char *argv[], std::ptrdiff_t x,
 
   // Define the kernel.
   float *kernelAlign = crossKernelAlign3x3;
-  int kernelRows = crossKernelRows3x3;
-  int kernelCols = crossKernelCols3x3;
+  size_t kernelRows = crossKernelRows3x3;
+  size_t kernelCols = crossKernelCols3x3;
 
   // Define sizes and strides.
-  intptr_t sizesKernel[2] = {kernelRows, kernelCols};
-  intptr_t sizesOutput[2] = {image.rows, image.cols};
+  size_t sizesKernel[2] = {kernelRows, kernelCols};
+  size_t sizesOutput[2] = {static_cast<size_t>(image.rows), static_cast<size_t>(image.cols)};
 
   // Define memref containers.
   Img<float, 2> input(image);

--- a/examples/DIPDialect/resize2D.cpp
+++ b/examples/DIPDialect/resize2D.cpp
@@ -41,7 +41,7 @@ bool testImplementation(int argc, char *argv[]) {
   // Define memref container for image.
   Img<float, 2> input(image);
 
-  intptr_t outputSize[2] = {250, 250};
+  size_t outputSize[2] = {250, 250};
   std::vector<float> scalingRatios = {4, 4};
 
   // dip::Resize2D() can be called with either scaling ratios

--- a/include/Interface/buddy/core/Container.h
+++ b/include/Interface/buddy/core/Container.h
@@ -32,12 +32,12 @@
 template <typename T, size_t N> class MemRef {
 public:
   // Constructor from shape.
-  MemRef(intptr_t sizes[N], T init = T(0));
+  MemRef(size_t sizes[N], T init = T(0));
   MemRef(std::vector<size_t> sizes, T init = T(0));
   // Constructor from data.
-  MemRef(const T *data, intptr_t sizes[N], intptr_t offset = 0);
+  MemRef(const T *data, size_t sizes[N], size_t offset = 0);
   // Constructor from a unique_ptr, taking over.
-  MemRef(std::unique_ptr<T> &uptr, intptr_t sizes[N], intptr_t offset = 0);
+  MemRef(std::unique_ptr<T> &uptr, size_t sizes[N], size_t offset = 0);
   // Copy constructor.
   MemRef(const MemRef<T, N> &other);
   // Copy assignment operator.
@@ -51,9 +51,9 @@ public:
   // Get the data pointer.
   T *getData();
   // Get the sizes (shape).
-  const intptr_t *getSizes() { return sizes; }
+  const size_t *getSizes() { return sizes; }
   // Get the strides.
-  const intptr_t *getStrides() { return strides; }
+  const size_t *getStrides() { return strides; }
   // Get the rank of the memref.
   size_t getRank() const { return N; }
   // Get the size (number of elements).
@@ -72,7 +72,7 @@ protected:
   // Computes the strides of the transposed tensor for transpose=true.
   void setStrides();
   // Compute the product of array elements.
-  size_t product(intptr_t sizes[N]) const;
+  size_t product(size_t sizes[N]) const;
 
   // Data.
   // The `aligned` and `allocated` members point to the same address, `aligned`
@@ -81,11 +81,11 @@ protected:
   T *allocated = nullptr;
   T *aligned = nullptr;
   // Offset.
-  intptr_t offset = 0;
+  size_t offset = 0;
   // Shape.
-  intptr_t sizes[N];
+  size_t sizes[N];
   // Strides.
-  intptr_t strides[N];
+  size_t strides[N];
   // Number of elements.
   size_t size;
 };

--- a/include/Interface/buddy/dip/dip.h
+++ b/include/Interface/buddy/dip/dip.h
@@ -156,7 +156,7 @@ void _mlir_ciface_morphgrad_2d_replicate_padding(
 // Helper function for applying 2D resize operation on images.
 MemRef<float, 2> Resize2D_Impl(Img<float, 2> *input, INTERPOLATION_TYPE type,
                                std::vector<float> scalingRatios,
-                               intptr_t outputSize[2]) {
+                               size_t outputSize[2]) {
   MemRef<float, 2> output(outputSize);
 
   if (type == INTERPOLATION_TYPE::NEAREST_NEIGHBOUR_INTERPOLATION) {
@@ -209,7 +209,7 @@ MemRef<float, 2> Rotate2D(Img<float, 2> *input, float angle,
                               std::abs(input->getSizes()[0] * sinAngle)) +
                    1;
 
-  intptr_t sizesOutput[2] = {outputRows, outputCols};
+  size_t sizesOutput[2] = {static_cast<size_t>(outputRows), static_cast<size_t>(outputCols)};
   MemRef<float, 2> output(sizesOutput);
 
   detail::_mlir_ciface_rotate_2d(input, angleRad, &output);
@@ -227,7 +227,7 @@ MemRef<float, 2> Resize2D(Img<float, 2> *input, INTERPOLATION_TYPE type,
         "input_image_dimension / output_image_dimension\n");
   }
 
-  intptr_t outputSize[2] = {
+  size_t outputSize[2] = {
       static_cast<unsigned int>(input->getSizes()[0] / scalingRatios[1]),
       static_cast<unsigned int>(input->getSizes()[1] / scalingRatios[0])};
 
@@ -236,7 +236,7 @@ MemRef<float, 2> Resize2D(Img<float, 2> *input, INTERPOLATION_TYPE type,
 
 // User interface for 2D Resize.
 MemRef<float, 2> Resize2D(Img<float, 2> *input, INTERPOLATION_TYPE type,
-                          intptr_t outputSize[2]) {
+                          size_t outputSize[2]) {
   if (!outputSize[0] || !outputSize[1]) {
     throw std::invalid_argument(
         "Please enter non-zero values of output dimensions.\n");
@@ -252,9 +252,9 @@ void Erosion2D(Img<float, 2> input, MemRef<float, 2> *kernel,
                MemRef<float, 2> *output, unsigned int centerX,
                unsigned int centerY, unsigned int iterations,
                BOUNDARY_OPTION option, float constantValue = 0) {
-  intptr_t outputRows = output->getSizes()[0];
-  intptr_t outputCols = output->getSizes()[1];
-  intptr_t sizesOutput[2] = {outputRows, outputCols};
+  size_t outputRows = output->getSizes()[0];
+  size_t outputCols = output->getSizes()[1];
+  size_t sizesOutput[2] = {outputRows, outputCols};
   MemRef<float, 2> copymemref(sizesOutput, 256.f);
 
   if (option == BOUNDARY_OPTION::CONSTANT_PADDING) {
@@ -271,9 +271,9 @@ void Dilation2D(Img<float, 2> input, MemRef<float, 2> *kernel,
                 MemRef<float, 2> *output, unsigned int centerX,
                 unsigned int centerY, unsigned int iterations,
                 BOUNDARY_OPTION option, float constantValue = 0) {
-  intptr_t outputRows = output->getSizes()[0];
-  intptr_t outputCols = output->getSizes()[1];
-  intptr_t sizesOutput[2] = {outputRows, outputCols};
+  size_t outputRows = output->getSizes()[0];
+  size_t outputCols = output->getSizes()[1];
+  size_t sizesOutput[2] = {outputRows, outputCols};
   MemRef<float, 2> copymemref(sizesOutput, -1.f);
   if (option == BOUNDARY_OPTION::CONSTANT_PADDING) {
     detail::_mlir_ciface_dilation_2d_constant_padding(
@@ -289,10 +289,10 @@ void Opening2D(Img<float, 2> input, MemRef<float, 2> *kernel,
                MemRef<float, 2> *output, unsigned int centerX,
                unsigned int centerY, unsigned int iterations,
                BOUNDARY_OPTION option, float constantValue = 0) {
-  intptr_t outputRows = output->getSizes()[0];
-  intptr_t outputCols = output->getSizes()[1];
+  size_t outputRows = output->getSizes()[0];
+  size_t outputCols = output->getSizes()[1];
 
-  intptr_t sizesOutput[2] = {outputRows, outputCols};
+  size_t sizesOutput[2] = {outputRows, outputCols};
   MemRef<float, 2> output1(sizesOutput);
   MemRef<float, 2> copymemref(sizesOutput, 256.f);
   MemRef<float, 2> copymemref1(sizesOutput, -1.f);
@@ -311,10 +311,10 @@ void Closing2D(Img<float, 2> input, MemRef<float, 2> *kernel,
                MemRef<float, 2> *output, unsigned int centerX,
                unsigned int centerY, unsigned int iterations,
                BOUNDARY_OPTION option, float constantValue = 0) {
-  intptr_t outputRows = output->getSizes()[0];
-  intptr_t outputCols = output->getSizes()[1];
+  size_t outputRows = output->getSizes()[0];
+  size_t outputCols = output->getSizes()[1];
 
-  intptr_t sizesOutput[2] = {outputRows, outputCols};
+  size_t sizesOutput[2] = {outputRows, outputCols};
   MemRef<float, 2> output1(sizesOutput);
   MemRef<float, 2> copymemref(sizesOutput, -1.f);
   MemRef<float, 2> copymemref1(sizesOutput, 256.f);
@@ -333,9 +333,9 @@ void TopHat2D(Img<float, 2> input, MemRef<float, 2> *kernel,
               MemRef<float, 2> *output, unsigned int centerX,
               unsigned int centerY, unsigned int iterations,
               BOUNDARY_OPTION option, float constantValue = 0) {
-  intptr_t outputRows = output->getSizes()[0];
-  intptr_t outputCols = output->getSizes()[1];
-  intptr_t sizesOutput[2] = {outputRows, outputCols};
+  size_t outputRows = output->getSizes()[0];
+  size_t outputCols = output->getSizes()[1];
+  size_t sizesOutput[2] = {outputRows, outputCols};
   MemRef<float, 2> output1(sizesOutput);
   MemRef<float, 2> output2(sizesOutput);
   MemRef<float, 2> input1(sizesOutput);
@@ -356,9 +356,9 @@ void BottomHat2D(Img<float, 2> input, MemRef<float, 2> *kernel,
                  MemRef<float, 2> *output, unsigned int centerX,
                  unsigned int centerY, unsigned int iterations,
                  BOUNDARY_OPTION option, float constantValue = 0) {
-  intptr_t outputRows = output->getSizes()[0];
-  intptr_t outputCols = output->getSizes()[1];
-  intptr_t sizesOutput[2] = {outputRows, outputCols};
+  size_t outputRows = output->getSizes()[0];
+  size_t outputCols = output->getSizes()[1];
+  size_t sizesOutput[2] = {outputRows, outputCols};
   MemRef<float, 2> output1(sizesOutput);
   MemRef<float, 2> output2(sizesOutput);
   MemRef<float, 2> input1(sizesOutput);
@@ -379,9 +379,9 @@ void MorphGrad2D(Img<float, 2> input, MemRef<float, 2> *kernel,
                  MemRef<float, 2> *output, unsigned int centerX,
                  unsigned int centerY, unsigned int iterations,
                  BOUNDARY_OPTION option, float constantValue = 0) {
-  intptr_t outputRows = output->getSizes()[0];
-  intptr_t outputCols = output->getSizes()[1];
-  intptr_t sizesOutput[2] = {outputRows, outputCols};
+  size_t outputRows = output->getSizes()[0];
+  size_t outputCols = output->getSizes()[1];
+  size_t sizesOutput[2] = {outputRows, outputCols};
   MemRef<float, 2> output1(sizesOutput);
   MemRef<float, 2> output2(sizesOutput);
   MemRef<float, 2> input1(sizesOutput);

--- a/lib/Interface/core/AudioContainer.cpp
+++ b/lib/Interface/core/AudioContainer.cpp
@@ -43,7 +43,7 @@ void Audio<T, N>::fetchMetadata(const AudioFile<T> &aud) {
 }
 template <typename T, size_t N> void Audio<T, N>::moveToMemRef() {
   if(data) delete data;
-  intptr_t sizes[N];
+  size_t sizes[N];
   for (size_t i = 0; i < N; ++i) {
     sizes[i] = audioFile.numSamples;
   }

--- a/lib/Interface/core/Container.cpp
+++ b/lib/Interface/core/Container.cpp
@@ -33,7 +33,7 @@
 // Construct a MemRef object from the data shape and initial value.
 // The default initial value is 0.
 template <typename T, std::size_t N>
-MemRef<T, N>::MemRef(intptr_t sizes[N], T init) {
+MemRef<T, N>::MemRef(size_t sizes[N], T init) {
   for (size_t i = 0; i < N; i++) {
     this->sizes[i] = sizes[i];
   }
@@ -63,7 +63,7 @@ MemRef<T, N>::MemRef(std::vector<size_t> sizes, T init) {
 // Construct a MemRef object from the data pointer, sizes, and offset.
 // The default offset is 0.
 template <typename T, std::size_t N>
-MemRef<T, N>::MemRef(const T *data, intptr_t sizes[N], intptr_t offset) {
+MemRef<T, N>::MemRef(const T *data, size_t sizes[N], size_t offset) {
   this->offset = offset;
   for (size_t i = 0; i < N; i++) {
     this->sizes[i] = sizes[i];
@@ -218,15 +218,15 @@ template <typename T, std::size_t N> void MemRef<T, N>::setStrides() {
 
 // Calculate the total number of elements in the MemRef container.
 template <typename T, std::size_t N>
-size_t MemRef<T, N>::product(intptr_t sizes[N]) const {
+size_t MemRef<T, N>::product(size_t sizes[N]) const {
   size_t size = 1;
   for (size_t i = 0; i < N; i++)
     size *= sizes[i];
   return size;
 }
 template <typename T, size_t N>
-MemRef<T, N>::MemRef(std::unique_ptr<T> &uptr, intptr_t *sizes,
-                     intptr_t offset) {
+MemRef<T, N>::MemRef(std::unique_ptr<T> &uptr, size_t *sizes,
+                     size_t offset) {
   if (!uptr)
     assert(0 && "Taking over an empty unique pointer.");
   T *data = uptr.release();

--- a/tests/Interface/core/ContainerTest.cpp
+++ b/tests/Interface/core/ContainerTest.cpp
@@ -23,7 +23,7 @@
 #include "Interface/buddy/core/Container.h"
 
 int main() {
-  intptr_t sizes[] = {2, 3};
+  size_t sizes[] = {2, 3};
   //===--------------------------------------------------------------------===//
   // Test default shape constructor.
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
This PR intends to replace `intptr_t` with `size_t` for expressing the type of `memref` dimensions, strides and offsets. Usage of `size_t` for expressing dimensions is more logical and would help us better model the maximum allowed dimensions of a `memref` (an overflowing `size_t` variable would indicate that we are surpassing the memory bound of container, which is not necessarily the case with `intptr_t` type).

There is a case in 2D DFT/IDFT implementation where we might actually surpass the allowed container dimension upper bound, `size_t` type instead of `intptr_t` would help me better handle this situation. 
(Related PR: #76)

I have made some changes in audio processing examples as well (to avoid breaking them), please verify these changes (/cc @amanchhaparia @SForeKeeper).