### PR TITLE
[cmake] fix llvm out-of-tree build for one-step build strategy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,11 +62,9 @@ else()
     # MLIR/LLVM Configuration
     #-------------------------------------------------------------------------------
 
-    # Allow passing external LLVM source, instead of forcing user using the vendored one
-    if (NOT LLVM_PROJECT_SOURCE_DIR)
-      set(LLVM_PROJECT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/llvm")
-      message(STATUS "Using LLVM Project ${LLVM_PROJECT_SOURCE_DIR}")
-    endif()
+    # Allow using out-of-tree llvm directory
+    set(LLVM_PROJECT_SOURCE_DIR ${LLVM_MAIN_SRC_DIR}/..)
+    message(STATUS "Using LLVM Project ${LLVM_PROJECT_SOURCE_DIR}")
 
     set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir)
     set(MLIR_INCLUDE_DIR ${MLIR_MAIN_SRC_DIR}/include)


### PR DESCRIPTION
The current one-step build strategy requires LLVM sources to be placed in the buddy-mlir project and named 'llvm'. This makes packaging a difficult task, as users can't build buddy-mlir with other working llvm source code that has a different version to the one provided by buddy-mlir.

This commit sets 'LLVM_PROJECT_SOURCE_DIR' to be the up dir of 'LLVM_MAIN_SRC_DIR'. 'LLVM_MAIN_SRC_DIR' is set when building within the llvm source directory, so it is safe to use it as the relative path to llvm project.