### PR TITLE
[midend] Optimization on matmul-transpose-b vectorization

### DIFF
--- a/midend/lib/Conversion/MatMulOptimization/MatMulTransposeBVec.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/MatMulTransposeBVec.cpp
@@ -19,12 +19,16 @@
 //===----------------------------------------------------------------------===//
 
 #include <mlir/Dialect/Affine/IR/AffineOps.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/Linalg/Transforms/Transforms.h>
+#include <mlir/Dialect/MemRef/IR/MemRef.h>
+#include <mlir/Dialect/Vector/IR/VectorOps.h>
 #include <mlir/IR/Dialect.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/IR/TypeUtilities.h>
 #include <mlir/IR/Value.h>
+#include <mlir/IR/ValueRange.h>
 #include <mlir/Pass/Pass.h>
 
 #include "Utils/Utils.h"
@@ -37,132 +41,138 @@ using namespace vector;
 //===----------------------------------------------------------------------===//
 
 namespace {
-class MatMulTransposeBVecPattern : public ConversionPattern{
+class MatMulTransposeBVecPattern : public ConversionPattern {
 public:
-    explicit MatMulTransposeBVecPattern(MLIRContext *context,int64_t vecSizeparam)
-        : ConversionPattern(linalg::MatmulTransposeBOp::getOperationName(),1,context){
-            vecSize = vecSizeparam;
-        }
-    
-    LogicalResult
-    matchAndRewrite(Operation *op,ArrayRef<Value> /*operands*/,
-                ConversionPatternRewriter &rewriter) const override{
-        auto loc = op->getLoc();
-        auto ctx = op->getContext();
-        // Get input A, B, C.
-        Value A = op->getOperand(0);
-        Value B = op->getOperand(1);
-        Value C = op->getOperand(2);
+  explicit MatMulTransposeBVecPattern(MLIRContext *context,
+                                      int64_t vecSizeparam)
+      : ConversionPattern(linalg::MatmulTransposeBOp::getOperationName(), 1,
+                          context) {
+    vecSize = vecSizeparam;
+  }
 
-        // Get shape of input and output.
-        ShapedType ATy = A.getType().cast<ShapedType>();
-        Type eleTy = ATy.getElementType();
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> /*operands*/,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op->getLoc();
+    auto ctx = op->getContext();
+    // Get input A, B, C.
+    Value A = op->getOperand(0);
+    Value B = op->getOperand(1);
+    Value C = op->getOperand(2);
 
-        // the element type for mask vector.
-        IntegerType i1 = IntegerType::get(ctx, 1);
-        
-        VectorType vectorTy = mlir::VectorType::get({vecSize}, eleTy);
-        VectorType vectorMaskTy = VectorType::get({vecSize}, i1);
-        
-        const Value c0 =
-            rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
-        const Value c1 =
-            rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
-        const Value step = rewriter.create<arith::ConstantIndexOp>(loc, vecSize);
-        
-        const Value c0Ele = buddy::insertZeroConstantOp(ctx, rewriter, loc, eleTy);
-        Value passthruVec = rewriter.create<SplatOp>(loc, vectorTy, c0Ele);
+    // Get shape of input and output.
+    ShapedType ATy = A.getType().cast<ShapedType>();
+    Type eleTy = ATy.getElementType();
 
-        const Value aRow = rewriter.create<memref::DimOp>(loc, A, c0);
-        const Value bRow = rewriter.create<memref::DimOp>(loc, B, c0);
-        const Value bCol = rewriter.create<memref::DimOp>(loc, B, c1);
-        
-        AffineExpr d0;
-        bindDims(ctx, d0);
-        AffineMap vecTailMap = AffineMap::get(1, 0, {d0.ceilDiv(vecSize)}, ctx);
-        SmallVector<Value, 8> lowerBounds(2, c0);
-        SmallVector<Value, 8> uperBounds{aRow, bRow};
-        SmallVector<int64_t, 8> steps(2, 1);
-        // clang-format off
-        affine::buildAffineLoopNest(
-            rewriter, loc, lowerBounds, uperBounds, steps,
-            [&](OpBuilder &builder, Location loc, ValueRange ivs) {
-                // Create loop based on vector size.
-                builder.create<affine::AffineForOp>(
-                    loc, ValueRange{c0}, builder.getDimIdentityMap(),
-                    ValueRange{bCol}, vecTailMap, 1, std::nullopt,
-                    [&](OpBuilder &nestedBuilder, Location nestedLoc, Value iv,
-                        ValueRange itrArgs) {
-                        AffineExpr a,b,c;
-                        bindDims(ctx, a,b,c);
-                        AffineMap AVectorMap = AffineMap::get(
-                            /*dimCount=*/3, /*symbolCount=*/0, {a, c * vecSize}, ctx);
-                        // Check tail.
-                        AffineExpr m, n, k;
-                        bindDims(ctx, m, n, k);
-                        AffineMap BVectorMap = AffineMap::get(
-                            /*dimCount=*/3, /*symbolCount=*/0, {m, k * vecSize}, ctx);
-                        
-                        // Calculate the tail.
-                        Value bColCur = builder.create<arith::MulIOp>(loc, iv, step);
-                        Value tailLen = builder.create<arith::SubIOp>(loc, bCol, bColCur);
-                        Value tailFlag = rewriter.create<arith::CmpIOp>(
-                            loc, arith::CmpIPredicate::sge, tailLen, step);
-                        // If the current column does not reach the tail.
-                        builder.create<scf::IfOp>(loc, tailFlag,
-                            [&](OpBuilder &builder, Location loc) {
-                            Value aVec = builder.create<affine::AffineVectorLoadOp>(
-                                loc, vectorTy, A, AVectorMap, ValueRange{ivs[0], ivs[1], iv});
-                            Value bVec = builder.create<affine::AffineVectorLoadOp>(
-                                loc, vectorTy, B, BVectorMap, ValueRange{ivs[1], ivs[1], iv});
-                            Value resvec = builder.create<arith::MulFOp>(loc,aVec,bVec);
-                            Value res1 = builder.create<mlir::vector::ReductionOp>(
-                                loc,mlir::vector::CombiningKind::ADD,resvec);
-                            Value res2 = builder.create<memref::LoadOp>(
-                                loc, C, ValueRange{ivs[0], ivs[1]});
-                            Value sum = builder.create<arith::AddFOp>(loc, res1, res2);
-                            builder.create<memref::StoreOp>(loc, sum, 
-                                C, ValueRange{ivs[0], ivs[1]});
-                            builder.create<scf::YieldOp>(loc);
-                            },
-                        // The else branch 
-                        [&](OpBuilder &builder, Location loc) {
-                            // TODO: remove this value and operation?
-                            // Value aVec = builder.create<affine::AffineVectorLoadOp>(
-                            //     loc, vectorTy, A, AVectorMap, ValueRange{ivs[0], ivs[1], iv});
-                            builder.create<affine::AffineVectorLoadOp>(
-                                loc, vectorTy, A, AVectorMap, ValueRange{ivs[0], ivs[1], iv});
-                            // Create mask according to the tail.
-                            Value maskVec = builder.create<CreateMaskOp>(
-                                loc, vectorMaskTy, tailLen);
-                            Value ColIdxTail = builder.create<arith::MulIOp>(loc, iv, step);
+    // the element type for mask vector.
+    IntegerType i1 = IntegerType::get(ctx, 1);
 
-                            Value aVecTail = builder.create<MaskedLoadOp>(
-                                loc, vectorTy, A, ValueRange{ivs[0], ColIdxTail},
-                                maskVec, passthruVec);
-                            
-                            Value bVecTail = builder.create<MaskedLoadOp>(
-                                loc, vectorTy, B, ValueRange{ivs[1], ColIdxTail},
-                                maskVec, passthruVec);
-                        
-                            Value resvec = builder.create<arith::MulFOp>(loc,aVecTail,bVecTail);
-                            Value res1 = builder.create<mlir::vector::ReductionOp>(
-                                loc,mlir::vector::CombiningKind::ADD,resvec);
-                            Value res2 = builder.create<memref::LoadOp>(
-                                loc, C, ValueRange{ivs[0], ivs[1]});
-                            Value sum = builder.create<arith::AddFOp>(loc, res1, res2);
-                            builder.create<memref::StoreOp>(loc, sum, C, ValueRange{ivs[0], ivs[1]});
-                            builder.create<scf::YieldOp>(loc);
-                        });
-                        builder.create<affine::AffineYieldOp>(loc);
-                });
+    VectorType vectorTy = mlir::VectorType::get({vecSize}, eleTy);
+    VectorType vectorMaskTy = VectorType::get({vecSize}, i1);
+
+    const Value c0 =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+    const Value c1 =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
+    const Value step = rewriter.create<arith::ConstantIndexOp>(loc, vecSize);
+
+    const Value c0Ele = buddy::insertZeroConstantOp(ctx, rewriter, loc, eleTy);
+    Value passthruVec = rewriter.create<SplatOp>(loc, vectorTy, c0Ele);
+
+    const Value aRow = rewriter.create<memref::DimOp>(loc, A, c0);
+    const Value bRow = rewriter.create<memref::DimOp>(loc, B, c0);
+    const Value bCol = rewriter.create<memref::DimOp>(loc, B, c1);
+
+    AffineExpr d0;
+    bindDims(ctx, d0);
+    AffineMap vecTailMap = AffineMap::get(1, 0, {d0.ceilDiv(vecSize)}, ctx);
+    SmallVector<Value, 8> lowerBounds(2, c0);
+    SmallVector<Value, 8> uperBounds{aRow, bRow};
+    SmallVector<int64_t, 8> steps(2, 1);
+
+    affine::buildAffineLoopNest(
+        rewriter, loc, lowerBounds, uperBounds, steps,
+        [&](OpBuilder &builder, Location loc, ValueRange ivs) {
+          // Create loop based on vector size.
+          auto innerLoop = builder.create<affine::AffineForOp>(
+              loc, ValueRange{c0}, builder.getDimIdentityMap(),
+              ValueRange{bCol}, vecTailMap, 1, ValueRange{passthruVec},
+              [&](OpBuilder &nestedBuilder, Location nestedLoc, Value iv,
+                  ValueRange itrArgs) {
+                Value acc = itrArgs[0];
+
+                AffineExpr a, b, c;
+                bindDims(ctx, a, b, c);
+                AffineMap AVectorMap = AffineMap::get(
+                    /*dimCount=*/3, /*symbolCount=*/0, {a, c * vecSize}, ctx);
+                // Check tail.
+                AffineExpr m, n, k;
+                bindDims(ctx, m, n, k);
+                AffineMap BVectorMap = AffineMap::get(
+                    /*dimCount=*/3, /*symbolCount=*/0, {m, k * vecSize}, ctx);
+
+                // Calculate the tail.
+                Value bColCur = builder.create<arith::MulIOp>(loc, iv, step);
+                Value tailLen =
+                    builder.create<arith::SubIOp>(loc, bCol, bColCur);
+                Value tailFlag = rewriter.create<arith::CmpIOp>(
+                    loc, arith::CmpIPredicate::sge, tailLen, step);
+                // If the current column does not reach the tail.
+                auto ifOp = builder.create<scf::IfOp>(
+                    loc, tailFlag,
+                    [&](OpBuilder &builder, Location loc) {
+                      Value aVec = builder.create<affine::AffineVectorLoadOp>(
+                          loc, vectorTy, A, AVectorMap,
+                          ValueRange{ivs[0], ivs[1], iv});
+                      Value bVec = builder.create<affine::AffineVectorLoadOp>(
+                          loc, vectorTy, B, BVectorMap,
+                          ValueRange{ivs[1], ivs[1], iv});
+                      Value resvec =
+                          builder.create<arith::MulFOp>(loc, aVec, bVec);
+                      Value newAcc =
+                          builder.create<arith::AddFOp>(loc, acc, resvec);
+                      builder.create<scf::YieldOp>(loc, newAcc);
+                    },
+                    // The else branch
+                    [&](OpBuilder &builder, Location loc) {
+                      // Create mask according to the tail.
+                      Value maskVec = builder.create<CreateMaskOp>(
+                          loc, vectorMaskTy, tailLen);
+                      Value ColIdxTail =
+                          builder.create<arith::MulIOp>(loc, iv, step);
+
+                      Value aVecTail = builder.create<MaskedLoadOp>(
+                          loc, vectorTy, A, ValueRange{ivs[0], ColIdxTail},
+                          maskVec, passthruVec);
+
+                      Value bVecTail = builder.create<MaskedLoadOp>(
+                          loc, vectorTy, B, ValueRange{ivs[1], ColIdxTail},
+                          maskVec, passthruVec);
+
+                      Value resvec = builder.create<arith::MulFOp>(
+                          loc, aVecTail, bVecTail);
+                      Value newAcc =
+                          builder.create<arith::AddFOp>(loc, acc, resvec);
+                      builder.create<scf::YieldOp>(loc, newAcc);
+                    });
+                builder.create<affine::AffineYieldOp>(loc, ifOp.getResult(0));
+              });
+
+          Value load = builder.create<memref::LoadOp>(
+              loc, C, ValueRange{ivs[0], ivs[1]});
+          Value reduction = builder.create<vector::ReductionOp>(
+              loc, CombiningKind::ADD, innerLoop->getResult(0), load,
+              arith::FastMathFlags::reassoc);
+          builder.create<memref::StoreOp>(loc, reduction, C,
+                                          ValueRange{ivs[0], ivs[1]});
         });
-        // clang-format on
-        rewriter.eraseOp(op);
-        return success();
-    }
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+
 private:
-    int64_t vecSize;
+  int64_t vecSize;
 };
 } // end anonymous namespace
 
@@ -170,41 +180,45 @@ private:
 // MatMulVectorizationPass
 //===----------------------------------------------------------------------===//
 
-namespace{
-    class MatMulTransposeBVecPass
-        :public PassWrapper<MatMulTransposeBVecPass,OperationPass<ModuleOp>>{
+namespace {
+class MatMulTransposeBVecPass
+    : public PassWrapper<MatMulTransposeBVecPass, OperationPass<ModuleOp>> {
 public:
-    MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MatMulTransposeBVecPass)
-    StringRef getArgument() const final{ return "matmul-transpose-b-vectorization"; }
-    StringRef getDescription() const final { return "vectorize linalg MatmulTransposeBOp"; }
-    MatMulTransposeBVecPass() = default;
-    MatMulTransposeBVecPass(const MatMulTransposeBVecPass &) {}
-    void runOnOperation()   override;
-    void getDependentDialects(DialectRegistry &registry) const override{
-        registry.insert<linalg::LinalgDialect,scf::SCFDialect,
-            affine::AffineDialect,VectorDialect>();
-    }
-    Option<int64_t> vecSize{*this,"vec-size",
-                            llvm::cl::desc("The size of vectorization"),
-                            llvm::cl::init(32)};
-                            
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MatMulTransposeBVecPass)
+  StringRef getArgument() const final {
+    return "matmul-transpose-b-vectorization";
+  }
+  StringRef getDescription() const final {
+    return "vectorize linalg MatmulTransposeBOp";
+  }
+  MatMulTransposeBVecPass() = default;
+  MatMulTransposeBVecPass(const MatMulTransposeBVecPass &) {}
+  void runOnOperation() override;
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect, scf::SCFDialect,
+                    affine::AffineDialect, VectorDialect>();
+  }
+  Option<int64_t> vecSize{*this, "vec-size",
+                          llvm::cl::desc("The size of vectorization"),
+                          llvm::cl::init(32)};
 };
-}
+} // namespace
 
-void MatMulTransposeBVecPass::runOnOperation(){
-    MLIRContext *context = &getContext();
-    ModuleOp module = getOperation();
+void MatMulTransposeBVecPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  ModuleOp module = getOperation();
 
-    ConversionTarget target(*context);
-    target.addLegalDialect<arith::ArithDialect, affine::AffineDialect,
+  ConversionTarget target(*context);
+  target
+      .addLegalDialect<arith::ArithDialect, affine::AffineDialect,
                        scf::SCFDialect, memref::MemRefDialect, VectorDialect>();
-    target.addLegalOp<ModuleOp,func::FuncOp,func::ReturnOp>();
-    target.addLegalOp<linalg::FillOp>();
+  target.addLegalOp<ModuleOp, func::FuncOp, func::ReturnOp>();
+  target.addLegalOp<linalg::FillOp>();
 
-    RewritePatternSet patterns(context);
-    patterns.add<MatMulTransposeBVecPattern>(context,vecSize);
+  RewritePatternSet patterns(context);
+  patterns.add<MatMulTransposeBVecPattern>(context, vecSize);
 
-    if (failed(applyPartialConversion(module, target, std::move(patterns))))
+  if (failed(applyPartialConversion(module, target, std::move(patterns))))
     signalPassFailure();
 }
 

--- a/tests/Conversion/matmul-transpose-b-vectorization.mlir
+++ b/tests/Conversion/matmul-transpose-b-vectorization.mlir
@@ -1,0 +1,101 @@
+// RUN: buddy-opt %s \
+// RUN:     -matmul-transpose-b-vectorization="vec-size=64" \
+// RUN:     -convert-linalg-to-loops -lower-affine -convert-scf-to-cf \
+// RUN:     -convert-vector-to-llvm -finalize-memref-to-llvm -convert-arith-to-llvm \
+// RUN:     -convert-func-to-llvm -reconcile-unrealized-casts \
+// RUN: | mlir-cpu-runner -e main -entry-point-result=void \
+// RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_runner_utils%shlibext \
+// RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_c_runner_utils%shlibext \
+// RUN: | FileCheck %s
+
+module{
+  func.func private @printMemrefF32(memref<*xf32>)
+  func.func private @printMemrefF64(memref<*xf64>)
+
+  func.func @matmul_f32(%a : memref<?x?xf32>, %b : memref<?x?xf32>, %c : memref<?x?xf32>) {
+    linalg.matmul_transpose_b
+      ins(%a, %b: memref<?x?xf32>, memref<?x?xf32>)
+      outs(%c:memref<?x?xf32>)
+    return
+  }
+
+  func.func @matmul_f64(%a : memref<?x?xf64>, %b : memref<?x?xf64>, %c : memref<?x?xf64>) {
+    linalg.matmul_transpose_b
+      ins(%a, %b: memref<?x?xf64>, memref<?x?xf64>)
+      outs(%c:memref<?x?xf64>)
+    return
+  }
+
+  func.func @main(){
+    // Set up dims.
+    %cM = arith.constant 4 : index
+    %cN = arith.constant 4 : index
+    %cK = arith.constant 4 : index
+
+    //--------------------------------------------------------------------------
+    // Test f32 as element type.
+    //--------------------------------------------------------------------------
+
+    // Set Init Value.
+    %cf1_32 = arith.constant 1.0 : f32
+
+    %A_f32 = memref.alloc(%cM, %cK) : memref<?x?xf32>
+    %B_f32 = memref.alloc(%cK, %cN) : memref<?x?xf32>
+    %C_f32 = memref.alloc(%cM, %cN) : memref<?x?xf32>
+
+    linalg.fill ins(%cf1_32 : f32) outs(%A_f32 : memref<?x?xf32>)
+    linalg.fill ins(%cf1_32 : f32) outs(%B_f32 : memref<?x?xf32>)
+    linalg.fill ins(%cf1_32 : f32) outs(%C_f32 : memref<?x?xf32>)
+
+    call @matmul_f32(%A_f32, %B_f32, %C_f32) : (memref<?x?xf32>, memref<?x?xf32>, memref<?x?xf32>) -> ()
+
+    // Print output.
+    // CHECK: Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [4, 4] strides = [4, 1] data =
+    // CHECK-NEXT: [
+    // CHECK-SAME:  [5, 5, 5, 5],
+    // CHECK-NEXT:  [5, 5, 5, 5],
+    // CHECK-NEXT:  [5, 5, 5, 5],
+    // CHECK-NEXT:  [5, 5, 5, 5]
+    // CHECK-SAME: ]
+    %print_C_f32 = memref.cast %C_f32 : memref<?x?xf32> to memref<*xf32>
+    call @printMemrefF32(%print_C_f32) : (memref<*xf32>) -> ()
+
+    memref.dealloc %C_f32 : memref<?x?xf32>
+    memref.dealloc %B_f32 : memref<?x?xf32>
+    memref.dealloc %A_f32 : memref<?x?xf32>
+
+    //--------------------------------------------------------------------------
+    // Test f64 as element type.
+    //--------------------------------------------------------------------------
+
+    // Set Init Value.
+    %cf1_64 = arith.constant 1.0 : f64
+
+    %A_f64 = memref.alloc(%cM, %cK) : memref<?x?xf64>
+    %B_f64 = memref.alloc(%cK, %cN) : memref<?x?xf64>
+    %C_f64 = memref.alloc(%cM, %cN) : memref<?x?xf64>
+
+    linalg.fill ins(%cf1_64 : f64) outs(%A_f64 : memref<?x?xf64>)
+    linalg.fill ins(%cf1_64 : f64) outs(%B_f64 : memref<?x?xf64>)
+    linalg.fill ins(%cf1_64 : f64) outs(%C_f64 : memref<?x?xf64>)
+
+    call @matmul_f64(%A_f64, %B_f64, %C_f64) : (memref<?x?xf64>, memref<?x?xf64>, memref<?x?xf64>) -> ()
+
+    // Print output.
+    // CHECK: Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [4, 4] strides = [4, 1] data =
+    // CHECK-NEXT: [
+    // CHECK-SAME:  [5, 5, 5, 5],
+    // CHECK-NEXT:  [5, 5, 5, 5],
+    // CHECK-NEXT:  [5, 5, 5, 5],
+    // CHECK-NEXT:  [5, 5, 5, 5]
+    // CHECK-SAME: ]
+    %print_C_f64 = memref.cast %C_f64 : memref<?x?xf64> to memref<*xf64>
+    call @printMemrefF64(%print_C_f64) : (memref<*xf64>) -> ()
+
+    memref.dealloc %C_f64 : memref<?x?xf64>
+    memref.dealloc %B_f64 : memref<?x?xf64>
+    memref.dealloc %A_f64 : memref<?x?xf64>
+
+    return 
+  }
+}


### PR DESCRIPTION
Current vectorization pass of matmul-transpose-b reduce the vector in each iteration and accumulate it to the result element. This commit modify it into elementwise addition and do the reduction after the inner loop with reassoc enabled.

This leads to a ~4x speedup on musepi

```
----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
benchMatmulTransposeB/matmul                   334 ms          334 ms            2
benchMatmulTransposeB/matmul_vectorized        707 ms          707 ms            1
benchMatmulTransposeB/matmul_opt0              174 ms          174 ms            4
------------------------------------------------
MatmulTransposeB-vectorized PASS
MatmulTransposeB-opt0 PASS
------------------------------------------------
```

And if with `-mllvm --riscv-v-vector-bits-min=256` options enabled, the speedup is ~3x

```
----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
benchMatmulTransposeB/matmul                   333 ms          333 ms            2
benchMatmulTransposeB/matmul_vectorized        325 ms          325 ms            2
benchMatmulTransposeB/matmul_opt0              108 ms          108 ms            6
------------------------------------------------
MatmulTransposeB-vectorized PASS
MatmulTransposeB-opt0 PASS
------------------------------------------------
```

And, if enable reduction `reassoc` on the current vectorization result, there is still a speedup

```
----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
benchMatmulTransposeB/matmul                   334 ms          333 ms            2
benchMatmulTransposeB/matmul_vectorized        155 ms          155 ms            5
benchMatmulTransposeB/matmul_opt0              108 ms          108 ms            6
------------------------------------------------
MatmulTransposeB-vectorized PASS
MatmulTransposeB-opt0 PASS
------------------------------------------------
```

The vectorized code compared to the current version:

```mlir
  // current vectorization result
  func.func @matmul_transpose_b_kernel_vectorized(%arg0: memref<?x?xf32>, %arg1: memref<?x?xf32>, %arg2: memref<?x?xf32>) {
    %c0 = arith.constant 0 : index
    %c1 = arith.constant 1 : index
    %c32 = arith.constant 32 : index
    %cst = arith.constant 0.000000e+00 : f32
    %0 = vector.splat %cst : vector<32xf32>
    %dim = memref.dim %arg0, %c0 : memref<?x?xf32>
    %dim_0 = memref.dim %arg1, %c0 : memref<?x?xf32>
    %dim_1 = memref.dim %arg1, %c1 : memref<?x?xf32>
    affine.for %arg3 = #map(%c0) to #map(%dim) {
      affine.for %arg4 = #map(%c0) to #map(%dim_0) {
        affine.for %arg5 = #map(%c0) to #map1(%dim_1) {
          %1 = arith.muli %arg5, %c32 : index
          %2 = arith.subi %dim_1, %1 : index
          %3 = arith.cmpi sge, %2, %c32 : index
          scf.if %3 {
            %4 = affine.vector_load %arg0[%arg3, %arg5 * 32] : memref<?x?xf32>, vector<32xf32>
            %5 = affine.vector_load %arg1[%arg4, %arg5 * 32] : memref<?x?xf32>, vector<32xf32>
            %6 = arith.mulf %4, %5 : vector<32xf32>
            %7 = vector.reduction <add>, %6 : vector<32xf32> into f32
            %8 = memref.load %arg2[%arg3, %arg4] : memref<?x?xf32>
            %9 = arith.addf %7, %8 : f32
            memref.store %9, %arg2[%arg3, %arg4] : memref<?x?xf32>
          } else {
            %4 = affine.vector_load %arg0[%arg3, %arg5 * 32] : memref<?x?xf32>, vector<32xf32>
            %5 = vector.create_mask %2 : vector<32xi1>
            %6 = arith.muli %arg5, %c32 : index
            %7 = vector.maskedload %arg0[%arg3, %6], %5, %0 : memref<?x?xf32>, vector<32xi1>, vector<32xf32> into vector<32xf32>
            %8 = vector.maskedload %arg1[%arg4, %6], %5, %0 : memref<?x?xf32>, vector<32xi1>, vector<32xf32> into vector<32xf32>
            %9 = arith.mulf %7, %8 : vector<32xf32>
            %10 = vector.reduction <add>, %9 : vector<32xf32> into f32
            %11 = memref.load %arg2[%arg3, %arg4] : memref<?x?xf32>
            %12 = arith.addf %10, %11 : f32
            memref.store %12, %arg2[%arg3, %arg4] : memref<?x?xf32>
          }
        }
      }
    }
    return
  }

  // after this commit
  func.func @matmul_transpose_b_kernel_opt0(%arg0: memref<?x?xf32>, %arg1: memref<?x?xf32>, %arg2: memref<?x?xf32>) {
    %c0 = arith.constant 0 : index
    %c1 = arith.constant 1 : index
    %c32 = arith.constant 32 : index
    %cst = arith.constant 0.000000e+00 : f32
    %0 = vector.splat %cst : vector<32xf32>
    %dim = memref.dim %arg0, %c0 : memref<?x?xf32>
    %dim_0 = memref.dim %arg1, %c0 : memref<?x?xf32>
    %dim_1 = memref.dim %arg1, %c1 : memref<?x?xf32>
    affine.for %arg3 = #map(%c0) to #map(%dim) {
      affine.for %arg4 = #map(%c0) to #map(%dim_0) {
        %1 = affine.for %arg5 = #map(%c0) to #map1(%dim_1) iter_args(%arg6 = %0) -> (vector<32xf32>) {
          %4 = arith.muli %arg5, %c32 : index
          %5 = arith.subi %dim_1, %4 : index
          %6 = arith.cmpi sge, %5, %c32 : index
          %7 = scf.if %6 -> (vector<32xf32>) {
            %8 = affine.vector_load %arg0[%arg3, %arg5 * 32] : memref<?x?xf32>, vector<32xf32>
            %9 = affine.vector_load %arg1[%arg4, %arg5 * 32] : memref<?x?xf32>, vector<32xf32>
            %10 = arith.mulf %8, %9 : vector<32xf32>
            %11 = arith.addf %arg6, %10 : vector<32xf32>
            scf.yield %11 : vector<32xf32>
          } else {
            %8 = vector.create_mask %5 : vector<32xi1>
            %9 = arith.muli %arg5, %c32 : index
            %10 = vector.maskedload %arg0[%arg3, %9], %8, %0 : memref<?x?xf32>, vector<32xi1>, vector<32xf32> into vector<32xf32>
            %11 = vector.maskedload %arg1[%arg4, %9], %8, %0 : memref<?x?xf32>, vector<32xi1>, vector<32xf32> into vector<32xf32>
            %12 = arith.mulf %10, %11 : vector<32xf32>
            %13 = arith.addf %arg6, %12 : vector<32xf32>
            scf.yield %13 : vector<32xf32>
          }
          affine.yield %7 : vector<32xf32>
        }
        %2 = memref.load %arg2[%arg3, %arg4] : memref<?x?xf32>
        %3 = vector.reduction <add>, %1, %2 fastmath<reassoc> : vector<32xf32> into f32
        memref.store %3, %arg2[%arg3, %arg4] : memref<?x?xf32>
      }
    }
    return
  }
```

A simple testcase is also added under the tests dir.