### PR TITLE
[CAAS] Add static MLIR libraries for online static compilation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,10 +43,15 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR OR BUDDY_MLIR_OUT_OF_TREE_
 
     set(LLVM_MLIR_BINARY_DIR ${MLIR_DIR}/../../../bin)
     set(LLVM_MLIR_LIBRARY_DIR ${MLIR_DIR}/../../../lib)
-    set(LLVM_MLIR_SOURCE_DIR ${MLIR_DIR}/../../../../mlir)
     set(LLVM_PROJECT_BUILD_DIR ${MLIR_DIR}/../../../)
-    set(LLVM_PROJECT_SOURCE_DIR ${MLIR_DIR}/../../../../)
 
+    if(NOT DEFINED LLVM_PROJECT_SOURCE_DIR)
+      set(LLVM_MLIR_SOURCE_DIR ${MLIR_DIR}/../../../../mlir)
+      set(LLVM_PROJECT_SOURCE_DIR ${MLIR_DIR}/../../../../)
+    else()
+      set(LLVM_MLIR_SOURCE_DIR ${LLVM_PROJECT_SOURCE_DIR}/mlir)
+      message(STATUS "Using specified LLVM source dir: ${LLVM_PROJECT_SOURCE_DIR}")
+    endif()
     list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
     list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 

--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(include/llvm)
 add_subdirectory(llvm)
+add_subdirectory(mlir)

--- a/backend/mlir/CMakeLists.txt
+++ b/backend/mlir/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(lib)

--- a/backend/mlir/lib/CMakeLists.txt
+++ b/backend/mlir/lib/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(ExecutionEngine)

--- a/backend/mlir/lib/ExecutionEngine/CMakeLists.txt
+++ b/backend/mlir/lib/ExecutionEngine/CMakeLists.txt
@@ -1,0 +1,24 @@
+# ExecutionEngine
+
+set(MLIR_ExecutionEngine_DIR ${LLVM_PROJECT_SOURCE_DIR}/mlir/lib/ExecutionEngine)
+
+add_mlir_library(MLIRCRunnerUtils
+  ${MLIR_ExecutionEngine_DIR}/CRunnerUtils.cpp
+  ${MLIR_ExecutionEngine_DIR}/SparseTensorRuntime.cpp
+
+  EXCLUDE_FROM_LIBMLIR
+
+  LINK_LIBS PUBLIC
+  mlir_float16_utils
+  MLIRSparseTensorEnums
+  MLIRSparseTensorRuntime
+  )
+set_property(TARGET MLIRCRunnerUtils PROPERTY CXX_STANDARD 17)
+target_compile_definitions(MLIRCRunnerUtils PRIVATE MLIRCRunnerUtils_EXPORTS)
+
+add_mlir_library(MLIRRunnerUtils
+  ${MLIR_ExecutionEngine_DIR}/RunnerUtils.cpp
+
+  EXCLUDE_FROM_LIBMLIR
+  )
+target_compile_definitions(MLIRRunnerUtils PRIVATE MLIRRunnerUtils_EXPORTS)

--- a/thirdparty/.gitignore
+++ b/thirdparty/.gitignore
@@ -9,3 +9,4 @@
 /build-local-clang
 /build-cross-clang
 /build-cross-mlir
+/build-cross-buddy-mlir

--- a/thirdparty/build-rvv-env.sh
+++ b/thirdparty/build-rvv-env.sh
@@ -139,3 +139,33 @@ then
 else
   echo "mlir for riscv64 was built already"
 fi
+
+#-------------------------------------------------------------------------------
+# Build cross Buddy-MLIR
+#-------------------------------------------------------------------------------
+
+if [ ! -d "build-cross-buddy-mlir" ]
+then
+  mkdir build-cross-buddy-mlir
+  cd build-cross-buddy-mlir
+  cmake -G Ninja ../../ \
+    -DCMAKE_SYSTEM_NAME=Linux \
+    -DMLIR_DIR=../build-cross-mlir/lib/cmake/mlir \
+    -DLLVM_DIR=../build-cross-mlir/lib/cmake/llvm \
+    -DLLVM_PROJECT_SOURCE_DIR=/home/hongbin/test/buddy-mlir/llvm \
+    -DCMAKE_CROSSCOMPILING=True \
+    -DLLVM_TARGETS_TO_BUILD=RISCV \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DLLVM_ENABLE_ASSERTIONS=ON \
+    -DLLVM_NATIVE_ARCH=RISCV \
+    -DLLVM_HOST_TRIPLE=riscv64-unknown-linux-gnu \
+    -DCMAKE_C_COMPILER=$PWD/../build-local-clang/bin/clang \
+    -DCMAKE_CXX_COMPILER=$PWD/../build-local-clang/bin/clang++ \
+    -DCMAKE_C_FLAGS="--target=riscv64-unknown-linux-gnu --sysroot=$PWD/../build-riscv-gnu-toolchain/sysroot --gcc-toolchain=$PWD/../build-riscv-gnu-toolchain" \
+    -DCMAKE_CXX_FLAGS="--target=riscv64-unknown-linux-gnu --sysroot=$PWD/../build-riscv-gnu-toolchain/sysroot --gcc-toolchain=$PWD/../build-riscv-gnu-toolchain" \
+    -DLLVM_ENABLE_ZSTD=Off
+  ninja MLIRCRunnerUtils MLIRRunnerUtils
+else
+  echo "buddy-mlir libs for riscv64 was built already"
+fi
+


### PR DESCRIPTION
This pull request adds llvm library in buddy-mlir project for buddy-caas to use.
Specifically, added an option when compiling buddy-mlir, to specify the source folder location of llvm. 