### PR TITLE
[DAP/Whisper] Extract RFFT operation from 'dap.whisper_preprocess'.

### DIFF
--- a/frontend/Interfaces/buddy/DAP/DSP/WhisperPreprocess.h
+++ b/frontend/Interfaces/buddy/DAP/DSP/WhisperPreprocess.h
@@ -29,15 +29,24 @@ namespace dap {
 namespace detail {
 // Declare the whisper preprocess C interface.
 extern "C" {
-void _mlir_ciface_buddy_whisperPreprocess(MemRef<double, 1> *inputRawSpeech,
-                                          MemRef<float, 3> *outputFeatures);
+// The original MLIR function:
+//    ```mlir
+//    func.func @buddy_whisperPreprocess(%in : memref<?xf64>) ->
+//        memref<1x80x3000xf32>
+//    ```
+//
+// After applying the '-llvm-request-c-wrappers' pass:
+//    The result of the function (memref<1x80x3000xf32>) is modified to be the
+//    first operand.
+void _mlir_ciface_buddy_whisperPreprocess(MemRef<float, 3> *outputFeatures,
+                                          MemRef<double, 1> *inputRawSpeech);
 }
 } // namespace detail
 
 // Function for Whisper preprocess
 void whisperPreprocess(MemRef<double, 1> *inputRawSpeech,
                        MemRef<float, 3> *outputFeatures) {
-  detail::_mlir_ciface_buddy_whisperPreprocess(inputRawSpeech, outputFeatures);
+  detail::_mlir_ciface_buddy_whisperPreprocess(outputFeatures, inputRawSpeech);
 }
 
 } // namespace dap

--- a/frontend/Interfaces/lib/DAP-extend.mlir
+++ b/frontend/Interfaces/lib/DAP-extend.mlir
@@ -1,4 +1,4 @@
-func.func @buddy_whisperPreprocess(%in : memref<?xf64>, %out : memref<1x80x3000xf32>) -> () {
-  dap.whisper_preprocess %in, %out : memref<?xf64>, memref<1x80x3000xf32>
-  return
+func.func @buddy_whisperPreprocess(%in : memref<?xf64>) -> memref<1x80x3000xf32> {
+  %out = dap.whisper_preprocess %in : memref<?xf64> to memref<1x80x3000xf32>
+  return %out : memref<1x80x3000xf32>
 }

--- a/midend/include/Dialect/DAP/DAPOps.td
+++ b/midend/include/Dialect/DAP/DAPOps.td
@@ -50,8 +50,7 @@ def DAP_FirOp : DAP_Op<"fir"> {
   }];
 }
 
-def DAP_BiquadOp : DAP_Op<"biquad">
-{
+def DAP_BiquadOp : DAP_Op<"biquad"> {
   let summary = [{Biquad filter, a infinite impulse response (IIR) filter.
 
   ```mlir
@@ -95,22 +94,25 @@ def DAP_IirOp : DAP_Op<"iir"> {
 }
 
 def DAP_WhisperPreprocessOp : DAP_Op<"whisper_preprocess"> {
-  let summary = [{Preprocessor for Whisper model, do features extraction for input audio.
-  Input MemRef stores the raw speech data, Output MemRef contains computed features with 
-  shape memref<1x80x3000xf32>.
+  let summary = "preprocessor for Whisper model";
+  let description = [{
+    Preprocessor for Whisper model, do features extraction for input audio. 
+    Input MemRef stores the raw speech data, Output MemRef contains computed 
+    features with shape memref<1x80x3000xf32>.
 
-  ```mlir
-    dap.whisper_preprocess %input, %output : memref<?xf64>, memref<1x80x3000xf32>
-  ```
+    Example:
+
+    ```mlir
+    %output = dap.whisper_preprocess %input : memref<?xf64> to memref<1x80x3000xf32>
+    ```
   }];
 
   let arguments = (ins Arg<AnyRankedOrUnrankedMemRef, "inputMemref",
-                           [MemRead]>:$memrefI,
-                       Arg<AnyRankedOrUnrankedMemRef, "outputMemref",
-                           [MemRead]>:$memrefO);
-
+                           [MemRead]>:$memrefI);
+  let results = (outs Res<AnyRankedOrUnrankedMemRef, "outputMemref",
+                           [MemAlloc]>:$memrefO);
   let assemblyFormat = [{
-    $memrefI `,` $memrefO attr-dict `:` type($memrefI) `,` type($memrefO) 
+    $memrefI attr-dict `:` type($memrefI) `to` type($memrefO) 
   }];
 }
 

--- a/midend/include/Dialect/DAP/DAPOps.td
+++ b/midend/include/Dialect/DAP/DAPOps.td
@@ -93,6 +93,28 @@ def DAP_IirOp : DAP_Op<"iir"> {
   }];
 }
 
+def DAP_RFFT400Op : DAP_Op<"rfft400"> {
+  let summary = "RFFT operation for length 400.";
+  let description = [{
+    The RFFT algorithm is designed to handle real-valued input signals. Real 
+    signals exhibit conjugate symmetry in the frequency domain, meaning that 
+    the positive and negative frequency components are complex conjugates of 
+    each other. This symmetry property allows the RFFT algorithm to compute 
+    only half of the frequency spectrum, reducing computational costs.
+
+    Example:
+
+    ```mlir
+    dap.rfft400 %data : memref<400xf64> 
+    ```
+  }];
+
+  let arguments = (ins AnyRankedOrUnrankedMemRef:$memref);
+  let assemblyFormat = [{
+    $memref attr-dict `:` type($memref)
+  }];
+}
+
 def DAP_WhisperPreprocessOp : DAP_Op<"whisper_preprocess"> {
   let summary = "preprocessor for Whisper model";
   let description = [{


### PR DESCRIPTION
- [x] Extract RFFT operation.
- [x] Remove `memref.copy` operation in `dap.whisper_preprocess`.

> Change the format of **`dap.whisper_preprocess`** and top level function **`@buddy_whisperPreprocess`**
> Previous version: 
>  ```mlir
>  dap.whisper_preprocess %input, %output : memref<?xf64>, memref<1x80x3000xf32>
>  ```
> Current version:
>  ```mlir
>  %output = dap.whisper_preprocess %input : memref<?xf64> to memref<1x80x3000xf32>
>  ```
>
>For changing **`%output`** from operand to result, we can use **`replaceOp()`** to replace the combination of **`memref.copy`** and **`eraseOp()`**.