### PR TITLE
[BUG]Add missing slash in CMakeLists.txt

### DIFF
--- a/examples/BuddyStableDiffusion/CMakeLists.txt
+++ b/examples/BuddyStableDiffusion/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/arg0_text_encoder.data
-         ${CMAKE_CURRENT_BINARY_DIR}arg1_text_encoder.data
+         ${CMAKE_CURRENT_BINARY_DIR}/arg1_text_encoder.data
          ${CMAKE_CURRENT_BINARY_DIR}/arg0_unet.data
          ${CMAKE_CURRENT_BINARY_DIR}/arg0_vae.data
          ${CMAKE_CURRENT_BINARY_DIR}/forward_text_encoder.mlir


### PR DESCRIPTION
In `examples/BuddyStableDiffusion/CMakeLists.txt` line 3, the cmake scripts is missing the required slash:

`${CMAKE_CURRENT_BINARY_DIR}arg1_text_encoder.data`

I think this should be fixed. Lookforward to your feedback!