### PR TITLE
Pretask: Add next-softmax.mlir and next-softmax-manual.mlir

### DIFF
--- a/examples/BuddyNext/makefile
+++ b/examples/BuddyNext/makefile
@@ -1711,23 +1711,18 @@ next-softmax-run:
 	${BUDDY_OPT} \
 		-arith-expand \
 		-eliminate-empty-tensors \
-		-one-shot-bufferize \
+		-empty-tensor-to-alloc-tensor \
+		-one-shot-bufferize="bufferize-function-boundaries" \
 		-convert-linalg-to-affine-loops \
 		-affine-loop-fusion \
 		-lower-affine \
-		-func-bufferize \
-		-arith-bufferize \
-		-tensor-bufferize \
-		-buffer-deallocation \
-		-finalizing-bufferize \
 		-convert-vector-to-scf \
 		-expand-strided-metadata \
 		-convert-vector-to-llvm \
-		-memref-expand \
-		-arith-expand \
 		-convert-arith-to-llvm \
 		-finalize-memref-to-llvm \
 		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
 		-convert-openmp-to-llvm \
 		-convert-arith-to-llvm \
 		-convert-math-to-llvm \
@@ -1743,15 +1738,11 @@ next-softmax-lower:
 	${BUDDY_OPT} \
 		-arith-expand \
 		-eliminate-empty-tensors \
-		-one-shot-bufferize \
+		-empty-tensor-to-alloc-tensor \
+		-one-shot-bufferize="bufferize-function-boundaries" \
 		-convert-linalg-to-affine-loops \
 		-affine-loop-fusion \
 		-lower-affine \
-		-func-bufferize \
-		-arith-bufferize \
-		-tensor-bufferize \
-		-buffer-deallocation \
-		-finalizing-bufferize \
 		-convert-vector-to-scf \
 		-expand-strided-metadata \
 		-reconcile-unrealized-casts -o next-softmax-lower.mlir
@@ -1764,6 +1755,7 @@ next-softmax-manual-run:
 		-convert-arith-to-llvm \
 		-finalize-memref-to-llvm \
 		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
 		-convert-arith-to-llvm \
 		-convert-math-to-llvm \
 		-convert-func-to-llvm \

--- a/examples/BuddyNext/next-softmax-manual.mlir
+++ b/examples/BuddyNext/next-softmax-manual.mlir
@@ -1,3 +1,22 @@
+// RUN: buddy-opt %s \
+// RUN:     -convert-vector-to-llvm \
+// RUN:     -memref-expand \
+// RUN:     -arith-expand \
+// RUN:     -convert-arith-to-llvm \
+// RUN:     -finalize-memref-to-llvm \
+// RUN:     -convert-scf-to-cf \
+// RUN:     -convert-cf-to-llvm \
+// RUN:     -convert-arith-to-llvm \
+// RUN:     -convert-math-to-llvm \
+// RUN:     -convert-func-to-llvm \
+// RUN:     -reconcile-unrealized-casts \
+// RUN: | mlir-runner -e main -entry-point-result=void \
+// RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_runner_utils%shlibext \
+// RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_c_runner_utils%shlibext \
+// RUN: | FileCheck %s
+//
+// CHECK: {{[0-9]+\.[0-9]+}}
+
 module {
   memref.global "private" constant @__constant_1x40x151936xf32 : memref<1x40x151936xf32> = dense<2.000000e+00> {alignment = 64 : i64}
   func.func private @rtclock() -> f64

--- a/examples/BuddyNext/next-softmax.mlir
+++ b/examples/BuddyNext/next-softmax.mlir
@@ -3,15 +3,11 @@
 // RUN: | buddy-opt \
 // RUN:     -arith-expand \
 // RUN:     -eliminate-empty-tensors \
-// RUN:     -one-shot-bufferize \
+// RUN:     -empty-tensor-to-alloc-tensor \
+// RUN:     -one-shot-bufferize="bufferize-function-boundaries" \
 // RUN:     -convert-linalg-to-affine-loops \
 // RUN:     -affine-loop-fusion \
 // RUN:     -lower-affine \
-// RUN:     -func-bufferize \
-// RUN:     -arith-bufferize \
-// RUN:     -tensor-bufferize \
-// RUN:     -buffer-deallocation \
-// RUN:     -finalizing-bufferize \
 // RUN:     -convert-vector-to-scf \
 // RUN:     -expand-strided-metadata \
 // RUN:     -convert-vector-to-llvm \
@@ -20,16 +16,19 @@
 // RUN:     -convert-arith-to-llvm \
 // RUN:     -finalize-memref-to-llvm \
 // RUN:     -convert-scf-to-cf \
+// RUN:     -convert-cf-to-llvm \
 // RUN:     -convert-openmp-to-llvm \
 // RUN:     -convert-arith-to-llvm \
 // RUN:     -convert-math-to-llvm \
 // RUN:     -convert-math-to-libm  \
 // RUN:     -convert-func-to-llvm \
 // RUN:     -reconcile-unrealized-casts \
-// RUN: | mlir-cpu-runner -e main -entry-point-result=void \
+// RUN: | mlir-runner -e main -entry-point-result=void \
 // RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_runner_utils%shlibext \
 // RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_c_runner_utils%shlibext \
 // RUN: | FileCheck %s
+//
+// CHECK: {{[0-9]+\.[0-9]+}}
 
 func.func private @rtclock() -> f64
 func.func private @printMemrefF32(%ptr : tensor<*xf32>)


### PR DESCRIPTION
Add next-softmax.mlir, whichAdd next-softmax.mlir, using TOSA representation as the baseline.
Add next-softmax-manual.mlir, using vectorization optimization, with a width of 16 × f32 = 512 bits, for AVX512.
Add next-softmax-run, next-softmax-lower, and next-softmax-vec-manual-run to the Makefile.