### PR TITLE
[thirdparty] change std::int32_t to int32_t

### DIFF
--- a/thirdparty/include/AudioFile.h
+++ b/thirdparty/include/AudioFile.h
@@ -546,7 +546,7 @@ bool AudioFile<T>::decodeWaveFile(std::vector<uint8_t> &fileData) {
           std::memcpy(&sample, &sampleAsInt, sizeof(sampleAsInt));
         } else // assume PCM
           sample = (T)sampleAsInt /
-                   static_cast<float>(std::numeric_limits<std::int32_t>::max());
+                   static_cast<float>(std::numeric_limits<int32_t>::max());
 
         getSample(channel, i) = sample;
       } else {
@@ -700,7 +700,7 @@ bool AudioFile<T>::decodeAiffFile(std::vector<uint8_t> &fileData) {
           std::memcpy(&sample, &sampleAsInt, sizeof(sampleAsInt));
         } else // assume uncompressed
           sample = (T)sampleAsInt /
-                   static_cast<float>(std::numeric_limits<std::int32_t>::max());
+                   static_cast<float>(std::numeric_limits<int32_t>::max());
 
         getSample(channel, i) = sample;
       } else {


### PR DESCRIPTION
This fixed the compile error on latest compiler toolchain.