### PR TITLE
[nix] bump nixpkgs and fix buddy-mlir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@
 
 # Clangd configurations
 .clangd
+
+# nix output
+result
+
+# ccls
+.ccls-cache/

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ This repository have nix flake support. You can follow the [nix installation ins
 - If you want to contribute to this project:
 
 ```bash
-nix develop .
+nix develop .#buddy-mlir
 ```
 
 This will setup a bash shell with `clang`, `ccls`, `cmake`, `ninja`, and other necessary dependencies to build buddy-mlir from source.
@@ -163,8 +163,11 @@ This will setup a bash shell with `clang`, `ccls`, `cmake`, `ninja`, and other n
 - If you want to use the buddy-mlir bintools
 
 ```bash
-nix build .#buddy-mlir
-./result/bin/buddy-opt --version
+nix develop .
+buddy-opt --version
+llc --version
+mlir-tblgen --version
+python -c "import torch; print(torch.__version__)"
 ```
 
 ## Dialects

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722813957,
-        "narHash": "sha256-IAoYyYnED7P8zrBFMnmp7ydaJfwTnwcnqxUElC1I26Y=",
+        "lastModified": 1734119587,
+        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cb9a96f23c491c081b38eab96d22fa958043c9fa",
+        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Generic devshell setup";
+  description = "Buddy MLIR nix flake setup";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -19,7 +19,31 @@
           # Help other use packages in this flake
           legacyPackages = pkgs;
 
-          devShells.default = pkgs.buddy-mlir.devShell;
+          # A shell with buddy-mlir tools and Python environment
+          # run: nix develop .
+          devShells.default = pkgs.mkShell {
+            nativeBuildInputs = with pkgs; [
+              buddy-mlir
+              buddy-mlir.llvm
+              buddy-mlir.pyenv
+            ];
+          };
+
+          # A shell for writing buddy-mlir code
+          # run: nix develop .#buddy-mlir
+          devShells.buddy-mlir = pkgs.mkShell {
+            nativeBuildInputs = with pkgs;
+              # Add following extra packages to buddy-mlir developement environment
+              pkgs.buddy-mlir.nativeBuildInputs ++ [
+                libjpeg
+                libpng
+                zlib-ng
+                ccls
+              ];
+          };
+
+          # run: nix build .
+          packages.default = pkgs.buddy-mlir;
 
           formatter = pkgs.nixpkgs-fmt;
         }) //

--- a/nix/buddy-mlir.nix
+++ b/nix/buddy-mlir.nix
@@ -1,68 +1,78 @@
 { lib
 , stdenv
+, fetchFromGitHub
 , buddy-llvm
 , cmake
 , ninja
 , llvmPkgs
-, libjpeg
-, libpng
-, zlib-ng
-, ccls
+, python3
 }:
-let
-  self = stdenv.mkDerivation {
-    pname = "buddy-mlir";
-    version = "unstable-2024-07-18";
+stdenv.mkDerivation (finalAttrs: {
+  name = "buddy-mlir";
 
-    src = with lib.fileset; toSource {
-      root = ./..;
-      fileset = unions [
-        ./../backend
-        ./../cmake
-        ./../examples
-        ./../frontend
-        ./../midend
-        ./../tests
-        ./../tools
-        ./../thirdparty
-        ./../CMakeLists.txt
-        ./../flake.lock
-        ./../flake.nix
-      ];
-    };
-
-    nativeBuildInputs = [
-      cmake
-      ninja
-      llvmPkgs.bintools
+  # Manually specify buddy-mlir source here to avoic rebuild on miscellaneous files
+  src = with lib.fileset; toSource {
+    root = ./..;
+    fileset = unions [
+      ./../backend
+      ./../cmake
+      ./../examples
+      ./../frontend
+      ./../midend
+      ./../tests
+      ./../tools
+      ./../thirdparty
+      ./../CMakeLists.txt
     ];
-
-    buildInputs = [
-      buddy-llvm
-    ];
-
-    cmakeFlags = [
-      "-DMLIR_DIR=${buddy-llvm.dev}/lib/cmake/mlir"
-      "-DLLVM_DIR=${buddy-llvm.dev}/lib/cmake/llvm"
-      "-DLLVM_MAIN_SRC_DIR=${buddy-llvm.src}/llvm"
-      "-DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON"
-      "-DCMAKE_BUILD_TYPE=Release"
-    ];
-
-    passthru = {
-      llvm = buddy-llvm;
-      devShell = self.overrideAttrs (old: {
-        nativeBuildInputs = old.nativeBuildInputs ++ [
-          libjpeg
-          libpng
-          zlib-ng
-          ccls
-        ];
-      });
-    };
-
-    # No need to do check, and it also takes too much time to finish.
-    doCheck = false;
   };
-in
-self
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    llvmPkgs.bintools
+  ];
+
+  buildInputs = [
+    buddy-llvm
+  ];
+
+  cmakeFlags = [
+    "-DMLIR_DIR=${buddy-llvm.dev}/lib/cmake/mlir"
+    "-DLLVM_DIR=${buddy-llvm.dev}/lib/cmake/llvm"
+    "-DLLVM_MAIN_SRC_DIR=${buddy-llvm.src}/llvm"
+    "-DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON"
+  ];
+
+  # This fixup script concatenate the LLVM and Buddy python module into one directory for easier import
+  postFixup = ''
+    mkdir -p $out/lib/python${python3.pythonVersion}/site-packages
+    cp -vr $out/python_packages/buddy $out/lib/python${python3.pythonVersion}/site-packages/
+    cp -vr ${buddy-llvm}/python_packages/mlir_core/mlir $out/lib/python${python3.pythonVersion}/site-packages/
+  '';
+
+  passthru = {
+    llvm = buddy-llvm;
+
+    # Below three fields are nixpkgs black magic that allow site-packages automatically imported with nixpkgs hooks
+    # Update here only when you know what will happen
+    pythonModule = python3;
+    pythonPath = [ ];
+    requiredPythonModules = [ ];
+
+    # nix run .#buddy-mlir.pyenv to start a python with PyTorch/LLVM MLIR/Buddy Frontend support
+    pyenv = python3.withPackages (ps: [
+      finalAttrs.finalPackage
+      ps.torch
+
+      # mobilenet
+      ps.torchvision
+
+      # tinyllama
+      ps.transformers
+      ps.accelerate
+    ]);
+  };
+
+  # No need to do check, and it also takes too much time to finish.
+  doCheck = false;
+})


### PR DESCRIPTION
This is an initial update to buddy mlir nix environment. Adding new python environment to the old derivation. This PR also provided two separate shell. The default shell gives llvm tools, buddy tools, and python environment. The buddy-mlir shell gives a buddy-mlir development environment that contains cmake, ninja, llvm.