### PR TITLE
[examples][MLIRVector] improve vector dialect examples for element access

### DIFF
--- a/examples/MLIRVector/vector-extract-strided-slice.mlir
+++ b/examples/MLIRVector/vector-extract-strided-slice.mlir
@@ -1,20 +1,114 @@
 func.func @main() -> i32 {
-  %0 = arith.constant dense<[[[1, 2, 3, 4], [1, 7, 8, 9],
-                              [12, 11, 14, 19], [100, 101, 112, 111]],
-                             [[100, 101, 109, 117], [111, 156, 167, 189],
-                              [12, 167, 189, 119], [123, 56, 77, 88]]]> : vector<2x4x4xi32>
+  // vector.extract_strided_slice can extract elements from a vector with 
+  // offsets and strides, then group them into a new vector.
 
-  %1 = vector.extract_strided_slice %0 
-         {offsets = [0, 0], sizes = [2, 2], strides = [1, 1]} : 
-         vector<2x4x4xi32> to vector<2x2x4xi32>
+  // Unlike vector.extract, which could only extract "element"/"sub-vector" from a vector, 
+  // vector.extract_strided_slice let you select element almost freely from the 
+  // source vector using a "offset-strides" style.
 
-  vector.print %1 : vector<2x2x4xi32>
+  %base = arith.constant dense<[[0, 1, 2, 3], [10, 11, 12, 13], 
+                                [20, 21, 22, 23], [30, 31, 32, 33]]> : vector<4x4xi32>
 
-  %2 = vector.extract_strided_slice %0 
-       {offsets = [0, 1], sizes = [2, 2], strides = [1, 1]} : 
-       vector<2x4x4xi32> to vector<2x2x4xi32>
 
-  vector.print %2 : vector<2x2x4xi32>
+  // With offsets = [0, 0], strides = [1, 1], it will extract:
+  // x x o o
+  // x x o o
+  // o o o o
+  // o o o o
+  %w0 = vector.extract_strided_slice %base 
+    { offsets = [0, 0], sizes = [2, 2], strides = [1, 1] }
+    : vector<4x4xi32> to vector<2x2xi32>
+  vector.print %w0 : vector<2x2xi32>
+
+
+  // we can add offsets to both dim 0 and dim 1:
+  // when strides = [1, 1], offset = 
+  // [1, 0]:  o o o o    | [0, 1]:  o x x o   | [1, 1]: o o o o
+  //          x x o o    |          o x x o   |         o x x o
+  //          x x o o    |          o o o o   |         o x x o
+  //          o o o o    |          o o o o   |         o o o o
+  %w1_0 = vector.extract_strided_slice %base 
+    { offsets = [1, 0], sizes = [2, 2], strides = [1, 1] }
+    : vector<4x4xi32> to vector<2x2xi32>
+  %w1_1 = vector.extract_strided_slice %base 
+    { offsets = [0, 1], sizes = [2, 2], strides = [1, 1] }
+    : vector<4x4xi32> to vector<2x2xi32>
+  %w1_2 = vector.extract_strided_slice %base 
+    { offsets = [1, 1], sizes = [2, 2], strides = [1, 1] }
+    : vector<4x4xi32> to vector<2x2xi32>
+
+  vector.print %w1_0 : vector<2x2xi32>
+  vector.print %w1_1 : vector<2x2xi32>
+  vector.print %w1_2 : vector<2x2xi32>
+
+
+  // NEED-IMPL: strides are used to specify how sub-vector are inserted with steps
+  // Currently strides only allow 1s, so the example above could not work yet.
+  // when offset = [0, 0], strides =  
+  // [2, 1]:  x x o o    | [1, 2]:  x o x o   | [2, 2]: x o x o
+  //          o o o o    |          x o x o   |         o o o o
+  //          x x o o    |          o o o o   |         x o x o
+  //          o o o o    |          o o o o   |         o o o o
+
+  // %w2_0 = vector.extract_strided_slice %base { offsets = [0, 0], sizes = [2, 2], strides = [2, 1] }
+  //   : vector<4x4xi32> to vector<2x2xi32>
+  // %w2_1 = vector.extract_strided_slice %base { offsets = [0, 0], sizes = [2, 2], strides = [1, 2] }
+  //   : vector<4x4xi32> to vector<2x2xi32>
+  // %w2_2 = vector.extract_strided_slice %base { offsets = [0, 0], sizes = [2, 2], strides = [2, 2] }
+  //   : vector<4x4xi32> to vector<2x2xi32>
+
+  // vector.print %w2_0 : vector<2x2xi32>
+  // vector.print %w2_1 : vector<2x2xi32>
+  // vector.print %w2_2 : vector<2x2xi32>
+
+
+  // vector.extract_strided_slice with any rank can be defined recursively:
+
+  // vector.extract_strided_slice %b { offsets = [o0, ...], sizes = [l0, ...], strides = [s0, ...] }
+  // <==> 
+  // [
+  //    vector.extract_strided_slice %b[o0 + 0*s0] { offsets = [...], sizes = [...], strides = [...] },
+  //    vector.extract_strided_slice %b[o0 + 1*s0] { offsets = [...], sizes = [...], strides = [...] },
+  //    vector.extract_strided_slice %b[o0 + 2*s0] { offsets = [...], sizes = [...], strides = [...] },
+  //    ...
+  //    vector.extract_strided_slice %b[o0 + (l0-1)*s0] { offsets = [...], sizes = [...], strides = [...] }
+  // ]
+
+  %big_base = arith.constant dense<[
+    [[0, 10, 20, 30], [100, 110, 120, 130], [200, 210, 220, 230], [300, 310, 320, 330]],
+    [[1, 11, 21, 31], [101, 111, 121, 131], [201, 211, 221, 231], [301, 311, 321, 331]],
+    [[2, 12, 22, 32], [102, 112, 122, 132], [202, 212, 222, 232], [302, 312, 322, 332]],
+    [[3, 13, 23, 33], [103, 113, 123, 133], [203, 213, 223, 233], [303, 313, 323, 333]]]> 
+  : vector<4x4x4xi32>
+
+
+  %w3 = vector.extract_strided_slice %big_base 
+    { offsets = [1, 0, 0], sizes = [2, 3, 3], strides = [1, 1, 1] } 
+    : vector<4x4x4xi32> to vector<2x3x3xi32>
+  vector.print %w3 : vector<2x3x3xi32>
+
+
+  // Note that currently vector.extract_strided_slice do NOT support to extract 
+  // a lower-rank vector from a bigger one. 
+  // So if we want a lower-rank sub-vector from a bigger one, we can NOT write this:
+
+  // %w4_0 = vector.extract_strided_slice %big_base 
+  //   { offsets = [1, 0, 0], sizes = [3, 3], strides = [1, 1] }
+  //   : vector<4x4x4xi32> to vector<3x3xi32>
+
+  // Instead, we either first extract %big_base[1], or do an extra extract with result:
+  %t1 = vector.extract %big_base[1] : vector<4x4x4xi32>
+  %w4_1 = vector.extract_strided_slice %t1
+    { offsets = [0, 0], sizes = [3, 3], strides = [1, 1] }
+    : vector<4x4xi32> to vector<3x3xi32>
+
+  %t2 = vector.extract_strided_slice %big_base
+    { offsets = [1, 0, 0], sizes = [1, 3, 3], strides = [1, 1, 1] }
+    : vector<4x4x4xi32> to vector<1x3x3xi32>
+  %w4_2 = vector.extract %t2[0] : vector<1x3x3xi32>
+
+  vector.print %w4_1 : vector<3x3xi32>
+  vector.print %w4_2 : vector<3x3xi32>
 
   %ret = arith.constant 0 : i32
   return %ret : i32

--- a/examples/MLIRVector/vector-extract.mlir
+++ b/examples/MLIRVector/vector-extract.mlir
@@ -1,19 +1,28 @@
 func.func @main() -> i32 {
-  %0 = arith.constant dense<[1, 2, 3, 4]> : vector<4xi32>
-  vector.print %0 : vector<4xi32>
+  // vector.extract can get scalar/sub-vector from a vector.
 
-  %value = vector.extract %0[2] : vector<4xi32>
-  vector.print %value : i32
+  // vector.extract only support literal as indices, if you need to extract 
+  // something from a vector with runtime values as indices, you need to cast
+  // your base vector to 1-D vector and use vector.extractelement instead.
 
-  %1 = arith.constant dense<[[[12, 13, 14], [14, 15, 16]],
-                             [[14, 16, 19], [22, 89, 78]]]> : vector<2x2x3xi32>
-  vector.print %1 : vector<2x2x3xi32>
+  %base = arith.constant dense<[[0, 1, 2], [10, 11, 12], [20, 21, 22]]> 
+    : vector<3x3xi32>
 
-  %value1 = vector.extract %1[0, 1] : vector<2x2x3xi32> // extracts [14,15,16]
-  vector.print %value1 : vector<3xi32>
+  
+  // Extract a scalar:
+  %c0 = vector.extract %base[1, 1] : vector<3x3xi32>
+  vector.print %c0 : i32
 
-  %value2 = vector.extract %1[1, 1, 2] : vector<2x2x3xi32> // extracts 78
-  vector.print %value2 : i32
+
+  // Extract a sub-vector:
+  %w1 = vector.extract %base[1] : vector<3x3xi32>
+  vector.print %w1 : vector<3xi32>
+
+
+  // For edge case, you can "extract" a vector itself.
+  // %w2 will be exactly as same as %base
+  %w2 = vector.extract %base[] : vector<3x3xi32>
+  vector.print %w2 : vector<3x3xi32>
 
   %ret = arith.constant 0 : i32
   return %ret : i32

--- a/examples/MLIRVector/vector-insert-strided-slice.mlir
+++ b/examples/MLIRVector/vector-insert-strided-slice.mlir
@@ -1,23 +1,91 @@
 func.func @main() -> i32 {
-  %0 = arith.constant dense<[[[121, 123, 432, 121], [100, 89, 98, 45], [21, 24, 52, 67], [31, 81, 99, 65]],
-                               [[100, 90, 87, 67], [101, 23, 49, 12], [22, 34, 45, 89], [33, 44, 67, 89]],
-                               [[100, 90, 97, 67], [112, 113, 45, 95], [122, 78, 67, 54], [33, 56, 89, 64]],
-                               [[12, 13, 45, 67], [123, 45, 62, 17], [78, 90, 43, 12], [12, 90, 88, 23]]]> : vector<4x4x4xi32>
+  // vector.insert_strided_slice can insert a vector into an area of bigger 
+  // vector with offsets and strides. 
+
+  // Unlike vector.insert, which could only insert "element"/"sub-vector" into a vector, 
+  // vector.insert_strided_slice let you insert data in small vector almost 
+  // freely into any where of the base vector, using a "offset-strides" style.
+
+  %base = arith.constant dense<[[0, 1, 2, 3], [10, 11, 12, 13], 
+                                [20, 21, 22, 23], [30, 31, 32, 33]]> : vector<4x4xi32>
+
+  %val = arith.constant dense<[[100, 101], [110, 111]]> : vector<2x2xi32>
+
+
+  // With offsets = [0, 0], strides = [1, 1], the insertion does:
+  // x x o o
+  // x x o o
+  // o o o o
+  // o o o o
+  %w0 = vector.insert_strided_slice %val, %base { offsets = [0, 0], strides = [1, 1] }
+    : vector<2x2xi32> into vector<4x4xi32>
+
+  vector.print %w0 : vector<4x4xi32>
+
+
+  // we can add offsets to both dim 0 and dim 1:
+  // when strides = [1, 1], offset = 
+  // [1, 0]:  o o o o    | [0, 1]:  o x x o   | [1, 1]: o o o o
+  //          x x o o    |          o x x o   |         o x x o
+  //          x x o o    |          o o o o   |         o x x o
+  //          o o o o    |          o o o o   |         o o o o
+  %w1_0 = vector.insert_strided_slice %val, %base { offsets = [1, 0], strides = [1, 1] }
+    : vector<2x2xi32> into vector<4x4xi32>
+  %w1_1 = vector.insert_strided_slice %val, %base { offsets = [0, 1], strides = [1, 1] }
+    : vector<2x2xi32> into vector<4x4xi32>
+  %w1_2 = vector.insert_strided_slice %val, %base { offsets = [1, 1], strides = [1, 1] }
+    : vector<2x2xi32> into vector<4x4xi32>
+
+  vector.print %w1_0 : vector<4x4xi32>
+  vector.print %w1_1 : vector<4x4xi32>
+  vector.print %w1_2 : vector<4x4xi32>
+
+
+  // NEED-IMPL: strides are used to specify how sub-vector are inserted with steps
+  // Currently strides only allow 1s, so the example above could not work yet.
+  // when offset = [0, 0], strides =  
+  // [2, 1]:  x x o o    | [1, 2]:  x o x o   | [2, 2]: x o x o
+  //          o o o o    |          x o x o   |         o o o o
+  //          x x o o    |          o o o o   |         x o x o
+  //          o o o o    |          o o o o   |         o o o o
+
+  // %w2_0 = vector.insert_strided_slice %val, %base { offsets = [0, 0], strides = [2, 1] }
+  //   : vector<2x2xi32> into vector<4x4xi32>
+  // %w2_1 = vector.insert_strided_slice %val, %base { offsets = [0, 0], strides = [1, 2] }
+  //   : vector<2x2xi32> into vector<4x4xi32>
+  // %w2_2 = vector.insert_strided_slice %val, %base { offsets = [0, 0], strides = [2, 2] }
+  //   : vector<2x2xi32> into vector<4x4xi32>
+
+  // vector.print %w2_0 : vector<4x4xi32>
+  // vector.print %w2_1 : vector<4x4xi32>
+  // vector.print %w2_2 : vector<4x4xi32>
+
+
+  // vector.insert_strided_slice with any rank can be defined recursively:
+
+  // vector.insert_strided_slice %v, %b { offsets = [o0, ...], strides = [s0, ...] }
+  // <==> 
+  // if rank(%v) < rank(%b):
+  //    vector.insert_strided_slice %v, %b[o0] { offsets = [...], strides = [...] }
+  //
+  // if rank(%v) == rank(%b):
+  //    for (i = o0; i < dim(%v); i += s0)
+  //      vector.insert_strided_slice %v[i], %b[i] { offsets = [...], strides = [...] }
+
+  %big_base = arith.constant dense<[
+    [[0, 10, 20, 30], [100, 110, 120, 130], [200, 210, 220, 230], [300, 310, 320, 330]],
+    [[1, 11, 21, 31], [101, 111, 121, 131], [201, 211, 221, 231], [301, 311, 321, 331]],
+    [[2, 12, 22, 32], [102, 112, 122, 132], [202, 212, 222, 232], [302, 312, 322, 332]],
+    [[3, 13, 23, 33], [103, 113, 123, 133], [203, 213, 223, 233], [303, 313, 323, 333]]]> 
+  : vector<4x4x4xi32>
     
-  %1 = arith.constant dense<[[12, 56, 76],
-                             [12, 65, 90],
-                             [12, 54, 55]]> : vector<3x3xi32>
+  %big_value = arith.constant dense<[[1000, 1001, 1002],
+                                     [1010, 1011, 1012],
+                                     [1020, 1021, 1022]]> : vector<3x3xi32>
 
-  %2 = vector.insert_strided_slice %1, %0 {offsets = [1, 0, 0], strides = [1, 1]} : 
-  vector<3x3xi32> into vector<4x4x4xi32>
-
-  vector.print %2 : vector<4x4x4xi32>
-  %3 = arith.constant dense<[[23, 56],
-                             [451, 651]]> : vector<2x2xi32>
-
-  %4 = vector.insert_strided_slice %3, %1 {offsets = [0, 0], strides = [1, 1]} : 
-  vector<2x2xi32> into vector<3x3xi32>
-  vector.print %4 : vector<3x3xi32>
+  %w3 = vector.insert_strided_slice %big_value, %big_base {offsets = [1, 0, 0], strides = [1, 1]} 
+    : vector<3x3xi32> into vector<4x4x4xi32>
+  vector.print %w3 : vector<4x4x4xi32>
 
   %ret = arith.constant 0 : i32
   return %ret : i32


### PR DESCRIPTION
improve examples for vector element access related operations in vector dialect, including:

- insert/extract
- insert-strided-slice/extract-strided-slice

This PR is a small and finished part of PR #90 .