### PR TITLE
[examples] Add Gemmini depthwise_conv examples

### DIFF
--- a/examples/GemminiDialect/dw-tile-conv.mlir
+++ b/examples/GemminiDialect/dw-tile-conv.mlir
@@ -1,0 +1,101 @@
+// RUN: buddy-opt %s \
+// RUN:     --lower-gemmini | \
+// RUN: FileCheck %s
+
+// n x h x w x c
+// batchSize = 1 inputDim = 5 inChannels = 2
+memref.global "private" @input : memref<1x5x5x2xi8> = dense<[[[[1, 2], [0, 0], [-1, -1], [0, 0], [1, 1]],
+                                                              [[1, 2], [0, 0], [-1, -1], [0, 0], [1, 1]],
+                                                              [[1, 2], [0, 0], [-1, -1], [0, 0], [1, 1]],
+                                                              [[1, 2], [0, 0], [-1, -1], [0, 0], [1, 1]],
+                                                              [[1, 2], [0, 0], [-1, -1], [0, 0], [1, 1]]]]>
+
+// chw x f
+// outChannels = 2 kernelDim = 3 inChannels = 2
+memref.global "private" @weight : memref<9x1xi8> = dense<[[1], [1], [1],
+                                                          [1], [1], [1],
+                                                          [1], [1], [1]]>
+
+// outChannels = 1
+memref.global "private" @bias : memref<1xi32> = dense<[1]>
+
+func.func @main() -> i64 {
+  %0 = arith.constant 0 : i64
+  %3 = arith.constant 3 : i64
+  %input = memref.get_global @input : memref<1x5x5x2xi8>
+  %weight = memref.get_global @weight : memref<9x1xi8>
+  %bias = memref.get_global @bias : memref<1xi32>
+  %output0 = memref.alloc() : memref<9x1xi8>
+  %output1 = memref.alloc() : memref<9x1xi8>
+  %output = memref.alloc() : memref<9x2xi8>
+
+  %subview0 = memref.alloc() : memref<1x5x5x1xi8>
+  %subview1 = memref.alloc() : memref<1x5x5x1xi8>
+
+  linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3*2)>, 
+      affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> 
+    ],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+  }
+  ins (%input : memref<1x5x5x2xi8>)
+  outs (%subview0 : memref<1x5x5x1xi8>) {
+    ^bb0(%in : i8, %out : i8):
+      linalg.yield %in : i8
+  }
+
+  linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3*2 + 1)>, 
+      affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)> 
+    ],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+  }
+  ins (%input : memref<1x5x5x2xi8>)
+  outs (%subview1 : memref<1x5x5x1xi8>) {
+    ^bb0(%in : i8, %out : i8):
+      linalg.yield %in : i8
+  }
+
+  //gemmini.print %subview0 : memref<1x5x5x1xi8>
+  //gemmini.print %subview1 : memref<1x5x5x1xi8>
+  
+  gemmini.tile_conv %subview0 %weight %bias %output0 %3 %3 %3 {stride = 1}:
+     memref<1x5x5x1xi8> memref<9x1xi8> memref<1xi32> memref<9x1xi8> i64 i64 i64
+  // gemmini.print %output0 : memref<9x1xi8>
+
+  gemmini.tile_conv %subview1 %weight %bias %output1 %3 %3 %3 {stride = 1}:
+     memref<1x5x5x1xi8> memref<9x1xi8> memref<1xi32> memref<9x1xi8> i64 i64 i64
+  // gemmini.print %output1 : memref<9x1xi8>
+
+  linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1) -> (d0, d1)>,        
+      affine_map<(d0, d1) -> (d0, d1 * 2)>     
+    ],
+    iterator_types = ["parallel", "parallel"]
+  }
+  ins(%output0 : memref<9x1xi8>) 
+  outs(%output : memref<9x2xi8>) {
+    ^bb0(%in: i8, %out: i8):
+      linalg.yield %in : i8
+  }
+
+  linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1) -> (d0, d1)>,        
+      affine_map<(d0, d1) -> (d0, d1 * 2 + 1)>
+    ],
+    iterator_types = ["parallel", "parallel"]
+  }
+  ins(%output1 : memref<9x1xi8>) 
+  outs(%output : memref<9x2xi8>) {
+    ^bb0(%in: i8, %out: i8):
+      linalg.yield %in : i8
+  }
+
+  gemmini.print %output : memref<9x2xi8>
+
+  return %0 : i64
+}

--- a/examples/GemminiDialect/dw_conv_2d_nchw_chw_i8.mlir
+++ b/examples/GemminiDialect/dw_conv_2d_nchw_chw_i8.mlir
@@ -1,0 +1,43 @@
+// RUN: buddy-opt %s \
+// RUN:     --convert-linalg-to-gemmini | \
+// RUN: FileCheck %s
+
+memref.global "private" @input : memref<2x2x5x5xi8> = dense<[[[[1, 0, -1, 0, 1],
+                                                               [1, 0, -1, 0, 1],
+                                                               [1, 0, -1, 0, 1],
+                                                               [1, 0, -1, 0, 1],
+                                                               [-1, 0, 1, 0, -1]],
+                                                              [[-1, 0, 1, 0, -1],
+                                                               [-1, 0, 1, 0, -1],
+                                                               [-1, 0, 1, 0, -1],
+                                                               [-1, 0, 1, 0, -1],
+                                                               [-1, 0, 1, 0, -1]]],
+                                                             [[[1, 0, 2, 0, 1],
+                                                               [1, 0, 2, 0, 1],
+                                                               [1, 0, 2, 0, 1],
+                                                               [1, 0, 2, 0, 1],
+                                                               [-1, 0, 2, 0, -1]],
+                                                              [[-1, 0, 2, 0, -1],
+                                                               [-1, 0, 2, 0, -1],
+                                                               [-1, 0, 2, 0, -1],
+                                                               [-1, 0, 2, 0, -1],
+                                                               [-1, 0, 2, 0, -1]]]]>
+
+memref.global "private" @weight : memref<2x3x3xi8> = dense<[[[1, 2, 3],
+                                                             [3, 2, 1],
+                                                             [1, 2, 3]],
+                                                            [[3, 2, 1],
+                                                             [1, 2, 3],
+                                                             [3, 2, 1]]]>
+
+func.func @main() -> i8 {
+  %0 = arith.constant 0 : i8
+  %mem0 = memref.get_global @input  : memref<2x2x5x5xi8> 
+  %mem1 = memref.get_global @weight : memref<2x3x3xi8>
+  %mem2 = memref.alloc() : memref<2x2x3x3xi8> 
+  linalg.depthwise_conv_2d_nchw_chw 
+    ins (%mem0, %mem1 : memref<2x2x5x5xi8>, memref<2x3x3xi8>)
+  outs(%mem2 : memref<2x2x3x3xi8>)
+  gemmini.print %mem2 : memref<2x2x3x3xi8>
+  return %0 : i8
+}

--- a/examples/GemminiDialect/makefile
+++ b/examples/GemminiDialect/makefile
@@ -396,6 +396,37 @@ tile-conv-run:
 	@riscv64-unknown-linux-gnu-gcc log.o -O2 -static -o a.out
 	@spike --extension=gemmini pk a.out
 
+dw-tile-conv-lower:
+	@${BUDDY_OPT} ./dw-tile-conv.mlir \
+		-convert-linalg-to-loops \
+		-lower-gemmini \
+		-o log.mlir
+
+dw-tile-conv-translate:
+	@${BUDDY_OPT} ./dw-tile-conv.mlir \
+		-convert-linalg-to-loops \
+		-lower-gemmini | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+dw-tile-conv-asm:
+	@${BUDDY_OPT} ./dw-tile-conv.mlir \
+		-convert-linalg-to-loops \
+		-lower-gemmini | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+buddyext,+D -float-abi=hard \
+		-o log.s
+
+dw-tile-conv-run:
+	@${BUDDY_OPT} ./dw-tile-conv.mlir -convert-linalg-to-loops -lower-gemmini | \
+	${BUDDY_TRANSLATE} --buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=obj -mtriple=riscv64 \
+		-mattr=+buddyext,+D -float-abi=hard \
+		-o log.o
+	@riscv64-unknown-linux-gnu-gcc log.o -O2 -static -o a.out
+	@spike --extension=gemmini pk a.out
+
 tile-conv-igelu-lower:
 	@${BUDDY_OPT} ./tile-conv-igelu.mlir \
 		-lower-gemmini \
@@ -600,6 +631,43 @@ gemmini-linalg-conv2d-nchw-fchw-i8-asm:
 
 gemmini-linalg-conv2d-nchw-fchw-i8-run:
 	@${BUDDY_OPT} ./conv_2d_nchw_fchw_i8.mlir \
+		-convert-linalg-to-gemmini \
+		-convert-linalg-to-loops \
+		-lower-gemmini | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=obj -mtriple=riscv64 \
+		-mattr=+buddyext,+D -float-abi=hard \
+		-o log.o
+	@riscv64-unknown-linux-gnu-gcc log.o -O2 -static -o a.out
+	@spike --extension=gemmini pk a.out
+
+gemmini-linalg-dw-conv2d-nchw-chw-i8-lower:
+	@${BUDDY_OPT} ./dw_conv_2d_nchw_chw_i8.mlir \
+		-convert-linalg-to-gemmini \
+		-convert-linalg-to-loops \
+		-lower-gemmini \
+		-o log.mlir
+
+gemmini-linalg-dw-conv2d-nchw-chw-i8-translate:
+	@${BUDDY_OPT} ./dw_conv_2d_nchw_chw_i8.mlir \
+		-convert-linalg-to-gemmini \
+		-convert-linalg-to-loops \
+		-lower-gemmini | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+gemmini-linalg-dw-conv2d-nchw-chw-i8-asm:
+	@${BUDDY_OPT} ./dw_conv_2d_nchw_chw_i8.mlir \
+		-convert-linalg-to-gemmini \
+		-convert-linalg-to-loops \
+		-lower-gemmini | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+buddyext,+D -float-abi=hard \
+		-o log.s
+
+gemmini-linalg-dw-conv2d-nchw-chw-i8-run:
+	@${BUDDY_OPT} ./dw_conv_2d_nchw_chw_i8.mlir \
 		-convert-linalg-to-gemmini \
 		-convert-linalg-to-loops \
 		-lower-gemmini | \


### PR DESCRIPTION
Two Gemmini depthwise convolution examples have been added.

In dw_conv_2d_nchw_chw_i8.mlir, the -convert-linalg-to-loops option is used to convert linalg.depthwise_conv_2d_nchw_chw into loops for computation. In the future, a new pass may be added to enable its computation to leverage gemmini.tile_conv.

In dw-tile-conv.mlir, the multiple channels of the input tensor are split, and gemmini.tile_conv is invoked multiple times to compute the depthwise convolution. The correctness of this approach has been verified, although its performance might be relatively low and could be improved later.