### PR TITLE
[DAP] Removed warnings

### DIFF
--- a/lib/Conversion/LowerDAP/LowerDAPPass.cpp
+++ b/lib/Conversion/LowerDAP/LowerDAPPass.cpp
@@ -84,14 +84,14 @@ public:
     Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
     Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
     Value c2 = rewriter.create<ConstantIndexOp>(loc, 2);
-    Value c3 = rewriter.create<ConstantIndexOp>(loc, 3);
+    // Value c3 = rewriter.create<ConstantIndexOp>(loc, 3);
     Value c4 = rewriter.create<ConstantIndexOp>(loc, 4);
     Value c5 = rewriter.create<ConstantIndexOp>(loc, 5);
 
     Value b0 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c0});
     Value b1 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c1});
     Value b2 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c2});
-    Value a0 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c3});
+    // Value a0 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c3});
     Value a1 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c4});
     Value a2 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c5});
 
@@ -192,7 +192,7 @@ public:
     Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
     Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
     Value c2 = rewriter.create<ConstantIndexOp>(loc, 2);
-    Value c3 = rewriter.create<ConstantIndexOp>(loc, 3);
+    // Value c3 = rewriter.create<ConstantIndexOp>(loc, 3);
     Value c4 = rewriter.create<ConstantIndexOp>(loc, 4);
     Value c5 = rewriter.create<ConstantIndexOp>(loc, 5);
 
@@ -217,8 +217,8 @@ public:
                                                     ValueRange{ivs[0], c1});
           Value b2 = builder.create<memref::LoadOp>(loc, kernel,
                                                     ValueRange{ivs[0], c2});
-          Value a0 = builder.create<memref::LoadOp>(loc, kernel,
-                                                    ValueRange{ivs[0], c3});
+        //   Value a0 = builder.create<memref::LoadOp>(loc, kernel,
+        //                                             ValueRange{ivs[0], c3});
           Value a1 = builder.create<memref::LoadOp>(loc, kernel,
                                                     ValueRange{ivs[0], c4});
           Value a2 = builder.create<memref::LoadOp>(loc, kernel,

--- a/lib/Conversion/LowerDAP/LowerDAPPass.cpp
+++ b/lib/Conversion/LowerDAP/LowerDAPPass.cpp
@@ -84,14 +84,13 @@ public:
     Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
     Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
     Value c2 = rewriter.create<ConstantIndexOp>(loc, 2);
-    // Value c3 = rewriter.create<ConstantIndexOp>(loc, 3);
     Value c4 = rewriter.create<ConstantIndexOp>(loc, 4);
     Value c5 = rewriter.create<ConstantIndexOp>(loc, 5);
 
     Value b0 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c0});
     Value b1 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c1});
     Value b2 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c2});
-    // Value a0 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c3});
+    // Value a0 of kernel is not used
     Value a1 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c4});
     Value a2 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c5});
 
@@ -192,7 +191,6 @@ public:
     Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
     Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
     Value c2 = rewriter.create<ConstantIndexOp>(loc, 2);
-    // Value c3 = rewriter.create<ConstantIndexOp>(loc, 3);
     Value c4 = rewriter.create<ConstantIndexOp>(loc, 4);
     Value c5 = rewriter.create<ConstantIndexOp>(loc, 5);
 
@@ -217,8 +215,7 @@ public:
                                                     ValueRange{ivs[0], c1});
           Value b2 = builder.create<memref::LoadOp>(loc, kernel,
                                                     ValueRange{ivs[0], c2});
-        //   Value a0 = builder.create<memref::LoadOp>(loc, kernel,
-        //                                             ValueRange{ivs[0], c3});
+          // Value a0 of kernel is not used
           Value a1 = builder.create<memref::LoadOp>(loc, kernel,
                                                     ValueRange{ivs[0], c4});
           Value a2 = builder.create<memref::LoadOp>(loc, kernel,

--- a/thirdparty/include/AudioFile.h
+++ b/thirdparty/include/AudioFile.h
@@ -541,9 +541,10 @@ bool AudioFile<T>::decodeWaveFile(std::vector<uint8_t> &fileData) {
         int32_t sampleAsInt = fourBytesToInt(fileData, sampleIndex);
         T sample;
 
-        if (audioFormat == WavAudioFormat::IEEEFloat)
-          sample = (T) reinterpret_cast<float &>(sampleAsInt);
-        else // assume PCM
+        if (audioFormat == WavAudioFormat::IEEEFloat) {
+          static_assert(sizeof(sampleAsInt) == sizeof(sample));
+          std::memcpy(&sample, &sampleAsInt, sizeof(sampleAsInt));
+        } else // assume PCM
           sample = (T)sampleAsInt /
                    static_cast<float>(std::numeric_limits<std::int32_t>::max());
 
@@ -575,9 +576,10 @@ bool AudioFile<T>::decodeAiffFile(std::vector<uint8_t> &fileData) {
   // Endianness::BigEndian) + 8;
   std::string format(fileData.begin() + 8, fileData.begin() + 12);
 
-  int audioFormat = format == "AIFF"   ? AIFFAudioFormat::Uncompressed
-                    : format == "AIFC" ? AIFFAudioFormat::Compressed
-                                       : AIFFAudioFormat::Error;
+  int audioFormat = format == "AIFF"
+                        ? AIFFAudioFormat::Uncompressed
+                        : format == "AIFC" ? AIFFAudioFormat::Compressed
+                                           : AIFFAudioFormat::Error;
 
   // -----------------------------------------------------------
   // try and find the start points of key chunks
@@ -693,9 +695,10 @@ bool AudioFile<T>::decodeAiffFile(std::vector<uint8_t> &fileData) {
             fourBytesToInt(fileData, sampleIndex, Endianness::BigEndian);
         T sample;
 
-        if (audioFormat == AIFFAudioFormat::Compressed)
-          sample = (T) reinterpret_cast<float &>(sampleAsInt);
-        else // assume uncompressed
+        if (audioFormat == AIFFAudioFormat::Compressed) {
+          static_assert(sizeof(sampleAsInt) == sizeof(sample));
+          std::memcpy(&sample, &sampleAsInt, sizeof(sampleAsInt));
+        } else // assume uncompressed
           sample = (T)sampleAsInt /
                    static_cast<float>(std::numeric_limits<std::int32_t>::max());
 


### PR DESCRIPTION
This PR removes the warnings generated due to DAP dialect and its dependent third party library.
Closes #92 