### PR TITLE
[midend] pretask: Add next-matmul.mlir, next-matmul-manual.mlir and integrate the vectorization pass into the compilation pipeline.

### DIFF
--- a/examples/BuddyNext/makefile
+++ b/examples/BuddyNext/makefile
@@ -811,3 +811,116 @@ next-compass-run:
 	${MLIR_CPU_RUNNER} ${OPT_FLAG} -e main -entry-point-result=void \
 		-shared-libs=${MLIR_RUNNER_UTILS} \
 		-shared-libs=${MLIR_C_RUNNER_UTILS}
+
+next-matmul-run:
+	@${MLIR_OPT} ./next-matmul.mlir \
+		-pass-pipeline "builtin.module(func.func(tosa-to-linalg-named),func.func(tosa-to-linalg),func.func(tosa-to-tensor),func.func(tosa-to-arith))" | \
+	${BUDDY_OPT} \
+		-arith-expand \
+		-eliminate-empty-tensors \
+		-empty-tensor-to-alloc-tensor \
+		-one-shot-bufferize \
+		-convert-linalg-to-affine-loops \
+		-lower-affine \
+		-func-bufferize \
+		-arith-bufferize \
+		-tensor-bufferize \
+		-buffer-deallocation \
+		-finalizing-bufferize \
+		-convert-vector-to-scf \
+		-expand-strided-metadata \
+		-convert-vector-to-llvm \
+		-memref-expand \
+		-arith-expand \
+		-convert-arith-to-llvm \
+		-finalize-memref-to-llvm \
+		-convert-scf-to-cf \
+		-convert-openmp-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-math-to-libm  \
+		-convert-func-to-llvm \
+		-reconcile-unrealized-casts | \
+	${MLIR_CPU_RUNNER} ${OPT_FLAG} -e main -entry-point-result=void \
+		-shared-libs=${MLIR_RUNNER_UTILS} -shared-libs=${MLIR_C_RUNNER_UTILS}
+
+next-matmul-lower:
+	@${MLIR_OPT} ./next-matmul.mlir \
+		-pass-pipeline "builtin.module(func.func(tosa-to-linalg-named),func.func(tosa-to-linalg),func.func(tosa-to-tensor),func.func(tosa-to-arith))" | \
+	${BUDDY_OPT} \
+		-arith-expand \
+		-one-shot-bufferize \
+		-convert-linalg-to-affine-loops \
+		-lower-affine \
+		-func-bufferize \
+		-arith-bufferize \
+		-tensor-bufferize \
+		-buffer-deallocation \
+		-finalizing-bufferize \
+		-convert-vector-to-scf \
+		-expand-strided-metadata \
+		-reconcile-unrealized-casts -o next-matmul-lower.mlir
+
+next-matmul-lower-manual-run:
+	@${BUDDY_OPT} ./next-matmul-manual.mlir \
+		-convert-vector-to-llvm \
+		-memref-expand \
+		-arith-expand \
+		-convert-arith-to-llvm \
+		-finalize-memref-to-llvm \
+		-convert-scf-to-cf \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-math-to-libm  \
+		-convert-func-to-llvm \
+		-reconcile-unrealized-casts | \
+	${MLIR_CPU_RUNNER} ${OPT_FLAG} -e main -entry-point-result=void \
+		-shared-libs=${MLIR_RUNNER_UTILS} -shared-libs=${MLIR_C_RUNNER_UTILS}
+
+next-matmul-vectorization-lower:
+	@${MLIR_OPT} ./next-matmul.mlir \
+		-pass-pipeline "builtin.module(func.func(tosa-to-linalg-named),func.func(tosa-to-linalg),func.func(tosa-to-tensor),func.func(tosa-to-arith))" | \
+	${BUDDY_OPT} \
+		-arith-expand \
+		-one-shot-bufferize \
+		-matmul-vectorization-512 \
+		-convert-linalg-to-affine-loops \
+		-lower-affine \
+		-func-bufferize \
+		-arith-bufferize \
+		-tensor-bufferize \
+		-buffer-deallocation \
+		-finalizing-bufferize \
+		-convert-vector-to-scf \
+		-expand-strided-metadata \
+		-reconcile-unrealized-casts -o next-matmul-lower-pass.mlir
+
+next-matmul-vectorization-run:
+	@${MLIR_OPT} ./next-matmul.mlir \
+		-pass-pipeline "builtin.module(func.func(tosa-to-linalg-named),func.func(tosa-to-linalg),func.func(tosa-to-tensor),func.func(tosa-to-arith))" | \
+	${BUDDY_OPT} \
+		-arith-expand \
+		-one-shot-bufferize \
+		-matmul-vectorization-512 \
+		-convert-linalg-to-affine-loops \
+		-lower-affine \
+		-func-bufferize \
+		-arith-bufferize \
+		-tensor-bufferize \
+		-buffer-deallocation \
+		-finalizing-bufferize \
+		-convert-vector-to-scf \
+		-expand-strided-metadata \
+		-convert-vector-to-llvm \
+		-memref-expand \
+		-arith-expand \
+		-convert-arith-to-llvm \
+		-finalize-memref-to-llvm \
+		-convert-scf-to-cf \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-math-to-libm  \
+		-convert-func-to-llvm \
+		-reconcile-unrealized-casts | \
+	${MLIR_CPU_RUNNER} ${OPT_FLAG} -e main -entry-point-result=void \
+		-shared-libs=${MLIR_RUNNER_UTILS} -shared-libs=${MLIR_C_RUNNER_UTILS}

--- a/examples/BuddyNext/next-matmul-manual.mlir
+++ b/examples/BuddyNext/next-matmul-manual.mlir
@@ -1,0 +1,76 @@
+// RUN: buddy-opt %s \
+// RUN:     -convert-vector-to-llvm \
+// RUN:     -memref-expand \
+// RUN:     -arith-expand \
+// RUN:     -convert-arith-to-llvm \
+// RUN:     -finalize-memref-to-llvm \
+// RUN:     -convert-scf-to-cf \
+// RUN:     -convert-arith-to-llvm \
+// RUN:     -convert-math-to-llvm \
+// RUN:     -convert-math-to-libm \
+// RUN:     -convert-func-to-llvm \
+// RUN:     -reconcile-unrealized-casts \
+// RUN: | mlir-cpu-runner -e main -entry-point-result=void \
+// RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_runner_utils%shlibext \
+// RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_c_runner_utils%shlibext
+
+module {
+  memref.global "private" constant @__constant_3072x1536xf32 : memref<3072x1536xf32> = dense<3.000000e+00> {alignment = 64 : i64}
+  memref.global "private" constant @__constant_40x3072xf32_0 : memref<40x3072xf32> = dense<2.000000e+00> {alignment = 64 : i64}
+  memref.global "private" constant @__constant_40x1536xf32 : memref<40x1536xf32> = dense<0.000000e+00> {alignment = 64 : i64}
+  func.func private @rtclock() -> f64
+  func.func private @printMemrefF32(memref<*xf32>)
+  
+  func.func @kernel(%arg0: memref<40x3072xf32>, %arg1: memref<3072x1536xf32>) {
+    %c3072 = arith.constant 3072 : index
+    %c1536 = arith.constant 1536 : index
+    %c1 = arith.constant 1 : index
+    %c40 = arith.constant 40 : index
+    %c0 = arith.constant 0 : index
+    %c16 = arith.constant 16 : index  
+    %c0_f32 = arith.constant 0.000000e+00 : f32
+    
+    %0 = call @rtclock() : () -> f64
+
+    %alloc = memref.alloc() {alignment = 64 : i64} : memref<40x1536xf32>
+    
+    %zero_vec = vector.broadcast %c0_f32 : f32 to vector<16xf32>
+    scf.for %i = %c0 to %c40 step %c1 {
+      scf.for %j = %c0 to %c1536 step %c16 {
+        vector.store %zero_vec, %alloc[%i, %j] : memref<40x1536xf32>, vector<16xf32>
+      }
+    }
+    scf.for %arg2 = %c0 to %c40 step %c1 {
+      scf.for %arg3 = %c0 to %c1536 step %c16 {
+        %acc = vector.load %alloc[%arg2, %arg3] : memref<40x1536xf32>, vector<16xf32>
+        
+        %final_acc = scf.for %arg4 = %c0 to %c3072 step %c1 iter_args(%acc_iter = %acc) -> (vector<16xf32>) {
+          %a_scalar = memref.load %arg0[%arg2, %arg4] : memref<40x3072xf32>
+          %a_vec = vector.broadcast %a_scalar : f32 to vector<16xf32>
+          
+          %b_vec = vector.load %arg1[%arg4, %arg3] : memref<3072x1536xf32>, vector<16xf32>
+          
+          %new_acc = vector.fma %a_vec, %b_vec, %acc_iter : vector<16xf32>
+          scf.yield %new_acc : vector<16xf32>
+        }
+        
+        vector.store %final_acc, %alloc[%arg2, %arg3] : memref<40x1536xf32>, vector<16xf32>
+      }
+    }
+    
+    %2 = call @rtclock() : () -> f64
+    %3 = arith.subf %2, %0 : f64
+    %cast = memref.cast %alloc : memref<40x1536xf32> to memref<*xf32>
+    call @printMemrefF32(%cast) : (memref<*xf32>) -> ()
+    memref.dealloc %alloc : memref<40x1536xf32>
+    vector.print %3 : f64
+    return
+  }
+  
+  func.func @main() {
+    %0 = memref.get_global @__constant_40x3072xf32_0 : memref<40x3072xf32>
+    %1 = memref.get_global @__constant_3072x1536xf32 : memref<3072x1536xf32>
+    call @kernel(%0, %1) : (memref<40x3072xf32>, memref<3072x1536xf32>) -> ()
+    return
+  }
+}

--- a/examples/BuddyNext/next-matmul.mlir
+++ b/examples/BuddyNext/next-matmul.mlir
@@ -1,0 +1,65 @@
+// RUN: mlir-opt %s \
+// RUN:     -pass-pipeline "builtin.module(func.func(tosa-to-linalg-named),func.func(tosa-to-linalg),func.func(tosa-to-tensor),func.func(tosa-to-arith))" \
+// RUN: | buddy-opt \
+// RUN:     -arith-expand \
+// RUN:     -eliminate-empty-tensors \
+// RUN:     -empty-tensor-to-alloc-tensor \
+// RUN:     -one-shot-bufferize \
+// RUN:     -convert-linalg-to-affine-loops \
+// RUN:     -lower-affine \
+// RUN:     -func-bufferize \
+// RUN:     -arith-bufferize \
+// RUN:     -tensor-bufferize \
+// RUN:     -buffer-deallocation \
+// RUN:     -finalizing-bufferize \
+// RUN:     -convert-vector-to-scf \
+// RUN:     -expand-strided-metadata \
+// RUN:     -convert-vector-to-llvm \
+// RUN:     -memref-expand \
+// RUN:     -arith-expand \
+// RUN:     -convert-arith-to-llvm \
+// RUN:     -finalize-memref-to-llvm \
+// RUN:     -convert-scf-to-cf \
+// RUN:     -convert-openmp-to-llvm \
+// RUN:     -convert-arith-to-llvm \
+// RUN:     -convert-math-to-llvm \
+// RUN:     -convert-math-to-libm  \
+// RUN:     -convert-func-to-llvm \
+// RUN:     -reconcile-unrealized-casts \
+// RUN: | mlir-cpu-runner -e main -entry-point-result=void \
+// RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_runner_utils%shlibext \
+// RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_c_runner_utils%shlibext
+
+func.func private @rtclock() -> f64
+func.func private @printMemrefF32(%ptr : tensor<*xf32>)
+
+func.func @kernel(%lhs: tensor<40x3072xf32>, %rhs: tensor<3072x1536xf32>) {
+  %t_start = call @rtclock() : () -> f64
+  
+  // linalg.matmul 
+  %output_init = arith.constant dense<0.000000e+00> : tensor<40x1536xf32>
+  %result = linalg.matmul {cast = #linalg.type_fn<cast_signed>} 
+    ins(%lhs, %rhs : tensor<40x3072xf32>, tensor<3072x1536xf32>) 
+    outs(%output_init : tensor<40x1536xf32>) -> tensor<40x1536xf32>
+
+  %t_end = call @rtclock() : () -> f64
+  %time = arith.subf %t_end, %t_start : f64
+
+  %tensor_unranked = tensor.cast %result : tensor<40x1536xf32> to tensor<*xf32>
+
+  call @printMemrefF32(%tensor_unranked) : (tensor<*xf32>) -> ()
+
+  vector.print %time : f64
+
+  return
+}
+
+func.func @main() {
+
+  %c0 = arith.constant dense<2.0> : tensor<40x3072xf32>
+  %c1 = arith.constant dense<3.0> : tensor<3072x1536xf32>
+
+  call @kernel(%c0, %c1) : (tensor<40x3072xf32>, tensor<3072x1536xf32>) -> ()
+
+  return
+}

--- a/midend/lib/Conversion/MatMulOptimization/CMakeLists.txt
+++ b/midend/lib/Conversion/MatMulOptimization/CMakeLists.txt
@@ -10,6 +10,7 @@ add_mlir_library(MatMulOptimization
   BatchMatMulTileOptimize.cpp
   BatchMatMulSCFOptimize.cpp
   BatchMatMulTransBVec.cpp
+  MatMulVec.cpp
   LINK_LIBS PUBLIC
   BuddyUtils
 )

--- a/midend/lib/Conversion/MatMulOptimization/MatMulVec.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/MatMulVec.cpp
@@ -1,0 +1,174 @@
+//===- MatMulVec.cpp ------------------------------------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the MatMulVec pass for AVX-512 vectorization.
+//
+//===----------------------------------------------------------------------===//
+
+#include <mlir/Dialect/Affine/IR/AffineOps.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/Linalg/Transforms/Transforms.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/Dialect.h>
+#include <mlir/IR/Operation.h>
+#include <mlir/IR/TypeUtilities.h>
+#include <mlir/IR/Value.h>
+#include <mlir/Pass/Pass.h>
+
+#include "Utils/Utils.h"
+
+using namespace mlir;
+using namespace vector;
+
+//===----------------------------------------------------------------------===//
+// Rewrite Pattern
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class MatMulVecPattern : public ConversionPattern {
+public:
+  explicit MatMulVecPattern(MLIRContext *context, int64_t vecSizeParam)
+      : ConversionPattern(linalg::MatmulOp::getOperationName(), 1, context) {
+    vecSize = vecSizeParam;
+  }
+
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> /*operands*/,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op->getLoc();
+    
+    Value A = op->getOperand(0);
+    Value B = op->getOperand(1);
+    Value C = op->getOperand(2);
+    
+    ShapedType ATy = A.getType().cast<ShapedType>();
+    Type eleTy = ATy.getElementType();
+
+    auto ctx = op->getContext();
+    
+    VectorType vectorTy = mlir::VectorType::get({vecSize}, eleTy);
+    
+    const Value c0 = rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+    const Value c1 = rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
+    const Value step = rewriter.create<arith::ConstantIndexOp>(loc, vecSize);
+    
+    const Value c0Ele = buddy::insertZeroConstantOp(ctx, rewriter, loc, eleTy);
+    
+    const Value aRow = rewriter.create<memref::DimOp>(loc, A, c0);  // M = 40
+    const Value bRow = rewriter.create<memref::DimOp>(loc, B, c0);  // K = 3072
+    const Value bCol = rewriter.create<memref::DimOp>(loc, B, c1);  // N = 1536
+
+    // for i = 0 to M (40)
+    rewriter.create<scf::ForOp>(
+        loc, c0, aRow, c1, ValueRange{},
+        [&](OpBuilder &builder, Location loc, Value i, ValueRange iterArgs) {
+          // for j = 0 to N step vecSize (1536 step 16)
+          builder.create<scf::ForOp>(
+              loc, c0, bCol, step, ValueRange{},
+              [&](OpBuilder &builder, Location loc, Value j, ValueRange iterArgs) {
+                
+                Value accVec = builder.create<vector::TransferReadOp>(
+                    loc, vectorTy, C, ValueRange{i, j}, c0Ele);
+                
+                // for k = 0 to K (3072) 
+                auto forOp = builder.create<scf::ForOp>(
+                    loc, c0, bRow, c1, ValueRange{accVec},
+                    [&](OpBuilder &builder, Location loc, Value k, ValueRange iterArgs) {
+                      Value currentAcc = iterArgs[0];
+                      
+                      Value aScalar = builder.create<memref::LoadOp>(
+                          loc, A, ValueRange{i, k});
+                      Value aVec = builder.create<vector::BroadcastOp>(
+                          loc, vectorTy, aScalar);
+                      
+                      Value bVec = builder.create<vector::TransferReadOp>(
+                          loc, vectorTy, B, ValueRange{k, j}, c0Ele);
+                      
+                      // acc = a * b + acc
+                      Value newAcc = builder.create<FMAOp>(loc, aVec, bVec, currentAcc);
+                      
+                      builder.create<scf::YieldOp>(loc, ValueRange{newAcc});
+                    });
+                
+                builder.create<vector::TransferWriteOp>(
+                    loc, forOp.getResult(0), C, ValueRange{i, j});
+                
+                builder.create<scf::YieldOp>(loc);
+              });
+          builder.create<scf::YieldOp>(loc);
+        });
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  int64_t vecSize;
+};
+
+} // end anonymous namespace
+
+//===----------------------------------------------------------------------===//
+// MatMulVecPass
+//===----------------------------------------------------------------------===//
+
+namespace {
+class MatMulVecPass : public PassWrapper<MatMulVecPass, OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MatMulVecPass)
+  StringRef getArgument() const final { return "matmul-vectorization-512"; }
+  StringRef getDescription() const final { return "MatMul AVX-512 Vectorization."; }
+  MatMulVecPass() = default;
+  MatMulVecPass(const MatMulVecPass &) {}
+
+  void runOnOperation() override;
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect, scf::SCFDialect,
+                    affine::AffineDialect, VectorDialect>();
+  }
+  
+  Option<int64_t> vecSize{*this, "vector-size",
+                          llvm::cl::desc("Specify vector size for AVX-512."),
+                          llvm::cl::init(16)};
+};
+} // end anonymous namespace
+
+void MatMulVecPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  ModuleOp module = getOperation();
+
+  ConversionTarget target(*context);
+  target.addLegalDialect<arith::ArithDialect, scf::SCFDialect,
+                         memref::MemRefDialect, VectorDialect>();
+  target.addLegalOp<ModuleOp, func::FuncOp, func::ReturnOp>();
+  target.addLegalOp<linalg::FillOp>();
+
+  RewritePatternSet patterns(context);
+  patterns.add<MatMulVecPattern>(context, vecSize);
+
+  if (failed(applyPartialConversion(module, target, std::move(patterns))))
+    signalPassFailure();
+}
+
+namespace mlir {
+namespace buddy {
+void registerMatMulVecPass() {
+  PassRegistration<MatMulVecPass>();
+}
+} // namespace buddy
+} // namespace mlir

--- a/midend/lib/InitAll.cpp
+++ b/midend/lib/InitAll.cpp
@@ -48,6 +48,7 @@ void registerMatMulParallelVectorizationPass();
 void registerMatMulVectorizationPass();
 void registerDeviceSchedulePass();
 void registerTransposeOptimizationPass();
+void registerMatMulVecPass();
 } // namespace buddy
 } // namespace mlir
 
@@ -80,4 +81,5 @@ void mlir::buddy::registerAllPasses() {
   mlir::buddy::registerMatMulVectorizationPass();
   mlir::buddy::registerDeviceSchedulePass();
   mlir::buddy::registerTransposeOptimizationPass();
+  mlir::buddy::registerMatMulVecPass();
 }

--- a/tools/buddy-opt/buddy-opt.cpp
+++ b/tools/buddy-opt/buddy-opt.cpp
@@ -71,6 +71,7 @@ void registerLowerRVVPass();
 void registerMatMulOptimizePass();
 void registerMatMulVectorizationPass();
 void registerMatMulParallelVectorizationPass();
+void registerMatMulVecPass();
 void registerTransposeOptimizationPass();
 void registerConvOptimizePass();
 void registerConvNhwcFhwcOptimizePass();
@@ -119,6 +120,7 @@ int main(int argc, char **argv) {
   mlir::buddy::registerBatchMatMulTransVecPass();
   mlir::buddy::registerMatMulVectorizationPass();
   mlir::buddy::registerMatMulParallelVectorizationPass();
+  mlir::buddy::registerMatMulVecPass();
   mlir::buddy::registerTransposeOptimizationPass();
   mlir::buddy::registerConvOptimizePass();
   mlir::buddy::registerConvNhwcFhwcOptimizePass();


### PR DESCRIPTION
Add next-matmul.mlir, using linalg representation as the baseline.
Add next-matmul-manual.mlir, applying vectorization optimization for FMA and vectorized load/store, with a width of 16 × f32 = 512 bits.
Add next-matmul-run, next-matmul-lower, next-matmul-lower-manual-run, next-matmul-vectorization-lower, and next-matmul-vectorization-run to the Makefile.
Integrate the vectorization pass into the midend to automate the vectorization process.