### PR TITLE
[midend] Modify the matmulParallelVec pass

### DIFF
--- a/midend/lib/Conversion/MatMulOptimization/MatMulParallelVectorization.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/MatMulParallelVectorization.cpp
@@ -98,9 +98,14 @@ public:
         llvm::map_range(ArrayRef<LoopReduction>{},
                         [](const LoopReduction &red) { return red.value; }));
 
+    // Apply the column of matrix B
+    Value appliedColOfB = rewriter.create<affine::AffineApplyOp>(
+                          loc, AffineMap::get(1, 0, d0 - affineVectorSize + 1),
+                          ValueRange{bCol});                        
+
     // Create the primary parallel loop for matrix multiplication.
     AffineParallelOp parallelLoop = rewriter.create<affine::AffineParallelOp>(
-        loc, ValueRange(reducedValues).getTypes(), ValueRange{bCol},
+        loc, ValueRange(reducedValues).getTypes(), ValueRange{appliedColOfB},
         ArrayRef<NamedAttribute>{
             rewriter.getNamedAttr("lowerBoundsGroups",
                                   rewriter.getI32TensorAttr({1})),
@@ -116,6 +121,11 @@ public:
             rewriter.getNamedAttr("reductions", rewriter.getArrayAttr({})),
             rewriter.getNamedAttr("steps", rewriter.getI64ArrayAttr({affineVectorSize}))}); 
 
+    // Compile time branch detection.
+    if (C.getType().cast<MemRefType>().isDynamicDim(1) or
+        C.getType().cast<MemRefType>().getDimSize(1) % affineVectorSize != 0) {
+
+///////
     // Create the loop body for the parallel loop.
     Block *loopBody = new Block();
     rewriter.setInsertionPointToStart(loopBody);
@@ -126,22 +136,10 @@ public:
     rewriter.create<affine::AffinePrefetchOp>(
         loc, A, AffineMap::get(2, 0, {d0, d1}, rewriter.getContext()),
         ArrayRef<Value>{aRow, bRow}, false, 3, true);
+////////
 
-    // Compile time branch detection.
-    if (C.getType().cast<MemRefType>().isDynamicDim(1) or
-        C.getType().cast<MemRefType>().getDimSize(1) % affineVectorSize != 0) {
-
-      // Depending on the position, use either full vectors or tail vectors.
-      affine::AffineIfOp branchingOp = rewriter.create<affine::AffineIfOp>(
-          loc,
-          IntegerSet::get(
-              1, 1, {s0 - d0 - affineVectorSize}, {false}),
-          ValueRange{loopVarColOfB, bCol}, true);
-
-      // Branch handling full vector operations.
-      OpBuilder trueBranchBuilder = branchingOp.getThenBodyBuilder();
       affine::buildAffineLoopNest(  
-          trueBranchBuilder, loc, {zeroIndex}, {aRow}, 1,
+        rewriter, loc, {zeroIndex}, {aRow}, 1,
           [&](OpBuilder &builder, Location loc, ValueRange ivRange) {
             Value loopVarRowOfA = ivRange.front();
             Value cVec = builder.create<affine::AffineVectorLoadOp>(
@@ -186,21 +184,36 @@ public:
                     AffineMap::get(2, 0, {d0, d1},
                                     builder.getContext()),
                     ValueRange{loopVarRowOfA, loopVarColOfB});
-                  });     
+                  });
+                  rewriter.create<affine::AffineYieldOp>(loc);
+
+                  // Finalize the loop and erase the original operation.
+                  parallelLoop.getRegion().push_back(loopBody);
+                  rewriter.setInsertionPointAfter(parallelLoop);       
+
+      // Depending on the position, use either full vectors or tail vectors.
+      affine::AffineIfOp branchingOp = rewriter.create<affine::AffineIfOp>(
+          loc,
+          IntegerSet::get(
+              1, 0, {d0 % affineVectorSize - 1}, {false}),
+          ValueRange{bCol}, /*hasElse=*/false);
 
       // Branch handling operations on the tail.
-      OpBuilder falseBranchBuilder = branchingOp.getElseBodyBuilder();
-      Value tailSize = falseBranchBuilder.create<arith::SubIOp>(loc, bCol, loopVarColOfB);
-      Value maskVector = falseBranchBuilder.create<vector::CreateMaskOp>(
+      OpBuilder trueBranchBuilder = branchingOp.getThenBodyBuilder();
+      Value tailSize = trueBranchBuilder.create<affine::AffineApplyOp>(
+        loc, AffineMap::get(1, 0, d0 % affineVectorSize), ValueRange{bCol});
+      Value maskVector = trueBranchBuilder.create<vector::CreateMaskOp>(
         loc, VectorType::get({affineVectorSize}, rewriter.getI1Type()),
         ValueRange{tailSize});
+      Value loopVarColOfBTail = trueBranchBuilder.create<arith::SubIOp>(loc, bCol, tailSize);
+
         affine::buildAffineLoopNest(  
-          falseBranchBuilder, loc, {zeroIndex}, {aRow}, 1,
+          trueBranchBuilder, loc, {zeroIndex}, {aRow}, 1,
           [&](OpBuilder &builder, Location loc, ValueRange ivRange) {
             Value loopVarRowOfA = ivRange.front();
             Value cVec = builder.create<vector::MaskedLoadOp>(
                     loc, VectorType::get({affineVectorSize}, elementType), C,
-                    ValueRange{loopVarRowOfA, loopVarColOfB}, maskVector,
+                    ValueRange{loopVarRowOfA, loopVarColOfBTail}, maskVector,
                     zeroElementTypeVec);
 
             auto iter_vec = builder.create<affine::AffineForOp>(
@@ -213,10 +226,10 @@ public:
                     //   loc, VectorType::get({affineVectorSize}, elementType), B,
                     //   AffineMap::get(2, 0, {d0, d1},
                     //                   rewriter.getContext()),
-                    //   ValueRange{iv1, loopVarColOfB});
+                    //   ValueRange{iv1, loopVarColOfBTail});
                     Value bVec = builder.create<vector::MaskedLoadOp>(
                       loc, VectorType::get({affineVectorSize}, elementType), B,
-                      ValueRange{iv1, loopVarColOfB}, maskVector,
+                      ValueRange{iv1, loopVarColOfBTail}, maskVector,
                       zeroElementTypeVec);
                       
                     Value aElement = builder.create<memref::LoadOp>(
@@ -241,10 +254,20 @@ public:
                   builder.create<affine::AffineYieldOp>(loc, computedVec);
                   });
                   builder.create<vector::MaskedStoreOp>(
-                    loc, C, ValueRange{loopVarRowOfA, loopVarColOfB},
+                    loc, C, ValueRange{loopVarRowOfA, loopVarColOfBTail},
                     maskVector, iter_vec.getResult(0));
-                  });   
+                  });
+ 
     } else {
+      Block *loopBody = new Block();
+      rewriter.setInsertionPointToStart(loopBody);
+      loopBody->addArgument(rewriter.getIndexType(), loc);
+      Value loopVarColOfB = loopBody->getArguments()[0];
+  
+      // Prefetching data from tensor 'A' for better cache utilization.
+      rewriter.create<affine::AffinePrefetchOp>(
+          loc, A, AffineMap::get(2, 0, {d0, d1}, rewriter.getContext()),
+          ArrayRef<Value>{aRow, bRow}, false, 3, true);
       affine::buildAffineLoopNest(  
         rewriter, loc, {zeroIndex}, {aRow}, 1,
         [&](OpBuilder &builder, Location loc, ValueRange ivRange) {
@@ -292,13 +315,15 @@ public:
                                   builder.getContext()),
                   ValueRange{loopVarRowOfA, loopVarColOfB});
                 });
+      
+                rewriter.create<affine::AffineYieldOp>(loc);
+
+                // Finalize the loop and erase the original operation.
+                parallelLoop.getRegion().push_back(loopBody);
+                rewriter.setInsertionPointAfter(parallelLoop);
     }
 
-    rewriter.create<affine::AffineYieldOp>(loc);
 
-    // Finalize the loop and erase the original operation.
-    parallelLoop.getRegion().push_back(loopBody);
-    rewriter.setInsertionPointAfter(parallelLoop);
 
     rewriter.eraseOp(op);
     return success();


### PR DESCRIPTION
The current matmulParallelVectorization pass stores and loads the C matrix once at the innermost level. This modification changes the mode of accessing the matrix and reduces the number of times the C matrix is accessed. Also add blocking for k dimensions, default k=32, which can be modified using the parameter “k-block-size”.

For the case of multiplying large square matrices, there is about  ~5x speedup, ([1024x1024] x [1024x1024], from 411ms to 80ms)
For the case of narrower B matrices, there is about a ~7x speedup, ([4096x1024] x [1024x40], from 71ms to 11ms)
For the case of a flatter A matrix, there is about a ~2.5x speedup, ([40x4096] x [4096x4096], from 150ms to 60ms)


The same change was made to batch_matmul.
The optimization of these two operators is integrated into deepseek for testing on x86 platforms, and the speedup of generating a single token is improved from 25s/token to 20s/token when the omp parallel optimization is removed.

Tests on rvv devices with smaller cache show that setting the right k-block-size can improve the speed of operation:
In the following test of the linalg.matmul operator, set vec-size=64 and k-block-size=16.
Significant speedups were achieved in conjunction with openMP
![2f7883c4ad5572627668eae2ab23827](https://github.com/user-attachments/assets/04a3047b-e501-475e-8741-72306d41267e)
