### PR TITLE
Add support for lld linker in build config of llvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ $ cmake -G Ninja ../llvm \
     -DCMAKE_BUILD_TYPE=RELEASE
 ```
 
+If your target machine has lld installed, you can use the following configuration:
+
+```
+$ cmake -G Ninja ../llvm \
+    -DLLVM_ENABLE_PROJECTS="mlir;clang" \
+    -DLLVM_TARGETS_TO_BUILD="host;RISCV" \
+    -DLLVM_USE_LINKER=lld \
+    -DLLVM_ENABLE_ASSERTIONS=ON \
+    -DCMAKE_BUILD_TYPE=RELEASE
+```
 ### Build buddy-mlir
 
 ```


### PR DESCRIPTION
By default we use the gnu linker to build llvm. lld is a linker from the llvm project and is much [faster](https://llvm.org/devmtg/2017-10/slides/Ueyama-lld.pdf) than the default gnu linker. This PR aims to give the user an option to use the lld linker while building llvm.