### PR TITLE
[NFC] Make buddy tests and examples depends on `mlir-cpu-runner`

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -39,6 +39,7 @@ set(BUDDY_EXAMPLES_DEPENDS
   FileCheck count not
   buddy-opt
   buddy-translate
+  mlir-cpu-runner
   )
 
 add_lit_testsuite(check-examples "Checking the buddy-mlir examples..."

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(BUDDY_TEST_DEPENDS
   buddy-container-test
   buddy-audio-container-test
   buddy-text-container-test
+  mlir-cpu-runner
   )
 
 if(BUDDY_ENABLE_OPENCV)


### PR DESCRIPTION
When `ninja check-buddy` is called without any prior `ninja check-mlir`, the following test failure is raised:

```
<...>/linalg-transpose-f32.mlir.script: line 1: <...>/buddy-mlir/build/./bin/mlir-cpu-runner: No such file or director
```

This PR fixes this by explicitly setting `mlir-cpu-runner` as a dependency of buddy tests and examples.