### PR TITLE
[examples] Fix stand-alone conv-opt edge detection build

### DIFF
--- a/tests/Interface/core/CMakeLists.txt
+++ b/tests/Interface/core/CMakeLists.txt
@@ -7,7 +7,7 @@ if(BUDDY_ENABLE_OPENCV)
   include_directories(${OpenCV_INCLUDE_DIRS})
 endif()
 
-if(BUDDY_MLIR_ENABLE_DIP_LIB)
+if(BUDDY_MLIR_ENABLE_DIP_LIB OR BUDDY_ENABLE_OPENCV)
   set(DIP_LIBS ${JPEG_LIBRARY} ${PNG_LIBRARY})
   _add_test_executable(buddy-image-container-test
     ImageContainerTest.cpp


### PR DESCRIPTION
I was getting an error saying that cmake was not able to find the target `buddy-image-container-test` when I was trying to have a stand-alone build of the `edge-detection` example for testing `conv-opt`. 

This patch should fix that problem and users should be able to build `edge-detection` target without building any DIP target first.