### PR TITLE
[Examples] Add BF16 support for DeepSeekR1

### DIFF
--- a/examples/BuddyDeepSeekR1/CMakeLists.txt
+++ b/examples/BuddyDeepSeekR1/CMakeLists.txt
@@ -18,6 +18,16 @@ add_custom_command(
 )
 
 add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/forward-bf16.mlir
+         ${CMAKE_CURRENT_BINARY_DIR}/subgraph0-bf16.mlir
+         ${CMAKE_CURRENT_BINARY_DIR}/arg0-bf16.data
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/import-deepseek-r1.py
+          --output-dir ${CMAKE_CURRENT_BINARY_DIR}
+          --precision bf16
+  COMMENT "Generating forward.mlir, subgraph0.mlir and arg0.data..."
+)
+
+add_custom_command(
   OUTPUT forward.o
   COMMAND ${LLVM_TOOLS_BINARY_DIR}/mlir-opt ${CMAKE_CURRENT_BINARY_DIR}/forward.mlir
             -pass-pipeline "builtin.module(func.func(tosa-to-linalg-named),func.func(tosa-to-linalg),func.func(tosa-to-tensor),func.func(tosa-to-arith))" |
@@ -193,8 +203,97 @@ add_custom_command(
     COMMENT "Building subgraph.o "
     VERBATIM)
 
+add_custom_command(
+  OUTPUT forward-bf16.o
+  COMMAND ${LLVM_TOOLS_BINARY_DIR}/mlir-opt ${CMAKE_CURRENT_BINARY_DIR}/forward-bf16.mlir
+            -pass-pipeline "builtin.module(func.func(tosa-to-linalg-named),func.func(tosa-to-linalg),func.func(tosa-to-tensor),func.func(tosa-to-arith))" |
+          ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -one-shot-bufferize="bufferize-function-boundaries"
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -matmul-parallel-vectorization-optimize
+            -batchmatmul-optimize
+            -convert-linalg-to-affine-loops
+            -affine-loop-fusion
+            -affine-parallelize
+            -convert-vector-to-scf
+            -lower-affine
+            -convert-scf-to-openmp
+            -cse
+            -memref-expand
+            -arith-expand
+            -convert-vector-to-llvm
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -llvm-request-c-wrappers
+            -convert-openmp-to-llvm
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+        ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+        ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+        ${LLVM_TOOLS_BINARY_DIR}/llc -filetype=obj -relocation-model=pic -O3
+          -o ${CMAKE_CURRENT_BINARY_DIR}/forward-bf16.o
+  DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/forward-bf16.mlir
+  COMMENT "Building forward.o "
+  VERBATIM)
+
+add_custom_command(
+    OUTPUT subgraph-bf16.o
+    COMMAND ${LLVM_TOOLS_BINARY_DIR}/mlir-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0-bf16.mlir
+              -pass-pipeline "builtin.module(func.func(tosa-to-linalg-named),func.func(tosa-to-linalg),func.func(tosa-to-tensor),func.func(tosa-to-arith))" |
+            ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -convert-elementwise-to-linalg
+            -one-shot-bufferize="bufferize-function-boundaries"
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -matmul-parallel-vectorization-optimize
+            -batchmatmul-optimize
+            -convert-linalg-to-affine-loops
+            -affine-loop-fusion
+            -affine-parallelize
+            -convert-vector-to-scf
+            -lower-affine
+            -convert-scf-to-openmp
+            -func-bufferize-dynamic-offset
+            -cse
+            -memref-expand
+            -arith-expand
+            -convert-vector-to-llvm
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -llvm-request-c-wrappers
+            -convert-openmp-to-llvm
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+          ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+          ${LLVM_TOOLS_BINARY_DIR}/llc -filetype=obj -relocation-model=pic -O3
+            -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph-bf16.o
+    DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0-bf16.mlir
+    COMMENT "Building subgraph.o "
+    VERBATIM)
+
 add_library(DEEPSEEKR1 STATIC forward.o subgraph.o)
 add_library(DEEPSEEKR1_F16 STATIC forward-f16.o subgraph-f16.o)
+add_library(DEEPSEEKR1_BF16 STATIC forward-bf16.o subgraph-bf16.o)
 
 SET_SOURCE_FILES_PROPERTIES(
   template.o
@@ -212,8 +311,14 @@ SET_TARGET_PROPERTIES(
   PROPERTIES
   LINKER_LANGUAGE C)
 
+SET_TARGET_PROPERTIES(
+  DEEPSEEKR1_BF16
+  PROPERTIES
+  LINKER_LANGUAGE C)
+
 add_executable(buddy-deepseek-r1-run buddy-deepseek-r1-main.cpp)
 add_executable(buddy-deepseek-r1-f16-run buddy-deepseek-r1-f16-main.cpp)
+add_executable(buddy-deepseek-r1-bf16-run buddy-deepseek-r1-bf16-main.cpp)
 
 set(DEEPSEEKR1_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 set(DEEPSEEKR1_EXAMPLE_BUILD_PATH ${CMAKE_CURRENT_BINARY_DIR})
@@ -226,9 +331,14 @@ target_compile_definitions(buddy-deepseek-r1-f16-run PRIVATE
   DEEPSEEKR1_EXAMPLE_PATH="${DEEPSEEKR1_EXAMPLE_PATH}"
   DEEPSEEKR1_EXAMPLE_BUILD_PATH="${DEEPSEEKR1_EXAMPLE_BUILD_PATH}"
 )
+target_compile_definitions(buddy-deepseek-r1-bf16-run PRIVATE
+  DEEPSEEKR1_EXAMPLE_PATH="${DEEPSEEKR1_EXAMPLE_PATH}"
+  DEEPSEEKR1_EXAMPLE_BUILD_PATH="${DEEPSEEKR1_EXAMPLE_BUILD_PATH}"
+)
 
 target_link_directories(buddy-deepseek-r1-run PRIVATE ${LLVM_LIBRARY_DIR})
 target_link_directories(buddy-deepseek-r1-f16-run PRIVATE ${LLVM_LIBRARY_DIR})
+target_link_directories(buddy-deepseek-r1-bf16-run PRIVATE ${LLVM_LIBRARY_DIR})
 
 set(BUDDY_DEEPSEEKR1_LIBS
   DEEPSEEKR1
@@ -240,10 +350,17 @@ set(BUDDY_DEEPSEEKR1_F16_LIBS
   mlir_c_runner_utils
   omp
 )
+set(BUDDY_DEEPSEEKR1_BF16_LIBS
+  DEEPSEEKR1_BF16
+  mlir_c_runner_utils
+  omp
+)
 if(BUDDY_MLIR_USE_MIMALLOC)
   list(APPEND BUDDY_DEEPSEEKR1_LIBS mimalloc)
   list(APPEND BUDDY_DEEPSEEKR1_F16_LIBS mimalloc)
+  list(APPEND BUDDY_DEEPSEEKR1_BF16_LIBS mimalloc)
 endif()
 
 target_link_libraries(buddy-deepseek-r1-run ${BUDDY_DEEPSEEKR1_LIBS})
 target_link_libraries(buddy-deepseek-r1-f16-run ${BUDDY_DEEPSEEKR1_F16_LIBS})
+target_link_libraries(buddy-deepseek-r1-bf16-run ${BUDDY_DEEPSEEKR1_BF16_LIBS})

--- a/examples/BuddyDeepSeekR1/README.md
+++ b/examples/BuddyDeepSeekR1/README.md
@@ -87,6 +87,11 @@ $ ./buddy-deepseek-r1-run
 $ ninja buddy-deepseek-r1-f16-run
 $ cd bin
 $ ./buddy-deepseek-r1-f16-run
+
+//bf16
+$ ninja buddy-deepseek-r1-bf16-run
+$ cd bin
+$ ./buddy-deepseek-r1-bf16-run
 ```
 
 5. Enjoy it!

--- a/examples/BuddyDeepSeekR1/buddy-deepseek-r1-bf16-main.cpp
+++ b/examples/BuddyDeepSeekR1/buddy-deepseek-r1-bf16-main.cpp
@@ -1,0 +1,210 @@
+//===- buddy-deepseek-r1-bf16-main.cpp -----------------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include <buddy/Core/Container.h>
+#include <buddy/LLM/TextContainer.h>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <limits>
+
+using namespace buddy;
+
+constexpr size_t ParamsSize = 1777088064;
+constexpr size_t MaxVocabSize = 151936;
+constexpr size_t MaxTokenLength = 40;
+
+/// Declare DeepSeekR1 forward function.
+extern "C" void _mlir_ciface_forward(MemRef<uint16_t, 3> *result,
+                                     MemRef<uint16_t, 1> *arg0,
+                                     Text<size_t, 2> *arg1,
+                                     MemRef<long long, 2> *arg2);
+
+// -----------------------------------------------------------------------------
+// Helper Functions
+// -----------------------------------------------------------------------------
+
+/// Capture input message.
+void getUserInput(std::string &inputStr) {
+  std::cout << "\nPlease send a message:" << std::endl;
+  std::cout << ">>> ";
+  getline(std::cin, inputStr);
+  std::cout << std::endl;
+}
+
+/// Print [Log] label in bold blue format.
+void printLogLabel() { std::cout << "\033[34;1m[Log] \033[0m"; }
+
+/// Print information for each iteration.
+void printIterInfo(size_t iterIdx, std::string str, double time) {
+  std::cout << "\033[32;1m[Iteration " << iterIdx << "] \033[0m";
+  std::cout << "Token: " << str << " | "
+            << "Time: " << time << "s" << std::endl;
+}
+
+/// Tokenize input data in the container.
+void tokenizeInput(const std::string &vocabFile,
+                   Text<size_t, 2> &inputContainer) {
+  printLogLabel();
+  std::cout << "Vocab file: " << std::filesystem::canonical(vocabFile)
+            << std::endl;
+  const auto buddyTokenizeStart = std::chrono::high_resolution_clock::now();
+  inputContainer.tokenizeDeepSeekR1(vocabFile, MaxTokenLength);
+  const auto buddyTokenizeEnd = std::chrono::high_resolution_clock::now();
+  const std::chrono::duration<double, std::milli> buddyTokenizeTime =
+      buddyTokenizeEnd - buddyTokenizeStart;
+  printLogLabel();
+  std::cout << "Tokenize time: " << buddyTokenizeTime.count() << "ms"
+            << std::endl;
+}
+
+/// Load parameters into data container.
+void loadParameters(const std::string &paramFilePath,
+                    MemRef<uint16_t, 1> &params) {
+  const auto loadStart = std::chrono::high_resolution_clock::now();
+  std::ifstream paramFile(paramFilePath, std::ios::in | std::ios::binary);
+  if (!paramFile.is_open()) {
+    throw std::runtime_error("[Error] Failed to open params file!");
+  }
+  printLogLabel();
+  std::cout << "Loading params..." << std::endl;
+  printLogLabel();
+  std::cout << "Params file: " << std::filesystem::canonical(paramFilePath)
+            << std::endl;
+  paramFile.read(reinterpret_cast<char *>(params.getData()),
+                 sizeof(uint16_t) * (params.getSize()));
+  if (paramFile.fail()) {
+    throw std::runtime_error("Error occurred while reading params file!");
+  }
+  paramFile.close();
+  const auto loadEnd = std::chrono::high_resolution_clock::now();
+  const std::chrono::duration<double, std::milli> loadTime =
+      loadEnd - loadStart;
+  printLogLabel();
+  std::cout << "Params load time: " << (double)(loadTime.count()) / 1000
+            << "s\n"
+            << std::endl;
+}
+
+// bf16 to f32 conversion function (Brain floating point -> single precision)
+float decode_bf16(uint16_t h) {
+  // BF16 format: 1 sign bit, 8 exponent bits, 7 mantissa bits
+  // F32 format: 1 sign bit, 8 exponent bits, 23 mantissa bits
+  // BF16 is essentially F32 with the lower 16 bits truncated
+  uint32_t f32_bits = static_cast<uint32_t>(h) << 16;
+  return *reinterpret_cast<float*>(&f32_bits);
+}
+
+int findMaxIndex(const uint16_t *start, size_t length) {
+  int maxIdx = 0;
+  float maxVal = decode_bf16(start[0]);
+  for (int i = 1; i < (int)length; ++i) {
+    float val = decode_bf16(start[i]);
+    if (val > maxVal) {
+      maxVal = val;
+      maxIdx = i;
+    }
+  }
+  return maxIdx;
+}
+
+// -----------------------------------------------------------------------------
+// DeepSeekR1 Inference Main Entry
+// -----------------------------------------------------------------------------
+
+int main() {
+  /// Print the title of this example.
+  const std::string title = "DeepSeekR1 BF16 Inference Powered by Buddy Compiler";
+  std::cout << "\033[33;1m" << title << "\033[0m" << std::endl;
+
+  /// Define directories of vacabulary and parameter file.
+  std::string deepSeekR1Dir = DEEPSEEKR1_EXAMPLE_PATH;
+  std::string deepSeekR1BuildDir = DEEPSEEKR1_EXAMPLE_BUILD_PATH;
+  const std::string vocabDir = deepSeekR1Dir + "/vocab.txt";
+  const std::string paramsDir = deepSeekR1BuildDir + "/arg0-bf16.data";
+
+  /// Get user message.
+  std::string inputStr;
+  getUserInput(inputStr);
+
+  /// Initialize data containers
+  //  - Input container.
+  //  - Result container
+  //  - Output container.
+  //  - Parameters container.
+  Text<size_t, 2> outputContainer;
+  MemRef<uint16_t, 3> resultContainer({1, 40, 151936});
+  Text<size_t, 2> inputContainer(inputStr);
+  MemRef<uint16_t, 1> paramsContainer({ParamsSize});
+  MemRef<long long, 2> attention_mask({1, 40}, 0);
+
+  /// Fill data into containers
+  //  - Input: register vocabulary and tokenize the input string.
+  //  - Output: register vocabulary.
+  //  - Parameters: load parameters from the `arg0` file into the container.
+  tokenizeInput(vocabDir, inputContainer);
+  for (int i = 0; i < (int)inputContainer.getTokenCnt(); i++) {
+    attention_mask.getData()[i] = 1;
+  }
+  outputContainer.loadVocab(vocabDir);
+  loadParameters(paramsDir, paramsContainer);
+
+  /// Run DeepSeekR1 Inference
+  //  - Perform the forward function.
+  //  - Find and append the generated token.
+  //  - Continue iterating until the terminal condition is met.
+  int generateLen = MaxTokenLength - inputContainer.getTokenCnt();
+  for (int i = 0; i < generateLen; i++) {
+    const auto inferenceStart = std::chrono::high_resolution_clock::now();
+    // Execute the forward pass of the model.
+    _mlir_ciface_forward(&resultContainer, &paramsContainer, &inputContainer,
+                         &attention_mask);
+
+    const auto inferenceEnd = std::chrono::high_resolution_clock::now();
+    const std::chrono::duration<double, std::milli> inferenceTime =
+        inferenceEnd - inferenceStart;
+
+    // Determine the generated token.
+    int tokenIndex = inputContainer.getTokenCnt() - 1;
+    const uint16_t *startPtr =
+        resultContainer.getData() + tokenIndex * MaxVocabSize;
+    int maxIndex = findMaxIndex(startPtr, MaxVocabSize);
+    std::string tok = inputContainer.getStr(maxIndex);
+    // Print the generated token and inference time.
+    printIterInfo(i, tok, inferenceTime.count() / 1000);
+
+    // Stop if a <|end▁of▁sentence|> token is generated.
+    if (maxIndex == 151643) {
+      break;
+    }
+    // Append the generated token into the input and output container.
+    inputContainer.appendTokenIdx(maxIndex);
+    attention_mask.getData()[MaxTokenLength - generateLen + i] = 1;
+    outputContainer.appendTokenIdx(maxIndex);
+    free(resultContainer.release());
+  }
+
+  /// Print the final result
+  std::cout << "\n\033[33;1m[Input]\033[0m " << inputStr << std::endl;
+  std::cout << "\033[33;1m[Output]\033[0m "
+            << outputContainer.revertDeepSeekR1() << std::endl;
+
+  return 0;
+}

--- a/examples/BuddyDeepSeekR1/import-deepseek-r1.py
+++ b/examples/BuddyDeepSeekR1/import-deepseek-r1.py
@@ -44,8 +44,8 @@ parser.add_argument(
     "--precision",
     type=str,
     default="f32",
-    choices=["f32", "f16"],
-    help="Precision mode for generated MLIR and input data. Choose from 'f32' or 'f16'.",
+    choices=["f32", "f16", "bf16"],
+    help="Precision mode for generated MLIR and input data. Choose from 'f32', 'f16', or 'bf16'.",
 )
 args = parser.parse_args()
 
@@ -64,6 +64,12 @@ if args.precision == "f16":
         AutoModelForCausalLM.from_pretrained(model_path, torchscript=True)
         .eval()
         .half()
+    )
+elif args.precision == "bf16":
+    model = (
+        AutoModelForCausalLM.from_pretrained(model_path, torchscript=True)
+        .eval()
+        .bfloat16()
     )
 else:
     model = AutoModelForCausalLM.from_pretrained(
@@ -109,6 +115,20 @@ if args.precision == "f16":
         [param.detach().numpy().reshape([-1]) for param in params]
     )
     all_param.tofile(os.path.join(output_dir, "arg0-f16.data"))
+elif args.precision == "bf16":
+    with open(
+        os.path.join(output_dir, "subgraph0-bf16.mlir"), "w"
+    ) as module_file:
+        print(driver.subgraphs[0]._imported_module, file=module_file)
+    with open(os.path.join(output_dir, "forward-bf16.mlir"), "w") as module_file:
+        print(driver.construct_main_graph(True), file=module_file)
+    # Convert BF16 parameters to float32 first, then to numpy
+    all_param = numpy.concatenate(
+        [param.detach().float().numpy().reshape([-1]) for param in params]
+    )
+    # Convert float32 to BF16 format (uint16) for storage
+    all_param_bf16 = numpy.frombuffer(all_param.astype(numpy.float32).tobytes(), dtype=numpy.uint16)[1::2]
+    all_param_bf16.tofile(os.path.join(output_dir, "arg0-bf16.data"))
 else:
     with open(os.path.join(output_dir, "subgraph0.mlir"), "w") as module_file:
         print(driver.subgraphs[0]._imported_module, file=module_file)

--- a/frontend/Python/frontend.py
+++ b/frontend/Python/frontend.py
@@ -198,6 +198,8 @@ class DynamoCompiler:
                 return TensorDType.Int8
             case "torch.float16":
                 return TensorDType.Float16
+            case "torch.bfloat16":
+                return TensorDType.BFloat16
             case "torch.float32":
                 return TensorDType.Float32
             case "torch.float64":

--- a/frontend/Python/graph/graph.py
+++ b/frontend/Python/graph/graph.py
@@ -333,6 +333,9 @@ class Graph:
                     np_type = np.dtype(np.int64)
                 case "f16":
                     np_type = np.dtype(np.float16)
+                case "bf16":
+                    # BF16 is stored as uint16, similar to F16
+                    np_type = np.dtype(np.uint16)
                 case "f32":
                     np_type = np.dtype(np.float32)
                 case _:
@@ -472,6 +475,8 @@ class GraphImporter:
                 return ir.IntegerType.get_signless(64)
             case TensorDType.Float16:
                 return ir.F16Type.get()
+            case TensorDType.BFloat16:
+                return ir.BF16Type.get()
             case TensorDType.Float32:
                 return ir.F32Type.get()
             case TensorDType.Bool:

--- a/frontend/Python/graph/type.py
+++ b/frontend/Python/graph/type.py
@@ -26,20 +26,29 @@ class TensorDType(Enum):
     Enum class for declaring tensor data types.
 
     Members:
+    - Int8: str
+        Represents the 8-bit integer data type.
     - Int32: str
         Represents the 32-bit integer data type.
     - Int64: str
         Represents the 64-bit integer data type.
+    - Float16: str
+        Represents the 16-bit floating-point data type.
+    - BFloat16: str
+        Represents the 16-bit brain floating-point data type.
     - Float32: str
         Represents the 32-bit floating-point data type.
+    - Float64: str
+        Represents the 64-bit floating-point data type.
     - Bool: str
         Represents the boolean data type.
     """
-    
+
     Int8 = "int8"
     Int32 = "int32"
     Int64 = "int64"
     Float16 = "float16"
+    BFloat16 = "bfloat16"
     Float32 = "float32"
     Float64 = "float64"
     Bool = "bool"

--- a/frontend/Python/ops/func.py
+++ b/frontend/Python/ops/func.py
@@ -103,6 +103,7 @@ def param_extract(
     """
     dtype_mapping = {
         TensorDType.Float16: ir.F16Type.get(),
+        TensorDType.BFloat16: ir.BF16Type.get(),
         TensorDType.Float32: ir.F32Type.get(),
         TensorDType.Int64: ir.IntegerType.get_signless(64),
     }

--- a/frontend/Python/ops/tosa.py
+++ b/frontend/Python/ops/tosa.py
@@ -579,6 +579,7 @@ def convert_element_type_op(node: ConvertElementTypeOp, symbol_table):
         TensorDType.Float64: ir.F64Type.get(),
         TensorDType.Float32: ir.F32Type.get(),
         TensorDType.Float16: ir.F16Type.get(),
+        TensorDType.BFloat16: ir.BF16Type.get(),
         TensorDType.Int64: ir.IntegerType.get_signless(64),
         TensorDType.Int32: ir.IntegerType.get_signless(32),
         TensorDType.Bool: ir.IntegerType.get_signless(1),
@@ -933,6 +934,8 @@ def expand_op(node: ExpandOp, symbol_table) -> ir.Operation:
     elif result_element_type == ir.F32Type.get():
         element = ir.FloatAttr.get(result_element_type, 0.0)
     elif result_element_type == ir.F16Type.get():
+        element = ir.FloatAttr.get(result_element_type, 0.0)
+    elif result_element_type == ir.BF16Type.get():
         element = ir.FloatAttr.get(result_element_type, 0.0)
     else:
         raise NotImplementedError("Unsupported element type!")
@@ -1750,6 +1753,27 @@ def scaled_dot_product_flash_attention_for_cpu_op(
         )
         min_fp_attr = ir.FloatAttr.get(ir.F32Type.get(), f16_min_val)
         max_fp_attr = ir.FloatAttr.get(ir.F32Type.get(), f16_max_val)
+
+        matmul_op = tosa.ClampOp(
+            matmul_op.result.type,
+            matmul_op,
+            min_int_attr,
+            max_int_attr,
+            min_fp_attr,
+            max_fp_attr,
+        )
+    elif mlir_dtype == ir.BF16Type.get():
+        # BF16 has the same range as F32 but lower precision
+        bf16_max_val = 3.4028235e+38
+        bf16_min_val = -3.4028235e+38
+        min_int_attr = ir.IntegerAttr.get(
+            ir.IntegerType.get_signless(64), -sys.maxsize
+        )
+        max_int_attr = ir.IntegerAttr.get(
+            ir.IntegerType.get_signless(64), sys.maxsize
+        )
+        min_fp_attr = ir.FloatAttr.get(ir.F32Type.get(), bf16_min_val)
+        max_fp_attr = ir.FloatAttr.get(ir.F32Type.get(), bf16_max_val)
 
         matmul_op = tosa.ClampOp(
             matmul_op.result.type,

--- a/frontend/Python/ops/utils.py
+++ b/frontend/Python/ops/utils.py
@@ -33,6 +33,8 @@ def mlir_element_type_get(type_name):
     match type_name:
         case TensorDType.Float16:
             return ir.F16Type.get()
+        case TensorDType.BFloat16:
+            return ir.BF16Type.get()
         case TensorDType.Float32:
             return ir.F32Type.get()
         case TensorDType.Int32:
@@ -53,6 +55,8 @@ def mlir_element_attr_get(type_name, value):
     match type_name:
         case TensorDType.Float16:
             return ir.FloatAttr.get(ir.F16Type.get(), value)
+        case TensorDType.BFloat16:
+            return ir.FloatAttr.get(ir.BF16Type.get(), value)
         case TensorDType.Float32:
             return ir.FloatAttr.get(ir.F32Type.get(), value)
         case TensorDType.Int64:


### PR DESCRIPTION
- Add BFloat16 enum and type mappings in frontend Python
- Implement BF16 MLIR type conversions and TOSA operations
- Add BF16 precision option to import script with .bfloat16() conversion
- Create BF16 main program with decode_bf16 function
- Update CMakeLists.txt and README for BF16 build targets