### PR TITLE
[examples/BuddyNext] Add examples of matmul fused with the front and back transpose.

### DIFF
--- a/examples/BuddyNext/makefile
+++ b/examples/BuddyNext/makefile
@@ -811,3 +811,56 @@ next-compass-run:
 	${MLIR_CPU_RUNNER} ${OPT_FLAG} -e main -entry-point-result=void \
 		-shared-libs=${MLIR_RUNNER_UTILS} \
 		-shared-libs=${MLIR_C_RUNNER_UTILS}
+
+tosa-matmul-transpose2-lower:
+	@${BUDDY_OPT} ./tosa-matmultranspose2.mlir \
+			-transpose-fusion-vectorization \
+			-o log.mlir
+
+tosa-matmul-transpose2-run:
+	@${BUDDY_OPT} ./tosa-matmultranspose2.mlir \
+			-pass-pipeline "builtin.module(transpose-fusion-vectorization, func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith))" | \
+    ${BUDDY_OPT} \
+		-eliminate-empty-tensors \
+		-convert-tensor-to-linalg \
+		-linalg-bufferize \
+		-convert-linalg-to-affine-loops \
+		-lower-affine \
+		-func-bufferize \
+		-arith-bufferize \
+		-tensor-bufferize \
+		-buffer-deallocation \
+		-finalizing-bufferize \
+		-convert-vector-to-scf \
+		-expand-strided-metadata \
+		-convert-vector-to-llvm \
+		-convert-arith-to-llvm \
+		-finalize-memref-to-llvm \
+		-convert-scf-to-cf \
+		-convert-arith-to-llvm \
+		-convert-func-to-llvm \
+		-reconcile-unrealized-casts | \
+	${MLIR_CPU_RUNNER} ${OPT_FLAG} -e main -entry-point-result=void \
+		-shared-libs=${MLIR_RUNNER_UTILS} -shared-libs=${MLIR_C_RUNNER_UTILS}
+
+tosa-matmul-transpose2-vec-run:
+	@${BUDDY_OPT} ./tosa-matmultranspose2-vec.mlir\
+		-convert-linalg-to-affine-loops \
+		-affine-parallelize \
+		-lower-affine \
+		-convert-scf-to-openmp \
+		-convert-vector-to-scf \
+		-expand-strided-metadata \
+		-convert-vector-to-llvm \
+		-memref-expand \
+		-arith-expand \
+		-convert-arith-to-llvm \
+		-finalize-memref-to-llvm  \
+		-convert-scf-to-cf \
+		-convert-openmp-to-llvm \
+		-convert-math-to-llvm \
+		-convert-math-to-libm  \
+		-convert-func-to-llvm \
+		-reconcile-unrealized-casts | \
+	${MLIR_CPU_RUNNER} ${OPT_FLAG} -e main -entry-point-result=void \
+		-shared-libs=${MLIR_RUNNER_UTILS} -shared-libs=${MLIR_C_RUNNER_UTILS}

--- a/examples/BuddyNext/tosa-matmul-transpose2-vec.mlir
+++ b/examples/BuddyNext/tosa-matmul-transpose2-vec.mlir
@@ -1,0 +1,120 @@
+// RUN: buddy-opt %s \
+// RUN:     -matmul-transpose-b-vectorization \
+// RUN:     -convert-linalg-to-affine-loops \
+// RUN:     -lower-affine \
+// RUN:     -convert-vector-to-scf \
+// RUN:     -convert-scf-to-cf \
+// RUN:     -convert-vector-to-llvm \
+// RUN:     -convert-math-to-llvm \
+// RUN:     -convert-math-to-libm \
+// RUN:     -convert-arith-to-llvm \
+// RUN:     -convert-func-to-llvm \
+// RUN:     -expand-strided-metadata \
+// RUN:     -finalize-memref-to-llvm \
+// RUN:     -reconcile-unrealized-casts \
+// RUN: | mlir-cpu-runner -e main -entry-point-result=void \
+// RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_runner_utils%shlibext \
+// RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_c_runner_utils%shlibext \
+// RUN: | FileCheck %s
+
+func.func private @rtclock() -> f64
+func.func private @printMemrefF32(memref<*xf32>)
+
+func.func @test(%a : memref<?x?x?xf32>, %b : memref<?x?x?xf32>, %c : memref<?x?x?xf32>) {
+  %t_start = call @rtclock() : () -> f64
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %vl_step = arith.constant 32 : index
+  %c0_f32 = arith.constant 0.000000e+00 : f32
+  %v0 = vector.splat %c0_f32 : vector<32xf32>
+  %dim = memref.dim %a, %c0 : memref<?x?x?xf32>        // 
+  %dim_0 = memref.dim %a, %c1 : memref<?x?x?xf32>
+  %dim_1 = memref.dim %a, %c2 : memref<?x?x?xf32>
+  %dim_2 = memref.dim %b, %c2 : memref<?x?x?xf32>
+
+  // Calculate the upper bound for vectorized processing
+  // - Subtract `vl_step` is to avoid overflow at the vectorization tail.
+  // - Add 1 to ensure the final loop runs when the workload length 
+  //   is divisible by the vector size.
+  %dim_2_upbound_tmp = arith.subi %dim_2, %vl_step : index
+  %dim_2_upbound = arith.addi %dim_2_upbound_tmp, %c1 : index
+
+  affine.for %arg3 = %c0 to %dim {
+    affine.for %arg4 = %c0 to %dim_0 {
+      %iter_idx = scf.for %arg5 = %c0 to %dim_2_upbound 
+          step %vl_step iter_args(%iter_init = %c0) -> (index){
+        %0 = vector.load %c[%arg4, %arg3, %arg5] : memref<?x?x?xf32>, vector<32xf32>
+        %iter_value = scf.for %arg6 = %c0 to %dim_1 step %c1 iter_args(%value_init = %0) -> (vector<32xf32>){
+          %1 = memref.load %a[%arg3, %arg4, %arg6] : memref<?x?x?xf32>
+          %2 = vector.splat %1 : vector<32xf32>
+          %3 = vector.load %b[%arg6, %arg3, %arg5] : memref<?x?x?xf32>, vector<32xf32>
+          %4 = vector.fma %2, %3, %value_init : vector<32xf32>
+          scf.yield %4 : vector<32xf32>
+        }
+        vector.store %iter_value, %c[%arg4, %arg3, %arg5] : memref<?x?x?xf32>, vector<32xf32>
+        %idx_next = arith.addi %arg5, %vl_step : index
+        scf.yield %idx_next : index
+      }
+
+      // Compute the tail size and Process the remaining elements 
+      // using masked vector operations.
+      %tail_size = arith.subi %dim_1, %iter_idx : index
+      %mask = vector.create_mask %tail_size : vector<32xi1>
+      %0 = vector.maskedload %c[%arg4, %arg3, %iter_idx], %mask, %v0 : memref<?x?x?xf32>, vector<32xi1>, vector<32xf32> into vector<32xf32>
+      %iter_value = scf.for %arg6 = %c0 to %dim_1 step %c1 iter_args(%value_init = %0) -> (vector<32xf32>){
+        %1 = memref.load %a[%arg3, %arg4, %arg6] : memref<?x?x?xf32>
+        %2 = vector.splat %1 : vector<32xf32>
+        %3 = vector.maskedload %b[%arg6, %arg3, %iter_idx], %mask, %v0 : memref<?x?x?xf32>, vector<32xi1>, vector<32xf32> into vector<32xf32>
+        %4 = vector.fma %2, %3, %value_init : vector<32xf32>
+        scf.yield %4 : vector<32xf32>
+      }
+      vector.maskedstore %c[%arg4, %arg3, %iter_idx], %mask, %iter_value : memref<?x?x?xf32>, vector<32xi1>, vector<32xf32>
+    }
+  }
+  
+  %t_end = call @rtclock() : () -> f64
+  %time = arith.subf %t_end, %t_start : f64
+  // Print timings.
+  vector.print %time : f64
+  return
+}
+
+func.func @alloc_f32(%dim0: index, %dim1: index, %dim2: index, %arg4: f32) -> memref<?x?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %0 = memref.alloc(%dim0, %dim1, %dim2) : memref<?x?x?xf32>
+  scf.for %idx0 = %c0 to %dim0 step %c1 {
+    scf.for %idx1 = %c0 to %dim1 step %c1 {
+      scf.for %idx2 = %c0 to %dim2 step %c1 {
+        memref.store %arg4, %0[%idx0, %idx1, %idx2] : memref<?x?x?xf32>
+      }
+    }
+  }
+  return %0 : memref<?x?x?xf32>
+}
+
+
+func.func @main(){
+  %c32 = arith.constant 32 : index
+  %c40 = arith.constant 40 : index
+  %c128 = arith.constant 128 : index
+  %f0 = arith.constant 0.0 : f32
+  %f2 = arith.constant 2.0 : f32
+  %f3 = arith.constant 3.0 : f32
+
+  %m0 = call @alloc_f32(%c32, %c40, %c40, %f2) : (index, index, index, f32) -> memref<?x?x?xf32>
+  %m1 = call @alloc_f32(%c40, %c32, %c128, %f3) : (index, index, index, f32) -> memref<?x?x?xf32>
+  %m2 = call @alloc_f32(%c40, %c32, %c128, %f0) : (index, index, index, f32) -> memref<?x?x?xf32>
+
+  call @test(%m0, %m1, %m2) : (memref<?x?x?xf32>, memref<?x?x?xf32>, memref<?x?x?xf32>) -> ()
+
+  %printed_m2 = memref.cast %m2 : memref<?x?x?xf32> to memref<*xf32>
+
+  // CHECK: Unranked Memref base@ = {{.*}} rank = 2 offset = 0 sizes = [32, 32] strides = [32, 1] data = 
+  // CHECK-NEXT: [
+  // CHECK: [1024{{(, 1024)*}}]
+  // call @printMemrefF32(%printed_m2) : (memref<*xf32>) -> ()
+
+  return
+}

--- a/examples/BuddyNext/tosa-matmul-transpose2.mlir
+++ b/examples/BuddyNext/tosa-matmul-transpose2.mlir
@@ -1,0 +1,57 @@
+// RUN: buddy-opt %s \
+// RUN:     -batchmatmul-transpose-b-vectorization \
+// RUN:     -convert-linalg-to-affine-loops \
+// RUN:     -lower-affine \
+// RUN:     -convert-vector-to-scf \
+// RUN:     -convert-scf-to-cf \
+// RUN:     -convert-vector-to-llvm \
+// RUN:     -convert-math-to-llvm \
+// RUN:     -convert-math-to-libm \
+// RUN:     -convert-arith-to-llvm \
+// RUN:     -convert-func-to-llvm \
+// RUN:     -expand-strided-metadata \
+// RUN:     -finalize-memref-to-llvm \
+// RUN:     -reconcile-unrealized-casts \
+// RUN: | mlir-cpu-runner -e main -entry-point-result=void \
+// RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_runner_utils%shlibext \
+// RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_c_runner_utils%shlibext \
+// RUN: | FileCheck %s
+
+func.func private @rtclock() -> f64
+func.func private @printMemrefF32(tensor<*xf32>)
+
+func.func @test(%a : tensor<1x40x32x128xf32>, %b : tensor<32x40x40xf32>) -> (tensor<1x40x32x128xf32>) {
+    %t_start = call @rtclock() : () -> f64
+    %0 = "tosa.const"() <{value = dense<[0, 2, 1, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
+    %1 = tosa.transpose %a, %0 : (tensor<1x40x32x128xf32>, tensor<4xi32>) -> tensor<1x32x40x128xf32>
+    %2 = tosa.reshape %1 {new_shape = array<i64: 32, 40, 128>} : (tensor<1x32x40x128xf32>) -> tensor<32x40x128xf32>
+    %3 = tosa.matmul %b, %2 : (tensor<32x40x40xf32>, tensor<32x40x128xf32>) -> tensor<32x40x128xf32>
+    %4 = tosa.reshape %3 {new_shape = array<i64: 1, 32, 40, 128>} : (tensor<32x40x128xf32>) -> tensor<1x32x40x128xf32>
+    %5 = "tosa.const"() <{value = dense<[0, 2, 1, 3]> : tensor<4xi32>}> : () -> tensor<4xi32>
+    %6 = tosa.transpose %4, %5 : (tensor<1x32x40x128xf32>, tensor<4xi32>) -> tensor<1x40x32x128xf32> 
+    %t_end = call @rtclock() : () -> f64
+    %time = arith.subf %t_end, %t_start : f64
+    // Print timings.
+    vector.print %time : f64
+    return %6 : tensor<1x40x32x128xf32>
+  }
+
+func.func @main(){
+
+  %v2 = arith.constant dense<2.0> : tensor<32x40x40xf32>
+  %v3 = arith.constant dense<3.0> : tensor<1x40x32x128xf32>
+  // %m0 = tensor.cast %v2 : tensor<32x40x40xf32> to tensor<?x?x?xf32>
+  // %m1 = tensor.cast %v3 : tensor<40x32x128xf32> to tensor<?x?x?xf32>
+
+  %m2 = call @test(%v3, %v2) : (tensor<1x40x32x128xf32>, tensor<32x40x40xf32>) -> (tensor<1x40x32x128xf32>)
+
+  %printed_m2 = tensor.cast %m2 : tensor<1x40x32x128xf32> to tensor<*xf32>
+
+  // CHECK: Unranked Memref base@ = {{.*}} rank = 3 offset = 0 sizes = [32, 64, 64] strides = [4096, 64, 1] data = 
+  // CHECK-NEXT: [
+  // CHECK: [
+  // CHECK: [64{{(, 64)*}}]
+  // call @printMemrefF32(%printed_m2) : (tensor<*xf32>) -> ()
+
+  return
+}


### PR DESCRIPTION
Add examples of matmul fused with the front and back transpose.
```
%0 = "tosa.const"() <{value = dense<[0, 2, 1, 3]>
%1 = tosa.transpose %arg1, %0
%2 = tosa.reshape %1
%3 = tosa.matmul %arg0, %2
%4 = tosa.reshape %3
%5 = "tosa.const"() <{value = dense<[0, 2, 1, 3]>
%arg2 = tosa.transpose %4, %5
```
------------------>
```
%arg2 = FusionOp %arg0, %arg1
```
FusionOp stands for ops after fusion.