### PR TITLE
[examples] bump sparse-tensor examples to the new version.

### DIFF
--- a/examples/MLIRSparseTensor/sparse-tensor-binary.mlir
+++ b/examples/MLIRSparseTensor/sparse-tensor-binary.mlir
@@ -1,5 +1,6 @@
 #SV = #sparse_tensor.encoding<{
-  dimLevelType = [ "compressed" ]
+  // dimLevelType = [ "compressed" ]
+  map = (d0) -> (d0 : compressed)
 }>
 
 #trait = {

--- a/examples/MLIRSparseTensor/sparse-tensor-dump.mlir
+++ b/examples/MLIRSparseTensor/sparse-tensor-dump.mlir
@@ -1,13 +1,13 @@
 #SparseMatrix = #sparse_tensor.encoding<{
-  dimLevelType = [ "compressed", "compressed" ]
+  map = (d0, d1) -> (d0 : compressed, d1 : compressed)
 }>
 
 #SparseVector = #sparse_tensor.encoding<{
-  dimLevelType = ["compressed"]
+  map = (d0) -> (d0 : compressed)
 }>
 
 #CSR = #sparse_tensor.encoding<{
-  dimLevelType = [ "dense", "compressed" ]
+  map = (d0, d1) -> (d0 : dense, d1 : compressed)
 }>
 
 func.func private @printMemrefInd(%arg0 : memref<*xindex>)

--- a/examples/MLIRSparseTensor/sparse-tensor-expand.mlir
+++ b/examples/MLIRSparseTensor/sparse-tensor-expand.mlir
@@ -1,5 +1,5 @@
 #CSR = #sparse_tensor.encoding<{
-  dimLevelType = [ "dense", "compressed" ]
+  map = (d0, d1) -> (d0 : dense, d1 : compressed)
 }>
 
 // Use linalg.matmul to multiply matrix

--- a/examples/MLIRSparseTensor/sparse-tensor-fuse-tensor-cast.mlir
+++ b/examples/MLIRSparseTensor/sparse-tensor-fuse-tensor-cast.mlir
@@ -2,16 +2,17 @@
 // RUN: --pre-sparsification-rewrite
 
 #SparseVector = #sparse_tensor.encoding<{
-  dimLevelType = [ "compressed" ]
+  map = (d0) -> (d0 : compressed)
 }>
 
 #SortedCOO = #sparse_tensor.encoding<{
-  dimLevelType = [ "compressed-nu", "singleton" ]
+  map = (i, j) -> (i : compressed(nonunique), j : singleton)
 }>
 
 #Slice = #sparse_tensor.encoding<{
-  dimLevelType = [ "compressed-nu", "singleton" ],
-  slice = [ (?, 1, 1), (?, 3, 1) ]
+  map = (d0 : #sparse_tensor<slice(?, 1, 1)>,
+         d1 : #sparse_tensor<slice(?, 3, 1)>) ->
+        (d0 : compressed(nonunique), d1 : singleton)
 }>
 
 

--- a/examples/MLIRSparseTensor/sparse-tensor-insert.mlir
+++ b/examples/MLIRSparseTensor/sparse-tensor-insert.mlir
@@ -1,5 +1,5 @@
 #SV = #sparse_tensor.encoding<{
-  dimLevelType = [ "compressed" ]
+  map = (d0) -> (d0 : compressed)
 }>
 
 func.func @main() {

--- a/examples/MLIRSparseTensor/sparse-tensor-new.mlir
+++ b/examples/MLIRSparseTensor/sparse-tensor-new.mlir
@@ -1,7 +1,7 @@
 !Filename = !llvm.ptr<i8>
 
 #SparseMatrix = #sparse_tensor.encoding<{
-  dimLevelType = [ "compressed", "compressed" ]
+  map = (d0, d1) -> (d0 : compressed, d1 : compressed)
 }>
 
 // Get tensor filename from env $TENSOR+index

--- a/examples/MLIRSparseTensor/sparse-tensor-number-of-entries.mlir
+++ b/examples/MLIRSparseTensor/sparse-tensor-number-of-entries.mlir
@@ -3,7 +3,7 @@
 // of the non-zero entry in the given sparse tensor.
 
 #SparseMatrix = #sparse_tensor.encoding<{
-  dimLevelType = ["compressed", "compressed"]
+  map = (d0, d1) -> (d0 : compressed, d1 : compressed)
 }>
 
 func.func @main() {

--- a/examples/MLIRSparseTensor/sparse-tensor-vectorization.mlir
+++ b/examples/MLIRSparseTensor/sparse-tensor-vectorization.mlir
@@ -1,5 +1,9 @@
+// #SparseVector = #sparse_tensor.encoding<{
+  // dimLevelType = ["compressed"]
+// }>
+
 #SparseVector = #sparse_tensor.encoding<{
-  dimLevelType = ["compressed"]
+  map = (d0) -> (d0 : compressed)
 }>
 
 #trait_mul = {


### PR DESCRIPTION
Old version examples no longer work. The main changes in this PR are detailed as follows:
The method of creating a sparse tensor has been changed.
``pack/unpack`` has been changed to ``assembly/disassembly``.
The usage of ``slice`` has been changed.