### PR TITLE
[build strategy] Add a one-step building strategy by using LLVM_EXTERNAL_PROJECTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,26 +29,44 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 option(LLVM_INCLUDE_TOOLS "Generate build targets for the LLVM tools." ON)
 option(LLVM_BUILD_TOOLS "Build the LLVM tools. If OFF, just generate build targets." ON)
+option(BUDDY_MLIR_OUT_OF_TREE_BUILD "Specifies an out of tree build" OFF)
 
-#-------------------------------------------------------------------------------
-# MLIR/LLVM Configuration
-#-------------------------------------------------------------------------------
-find_package(MLIR REQUIRED CONFIG)
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR OR BUDDY_MLIR_OUT_OF_TREE_BUILD)
+    message(STATUS "Buddy-mlir out-of-tree build.")
+    # Out-of-tree build
+    #-------------------------------------------------------------------------------
+    # MLIR/LLVM Configuration
+    #-------------------------------------------------------------------------------
+    find_package(MLIR REQUIRED CONFIG)
+    message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
+    message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
-set(LLVM_MLIR_BINARY_DIR ${MLIR_DIR}/../../../bin)
-set(LLVM_MLIR_SOURCE_DIR ${MLIR_DIR}/../../../../mlir)
-set(LLVM_PROJECT_SOURCE_DIR ${MLIR_DIR}/../../../../)
+    set(LLVM_MLIR_BINARY_DIR ${MLIR_DIR}/../../../bin)
+    set(LLVM_MLIR_SOURCE_DIR ${MLIR_DIR}/../../../../mlir)
+    set(LLVM_PROJECT_SOURCE_DIR ${MLIR_DIR}/../../../../)
 
-list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
-list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+    list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
+    list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 
-find_program(LLVM_TABLEGEN_EXE "llvm-tblgen" ${LLVM_TOOLS_BINARY_DIR}
-    NO_DEFAULT_PATH)
+    find_program(LLVM_TABLEGEN_EXE "llvm-tblgen" ${LLVM_TOOLS_BINARY_DIR}
+            NO_DEFAULT_PATH)
 
-include(TableGen)
-include(AddLLVM)
-include(AddMLIR)
-include(HandleLLVMOptions)
+    include(TableGen)
+    include(AddLLVM)
+    include(AddMLIR)
+    include(HandleLLVMOptions)
+else()
+    message(STATUS "Buddy-mlir in-tree build.")
+    # In-tree build with LLVM_EXTERNAL_PROJECTS=buddy-mlir
+    
+    set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir)
+    set(MLIR_INCLUDE_DIR ${LLVM_MAIN_SRC_DIR}/../mlir/include)
+    set(MLIR_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
+    set(LLVM_MLIR_BINARY_DIR ${CMAKE_BINARY_DIR}/bin)
+    set(MLIR_INCLUDE_DIRS "${MLIR_INCLUDE_DIR};${MLIR_GENERATED_INCLUDE_DIR}")
+    set(LLVM_PROJECT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/llvm")
+    set(LLVM_MLIR_SOURCE_DIR "${LLVM_MAIN_SRC_DIR}/../mlir")
+endif()
 
 #-------------------------------------------------------------------------------
 # BUDDY configuration
@@ -84,6 +102,17 @@ include_directories(${BUDDY_SOURCE_DIR}/frontend/Interfaces)
 # Add MLIR and LLVM headers to the include path
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})
+
+# Configure CMake.
+list(APPEND CMAKE_MODULE_PATH ${MLIR_MAIN_SRC_DIR}/cmake/modules)
+list(APPEND CMAKE_MODULE_PATH ${LLVM_MAIN_SRC_DIR}/cmake)
+
+find_program(LLVM_TABLEGEN_EXE "llvm-tblgen" ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH)
+
+include(TableGen)
+include(AddLLVM)
+include(AddMLIR)
+include(HandleLLVMOptions)
 
 #-------------------------------------------------------------------------------
 # Hardware detection

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,8 @@ option(LLVM_BUILD_TOOLS "Build the LLVM tools. If OFF, just generate build targe
 option(BUDDY_MLIR_OUT_OF_TREE_BUILD "Specifies an out of tree build" OFF)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR OR BUDDY_MLIR_OUT_OF_TREE_BUILD)
-    message(STATUS "Buddy-mlir out-of-tree build.")
-    # Out-of-tree build
+    message(STATUS "buddy-mlir two-step build.")
+    # Two-step build
     #-------------------------------------------------------------------------------
     # MLIR/LLVM Configuration
     #-------------------------------------------------------------------------------
@@ -56,8 +56,11 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR OR BUDDY_MLIR_OUT_OF_TREE_
     include(AddMLIR)
     include(HandleLLVMOptions)
 else()
-    message(STATUS "Buddy-mlir in-tree build.")
-    # In-tree build with LLVM_EXTERNAL_PROJECTS=buddy-mlir
+    message(STATUS "buddy-mlir one-step build.")
+    # one-step build with LLVM_EXTERNAL_PROJECTS=buddy-mlir
+    #-------------------------------------------------------------------------------
+    # MLIR/LLVM Configuration
+    #-------------------------------------------------------------------------------
     
     set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir)
     set(MLIR_INCLUDE_DIR ${LLVM_MAIN_SRC_DIR}/../mlir/include)
@@ -74,6 +77,7 @@ endif()
 
 # BUDDY project.
 set(BUDDY_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(BUDDY_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(BUDDY_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/bin)
 set(BUDDY_EXAMPLES_DIR ${BUDDY_SOURCE_DIR}/examples)
 set(BUDDY_MIDEND_INCLUDE_DIR ${BUDDY_SOURCE_DIR}/midend/include/)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ $ cmake -G Ninja -Bbuild \
     -DLLVM_ENABLE_ASSERTIONS=ON \
     -DCMAKE_BUILD_TYPE=RELEASE \
     llvm/llvm
+$ cd build
 $ ninja check-mlir check-clang
 $ ninja
 $ ninja check-buddy

--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ $ ninja
 $ ninja check-buddy
 ```
 
+### Build One Step
+
+```
+$ cmake -G Ninja -Bbuild \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DLLVM_ENABLE_PROJECTS="mlir;clang" \
+    -DLLVM_TARGETS_TO_BUILD="host;RISCV" \
+    -DLLVM_EXTERNAL_PROJECTS="buddy-mlir" \
+    -DLLVM_EXTERNAL_BUDDY_MLIR_SOURCE_DIR="$PWD" \
+    -DLLVM_ENABLE_ASSERTIONS=ON \
+    -DCMAKE_BUILD_TYPE=RELEASE \
+    llvm/llvm
+$ ninja check-mlir check-clang
+$ ninja
+$ ninja check-buddy
+```
+
 If you want to add domain-specific framework support, please add the following cmake options:
 
 | Framework  | Enable Option | Other Options |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ MLIR-Based Ideas Landing Project ([Project page](https://buddy-compiler.github.i
 
 Two building strategies are provided: one-step building strategy and two-step building strategy. The one-step building strategy uses buddy-mlir as an external library, while the two-step building strategy uses LLVM/MLIR as an external library. 
 
-**However, the one-step building strategy is currently not compatible with buddy-benchmark targets and buddy-mlir examples, so our default building strategy is still the two-step one, and users of the one-step strategy are only those who use our toolchain in their own projects.**
+**However, the one-step building strategy is currently not compatible with [buddy-benchmark targets](https://github.com/buddy-compiler/buddy-benchmark) and [buddy-mlir examples](https://github.com/buddy-compiler/buddy-mlir/tree/main/examples), so our default building strategy is still the two-step one, and users of the one-step strategy are only those who use our toolchain in their own projects.**
 
 ### LLVM/MLIR Dependencies
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ MLIR-Based Ideas Landing Project ([Project page](https://buddy-compiler.github.i
 
 ## Getting Started
 
+Two building strategies are provided: one-step building strategy and two-step building strategy. The one-step building strategy uses buddy-mlir as an external library, while the two-step building strategy uses LLVM/MLIR as an external library. 
+
 ### LLVM/MLIR Dependencies
 
-This project uses LLVM/MLIR as an external library. Please make sure [the dependencies](https://llvm.org/docs/GettingStarted.html#requirements) are available
+Before building, please make sure [the dependencies](https://llvm.org/docs/GettingStarted.html#requirements) are available
 on your machine.
 
 ### Clone and Initialize
-
 
 ```
 $ git clone git@github.com:buddy-compiler/buddy-mlir.git
@@ -18,7 +19,30 @@ $ cd buddy-mlir
 $ git submodule update --init
 ```
 
-### Build and Test LLVM/MLIR/CLANG
+### One-step building strategy
+
+If you have not previously built llvm-project and you want to use buddy-mlir as an external library, you can follow these commands to build llvm-project as well as buddy-mlir.
+
+```
+$ cmake -G Ninja -Bbuild \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DLLVM_ENABLE_PROJECTS="mlir;clang" \
+    -DLLVM_TARGETS_TO_BUILD="host;RISCV" \
+    -DLLVM_EXTERNAL_PROJECTS="buddy-mlir" \
+    -DLLVM_EXTERNAL_BUDDY_MLIR_SOURCE_DIR="$PWD" \
+    -DLLVM_ENABLE_ASSERTIONS=ON \
+    -DCMAKE_BUILD_TYPE=RELEASE \
+    llvm/llvm
+$ ninja check-mlir check-clang
+$ ninja
+$ ninja check-buddy
+```
+
+### Two-step building strategy
+
+If you have not previously built llvm-project and you want to use LLVM/MLIR as an external library, you can follow these steps to build llvm-project first, and then build buddy-mlir.
+
+#### Build and Test LLVM/MLIR/CL
 
 ```
 $ cd buddy-mlir
@@ -53,7 +77,10 @@ $ cmake -G Ninja ../llvm \
     -DLLVM_ENABLE_ASSERTIONS=ON \
     -DCMAKE_BUILD_TYPE=RELEASE
 ```
-### Build buddy-mlir
+
+#### Build buddy-mlir
+
+If you have previously built the llvm-project, you can replace the $PWD with the path to the directory where you have successfully built the llvm-project.
 
 ```
 $ cd buddy-mlir
@@ -64,23 +91,6 @@ $ cmake -G Ninja .. \
     -DLLVM_DIR=$PWD/../llvm/build/lib/cmake/llvm \
     -DLLVM_ENABLE_ASSERTIONS=ON \
     -DCMAKE_BUILD_TYPE=RELEASE
-$ ninja
-$ ninja check-buddy
-```
-
-### Build One Step
-
-```
-$ cmake -G Ninja -Bbuild \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DLLVM_ENABLE_PROJECTS="mlir;clang" \
-    -DLLVM_TARGETS_TO_BUILD="host;RISCV" \
-    -DLLVM_EXTERNAL_PROJECTS="buddy-mlir" \
-    -DLLVM_EXTERNAL_BUDDY_MLIR_SOURCE_DIR="$PWD" \
-    -DLLVM_ENABLE_ASSERTIONS=ON \
-    -DCMAKE_BUILD_TYPE=RELEASE \
-    llvm/llvm
-$ ninja check-mlir check-clang
 $ ninja
 $ ninja check-buddy
 ```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ MLIR-Based Ideas Landing Project ([Project page](https://buddy-compiler.github.i
 
 Two building strategies are provided: one-step building strategy and two-step building strategy. The one-step building strategy uses buddy-mlir as an external library, while the two-step building strategy uses LLVM/MLIR as an external library. 
 
+**However, the one-step building strategy is currently not compatible with buddy-benchmark targets and buddy-mlir examples, so our default building strategy is still the two-step one, and users of the one-step strategy are only those who use our toolchain in their own projects.**
+
 ### LLVM/MLIR Dependencies
 
 Before building, please make sure [the dependencies](https://llvm.org/docs/GettingStarted.html#requirements) are available

--- a/backend/llvm/lib/Target/RISCV/CMakeLists.txt
+++ b/backend/llvm/lib/Target/RISCV/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-# Helper functions and variables.
+# Helper functions macro and variables.
 # ------------------------------------------------------------------------------
 function(copy_file_to_build_dir src_dir output_dir file)
   set(src ${src_dir}/${file})
@@ -9,6 +9,17 @@ function(copy_file_to_build_dir src_dir output_dir file)
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${src} ${dst}
     COMMENT "Copying RISCV Target - ${file}...")
 endfunction(copy_file_to_build_dir)
+
+# The macro helps to find the correct path of "IntrinsicsRISCV.h"
+macro(buddy_add_llvm_target target_name)
+  include_directories(BEFORE
+    ${BUDDY_BUILD_DIR}/backend/include/
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+  add_llvm_component_library(LLVM${target_name} ${ARGN})
+  set( CURRENT_LLVM_TARGET LLVM${target_name} )
+endmacro(buddy_add_llvm_target)
 
 set(LLVM_TARGET_RISCV_DIR ${LLVM_PROJECT_SOURCE_DIR}/llvm/lib/Target/RISCV)
 
@@ -65,7 +76,7 @@ foreach(file ${UPSTREAM_LLVM_TARGET_RISCV_GISEL_FILE})
 endforeach()
 
 # Build BuddyRISCVCodeGen target.
-add_llvm_target(BuddyRISCVCodeGen
+buddy_add_llvm_target(BuddyRISCVCodeGen
   ${CMAKE_CURRENT_BINARY_DIR}/RISCVAsmPrinter.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/RISCVCodeGenPrepare.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/RISCVMakeCompressible.cpp

--- a/backend/llvm/lib/Target/RISCV/CMakeLists.txt
+++ b/backend/llvm/lib/Target/RISCV/CMakeLists.txt
@@ -38,7 +38,7 @@ tablegen(LLVM RISCVGenRegisterInfo.inc -gen-register-info)
 tablegen(LLVM RISCVGenSearchableTables.inc -gen-searchable-tables)
 tablegen(LLVM RISCVGenSubtargetInfo.inc -gen-subtarget)
 
-add_public_tablegen_target(RISCVCommonTableGen)
+add_public_tablegen_target(RISCVBuddyCommonTableGen)
 
 # ------------------------------------------------------------------------------
 # Build RISC-V Buddy Extension CodeGen.

--- a/examples/lit.site.cfg.py.in
+++ b/examples/lit.site.cfg.py.in
@@ -50,4 +50,4 @@ import lit.llvm
 lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
-lit_config.load_config(config, "@CMAKE_SOURCE_DIR@/examples/lit.cfg.py")
+lit_config.load_config(config, "@PROJECT_SOURCE_DIR@/examples/lit.cfg.py")

--- a/frontend/Interfaces/lib/CMakeLists.txt
+++ b/frontend/Interfaces/lib/CMakeLists.txt
@@ -11,7 +11,7 @@ elseif(HAVE_NEON)
 endif()
 
 add_custom_command(OUTPUT DIP.o
-  COMMAND ${BUDDY_BINARY_DIR}/buddy-opt ${CMAKE_CURRENT_SOURCE_DIR}/DIP.mlir 
+  COMMAND ${CMAKE_BINARY_DIR}/bin/buddy-opt ${CMAKE_CURRENT_SOURCE_DIR}/DIP.mlir 
               -lower-dip="DIP-strip-mining=${SPLITING_SIZE}" 
               -arith-expand
               -lower-affine

--- a/midend/lib/Conversion/ConvVectorization/CMakeLists.txt
+++ b/midend/lib/Conversion/ConvVectorization/CMakeLists.txt
@@ -4,5 +4,5 @@ add_mlir_library(CBConvVectorization
   PoolingVectorization.cpp
   
   LINK_LIBS PUBLIC
-  Utils
+  BuddyUtils
   )

--- a/midend/lib/Conversion/LowerDIP/CMakeLists.txt
+++ b/midend/lib/Conversion/LowerDIP/CMakeLists.txt
@@ -2,5 +2,5 @@ add_mlir_library(LowerDIPPass
   LowerDIPPass.cpp
 
   LINK_LIBS PUBLIC
-  DIPUtils
+  BuddyDIPUtils
   )

--- a/midend/lib/Utils/CMakeLists.txt
+++ b/midend/lib/Utils/CMakeLists.txt
@@ -1,3 +1,15 @@
+add_mlir_library(BuddyUtils
+  Utils.cpp
+  DIPUtils.cpp
+  )
+
+add_mlir_library(BuddyDIPUtils
+  DIPUtils.cpp
+  
+  LINK_LIBS PUBLIC
+  BuddyUtils
+  )
+
 add_library(Utils Utils.cpp)
 
 add_library(DIPUtils DIPUtils.cpp)

--- a/midend/lib/Utils/CMakeLists.txt
+++ b/midend/lib/Utils/CMakeLists.txt
@@ -9,11 +9,3 @@ add_mlir_library(BuddyDIPUtils
   LINK_LIBS PUBLIC
   BuddyUtils
   )
-
-add_library(Utils Utils.cpp)
-
-add_library(DIPUtils DIPUtils.cpp)
-target_link_libraries(DIPUtils
-  PRIVATE
-  Utils
-  )

--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -47,7 +47,7 @@ config.test_source_root = os.path.dirname(__file__)
 
 # test_exec_root: The root path where tests should be run.
 config.test_exec_root = os.path.join(config.buddy_obj_root, 'tests')
-config.buddy_tools_dir = os.path.join(config.buddy_obj_root, 'bin')
+# config.buddy_tools_dir = os.path.join(config.buddy_obj_root, 'bin')
 
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)

--- a/tests/lit.site.cfg.py.in
+++ b/tests/lit.site.cfg.py.in
@@ -31,6 +31,7 @@ config.llvm_host_triple = '@LLVM_HOST_TRIPLE@'
 config.host_arch = "@HOST_ARCH@"
 config.buddy_src_root = "@CMAKE_SOURCE_DIR@"
 config.buddy_obj_root = "@CMAKE_BINARY_DIR@"
+config.buddy_tools_dir = "@BUDDY_BINARY_DIR@"
 config.buddy_enable_opencv = "@BUDDY_ENABLE_OPENCV@"
 config.mlir_runner_utils_dir = "@LLVM_LIBS_DIR@"
 
@@ -50,4 +51,4 @@ import lit.llvm
 lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
-lit_config.load_config(config, "@CMAKE_SOURCE_DIR@/tests/lit.cfg.py")
+lit_config.load_config(config, "@PROJECT_SOURCE_DIR@/tests/lit.cfg.py")


### PR DESCRIPTION
The PR is a solution for https://github.com/buddy-compiler/buddy-mlir/issues/132, I suppose a one-step building strategy by using LLVM_EXTERNAL_PROJECTS. 

It is implemented with reference to the build strategy of torch-mlir(https://github.com/llvm/torch-mlir/blob/0cf9ee340bc3264922e03b0df002e41c69184702/docs/development.md#building-torch-mlir-in-tree).

For one-step build, you can use the following commands:

```shell
$ cd buddy-mlir
$ git submodule update --init
$ cmake -G Ninja -Bbuild \
    -DCMAKE_BUILD_TYPE=Release \
    -DLLVM_ENABLE_PROJECTS="mlir;clang" \
    -DLLVM_TARGETS_TO_BUILD="host;RISCV" \
    -DLLVM_EXTERNAL_PROJECTS="buddy-mlir" \
    -DLLVM_EXTERNAL_BUDDY_MLIR_SOURCE_DIR="$PWD" \
    -DLLVM_ENABLE_ASSERTIONS=ON \
    -DCMAKE_BUILD_TYPE=RELEASE \
    llvm/llvm
$ ninja check-mlir check-clang
$ ninja
$ ninja check-buddy
```
For two-step build, the commands are the same as before.