### PR TITLE
[chore] add .cache directory into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # ONNX models
 *.onnx
+
+# Clangd cache
+.cache


### PR DESCRIPTION
The clangd lsp server will create a .cache directory in the buddy-mlir root directory which shouldn't be tracked by git.