### PR TITLE
[Fix bug] fixed the incompatibility issue with the latest version of MLIR in buddy/compiler.py.

### DIFF
--- a/examples/MLIRPython/batched_matmul.py
+++ b/examples/MLIRPython/batched_matmul.py
@@ -1,0 +1,11 @@
+from buddy import compiler
+import torch
+import torch._dynamo as dynamo
+
+def foo(x, y):
+  return torch.matmul(x, y)
+
+foo_mlir = dynamo.optimize(compiler.DynamoCompiler)(foo)
+in1 = torch.randn(2, 2, 3)
+in2 = torch.randn(2, 3, 5)
+foo_mlir(in1, in2)

--- a/examples/MLIRPython/buddy/compiler.py
+++ b/examples/MLIRPython/buddy/compiler.py
@@ -85,7 +85,7 @@ def CodeGen(node, symbolTable, argsList):
     ret = symbolTable.get(str(node._args[0][0]))
     symbolTable["output"] = ret
 
-def Lowering(module):
+def Lowering(module: Module):
   print("-------------------------------------------------------------------")
   print("Bufferizing the module ...")
   pm = PassManager('builtin.module')
@@ -94,7 +94,7 @@ def Lowering(module):
   pm.add("func.func(linalg-bufferize)")
   pm.add("func.func(tensor-bufferize)")
   pm.add("func-bufferize")
-  pm.run(module)
+  pm.run(module.operation)
   print(module)
   print("-------------------------------------------------------------------")
   print("Lowering the module to LLVM dialect ...")
@@ -102,9 +102,10 @@ def Lowering(module):
   pm.add("func.func(convert-linalg-to-loops)")
   pm.add("convert-scf-to-cf")
   pm.add("convert-linalg-to-llvm")
-  pm.add("convert-memref-to-llvm")
+  pm.add("expand-strided-metadata")
+  pm.add("finalize-memref-to-llvm")
   pm.add("convert-func-to-llvm")
   pm.add("reconcile-unrealized-casts")
-  pm.run(module)
+  pm.run(module.operation)
   print(module)
   return module

--- a/examples/MLIRPython/buddy/compiler.py
+++ b/examples/MLIRPython/buddy/compiler.py
@@ -4,6 +4,7 @@ import mlir.dialects.func as func
 from mlir.passmanager import *
 import torch
 from typing import List
+import array
 
 def DynamoCompiler(gm: torch.fx.GraphModule, inputs: List[torch.Tensor]):
   print("Custom Compiler from FX Graph to MLIR:")
@@ -55,8 +56,8 @@ def CodeGen(node, symbolTable, argsList):
   if node.op == "call_function" :
     # Parse a call_function operation.
     if node.target.__name__ == "add":
-      # Generate add operation.
-      input1 = symbolTable.get(str(node._args[0]))
+      # Generate add operation.  
+      input1 = symbolTable.get(str(node._args[0])) 
       input2 = symbolTable.get(str(node._args[1]))
       op = arith.AddFOp(input1, input2)
       symbolTable[str(node.name)] = op
@@ -65,21 +66,38 @@ def CodeGen(node, symbolTable, argsList):
       # Get two input values.
       input1 = symbolTable.get(str(node._args[0]))
       input2 = symbolTable.get(str(node._args[1]))
-      # Infer the output sizes.
-      size1 = RankedTensorType(input1.type).shape[0]
-      size2 = RankedTensorType(input2.type).shape[1]
-      sizes = [size1, size2]
-      # Generate an output tensor for matmul operation.
-      # For example:
-      # `arith.constant dense<0.000000e+00> : tensor<3x3xf32>`
+      shp1 = RankedTensorType(input1.type).shape
+      shp2 = RankedTensorType(input2.type).shape
+      assert len(shp1) == len(shp2)
       f32 = F32Type.get()
-      element = FloatAttr.get(f32, 0.0)
-      tensor_type = RankedTensorType.get(sizes, f32)
-      attr = DenseElementsAttr.get_splat(tensor_type, element)
-      init_result = arith.ConstantOp(tensor_type, attr)
-      # Generate matmul operation.
-      op = linalg.matmul(input1, input2, outs=[init_result.result])
-      symbolTable[str(node.name)] = op
+      zero_element = FloatAttr.get(f32, 0.0)
+      if len(shp1) == 2:
+        # Infer the output sizes.
+        size1 = shp1[0]
+        size2 = shp2[1]
+        sizes = [size1, size2]
+        # Generate an output tensor for matmul operation.
+        # For example:
+        # `arith.constant dense<0.000000e+00> : tensor<3x3xf32>`
+        tensor_type = RankedTensorType.get(sizes, f32)
+        attr = DenseElementsAttr.get_splat(tensor_type, zero_element)
+        init_result = arith.ConstantOp(tensor_type, attr)
+        # Generate matmul operation.
+        op = linalg.matmul(input1, input2, outs=[init_result.result])
+        symbolTable[str(node.name)] = op
+      elif len(shp1) == 3:
+        size0 = shp1[0]
+        size1 = shp1[1]
+        size2 = shp2[2]
+        sizes = [size0, size1, size2]
+        tensor_type = RankedTensorType.get(sizes, f32)
+        attr = DenseElementsAttr.get_splat(tensor_type, zero_element)
+        init_result = arith.ConstantOp(tensor_type, attr)
+        op = linalg.batch_matmul(input1, input2, outs=[init_result.result])
+        symbolTable[str(node.name)] = op
+      else:
+        raise NotImplementedError
+
   if node.op == "output" :
     # Generating return operation.
     ret = symbolTable.get(str(node._args[0][0]))
@@ -102,6 +120,7 @@ def Lowering(module: Module):
   pm.add("func.func(convert-linalg-to-loops)")
   pm.add("convert-scf-to-cf")
   pm.add("convert-linalg-to-llvm")
+  pm.add("convert-arith-to-llvm")
   pm.add("expand-strided-metadata")
   pm.add("finalize-memref-to-llvm")
   pm.add("convert-func-to-llvm")


### PR DESCRIPTION
The latest version of MLIR has updated the parameter type of passmanager.run() from `Module` to `Operation` ([check the diff here](https://github.com/llvm/llvm-project/commit/c00f81cc46bd88b001110e9c6564c4848f82900c#diff-6abcbf190088332ad74803a7c2f77cb6a91f700fecbec2302ba4ce7f9a1cab5aL119)).
Also, `convert-memref-to-llvm` should be updated to `finalize-memref-to-llvm`, with `expand-strided-metadata` which should be called beforehand.