### PR TITLE
[Examples][TOSA] Bug in TOSA examples

### DIFF
--- a/examples/MLIRTOSA/makefile
+++ b/examples/MLIRTOSA/makefile
@@ -73,125 +73,220 @@ tosa-resize-run:
 
 tosa-sigmoid-lower:
 	@${MLIR_OPT} ./tosa-sigmoid.mlir \
-		-pass-pipeline="func.func(tosa-to-linalg)" \
-		-arith-bufferize  -tensor-bufferize -linalg-bufferize \
-		-func-bufferize -buffer-deallocation -convert-linalg-to-loops \
-		-convert-scf-to-cf -convert-linalg-to-llvm  \
-		-finalize-memref-to-llvm -convert-math-to-llvm  -convert-func-to-llvm \
-		-reconcile-unrealized-casts \
-		-o ./log.mlir
+		-pass-pipeline="builtin.module( \
+			func.func(tosa-to-linalg), \
+			empty-tensor-to-alloc-tensor, \
+			arith-bufferize, \
+			func.func(tensor-bufferize, linalg-bufferize), \
+			func-bufferize, \
+			func.func(buffer-deallocation, convert-linalg-to-loops), \
+			convert-scf-to-cf, \
+			convert-linalg-to-llvm, \
+			finalize-memref-to-llvm, \
+			convert-math-to-llvm, \
+			convert-func-to-llvm, \
+			reconcile-unrealized-casts \
+		)" \
+		-o ./log.mlir		
 
 tosa-sigmoid-translate:
 	@${MLIR_OPT} ./tosa-sigmoid.mlir \
-		-pass-pipeline="func.func(tosa-to-linalg)" \
-		-arith-bufferize  -tensor-bufferize -linalg-bufferize \
-		-func-bufferize -buffer-deallocation -convert-linalg-to-loops \
-		-convert-scf-to-cf -convert-linalg-to-llvm  \
-		-finalize-memref-to-llvm -convert-math-to-llvm  -convert-func-to-llvm \
-		-reconcile-unrealized-casts | \
+		-pass-pipeline="builtin.module( \
+			func.func(tosa-to-linalg), \
+			empty-tensor-to-alloc-tensor, \
+			arith-bufferize, \
+			func.func(tensor-bufferize, linalg-bufferize), \
+			func-bufferize, \
+			func.func(buffer-deallocation, convert-linalg-to-loops), \
+			convert-scf-to-cf, \
+			convert-linalg-to-llvm, \
+			finalize-memref-to-llvm, \
+			convert-math-to-llvm, \
+			convert-func-to-llvm, \
+			reconcile-unrealized-casts \
+		)" | \
 	${MLIR_TRANSLATE} --mlir-to-llvmir -o log.ll
 
 tosa-sigmoid-run:
 	@${MLIR_OPT} ./tosa-sigmoid.mlir \
-		-pass-pipeline="func.func(tosa-to-linalg)" \
-		-arith-bufferize  -tensor-bufferize -linalg-bufferize \
-		-func-bufferize -buffer-deallocation -convert-linalg-to-loops \
-		-convert-scf-to-cf -convert-linalg-to-llvm  \
-		-finalize-memref-to-llvm -convert-math-to-llvm  -convert-func-to-llvm \
-		-reconcile-unrealized-casts | \
+		-pass-pipeline="builtin.module( \
+			func.func(tosa-to-linalg), \
+			empty-tensor-to-alloc-tensor, \
+			arith-bufferize, \
+			func.func(tensor-bufferize, linalg-bufferize), \
+			func-bufferize, \
+			func.func(buffer-deallocation, convert-linalg-to-loops), \
+			convert-scf-to-cf, \
+			convert-linalg-to-llvm, \
+			finalize-memref-to-llvm, \
+			convert-math-to-llvm, \
+			convert-func-to-llvm, \
+			reconcile-unrealized-casts \
+		)" | \
 	${MLIR_CPU_RUNNER} ${OPT_FLAG} -e main -entry-point-result=void \
 		-shared-libs=${MLIR_RUNNER_UTILS} -shared-libs=${MLIR_C_RUNNER_UTILS}
 
-
 tosa-log-lower:
 	@${MLIR_OPT} ./tosa-log.mlir \
-		-pass-pipeline="func.func(tosa-to-linalg)" \
-		-arith-bufferize  -tensor-bufferize -linalg-bufferize \
-		-func-bufferize -buffer-deallocation -convert-linalg-to-loops \
-		-convert-scf-to-cf -convert-linalg-to-llvm  \
-		-finalize-memref-to-llvm -convert-math-to-llvm  -convert-func-to-llvm \
-		-reconcile-unrealized-casts \
+		-pass-pipeline="builtin.module( \
+			func.func(tosa-to-linalg), \
+			empty-tensor-to-alloc-tensor, \
+			arith-bufferize, \
+			func.func(tensor-bufferize, linalg-bufferize), \
+			func-bufferize, \
+			func.func(buffer-deallocation, convert-linalg-to-loops), \
+			convert-scf-to-cf, \
+			convert-linalg-to-llvm, \
+			finalize-memref-to-llvm, \
+			convert-math-to-llvm, \
+			convert-func-to-llvm, \
+			reconcile-unrealized-casts \
+		)" \
 		-o ./log.mlir
 
 tosa-log-translate:
 	@${MLIR_OPT} ./tosa-log.mlir \
-		-pass-pipeline="func.func(tosa-to-linalg)" \
-		-arith-bufferize  -tensor-bufferize -linalg-bufferize \
-		-func-bufferize -buffer-deallocation -convert-linalg-to-loops \
-		-convert-scf-to-cf -convert-linalg-to-llvm  \
-		-finalize-memref-to-llvm -convert-math-to-llvm  -convert-func-to-llvm \
-		-reconcile-unrealized-casts | \
+		-pass-pipeline="builtin.module( \
+			func.func(tosa-to-linalg), \
+			empty-tensor-to-alloc-tensor, \
+			arith-bufferize, \
+			func.func(tensor-bufferize, linalg-bufferize), \
+			func-bufferize, \
+			func.func(buffer-deallocation, convert-linalg-to-loops), \
+			convert-scf-to-cf, \
+			convert-linalg-to-llvm, \
+			finalize-memref-to-llvm, \
+			convert-math-to-llvm, \
+			convert-func-to-llvm, \
+			reconcile-unrealized-casts \
+		)" | \
 	${MLIR_TRANSLATE} --mlir-to-llvmir -o log.ll
 
 tosa-log-run:
 	@${MLIR_OPT} ./tosa-log.mlir \
-		-pass-pipeline="func.func(tosa-to-linalg)" \
-		-arith-bufferize  -tensor-bufferize -linalg-bufferize \
-		-func-bufferize -buffer-deallocation -convert-linalg-to-loops \
-		-convert-scf-to-cf -convert-linalg-to-llvm  \
-		-finalize-memref-to-llvm -convert-math-to-llvm  -convert-func-to-llvm \
-		-reconcile-unrealized-casts | \
+		-pass-pipeline="builtin.module( \
+			func.func(tosa-to-linalg), \
+			empty-tensor-to-alloc-tensor, \
+			arith-bufferize, \
+			func.func(tensor-bufferize, linalg-bufferize), \
+			func-bufferize, \
+			func.func(buffer-deallocation, convert-linalg-to-loops), \
+			convert-scf-to-cf, \
+			convert-linalg-to-llvm, \
+			finalize-memref-to-llvm, \
+			convert-math-to-llvm, \
+			convert-func-to-llvm, \
+			reconcile-unrealized-casts \
+		)" | \
 	${MLIR_CPU_RUNNER} ${OPT_FLAG} -e main -entry-point-result=void \
-		-shared-libs=${MLIR_RUNNER_UTILS} -shared-libs=${MLIR_C_RUNNER_UTILS}
+		-shared-libs=${MLIR_RUNNER_UTILS} -shared-libs=${MLIR_C_RUNNER_UTILS}		
 
 tosa-add-lower:
 	@${MLIR_OPT} ./tosa-add.mlir \
-		-pass-pipeline="func.func(tosa-to-linalg)" \
-		-arith-bufferize  -tensor-bufferize -linalg-bufferize \
-		-func-bufferize -buffer-deallocation -convert-linalg-to-loops \
-		-convert-scf-to-cf -convert-linalg-to-llvm  \
-		-finalize-memref-to-llvm -convert-math-to-llvm  -convert-func-to-llvm \
-		-reconcile-unrealized-casts \
+		-pass-pipeline="builtin.module( \
+			func.func(tosa-to-linalg), \
+			empty-tensor-to-alloc-tensor, \
+			arith-bufferize, \
+			func.func(tensor-bufferize, linalg-bufferize), \
+			func-bufferize, \
+			func.func(buffer-deallocation, convert-linalg-to-loops), \
+			convert-scf-to-cf, \
+			convert-linalg-to-llvm, \
+			finalize-memref-to-llvm, \
+			convert-math-to-llvm, \
+			convert-func-to-llvm, \
+			reconcile-unrealized-casts \
+		)" \
 		-o ./log.mlir
 
 tosa-add-translate:
 	@${MLIR_OPT} ./tosa-add.mlir \
-		-pass-pipeline="func.func(tosa-to-linalg)" \
-		-arith-bufferize  -tensor-bufferize -linalg-bufferize \
-		-func-bufferize -buffer-deallocation -convert-linalg-to-loops \
-		-convert-scf-to-cf -convert-linalg-to-llvm  \
-		-finalize-memref-to-llvm -convert-math-to-llvm  -convert-func-to-llvm \
-		-reconcile-unrealized-casts | \
+		-pass-pipeline="builtin.module( \
+			func.func(tosa-to-linalg), \
+			empty-tensor-to-alloc-tensor, \
+			arith-bufferize, \
+			func.func(tensor-bufferize, linalg-bufferize), \
+			func-bufferize, \
+			func.func(buffer-deallocation, convert-linalg-to-loops), \
+			convert-scf-to-cf, \
+			convert-linalg-to-llvm, \
+			finalize-memref-to-llvm, \
+			convert-math-to-llvm, \
+			convert-func-to-llvm, \
+			reconcile-unrealized-casts \
+		)" | \
 	${MLIR_TRANSLATE} --mlir-to-llvmir -o log.ll
 
 tosa-add-run:
 	@${MLIR_OPT} ./tosa-add.mlir \
-		-pass-pipeline="func.func(tosa-to-linalg)" \
-		-arith-bufferize  -tensor-bufferize -linalg-bufferize \
-		-func-bufferize -buffer-deallocation -convert-linalg-to-loops \
-		-convert-scf-to-cf -convert-linalg-to-llvm  \
-		-finalize-memref-to-llvm -convert-math-to-llvm  -convert-func-to-llvm \
-		-reconcile-unrealized-casts | \
+		-pass-pipeline="builtin.module( \
+			func.func(tosa-to-linalg), \
+			empty-tensor-to-alloc-tensor, \
+			arith-bufferize, \
+			func.func(tensor-bufferize, linalg-bufferize), \
+			func-bufferize, \
+			func.func(buffer-deallocation, convert-linalg-to-loops), \
+			convert-scf-to-cf, \
+			convert-linalg-to-llvm, \
+			finalize-memref-to-llvm, \
+			convert-math-to-llvm, \
+			convert-func-to-llvm, \
+			reconcile-unrealized-casts \
+		)" | \
 	${MLIR_CPU_RUNNER} ${OPT_FLAG} -e main -entry-point-result=void \
 		-shared-libs=${MLIR_RUNNER_UTILS} -shared-libs=${MLIR_C_RUNNER_UTILS}
 
 tosa-concat-lower:
 	@${MLIR_OPT} ./tosa-concat.mlir \
-		-pass-pipeline="func.func(tosa-to-linalg)" \
-		-arith-bufferize  -tensor-bufferize -linalg-bufferize \
-		-func-bufferize -buffer-deallocation -convert-linalg-to-loops \
-		-convert-scf-to-cf -convert-linalg-to-llvm  \
-		-finalize-memref-to-llvm -convert-math-to-llvm  -convert-func-to-llvm \
-		-reconcile-unrealized-casts \
+		-pass-pipeline="builtin.module( \
+			func.func(tosa-to-linalg), \
+			empty-tensor-to-alloc-tensor, \
+			arith-bufferize, \
+			func.func(tensor-bufferize, linalg-bufferize), \
+			func-bufferize, \
+			func.func(buffer-deallocation, convert-linalg-to-loops), \
+			convert-scf-to-cf, \
+			convert-linalg-to-llvm, \
+			finalize-memref-to-llvm, \
+			convert-math-to-llvm, \
+			convert-func-to-llvm, \
+			reconcile-unrealized-casts \
+		)" \
 		-o ./log.mlir
 
 tosa-concat-translate:
 	@${MLIR_OPT} ./tosa-concat.mlir \
-		-pass-pipeline="func.func(tosa-to-linalg)" \
-		-arith-bufferize  -tensor-bufferize -linalg-bufferize \
-		-func-bufferize -buffer-deallocation -convert-linalg-to-loops \
-		-convert-scf-to-cf -convert-linalg-to-llvm  \
-		-finalize-memref-to-llvm -convert-math-to-llvm  -convert-func-to-llvm \
-		-reconcile-unrealized-casts | \
+		-pass-pipeline="builtin.module( \
+			func.func(tosa-to-linalg), \
+			empty-tensor-to-alloc-tensor, \
+			arith-bufferize, \
+			func.func(tensor-bufferize, linalg-bufferize), \
+			func-bufferize, \
+			func.func(buffer-deallocation, convert-linalg-to-loops), \
+			convert-scf-to-cf, \
+			convert-linalg-to-llvm, \
+			finalize-memref-to-llvm, \
+			convert-math-to-llvm, \
+			convert-func-to-llvm, \
+			reconcile-unrealized-casts \
+		)" | \
 	${MLIR_TRANSLATE} --mlir-to-llvmir -o log.ll
 
 tosa-concat-run:
 	@${MLIR_OPT} ./tosa-concat.mlir \
-		-pass-pipeline="func.func(tosa-to-linalg)" \
-		-arith-bufferize  -tensor-bufferize -linalg-bufferize \
-		-func-bufferize -buffer-deallocation -convert-linalg-to-loops \
-		-convert-scf-to-cf -convert-linalg-to-llvm  \
-		-finalize-memref-to-llvm -convert-math-to-llvm  -convert-func-to-llvm \
-		-reconcile-unrealized-casts | \
+		-pass-pipeline="builtin.module( \
+			func.func(tosa-to-linalg), \
+			empty-tensor-to-alloc-tensor, \
+			arith-bufferize, \
+			func.func(tensor-bufferize, linalg-bufferize), \
+			func-bufferize, \
+			func.func(buffer-deallocation, convert-linalg-to-loops), \
+			convert-scf-to-cf, \
+			convert-linalg-to-llvm, \
+			finalize-memref-to-llvm, \
+			convert-math-to-llvm, \
+			convert-func-to-llvm, \
+			reconcile-unrealized-casts \
+		)" | \
 	${MLIR_CPU_RUNNER} ${OPT_FLAG} -e main -entry-point-result=void \
 		-shared-libs=${MLIR_RUNNER_UTILS} -shared-libs=${MLIR_C_RUNNER_UTILS}

--- a/examples/MLIRTOSA/makefile
+++ b/examples/MLIRTOSA/makefile
@@ -179,7 +179,7 @@ tosa-log-run:
 			reconcile-unrealized-casts \
 		)" | \
 	${MLIR_CPU_RUNNER} ${OPT_FLAG} -e main -entry-point-result=void \
-		-shared-libs=${MLIR_RUNNER_UTILS} -shared-libs=${MLIR_C_RUNNER_UTILS}		
+		-shared-libs=${MLIR_RUNNER_UTILS} -shared-libs=${MLIR_C_RUNNER_UTILS}
 
 tosa-add-lower:
 	@${MLIR_OPT} ./tosa-add.mlir \

--- a/examples/MLIRTOSA/makefile
+++ b/examples/MLIRTOSA/makefile
@@ -27,7 +27,7 @@ tosa-resize-lower:
 			func.func(buffer-deallocation, convert-linalg-to-loops), \
 			convert-scf-to-cf, \
 			convert-linalg-to-llvm, \
-			convert-memref-to-llvm, \
+			finalize-memref-to-llvm, \
 			convert-math-to-llvm, \
 			convert-func-to-llvm, \
 			reconcile-unrealized-casts \
@@ -45,7 +45,7 @@ tosa-resize-translate:
 			func.func(buffer-deallocation, convert-linalg-to-loops), \
 			convert-scf-to-cf, \
 			convert-linalg-to-llvm, \
-			convert-memref-to-llvm, \
+			finalize-memref-to-llvm, \
 			convert-math-to-llvm, \
 			convert-func-to-llvm, \
 			reconcile-unrealized-casts \
@@ -63,7 +63,7 @@ tosa-resize-run:
 			func.func(buffer-deallocation, convert-linalg-to-loops), \
 			convert-scf-to-cf, \
 			convert-linalg-to-llvm, \
-			convert-memref-to-llvm, \
+			finalize-memref-to-llvm, \
 			convert-math-to-llvm, \
 			convert-func-to-llvm, \
 			reconcile-unrealized-casts \

--- a/examples/MLIRTOSA/makefile
+++ b/examples/MLIRTOSA/makefile
@@ -184,7 +184,7 @@ tosa-log-run:
 tosa-add-lower:
 	@${MLIR_OPT} ./tosa-add.mlir \
 		-pass-pipeline="builtin.module( \
-			func.func(tosa-to-linalg), \
+			func.func(tosa-to-linalg, tosa-to-tensor), \
 			empty-tensor-to-alloc-tensor, \
 			arith-bufferize, \
 			func.func(tensor-bufferize, linalg-bufferize), \
@@ -202,7 +202,7 @@ tosa-add-lower:
 tosa-add-translate:
 	@${MLIR_OPT} ./tosa-add.mlir \
 		-pass-pipeline="builtin.module( \
-			func.func(tosa-to-linalg), \
+			func.func(tosa-to-linalg, tosa-to-tensor), \
 			empty-tensor-to-alloc-tensor, \
 			arith-bufferize, \
 			func.func(tensor-bufferize, linalg-bufferize), \
@@ -220,7 +220,7 @@ tosa-add-translate:
 tosa-add-run:
 	@${MLIR_OPT} ./tosa-add.mlir \
 		-pass-pipeline="builtin.module( \
-			func.func(tosa-to-linalg), \
+			func.func(tosa-to-linalg, tosa-to-tensor), \
 			empty-tensor-to-alloc-tensor, \
 			arith-bufferize, \
 			func.func(tensor-bufferize, linalg-bufferize), \
@@ -239,7 +239,7 @@ tosa-add-run:
 tosa-concat-lower:
 	@${MLIR_OPT} ./tosa-concat.mlir \
 		-pass-pipeline="builtin.module( \
-			func.func(tosa-to-linalg), \
+			func.func(tosa-to-linalg, tosa-to-tensor), \
 			empty-tensor-to-alloc-tensor, \
 			arith-bufferize, \
 			func.func(tensor-bufferize, linalg-bufferize), \
@@ -247,6 +247,7 @@ tosa-concat-lower:
 			func.func(buffer-deallocation, convert-linalg-to-loops), \
 			convert-scf-to-cf, \
 			convert-linalg-to-llvm, \
+			expand-strided-metadata, \
 			finalize-memref-to-llvm, \
 			convert-math-to-llvm, \
 			convert-func-to-llvm, \
@@ -257,7 +258,7 @@ tosa-concat-lower:
 tosa-concat-translate:
 	@${MLIR_OPT} ./tosa-concat.mlir \
 		-pass-pipeline="builtin.module( \
-			func.func(tosa-to-linalg), \
+			func.func(tosa-to-linalg, tosa-to-tensor), \
 			empty-tensor-to-alloc-tensor, \
 			arith-bufferize, \
 			func.func(tensor-bufferize, linalg-bufferize), \
@@ -265,6 +266,7 @@ tosa-concat-translate:
 			func.func(buffer-deallocation, convert-linalg-to-loops), \
 			convert-scf-to-cf, \
 			convert-linalg-to-llvm, \
+			expand-strided-metadata, \
 			finalize-memref-to-llvm, \
 			convert-math-to-llvm, \
 			convert-func-to-llvm, \
@@ -275,7 +277,7 @@ tosa-concat-translate:
 tosa-concat-run:
 	@${MLIR_OPT} ./tosa-concat.mlir \
 		-pass-pipeline="builtin.module( \
-			func.func(tosa-to-linalg), \
+			func.func(tosa-to-linalg, tosa-to-tensor), \
 			empty-tensor-to-alloc-tensor, \
 			arith-bufferize, \
 			func.func(tensor-bufferize, linalg-bufferize), \
@@ -283,6 +285,7 @@ tosa-concat-run:
 			func.func(buffer-deallocation, convert-linalg-to-loops), \
 			convert-scf-to-cf, \
 			convert-linalg-to-llvm, \
+			expand-strided-metadata, \
 			finalize-memref-to-llvm, \
 			convert-math-to-llvm, \
 			convert-func-to-llvm, \

--- a/examples/MLIRTOSA/tosa-resize.mlir
+++ b/examples/MLIRTOSA/tosa-resize.mlir
@@ -2,6 +2,7 @@ func.func @main() {
   %input = arith.constant dense<[[[[1.0], [2.0]],[[3.0], [4.0]]]]> : tensor<1x2x2x1xf32>
   %output = "tosa.resize"(%input) {
     scale = array<i64 : 4, 2, 4, 2>, output_size = [4, 4], stride = [0, 0], offset = array<i64 : 0, 0>, 
+    stride_fp = [0.5 : f32, 0.5 : f32], offset_fp = [0.1 : f32, 0.2 : f32], shift = 0 : i32, 
     border = array<i64 : 0, 0>, mode = "NEAREST_NEIGHBOR"} : (tensor<1x2x2x1xf32>) -> (tensor<1x4x4x1xf32>) 
   %tensor_unranked = tensor.cast %output : tensor<1x4x4x1xf32> to tensor<*xf32>
   call @printMemrefF32(%tensor_unranked) : (tensor<*xf32>) -> ()

--- a/examples/MLIRTOSA/tosa-resize.mlir
+++ b/examples/MLIRTOSA/tosa-resize.mlir
@@ -1,7 +1,7 @@
 func.func @main() {
   %input = arith.constant dense<[[[[1.0], [2.0]],[[3.0], [4.0]]]]> : tensor<1x2x2x1xf32>
   %output = "tosa.resize"(%input) {
-    scale = array<i64 : 4, 2, 4, 2>, offset = array<i64 : 0, 0>, 
+    scale = array<i64 : 4, 2, 4, 2>, output_size = [4, 4], stride = [0, 0], offset = array<i64 : 0, 0>, 
     border = array<i64 : 0, 0>, mode = "NEAREST_NEIGHBOR"} : (tensor<1x2x2x1xf32>) -> (tensor<1x4x4x1xf32>) 
   %tensor_unranked = tensor.cast %output : tensor<1x4x4x1xf32> to tensor<*xf32>
   call @printMemrefF32(%tensor_unranked) : (tensor<*xf32>) -> ()

--- a/examples/MLIRTOSA/tosa-resize.mlir
+++ b/examples/MLIRTOSA/tosa-resize.mlir
@@ -1,9 +1,8 @@
 func.func @main() {
   %input = arith.constant dense<[[[[1.0], [2.0]],[[3.0], [4.0]]]]> : tensor<1x2x2x1xf32>
   %output = "tosa.resize"(%input) {
-    scale = [4, 2, 4, 2], output_size = [4, 4], stride = [0, 0], offset = [0, 0],
-    stride_fp = [0.5 : f32, 0.5 : f32], offset_fp = [0.1 : f32, 0.2 : f32], shift = 0 : i32,
-    mode = "NEAREST_NEIGHBOR", border = [0, 0]} : (tensor<1x2x2x1xf32>)  -> (tensor<1x4x4x1xf32>)
+    scale = array<i64 : 4, 2, 4, 2>, offset = array<i64 : 0, 0>, 
+    border = array<i64 : 0, 0>, mode = "NEAREST_NEIGHBOR"} : (tensor<1x2x2x1xf32>) -> (tensor<1x4x4x1xf32>) 
   %tensor_unranked = tensor.cast %output : tensor<1x4x4x1xf32> to tensor<*xf32>
   call @printMemrefF32(%tensor_unranked) : (tensor<*xf32>) -> ()
 


### PR DESCRIPTION
The PR aims to solve two bugs in TOSA examples
1) The pass pipeline bug
![image](https://github.com/buddy-compiler/buddy-mlir/assets/81592570/56a8f6c6-dc58-4637-b1f1-308f061cb5da)

2) The bug in tosa.resizeOp
![image](https://github.com/buddy-compiler/buddy-mlir/assets/81592570/f7236da6-97d4-4893-b2a8-a84f0fcfd07a)

These bugs mostly occurred when we synced to the latest llvm

Solves #156 