### PR TITLE
[examples][ConvOpt] Fixed libConv2D build error with wrong buddy-opt path.

### DIFF
--- a/examples/ConvOpt/CMakeLists.txt
+++ b/examples/ConvOpt/CMakeLists.txt
@@ -15,7 +15,7 @@ message(STATUS "Spliting size: ${SPLITING_SIZE}")
 
 
 add_custom_command(OUTPUT conv2d.o
-  COMMAND ${BUDDY_BINARY_DIR}/buddy-opt ${BUDDY_EXAMPLES_DIR}/ConvOpt/conv2d.mlir -conv-vectorization="strip-mining=${SPLITING_SIZE}" -lower-affine -convert-scf-to-cf -convert-vector-to-llvm -finalize-memref-to-llvm -llvm-request-c-wrappers -convert-func-to-llvm -reconcile-unrealized-casts | 
+  COMMAND ${CMAKE_BINARY_DIR}/bin/buddy-opt ${BUDDY_EXAMPLES_DIR}/ConvOpt/conv2d.mlir -conv-vectorization="strip-mining=${SPLITING_SIZE}" -lower-affine -convert-scf-to-cf -convert-vector-to-llvm -finalize-memref-to-llvm -llvm-request-c-wrappers -convert-func-to-llvm -reconcile-unrealized-casts | 
           ${LLVM_MLIR_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
           ${LLVM_MLIR_BINARY_DIR}/llc -mtriple=${BUDDY_TARGET_TRIPLE} -mattr=${BUDDY_OPT_ATTR} --filetype=obj -o ${BUDDY_BINARY_DIR}/../examples/ConvOpt/conv2d.o
   DEPENDS buddy-opt)


### PR DESCRIPTION
Now, when building the `libConv2D`, use the same path as in `frontend/Interfaces/lib/CMakeLists.txt` for building `libBuddyLibDAP` and `libBuddyLibDAP`. [Click here to view](https://github.com/buddy-compiler/buddy-mlir/blob/d43b4633666b2a66ee98e2cf8d34c0c76a2d0c0f/frontend/Interfaces/lib/CMakeLists.txt#L14C19-L14C19).