### PR TITLE
[RVV] Extend operands' data type in RVV dialect to support rv32

### DIFF
--- a/examples/VectorExpDialect/makefile
+++ b/examples/VectorExpDialect/makefile
@@ -95,3 +95,18 @@ vector-exp-predication-matmul-run:
 	${CROSS_LLI} -march=riscv64 -mattr=+m,+d,+v \
 		-dlopen=${CROSS_MLIR_C_RUNNER_UTILS} \
 		-dlopen=${CROSS_MLIR_RUNNER_UTILS}
+
+vector-exp-predication-matmul-rv32-asm:
+	@${BUDDY_OPT} ./vector-exp-predication-matmul-i32.mlir \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-math-to-llvm \
+		-lower-vector-exp \
+		-lower-rvv \
+		-convert-vector-to-llvm \
+		-convert-memref-to-llvm \
+		-convert-func-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	/home/xlinsist/intern/llvm/build/bin/llc -mtriple riscv32 -target-abi ilp32 \
+		-mattr=+m,+d,+v -riscv-v-vector-bits-min=128 --filetype=asm -opaque-pointers -o log.s

--- a/examples/VectorExpDialect/vector-exp-predication-matmul-i32.mlir
+++ b/examples/VectorExpDialect/vector-exp-predication-matmul-i32.mlir
@@ -1,0 +1,90 @@
+memref.global "private" @gv_i32 : memref<10x10xi32> = dense<[[0 , 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9],
+                                                             [0 , 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9],
+                                                             [0 , 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9],
+                                                             [0 , 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9],
+                                                             [0 , 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9],
+                                                             [0 , 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9],
+                                                             [0 , 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9],
+                                                             [0 , 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9],
+                                                             [0 , 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9],
+                                                             [0 , 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9]]>
+
+func.func private @printMemrefI32(memref<*xi32>)
+
+func.func @alloc_mem_i32() -> memref<10x10xi32> {
+  %i0 = arith.constant 0 : i32
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  %mem = memref.alloc() : memref<10x10xi32>
+  scf.for %idx0 = %c0 to %c10 step %c1 {
+    scf.for %idx1 = %c0 to %c10 step %c1 {
+      memref.store %i0, %mem[%idx0, %idx1] : memref<10x10xi32>
+    }
+  }
+  return %mem : memref<10x10xi32>
+}
+
+func.func @main() -> i32 {
+  %mem_i32 = memref.get_global @gv_i32 : memref<10x10xi32>
+  %result_mem = call @alloc_mem_i32() : () -> memref<10x10xi32>
+
+  %c0 = arith.constant 0 : index
+  %c0_i32 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : index
+
+  %aRow = memref.dim %mem_i32, %c0 : memref<10x10xi32>
+  %aCol = memref.dim %mem_i32, %c1 : memref<10x10xi32>
+  %bRow = memref.dim %mem_i32, %c0 : memref<10x10xi32>
+  %bCol = memref.dim %mem_i32, %c1 : memref<10x10xi32>
+  %bCol_i32 = arith.index_cast %bCol : index to i32
+
+  // Configure the register.
+  // SEW = 32
+  %sew = arith.constant 2 : i32
+  // LMUL = 2
+  %lmul = arith.constant 1 : i32
+
+  affine.for %idx0 = 0 to %bRow {
+    affine.for %idx1 = 0 to %aRow {
+      %aEle = affine.load %mem_i32[%idx1, %idx0] : memref<10x10xi32>
+      // While loop for strip-mining.
+      %tmpAVL, %tmpIdx = scf.while (%avl = %bCol_i32, %idx = %c0) : (i32, index) -> (i32, index) {
+        // If avl greater than zero.
+        %cond = arith.cmpi sgt, %avl, %c0_i32 : i32
+        // Pass avl, idx to the after region.
+        scf.condition(%cond) %avl, %idx : i32, index
+      } do {
+      ^bb0(%avl : i32, %idx : index):
+        // Perform the calculation according to the vl.
+        %vl = rvv.setvl %avl, %sew, %lmul : i32
+        %vl_ind = arith.index_cast %vl : i32 to index
+        %mask = vector.create_mask %vl_ind : vector<[4]xi1>
+        %input_vector = vector_exp.predication %mask, %vl : vector<[4]xi1>, i32 {
+          %ele = vector.load %mem_i32[%idx0, %idx] : memref<10x10xi32>, vector<[4]xi32>
+          vector.yield %ele : vector<[4]xi32>
+        } : vector<[4]xi32>
+        %mul_vector = rvv.mul %input_vector, %aEle, %vl : vector<[4]xi32>, i32, i32
+        %c_vector = vector_exp.predication %mask, %vl : vector<[4]xi1>, i32 {
+          %ele = vector.load %result_mem[%idx1, %idx] : memref<10x10xi32>, vector<[4]xi32>
+          vector.yield %ele : vector<[4]xi32>
+        } : vector<[4]xi32>
+        %result_vector = rvv.add %mul_vector, %c_vector, %vl : vector<[4]xi32>, vector<[4]xi32>, i32
+        vector_exp.predication %mask, %vl : vector<[4]xi1>, i32 {
+          vector.store %result_vector, %result_mem[%idx1, %idx] : memref<10x10xi32>, vector<[4]xi32>
+          vector.yield
+        } : () -> ()
+        // Update idx and avl.
+        %new_idx = arith.addi %idx, %vl_ind : index
+        %new_avl = arith.subi %avl, %vl : i32
+        scf.yield %new_avl, %new_idx : i32, index
+      }
+    }
+  }
+
+  %print_result_mem = memref.cast %result_mem : memref<10x10xi32> to memref<*xi32>
+  call @printMemrefI32(%print_result_mem) : (memref<*xi32>) -> ()
+
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/midend/include/Dialect/RVV/RVV.td
+++ b/midend/include/Dialect/RVV/RVV.td
@@ -65,8 +65,10 @@ class RVV_Op<string mnemonic, list<Trait> traits = []> :
 def RVVSetVlOp :
     RVV_Op<"setvl",
               !listconcat([], [AllTypesMatch<["avl", "sew", "lmul", "vl"]>])>,
-    Arguments<(ins Index:$avl, Index:$sew, Index:$lmul)>,
-    Results<(outs Index:$vl)> {
+    Arguments<(ins AnySignlessIntegerOrIndex:$avl, 
+                  AnySignlessIntegerOrIndex:$sew, 
+                  AnySignlessIntegerOrIndex:$lmul)>,
+    Results<(outs AnySignlessIntegerOrIndex:$vl)> {
   let summary = "Set vector length according to AVL, SEW, and LMUL";
   let description = [{
     SetVl operation sets the vector length according to AVL, SEW, and LMUL.
@@ -80,7 +82,7 @@ def RVVSetVlOp :
 
 def RVVLoadOp : RVV_Op<"load">,
     Arguments<(ins Arg<AnyMemRef, "", [MemRead]>:$base, Index:$index,
-                       Index:$length)>,
+                  AnySignlessIntegerOrIndex:$length)>,
     Results<(outs ScalableVectorOf<[AnyType]>:$result)> {
   let summary = "Load scalable vector from memory";
   let description = [{
@@ -97,7 +99,8 @@ def RVVLoadOp : RVV_Op<"load">,
 
 def RVVStoreOp : RVV_Op<"store">,
     Arguments<(ins ScalableVectorOf<[AnyType]>:$value, Arg<AnyMemRef, "",
-                   [MemWrite]>:$base, Index:$index, Index:$length)> {
+                   [MemWrite]>:$base, Index:$index, 
+                   AnySignlessIntegerOrIndex:$length)> {
   let summary = "Store scalable vector into memory";
   let description = [{
     Store the given element length of a scalable vector on a slice of memory.
@@ -112,7 +115,8 @@ def RVVStoreOp : RVV_Op<"store">,
 }
 
 def RsqrtOp : RVV_Op<"rsqrt", [Pure, AllTypesMatch<["src", "dst"]>]>,
-    Arguments<(ins ScalableVectorOf<[AnyType]>:$src, Index:$length)>,
+    Arguments<(ins ScalableVectorOf<[AnyType]>:$src, 
+                  AnySignlessIntegerOrIndex:$length)>,
     Results<(outs ScalableVectorOf<[AnyType]>:$dst)> {
   let summary = "Reciprocal of the square-root";
   let description = "Floating-point reciprocal square-root estimated to 7 bits.";
@@ -130,7 +134,7 @@ class RVV_BinaryAAXNoMask_Op<string mnemonic, string op_description,
   let arguments = (ins 
     ScalableVectorOf<[AnyInteger]>:$src1,
     AnyType:$src2,
-    Index:$length
+    AnySignlessIntegerOrIndex:$length
   );
   let results = (outs ScalableVectorOf<[AnyInteger]>:$dst);
   let assemblyFormat = "$src1 `,` $src2 `,` $length attr-dict `:` type($src1) "

--- a/midend/lib/Dialect/RVV/Transforms/LegalizeForLLVMExport.cpp
+++ b/midend/lib/Dialect/RVV/Transforms/LegalizeForLLVMExport.cpp
@@ -118,7 +118,7 @@ struct RVVLoadOpLowering : public ConvertOpToLLVMPattern<RVVLoadOp> {
     Value vl = loadOp.getOperand(2);
     Value vlCast = rewriter
                        .create<UnrealizedConversionCastOp>(
-                           loadOp.getLoc(), rewriter.getI64Type(), vl)
+                           loadOp.getLoc(), rewriter.getI32Type(), vl)
                        .getResult(0);
     rewriter.replaceOpWithNewOp<RVVIntrLoadEleOp>(loadOp, resultType, passthru,
                                                   bitCastedPtr, vlCast);
@@ -150,7 +150,7 @@ struct RVVStoreOpLowering : public ConvertOpToLLVMPattern<RVVStoreOp> {
     Value vl = storeOp.getOperand(3);
     Value vlCast = rewriter
                        .create<UnrealizedConversionCastOp>(
-                           storeOp.getLoc(), rewriter.getI64Type(), vl)
+                           storeOp.getLoc(), rewriter.getI32Type(), vl)
                        .getResult(0);
     rewriter.replaceOpWithNewOp<RVVIntrStoreEleOp>(storeOp, adaptor.getValue(),
                                                    bitCastedPtr, vlCast);
@@ -178,7 +178,7 @@ struct RsqrtOpLowering : public ConvertOpToLLVMPattern<RsqrtOp> {
     Value vl = op.getOperand(1);
     Value vlCast = rewriter
                        .create<UnrealizedConversionCastOp>(
-                           op.getLoc(), rewriter.getI64Type(), vl)
+                           op.getLoc(), rewriter.getI32Type(), vl)
                        .getResult(0);
     rewriter.replaceOpWithNewOp<IntrFrsqrt7Op>(op, resultType, passthru, src,
                                                vlCast);


### PR DESCRIPTION
To attain RVV intrinsics in rv32, for current operations in RVV dialects, change the data type of `vl` from `Index` to `AnySignlessIntegerOrIndex`. Here, `vl` is an essential parameter for RVV to represent current vector length to process.

After changing:
1. Both  `%vl = rvv.setvl %avl, %sew, %lmul : Index` and `%vl = rvv.setvl %avl, %sew, %lmul : i32` can be lowered correctly, which means the usage of `rvv.setvl` in original programs will not be effected.
2. Both Index integers and i32 integers can be passed into RVV operations as parameters. When passing i32 integers, the generated RVV intrinsics will be of rv32 instead of rv64.

To test the correctness,  a **i32-type matmul demo(vector-exp-predication-matmul-i32.mlir)** is added in /buddy-mlir/examples/VectorExpDialect, from which rv32 asemble code can be generated with these modifications in RVV dialect.