### PR TITLE
feat: add compilation and kernel time in verbose output

### DIFF
--- a/examples/BuddyJIT/README.md
+++ b/examples/BuddyJIT/README.md
@@ -20,6 +20,7 @@ Secondly, build the llvm with LLVM, MLIR and OpenMP.
 ```bash
 cd buddy-mlir
 mkdir llvm/build
+cd llvm/build
 cmake -G Ninja ../llvm \
   -DLLVM_ENABLE_PROJECTS="mlir;clang;openmp" \
   -DLLVM_TARGETS_TO_BUILD="host;RISCV" \

--- a/examples/BuddyJIT/pytorch_matrix_multiplication.py
+++ b/examples/BuddyJIT/pytorch_matrix_multiplication.py
@@ -27,14 +27,14 @@ def execute(a, b):
 c = torch.rand(2048, 2048, dtype=torch.float32)
 d = torch.rand(2048, 2048, dtype=torch.float32)
 
-start_time = time.process_time()
+start_time = time.time()
 actual = execute(c, d)
-end_time = time.process_time()
+end_time = time.time()
 mlir_time = end_time - start_time
 
-start_time = time.process_time()
+start_time = time.time()
 expect = MatrixMultiply().forward(c, d)
-end_time = time.process_time()
+end_time = time.time()
 torch_time = end_time - start_time
 
 # CHECK: Is MLIR equal to Torch? True

--- a/frontend/Python/frontend.py
+++ b/frontend/Python/frontend.py
@@ -592,12 +592,12 @@ class DynamoCompiler:
             args_memref = output_memref + input_memref
             # Invoke the graph's function using the provided execution engine
             # and memory references
-            start_time = time.time()
+            kernel_start_time = time.time()
             ee.invoke(graph._func_name, *args_memref)
-            end_time = time.time()
+            kernel_end_time = time.time()
 
             if self._verbose:
-                print(f"Kernel running time is {(end_time - start_time) * 1000:.2f}ms.")
+                print(f"Kernel running time is {(kernel_end_time - kernel_start_time) * 1000:.2f}ms.")
 
             output_tensor = []
             outdata_ptr = args_memref[0][0]

--- a/frontend/Python/frontend.py
+++ b/frontend/Python/frontend.py
@@ -24,6 +24,7 @@
 
 from typing import Any, List, Optional
 import operator
+import time
 import os
 import ctypes
 import platform
@@ -465,8 +466,13 @@ class DynamoCompiler:
         Returns:
             imported_graphs: The imported buddy graphs.
         """
+        start_end = time.time();
         exported_program = torch.export.export(module, args, kwargs)
         self._compile_fx(exported_program.graph_module, list(args))
+        end_time = time.time();
+
+        if self._verbose:
+            print(f"The graph compilation time is {(end_time - start_end) * 1000:.2f}ms.")
         return self._imported_graphs
 
     def dynamo_run(self):
@@ -486,6 +492,7 @@ class DynamoCompiler:
             else:
                 raise RuntimeError("Unsupported platform")
 
+        start_time = time.time()
         # Dynamo's graph break may import more than one graph.
         graph = self._imported_graphs[-1]
         graph.compile()
@@ -585,7 +592,12 @@ class DynamoCompiler:
             args_memref = output_memref + input_memref
             # Invoke the graph's function using the provided execution engine
             # and memory references
+            start_time = time.time()
             ee.invoke(graph._func_name, *args_memref)
+            end_time = time.time()
+
+            if self._verbose:
+                print(f"Kernel running time is {(end_time - start_time) * 1000:.2f}ms.")
 
             output_tensor = []
             outdata_ptr = args_memref[0][0]
@@ -604,4 +616,8 @@ class DynamoCompiler:
             # of tensors
             return [torch.from_numpy(tensor) for tensor in output_tensor]
 
+        end_time = time.time()
+
+        if self._verbose:
+            print(f"The MLIR compilation time is {(end_time - start_time) * 1000:.2f}ms.")
         return exec_buddy_graph


### PR DESCRIPTION
others:
- Use the `time.time` to gain the accuracy time instead of `time.process_time`.
- Add a missing instruction in the document.