### PR TITLE
[DIP] add libpng macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,11 @@ if(BUDDY_MLIR_ENABLE_DIP_LIB)
   find_package(PNG REQUIRED)
 endif()
 
+if(BUDDY_ENABLE_PNG)
+  add_definitions(-DBUDDY_ENABLE_PNG)
+  find_package(PNG REQUIRED)
+endif()
+
 # Generate libraries into `lib` of build directory.
 set(LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
 

--- a/frontend/Interfaces/buddy/DIP/ImgContainer.h
+++ b/frontend/Interfaces/buddy/DIP/ImgContainer.h
@@ -25,7 +25,9 @@
 #include <cstring>
 #include <fstream>
 #include <memory>
+#ifdef BUDDY_ENABLE_PNG
 #include <png.h>
+#endif
 
 namespace dip {
 enum ImageModes {
@@ -88,7 +90,9 @@ private:
   // Decodes a BMP image from raw file data.
   bool decodeBMP(const std::vector<uint8_t> &fileData);
   // Decodes a PNG image from raw file data.
+#ifdef BUDDY_ENABLE_PNG
   bool decodePNG(const std::vector<uint8_t> &fileData);
+#endif
 };
 
 // Image Container Constructor
@@ -129,13 +133,17 @@ Image<T, N>::Image(std::string filePath, ImageModes mode, bool norm)
       this->imageFormat = ImageFormat::ERROR;
       throw std::runtime_error("Failed to decode BMP file from " + filePath);
     };
-  } else if (this->imageFormat == ImageFormat::PNG) {
+  }
+#ifdef BUDDY_ENABLE_PNG
+  else if (this->imageFormat == ImageFormat::PNG) {
     bool success = decodePNG(fileData);
     if (!success) {
       this->imageFormat = ImageFormat::ERROR;
       throw std::runtime_error("Failed to decode PNG file from " + filePath);
     };
-  } else {
+  }
+#endif
+  else {
     throw std::runtime_error("Unsupported image file format.");
   }
 }
@@ -414,6 +422,7 @@ bool Image<T, N>::decodeBMP(const std::vector<uint8_t> &fileData) {
 }
 
 // PNG Image File Decoder
+#ifdef BUDDY_ENABLE_PNG
 template <typename T, std::size_t N>
 bool Image<T, N>::decodePNG(const std::vector<uint8_t> &fileData) {
   // Check if the provided data is large enough to contain a minimal PNG header
@@ -604,6 +613,7 @@ bool Image<T, N>::decodePNG(const std::vector<uint8_t> &fileData) {
   }
   return true;
 }
+#endif
 
 } // namespace dip
 

--- a/tests/Interface/core/NewImageContainerTest.cpp
+++ b/tests/Interface/core/NewImageContainerTest.cpp
@@ -167,6 +167,7 @@ int main() {
   // CHECK: 0.45490
   fprintf(stderr, "%f\n", bmp24bitRGBNorm.getData()[0]);
 
+#ifdef BUDDY_ENABLE_PNG
   // Default Gray Scale
   dip::Image<float, 4> pngGrayDefault(
       "../../../../tests/Interface/core/TestGrayImage.png", dip::DIP_GRAYSCALE);
@@ -221,6 +222,6 @@ int main() {
   fprintf(stderr, "%d\n", pngRGBNorm.getBitDepth());
   // CHECK: 0.5647
   fprintf(stderr, "%f\n", pngRGBNorm.getData()[0]);
-
+#endif
   return 0;
 }


### PR DESCRIPTION
add **BUDDY_ENABLE_PNG** macro

now, if you want to decode PNG images on the MobileNet example, you need the following command:
$ cmake -G Ninja .. -DBUDDY_MOBILENETV3_EXAMPLES=ON -DBUDDY_ENABLE_PNG=ON
$ ninja buddy-mobilenetv3-run