### PR TITLE
[Container] Support more image channels layout in ImageContainer

### DIFF
--- a/include/Interface/buddy/core/ImageContainer.h
+++ b/include/Interface/buddy/core/ImageContainer.h
@@ -31,7 +31,11 @@
 //   disabled by default.
 template <typename T, size_t N> class Img : public MemRef<T, N> {
 public:
-  Img(cv::Mat image, bool norm = false);
+  Img(cv::Mat image, intptr_t sizes[N] = nullptr, bool norm = false);
+
+private:
+  // Load image data from OpenCV Mat.
+  void loadImg(cv::Mat image, bool norm);
 };
 
 #include "Interface/core/ImageContainer.cpp"

--- a/lib/Interface/core/ImageContainer.cpp
+++ b/lib/Interface/core/ImageContainer.cpp
@@ -38,12 +38,13 @@ Img<T, N>::Img(cv::Mat image, intptr_t sizes[N], bool norm) : MemRef<T, N>() {
   }
   // Use default layout setting.
   if (sizes == nullptr) {
-    if (image.channels() == 1) {
+    // The size of the gray image is represented by height and width by default.
+    if (N == 2) {
       this->sizes[0] = image.rows;
       this->sizes[1] = image.cols;
     }
     // For RGB images, use NHWC layout by default.
-    else if (image.channels() == 3) {
+    else if (N == 4) {
       this->sizes[0] = 1;
       this->sizes[1] = image.rows;
       this->sizes[2] = image.cols;
@@ -64,7 +65,8 @@ Img<T, N>::Img(cv::Mat image, intptr_t sizes[N], bool norm) : MemRef<T, N>() {
 
 template <typename T, size_t N>
 void Img<T, N>::loadImg(cv::Mat image, bool norm) {
-  if (image.channels() == 1) {
+  // Load gray image data from OpenCV Mat.
+  if (N == 2) {
     size_t k = 0;
     for (int i = 0; i < this->sizes[0]; i++) {
       for (int j = 0; j < this->sizes[1]; j++) {
@@ -76,8 +78,8 @@ void Img<T, N>::loadImg(cv::Mat image, bool norm) {
         k++;
       }
     }
-  } else if (image.channels() == 3) {
-    // Detect NHWC layout.
+  } else if (N == 4) {
+    // Detect NHWC layout of RGB image data.
     if (this->sizes[1] == image.rows && this->sizes[2] == image.cols &&
         this->sizes[3] == 3) {
       size_t k = 0;
@@ -94,7 +96,7 @@ void Img<T, N>::loadImg(cv::Mat image, bool norm) {
         }
       }
     }
-    // Detect NCHW layout.
+    // Detect NCHW layout of RGB image data.
     else if (this->sizes[2] == image.rows && this->sizes[3] == image.cols &&
              this->sizes[1] == 3) {
       size_t k = 0;

--- a/lib/Interface/core/ImageContainer.cpp
+++ b/lib/Interface/core/ImageContainer.cpp
@@ -25,53 +25,95 @@
 
 // Image Constructor from OpenCV Mat.
 template <typename T, size_t N>
-Img<T, N>::Img(cv::Mat image, bool norm) : MemRef<T, N>() {
+Img<T, N>::Img(cv::Mat image, intptr_t sizes[N], bool norm) : MemRef<T, N>() {
   if (image.channels() == 1) {
-    assert((N == 2) &&
-           "Input image type does not match the selected dimension.");
-    this->sizes[0] = image.rows;
-    this->sizes[1] = image.cols;
-    this->size = image.rows * image.cols;
-    this->allocated = new T[this->size];
-    this->aligned = this->allocated;
-    int k = 0;
-    for (int i = 0; i < image.rows; i++) {
-      for (int j = 0; j < image.cols; j++) {
-        this->aligned[k] = (T)image.at<uchar>(i, j);
+    assert((N == 2) && "For gray images, the number of dimensions must be 2.");
+  } else if (image.channels() == 3) {
+    assert((N == 4) && "For RGB images, the number of dimensions must be 4, "
+                       "either in NHWC or NCHW layout.");
+  } else {
+    std::cerr << "Only 2-channel gray images and 3-channel RGB images are "
+                 "supported, but got images' channel equal to "
+              << image.channels() << "." << std::endl;
+  }
+  // Use default layout setting.
+  if (sizes == nullptr) {
+    if (image.channels() == 1) {
+      this->sizes[0] = image.rows;
+      this->sizes[1] = image.cols;
+    }
+    // For RGB images, use NHWC layout by default.
+    else if (image.channels() == 3) {
+      this->sizes[0] = 1;
+      this->sizes[1] = image.rows;
+      this->sizes[2] = image.cols;
+      this->sizes[3] = 3;
+    }
+  } else {
+    // Use custom layout setting.
+    for (size_t i = 0; i < N; i++) {
+      this->sizes[i] = sizes[i];
+    }
+  }
+  this->size = this->product(this->sizes);
+  this->setStrides();
+  this->allocated = new T[this->size];
+  this->aligned = this->allocated;
+  this->loadImg(image, norm);
+}
+
+template <typename T, size_t N>
+void Img<T, N>::loadImg(cv::Mat image, bool norm) {
+  if (image.channels() == 1) {
+    size_t k = 0;
+    for (int i = 0; i < this->sizes[0]; i++) {
+      for (int j = 0; j < this->sizes[1]; j++) {
+        if (norm) {
+          this->aligned[k] = (T)image.at<uchar>(i, j) / 255;
+        } else {
+          this->aligned[k] = (T)image.at<uchar>(i, j);
+        }
         k++;
       }
     }
-    this->setStrides();
-  }
-  // Use NHWC layout by default.
-  else if (image.channels() == 3) {
-    assert((N == 4) &&
-           "Input image type does not match the selected dimension.");
-    this->sizes[0] = 1;
-    this->sizes[1] = image.rows;
-    this->sizes[2] = image.cols;
-    this->sizes[3] = 3;
-    this->size = image.rows * image.cols * 3;
-    this->allocated = new T[this->size];
-    this->aligned = this->allocated;
-    int k = 0;
-    for (int i = 0; i < image.rows; i++) {
-      for (int j = 0; j < image.cols; j++) {
-        for (int color = 0; color < 3; color++) {
-          // Reorder to RGB layout.
-          if (norm) {
-            this->aligned[k] = (T)image.at<cv::Vec3b>(i, j)[2 - color] / 255;
-          } else {
-            this->aligned[k] = (T)image.at<cv::Vec3b>(i, j)[2 - color];
+  } else if (image.channels() == 3) {
+    // Detect NHWC layout.
+    if (this->sizes[1] == image.rows && this->sizes[2] == image.cols &&
+        this->sizes[3] == 3) {
+      size_t k = 0;
+      for (int i = 0; i < image.rows; i++) {
+        for (int j = 0; j < image.cols; j++) {
+          for (int color = 0; color < 3; color++) {
+            if (norm) {
+              this->aligned[k] = (T)image.at<cv::Vec3b>(i, j)[2 - color] / 255;
+            } else {
+              this->aligned[k] = (T)image.at<cv::Vec3b>(i, j)[2 - color];
+            }
+            k++;
           }
-          k++;
         }
       }
     }
-    this->setStrides();
-  } else {
-    // TODO: Add more image channels in this constructor.
-    std::cerr << "This image channels is not supported." << std::endl;
+    // Detect NCHW layout.
+    else if (this->sizes[2] == image.rows && this->sizes[3] == image.cols &&
+             this->sizes[1] == 3) {
+      size_t k = 0;
+      for (int color = 0; color < 3; color++) {
+        for (int i = 0; i < image.rows; i++) {
+          for (int j = 0; j < image.cols; j++) {
+            if (norm) {
+              this->aligned[k] = (T)image.at<cv::Vec3b>(i, j)[2 - color] / 255;
+            } else {
+              this->aligned[k] = (T)image.at<cv::Vec3b>(i, j)[2 - color];
+            }
+            k++;
+          }
+        }
+      }
+    } else {
+      std::cerr << "RGB images must be arranged in either NHWC or NCHW layout."
+                << std::endl;
+    }
   }
 }
 

--- a/tests/Interface/core/ImageContainerTest.cpp
+++ b/tests/Interface/core/ImageContainerTest.cpp
@@ -20,6 +20,11 @@
 
 // RUN: buddy-image-container-test 2>&1 | FileCheck %s
 
+// Suppress array-bounds warning since layout array subscript 2 and 3 will never
+// be reached when processing gray images with N equal to 2.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+
 #include "Interface/buddy/core/Container.h"
 #include "Interface/buddy/core/ImageContainer.h"
 #include <opencv2/imgcodecs.hpp>
@@ -33,13 +38,13 @@ int main() {
   // 195.0, 210.0, 225.0, 240.0
   // The test running directory is in <build dir>/tests/Interface/core, so the
   // `imread` function uses the following relative path.
-  cv::Mat image =
+  cv::Mat grayimage =
       cv::imread("../../../../tests/Interface/core/TestGrayImage.png",
                  cv::IMREAD_GRAYSCALE);
   //===--------------------------------------------------------------------===//
   // Test image constructor for OpenCV.
   //===--------------------------------------------------------------------===//
-  Img<float, 2> testOpenCVConstructor(image);
+  Img<float, 2> testOpenCVConstructor(grayimage);
   // CHECK: 15.0
   fprintf(stderr, "%f\n", testOpenCVConstructor.getData()[0]);
   // CHECK: 4, 4
@@ -88,15 +93,43 @@ int main() {
   //===--------------------------------------------------------------------===//
   // Test overloading bracket operator.
   //===--------------------------------------------------------------------===//
-  Img<float, 2> testBracketOperator1(image);
+  Img<float, 2> testBracketOperator1(grayimage);
   // CHECK: 240.0
   fprintf(stderr, "%f\n", testBracketOperator1[15]);
   testBracketOperator1[15] = 90.0;
   // CHECK: 90.0
   fprintf(stderr, "%f\n", testBracketOperator1[15]);
-  const Img<float, 2> testBracketOperator2(image);
+  const Img<float, 2> testBracketOperator2(grayimage);
   // CHECK: 240.0
   fprintf(stderr, "%f\n", testBracketOperator2[15]);
 
+  //===--------------------------------------------------------------------===//
+  // Test image channels layout of RGB images from ImgContainer.
+  //===--------------------------------------------------------------------===//
+  // The test image is a RGB image with size 1026 * 1026 from buddy-mlir/examples.
+  // The test running directory is in <build dir>/tests/Interface/core, so the
+  // `imread` function uses the following relative path.
+
+  cv::Mat RGBimage =
+      cv::imread("../../../../examples/ConvOpt/images/YuTu.png");
+
+  // Represent NHWC layout by default.
+  Img<float, 4> testRGBImageLayout1(RGBimage);
+  // CHECK: 1, 1026, 1026, 3
+  fprintf(stderr, "%ld, %ld, %ld, %ld\n", testRGBImageLayout1.getSizes()[0],
+          testRGBImageLayout1.getSizes()[1], testRGBImageLayout1.getSizes()[2],
+          testRGBImageLayout1.getSizes()[3]);
+
+  // Represent NCHW layout with sizes = {1, 3, 1026, 1026}
+  intptr_t sizesInput2[4] = {1, 3, RGBimage.rows, RGBimage.cols};
+  Img<float, 4> testRGBImageLayout2(RGBimage, sizesInput2);
+  // CHECK: 3158028, 1052676, 1026, 1
+  fprintf(stderr, "%ld, %ld, %ld, %ld\n", testRGBImageLayout2.getStrides()[0],
+          testRGBImageLayout2.getStrides()[1],
+          testRGBImageLayout2.getStrides()[2],
+          testRGBImageLayout2.getStrides()[3]);
+
   return 0;
 }
+
+#pragma GCC diagnostic pop

--- a/tests/Interface/core/ImageContainerTest.cpp
+++ b/tests/Interface/core/ImageContainerTest.cpp
@@ -20,11 +20,6 @@
 
 // RUN: buddy-image-container-test 2>&1 | FileCheck %s
 
-// Suppress array-bounds warning since layout array subscript 2 and 3 will never
-// be reached when processing gray images with N equal to 2.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Warray-bounds"
-
 #include "Interface/buddy/core/Container.h"
 #include "Interface/buddy/core/ImageContainer.h"
 #include <opencv2/imgcodecs.hpp>
@@ -106,12 +101,12 @@ int main() {
   //===--------------------------------------------------------------------===//
   // Test image channels layout of RGB images from ImgContainer.
   //===--------------------------------------------------------------------===//
-  // The test image is a RGB image with size 1026 * 1026 from buddy-mlir/examples.
-  // The test running directory is in <build dir>/tests/Interface/core, so the
-  // `imread` function uses the following relative path.
+  // The test image is an RGB image with size 1026 * 1026 from
+  // buddy-mlir/examples. The test running directory is in <build
+  // dir>/tests/Interface/core, so the `imread` function uses the following
+  // relative path.
 
-  cv::Mat RGBimage =
-      cv::imread("../../../../examples/ConvOpt/images/YuTu.png");
+  cv::Mat RGBimage = cv::imread("../../../../examples/ConvOpt/images/YuTu.png");
 
   // Represent NHWC layout by default.
   Img<float, 4> testRGBImageLayout1(RGBimage);
@@ -131,5 +126,3 @@ int main() {
 
   return 0;
 }
-
-#pragma GCC diagnostic pop


### PR DESCRIPTION
1. Add support for **NCHW layout** in ImageContainer. To customize the layout, an additional parameter `sizes[N]` (`N` is the rank of image data, normally 2 or 4), which represented the size of each dimentions, can be given like this:

```
cv::Mat image = imagePreprocessing();

Img<float, 4> input1(image);  // Represent NHWC layout by default.

intptr_t sizesInput2[4] = {1, image.rows, image.cols, 3};
Img<float, 4> input2(image, sizesInput2); // Represent NHWC layout.

intptr_t sizesInput3[4] = {1, 3, image.rows, image.cols};
Img<float, 4> input3(image, sizesInput3); // Represent NCHW layout.
```

2. Specify the error message.
~3. Replace `std::size_t` with `size_t` to improve readability.~
4. Support normalization when processing gray images with norm being set true.
5. Add ImageContainer layout test for RGB images.

