### PR TITLE
[Git] Add shallow option to speed up pulling code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,8 @@
 	path = llvm
 	url = https://github.com/llvm/llvm-project.git
 	branch = main
+	shallow = true
 [submodule "thirdparty/mimalloc"]
 	path = thirdparty/mimalloc
 	url = https://github.com/microsoft/mimalloc.git
+	shallow = true


### PR DESCRIPTION
When I use the `git submodule update --init` command to clone a submodule, it is very slow! (Maybe I need a proxy!) However, I think we do not need the entire LLVM history or that of any other third-party submodule. Using shallow = true in the .gitmodules file for a submodule configuration will reduce data transfer: a shallow clone fetches only the most recent commits instead of the entire commit history of the repository, resulting in faster cloning operations.