### PR TITLE
[DAP] Debug 'dap.fir' operation.

### DIFF
--- a/examples/DAPDialect/FIRLowpass.cpp
+++ b/examples/DAPDialect/FIRLowpass.cpp
@@ -62,7 +62,7 @@ int main() {
   printLogLabel();
   std::cout << "Running FIR operation..." << std::endl;
   const auto loadStart = std::chrono::high_resolution_clock::now();
-  dap::fir(&inputContainer, &kernel, &outputMemRef);
+  dap::FIR(&inputContainer, &kernel, &outputMemRef);
   const auto loadEnd = std::chrono::high_resolution_clock::now();
   const std::chrono::duration<double, std::milli> loadTime =
       loadEnd - loadStart;

--- a/frontend/Interfaces/buddy/DAP/DSP/FIR.h
+++ b/frontend/Interfaces/buddy/DAP/DSP/FIR.h
@@ -31,8 +31,8 @@ namespace detail {
 extern "C" {
 // TODO: support both float and double.
 void _mlir_ciface_buddy_fir(MemRef<float, 1> *inputBuddyConv1D,
-                               MemRef<float, 1> *kernelBuddyConv1D,
-                               MemRef<float, 1> *outputBuddyConv1D);
+                            MemRef<float, 1> *kernelBuddyConv1D,
+                            MemRef<float, 1> *outputBuddyConv1D);
 }
 } // namespace detail
 
@@ -67,7 +67,7 @@ void firLowpass(MemRef<T, N> &input, WINDOW_TYPE type, size_t len, T cutoff,
 }
 
 template <typename T, size_t N>
-void fir(MemRef<float, N> *input, MemRef<T, N> *filter,
+void FIR(MemRef<float, N> *input, MemRef<T, N> *filter,
          MemRef<float, N> *output) {
   if (N != 1)
     assert(0 && "Only mono audio is supported for now.");

--- a/frontend/Interfaces/lib/CMakeLists.txt
+++ b/frontend/Interfaces/lib/CMakeLists.txt
@@ -10,6 +10,10 @@ elseif (HAVE_NEON)
     set(SPLITING_SIZE 16)
 endif ()
 
+#-------------------------------------------------------------------------------
+# Generate Buddy DIP Library: BuddyLibDIP
+#-------------------------------------------------------------------------------
+
 add_custom_command(OUTPUT DIP.o
         COMMAND ${CMAKE_BINARY_DIR}/bin/buddy-opt ${CMAKE_CURRENT_SOURCE_DIR}/DIP.mlir
         -lower-dip="DIP-strip-mining=${SPLITING_SIZE}"
@@ -37,87 +41,97 @@ SET_TARGET_PROPERTIES(BuddyLibDIP PROPERTIES
   ARCHIVE_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_DIRECTORY}
   )
 
-add_custom_command(OUTPUT DAP.o
-  COMMAND ${CMAKE_BINARY_DIR}/bin/buddy-opt ${CMAKE_CURRENT_SOURCE_DIR}/DAP.mlir 
-              -lower-dap="DAP-vector-splitting=${SPLITING_SIZE}"
-              --convert-linalg-to-affine-loops
-              -arith-expand
-              -lower-affine
-              -convert-scf-to-cf
-              -convert-math-to-llvm
-              -convert-vector-to-llvm
-              -finalize-memref-to-llvm
-              -llvm-request-c-wrappers
-              -convert-func-to-llvm
-              -reconcile-unrealized-casts | 
-          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
-          ${LLVM_TOOLS_BINARY_DIR}/llc 
-              -mtriple=${BUDDY_TARGET_TRIPLE}
-              -mattr=${BUDDY_OPT_ATTR}
-              --filetype=obj
-              -o ${CMAKE_CURRENT_BINARY_DIR}/DAP.o
-  DEPENDS mlir-translate llc buddy-opt
-  )
+#-------------------------------------------------------------------------------
+# Generate Buddy DAP Library: BuddyLibDAP
+#-------------------------------------------------------------------------------
 
-add_custom_command(OUTPUT DAP-extend.o
-  COMMAND ${CMAKE_BINARY_DIR}/bin/buddy-opt ${CMAKE_CURRENT_SOURCE_DIR}/DAP-extend.mlir 
-              -extend-dap
-              -one-shot-bufferize
-              -convert-linalg-to-loops
-              -convert-scf-to-cf
-              -expand-strided-metadata
-              -lower-affine
-              -convert-vector-to-llvm 
-              -memref-expand 
-              -arith-expand
-              -convert-arith-to-llvm
-              -finalize-memref-to-llvm 
-              -convert-math-to-llvm
-              -llvm-request-c-wrappers
-              -convert-func-to-llvm
-              -reconcile-unrealized-casts | 
-          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-          ${LLVM_TOOLS_BINARY_DIR}/llc 
-              -mtriple=${BUDDY_TARGET_TRIPLE}
-              -mattr=${BUDDY_OPT_ATTR}
-              -filetype=obj -relocation-model=pic
-              -o ${CMAKE_CURRENT_BINARY_DIR}/DAP-extend.o
+add_custom_command(
+  OUTPUT DAP.o
+  COMMAND 
+    ${CMAKE_BINARY_DIR}/bin/buddy-opt ${CMAKE_CURRENT_SOURCE_DIR}/DAP.mlir 
+      -lower-dap="DAP-vector-splitting=${SPLITING_SIZE}"
+      --convert-linalg-to-affine-loops
+      -arith-expand
+      -lower-affine
+      -convert-scf-to-cf
+      -convert-math-to-llvm
+      -convert-vector-to-llvm
+      -finalize-memref-to-llvm
+      -llvm-request-c-wrappers
+      -convert-func-to-llvm
+      -reconcile-unrealized-casts | 
+    ${LLVM_TOOLS_BINARY_DIR}/mlir-translate --mlir-to-llvmir |
+    ${LLVM_TOOLS_BINARY_DIR}/llc 
+      -mtriple=${BUDDY_TARGET_TRIPLE}
+      -mattr=${BUDDY_OPT_ATTR}
+      --filetype=obj
+      -o ${CMAKE_CURRENT_BINARY_DIR}/DAP.o
   DEPENDS mlir-translate llc buddy-opt
-  )
+)
 
-add_custom_command(OUTPUT DAPVectorization.o
-  COMMAND cat ${CMAKE_CURRENT_SOURCE_DIR}/DAP.mlir |
-          sed 's/buddy_fir/buddy_fir_vectorization/' |
-          sed 's/buddy_iir/buddy_iir_vectorization/' |
-          sed 's/buddy_biquad/buddy_biquad_vectorization/' |
-          ${CMAKE_BINARY_DIR}/bin/buddy-opt
-              -vectorize-dap
-              -convert-linalg-to-affine-loops
-              -arith-expand
-              -lower-affine
-              -convert-scf-to-cf
-              -convert-math-to-llvm
-              -convert-vector-to-llvm
-              -finalize-memref-to-llvm
-              -llvm-request-c-wrappers
-              -convert-func-to-llvm
-              -reconcile-unrealized-casts | 
-          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-          ${LLVM_TOOLS_BINARY_DIR}/llc 
-              -mtriple=${BUDDY_TARGET_TRIPLE}
-              -mattr=${BUDDY_OPT_ATTR}
-              -filetype=obj
-              -o ${CMAKE_CURRENT_BINARY_DIR}/DAPVectorization.o
+add_custom_command(
+  OUTPUT DAP-extend.o
+  COMMAND 
+    ${CMAKE_BINARY_DIR}/bin/buddy-opt ${CMAKE_CURRENT_SOURCE_DIR}/DAP-extend.mlir 
+      -extend-dap
+      -one-shot-bufferize
+      -convert-linalg-to-loops
+      -convert-scf-to-cf
+      -expand-strided-metadata
+      -lower-affine
+      -convert-vector-to-llvm 
+      -memref-expand 
+      -arith-expand
+      -convert-arith-to-llvm
+      -finalize-memref-to-llvm 
+      -convert-math-to-llvm
+      -llvm-request-c-wrappers
+      -convert-func-to-llvm
+      -reconcile-unrealized-casts | 
+    ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+    ${LLVM_TOOLS_BINARY_DIR}/llc 
+      -mtriple=${BUDDY_TARGET_TRIPLE}
+      -mattr=${BUDDY_OPT_ATTR}
+      -filetype=obj -relocation-model=pic
+      -o ${CMAKE_CURRENT_BINARY_DIR}/DAP-extend.o
   DEPENDS mlir-translate llc buddy-opt
-  )
+)
+
+add_custom_command(
+  OUTPUT DAPVectorization.o
+  COMMAND 
+    cat ${CMAKE_CURRENT_SOURCE_DIR}/DAP.mlir |
+    sed -e 's/@buddy_fir/@buddy_fir_vectorization/'
+        -e 's/@buddy_iir/@buddy_iir_vectorization/'
+        -e 's/@buddy_biquad/@buddy_biquad_vectorization/' |
+    ${CMAKE_BINARY_DIR}/bin/buddy-opt
+      -vectorize-dap
+      -convert-linalg-to-affine-loops
+      -arith-expand
+      -lower-affine
+      -convert-scf-to-cf
+      -convert-math-to-llvm
+      -convert-vector-to-llvm
+      -finalize-memref-to-llvm
+      -llvm-request-c-wrappers
+      -convert-func-to-llvm
+      -reconcile-unrealized-casts | 
+    ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+    ${LLVM_TOOLS_BINARY_DIR}/llc 
+      -mtriple=${BUDDY_TARGET_TRIPLE}
+      -mattr=${BUDDY_OPT_ATTR}
+      -filetype=obj
+      -o ${CMAKE_CURRENT_BINARY_DIR}/DAPVectorization.o
+  DEPENDS mlir-translate llc buddy-opt
+)
 
 add_library(BuddyLibDAP STATIC 
   DAP.o 
   DAP-extend.o 
   DAPVectorization.o
-  )
+)
 
 SET_TARGET_PROPERTIES(BuddyLibDAP PROPERTIES
   LINKER_LANGUAGE CXX
   ARCHIVE_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_DIRECTORY}
-  )
+)


### PR DESCRIPTION
1. Redesign the `dap.fir` implementation.
 The previous design used `linalg.conv1D` for FIR operation, noting two differences: 
- FIR operation include zero paddings before the actual input.
- FIR operation do not incorporate bias in the formula.

 2. Reformat the `frontend/Interfaces/lib/CMakeLists.txt` file.
