### PR TITLE
[Examples] Fix cmake build file python command

### DIFF
--- a/examples/BuddyLlama/CMakeLists.txt
+++ b/examples/BuddyLlama/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_command(
   OUTPUT ${BUDDY_EXAMPLES_DIR}/BuddyLlama/llama.mlir ${BUDDY_EXAMPLES_DIR}/BuddyLlama/arg0.data
-  COMMAND python ${BUDDY_EXAMPLES_DIR}/BuddyLlama/import-llama2.py
+  COMMAND ${Python3_EXECUTABLE} ${BUDDY_EXAMPLES_DIR}/BuddyLlama/import-llama2.py
   COMMENT "Generating llama.mlir and arg0.data..."
 )
 


### PR DESCRIPTION
When I use CMake to build the LLAMA example on my MacBook, it encounters a 'python not found' issue. However, when I use the command python import-llama2.py in terminal, it works correctly. So, I want to use ${Python3_EXECUTABLE} to replace 'python'，it works correctly.Please review!