### PR TITLE
[midend] Support scalable vector for matmul-transpos-b vectorization

### DIFF
--- a/tests/Conversion/matmul-transpose-b-vectorization.mlir
+++ b/tests/Conversion/matmul-transpose-b-vectorization.mlir
@@ -1,5 +1,5 @@
 // RUN: buddy-opt %s \
-// RUN:     -matmul-transpose-b-vectorization="vec-size=64" \
+// RUN:     -matmul-transpose-b-vectorization="vf=8 scalable=true" \
 // RUN:     -convert-linalg-to-loops -lower-affine -convert-scf-to-cf \
 // RUN:     -convert-vector-to-llvm -finalize-memref-to-llvm -convert-arith-to-llvm \
 // RUN:     -convert-func-to-llvm -reconcile-unrealized-casts \


### PR DESCRIPTION
This PR adds scalable vector support to matmul-transpose-b vectorization. `vec-size` is renamed to `vf` (as vectorization factor), and `scalable` option is added to enable scalable vector.

The step is now computed with `vscale * vf` and a symbol is added into the affine maps.

The performances are just the same compared to static vector method on musepi:

```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
benchMatmulTransposeB/matmul             333 ms          333 ms            2
benchMatmulTransposeB/matmul_opt0        108 ms          108 ms            6
benchMatmulTransposeB/matmul_opt1        109 ms          109 ms            6
------------------------------------------------
MatmulTransposeB-opt0 PASS
MatmulTransposeB-opt1 PASS
------------------------------------------------
```

where opt0 is static vector with `vf=32` and `-mllvm --riscv-v-vector-bits-min=256` appended to clang args, and opt1 is scalable with `vf=8` (without explicit vlen arguments).

The tail processing is kept the same for now. I will resolve conflicts when it is modified (if there are any).