### PR TITLE
add steps for installing 'pybind11' in examples/BuddyLlama/README.md

### DIFF
--- a/examples/BuddyLlama/README.md
+++ b/examples/BuddyLlama/README.md
@@ -12,6 +12,7 @@ We recommend you to use anaconda3 to create python virtual environment. You shou
 $ conda activate <your virtual environment name>
 $ cd buddy-mlir
 $ pip install -r requirements.txt
+$ conda install pybind11 -c conda-forge
 ```
 
 3. LLaMA2 model convert to HuggingFace format

--- a/examples/BuddyLlama/README.md
+++ b/examples/BuddyLlama/README.md
@@ -12,7 +12,6 @@ We recommend you to use anaconda3 to create python virtual environment. You shou
 $ conda activate <your virtual environment name>
 $ cd buddy-mlir
 $ pip install -r requirements.txt
-$ conda install pybind11 -c conda-forge
 ```
 
 3. LLaMA2 model convert to HuggingFace format

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tokenizers == 0.13.3
 sentencepiece == 0.1.99
 accelerate
 protobuf
+pybind11 == 2.11.1


### PR DESCRIPTION
The BuddyLlama example requires `pybind11` package, which is not presented in `example/BuddyLlama/README.md`, so a supplement is made. ( #265 )