### PR TITLE
Revert "Fix gemmini legalize funcname."

### DIFF
--- a/midend/include/Dialect/Gemmini/Transform.h
+++ b/midend/include/Dialect/Gemmini/Transform.h
@@ -50,7 +50,7 @@ void populateGemminiLegalizeForLLVMExportPatterns(LLVMTypeConverter &converter,
                                                   RewritePatternSet &patterns,
                                                   int64_t dim, int64_t addrLen, 
                                                   size_t sizeOfElemT, size_t sizeOfAccT);
-void configureGemminiLegalizeForExportTarget(LLVMConversionTarget &target);
+void configureGemminiegalizeForExportTarget(LLVMConversionTarget &target);
 
 } // namespace mlir
 

--- a/midend/lib/Conversion/LowerGemmini/LowerGemminiPass.cpp
+++ b/midend/lib/Conversion/LowerGemmini/LowerGemminiPass.cpp
@@ -176,6 +176,7 @@ public:
   // Override explicitly to allow conditional dialect dependence.
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<LLVM::LLVMDialect>();
+    registry.insert<LLVM::LLVMDialect>();
     registry.insert<arith::ArithDialect>();
     registry.insert<memref::MemRefDialect>();
     registry.insert<scf::SCFDialect>();
@@ -202,7 +203,7 @@ void LowerGemminiToLLVMPass::runOnOperation() {
   LLVMTypeConverter converter(context);
   RewritePatternSet patterns(context);
   LLVMConversionTarget target(*context);
-  configureGemminiLegalizeForExportTarget(target);
+  configureGemminiegalizeForExportTarget(target);
   populateGemminiLegalizeForLLVMExportPatterns(
       converter, patterns, dim, addrLen, sizeOfElemT, sizeOfAccT);
   populateAffineToStdConversionPatterns(patterns);

--- a/midend/lib/Dialect/Gemmini/Transforms/LegalizeForLLVMExport.cpp
+++ b/midend/lib/Dialect/Gemmini/Transforms/LegalizeForLLVMExport.cpp
@@ -1380,7 +1380,7 @@ void mlir::populateGemminiLegalizeForLLVMExportPatterns(
                                         sizeOfAccT);
 }
 
-void mlir::configureGemminiLegalizeForExportTarget(
+void mlir::configureGemminiegalizeForExportTarget(
     LLVMConversionTarget &target) {
   target.addLegalOp<
       Flush_IntrOp, ConfigSt_IntrOp, ConifgLd_IntrOp, ConfigEX_IntrOp,


### PR DESCRIPTION
Reverts buddy-compiler/buddy-mlir#197
