### PR TITLE
[Frontend] Lower attention op to FlashAttention vectorized kernel.

### DIFF
--- a/examples/BuddyNext/makefile
+++ b/examples/BuddyNext/makefile
@@ -33,6 +33,35 @@ endif
 # ==============================================================================
 # Evaluation of Modules in DeepSeek-R1 Distill Qwen 1.5B
 # ==============================================================================
+next-flash-attention-vec-run:
+	@${MLIR_OPT} ./next-flash-attention-vec.mlir \
+		-pass-pipeline "builtin.module(func.func(tosa-to-linalg-named),func.func(tosa-to-linalg),func.func(tosa-to-tensor),func.func(tosa-to-arith))" | \
+		${MLIR_OPT} \
+		-arith-expand \
+		-eliminate-empty-tensors \
+		-empty-tensor-to-alloc-tensor \
+		-convert-elementwise-to-linalg \
+		-one-shot-bufferize="bufferize-function-boundaries" \
+		-convert-linalg-to-affine-loops \
+		-affine-loop-fusion \
+		-lower-affine \
+		-convert-vector-to-scf \
+		-expand-strided-metadata \
+		-convert-vector-to-llvm \
+		-memref-expand \
+		-arith-expand \
+		-convert-arith-to-llvm \
+		-finalize-memref-to-llvm \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-openmp-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-libm  \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-reconcile-unrealized-casts | \
+	${MLIR_CPU_RUNNER} ${OPT_FLAG} -e main -entry-point-result=void \
+		-shared-libs=${MLIR_RUNNER_UTILS} -shared-libs=${MLIR_C_RUNNER_UTILS}
 
 next-embedding-run:
 	@${MLIR_OPT} ./next-embedding.mlir \

--- a/examples/BuddyNext/next-flash-attention-vec.mlir
+++ b/examples/BuddyNext/next-flash-attention-vec.mlir
@@ -1,0 +1,174 @@
+// RUN: buddy-opt %s \
+// RUN:     -arith-expand \
+// RUN:     -eliminate-empty-tensors \
+// RUN:     -empty-tensor-to-alloc-tensor \
+// RUN:     -convert-elementwise-to-linalg \
+// RUN:     -one-shot-bufferize="bufferize-function-boundaries" \
+// RUN:     -convert-linalg-to-affine-loops \
+// RUN:     -affine-loop-fusion \
+// RUN:     -lower-affine \
+// RUN:     -convert-vector-to-scf \
+// RUN:     -expand-strided-metadata \
+// RUN:     -convert-vector-to-llvm \
+// RUN:     -memref-expand \
+// RUN:     -arith-expand \
+// RUN:     -convert-arith-to-llvm \
+// RUN:     -finalize-memref-to-llvm \
+// RUN:     -convert-scf-to-cf \
+// RUN:     -convert-cf-to-llvm \
+// RUN:     -convert-openmp-to-llvm \
+// RUN:     -convert-arith-to-llvm \
+// RUN:     -convert-math-to-libm  \
+// RUN:     -convert-math-to-llvm \
+// RUN:     -convert-func-to-llvm \
+// RUN:     -reconcile-unrealized-casts | \
+// RUN:     mlir-runner -e main -entry-point-result=void \
+// RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_runner_utils%shlibext \
+// RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_c_runner_utils%shlibext \
+// RUN:     -shared-libs=%mlir_runner_utils_dir/libomp%shlibext \
+// RUN:     | FileCheck %s
+
+// Flash Attention MLIR Implementation - vectorized version
+// Reference Paper: FlashAttention: Fast and Memory-Efficient Exact Attention with IO-Awareness
+// Vectorized version of Flash Attention
+
+#map = affine_map<(d0, d1, d2) -> (d1)>
+#map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map4 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map5 = affine_map<(d0) -> (d0)>
+func.func private @rtclock() -> f64
+func.func @kernel(
+  %Q: tensor<1x12x40x128xf32>,
+  %K: tensor<1x12x40x128xf32>,
+  %V: tensor<1x12x40x128xf32>,
+  %Mask: tensor<1x1x40x40xf32>
+) -> tensor<1x12x40x128xf32> {
+  %c0 = arith.constant 0 : index
+  %one_f32 = arith.constant 1.000000e+00 : f32
+  %scale = arith.constant 0.0883883461 : f32
+  %zero_f32 = arith.constant 0.000000e+00 : f32
+  %neg_inf = arith.constant -1.000000e+30 : f32
+
+  %Q_mem = bufferization.to_memref %Q : tensor<1x12x40x128xf32> to memref<1x12x40x128xf32>
+  %K_mem = bufferization.to_memref %K : tensor<1x12x40x128xf32> to memref<1x12x40x128xf32>
+  %V_mem = bufferization.to_memref %V : tensor<1x12x40x128xf32> to memref<1x12x40x128xf32>
+  %Mask_mem = bufferization.to_memref %Mask : tensor<1x1x40x40xf32> to memref<1x1x40x40xf32>
+
+  %c1 = arith.constant 1 : index
+  %c12 = arith.constant 12 : index
+  %c40 = arith.constant 40 : index
+  %c128 = arith.constant 128 : index
+
+  %output_mem = memref.alloc() : memref<1x12x40x128xf32>
+  %sum_exp_mem = memref.alloc() : memref<1x12x40xf32>
+  %attn_accum_mem = memref.alloc() : memref<128xf32>
+
+  affine.for %batch = 0 to #map5(%c1) {
+    affine.for %head = 0 to #map5(%c12) {
+      affine.for %query_idx = 0 to #map5(%c40) {
+        affine.for %dim_offset = 0 to #map5(%c128) step 16 {
+          %vec_zero = vector.splat %zero_f32 : vector<16xf32>
+          vector.transfer_write %vec_zero, %attn_accum_mem[%dim_offset] {in_bounds = [true]} : vector<16xf32>, memref<128xf32>
+        }
+
+        %softmax_state:2 = affine.for %key_idx = 0 to #map5(%c40) iter_args(%running_max = %neg_inf, %running_sum = %zero_f32) -> (f32, f32) {
+          %qk_acc = affine.for %dim_offset = 0 to #map5(%c128) step 16 iter_args(%qk_sum = %zero_f32) -> (f32) {
+            %q_vec = vector.transfer_read %Q_mem[%batch, %head, %query_idx, %dim_offset], %zero_f32 {in_bounds = [true]} : memref<1x12x40x128xf32>, vector<16xf32>
+            %k_vec = vector.transfer_read %K_mem[%batch, %head, %key_idx, %dim_offset], %zero_f32 {in_bounds = [true]} : memref<1x12x40x128xf32>, vector<16xf32>
+            %qk_mul = arith.mulf %q_vec, %k_vec : vector<16xf32>
+            %qk_red = vector.reduction <add>, %qk_mul : vector<16xf32> into f32
+            %qk_sum_next = arith.addf %qk_sum, %qk_red : f32
+            affine.yield %qk_sum_next : f32
+          }
+
+          %scaled_score = arith.mulf %qk_acc, %scale : f32
+          %mask_val = affine.load %Mask_mem[%batch, %c0, %query_idx, %key_idx] : memref<1x1x40x40xf32>
+          %score = arith.addf %scaled_score, %mask_val : f32
+
+          %is_new_max = arith.cmpf ogt, %score, %running_max : f32
+          %new_max = arith.select %is_new_max, %score, %running_max : f32
+
+          %diff_old = arith.subf %running_max, %score : f32
+          %exp_old = math.exp %diff_old : f32
+          %exp_old_running_sum = arith.mulf %exp_old, %running_sum : f32
+          %sum_if_new = arith.addf %exp_old_running_sum, %one_f32 : f32
+
+          %diff_new = arith.subf %score, %running_max : f32
+          %exp_new = math.exp %diff_new : f32
+          %sum_if_old = arith.addf %running_sum, %exp_new : f32
+
+          %new_sum = arith.select %is_new_max, %sum_if_new, %sum_if_old : f32
+
+          affine.for %dim_offset = 0 to #map5(%c128) step 16 {
+            %v_vec = vector.transfer_read %V_mem[%batch, %head, %key_idx, %dim_offset], %zero_f32 {in_bounds = [true]} : memref<1x12x40x128xf32>, vector<16xf32>
+            %acc_vec = vector.transfer_read %attn_accum_mem[%dim_offset], %zero_f32 {in_bounds = [true]} : memref<128xf32>, vector<16xf32>
+
+            %exp_old_vec = vector.splat %exp_old : vector<16xf32>
+            %acc_vec_exp_old_vec = arith.mulf %acc_vec, %exp_old_vec : vector<16xf32>
+            %updated_if_new = arith.addf %acc_vec_exp_old_vec, %v_vec : vector<16xf32>
+
+            %exp_new_vec = vector.splat %exp_new : vector<16xf32>
+            %exp_new_vec_v_vec = arith.mulf %exp_new_vec, %v_vec : vector<16xf32>
+            %updated_if_old = arith.addf %exp_new_vec_v_vec, %acc_vec : vector<16xf32>
+
+            %acc_next = arith.select %is_new_max, %updated_if_new, %updated_if_old : vector<16xf32>
+            vector.transfer_write %acc_next, %attn_accum_mem[%dim_offset] {in_bounds = [true]} : vector<16xf32>, memref<128xf32>
+          }
+
+          affine.yield %new_max, %new_sum : f32, f32
+        }
+
+        affine.store %softmax_state#1, %sum_exp_mem[%batch, %head, %query_idx] : memref<1x12x40xf32>
+
+        affine.for %dim_offset = 0 to #map5(%c128) step 16 {
+          %acc_vec = vector.transfer_read %attn_accum_mem[%dim_offset], %zero_f32 {in_bounds = [true]} : memref<128xf32>, vector<16xf32>
+          %sum_vec = vector.splat %softmax_state#1 : vector<16xf32>
+          %out_vec = arith.divf %acc_vec, %sum_vec : vector<16xf32>
+          vector.transfer_write %out_vec, %output_mem[%batch, %head, %query_idx, %dim_offset] {in_bounds = [true]} : vector<16xf32>, memref<1x12x40x128xf32>
+        }
+      }
+    }
+  }
+
+  %out_tensor = bufferization.to_tensor %output_mem restrict : memref<1x12x40x128xf32> to tensor<1x12x40x128xf32>
+  %sum_tensor = bufferization.to_tensor %sum_exp_mem restrict : memref<1x12x40xf32> to tensor<1x12x40xf32>
+  return %out_tensor : tensor<1x12x40x128xf32>
+}
+
+
+func.func @main() {
+
+  %t_start = call @rtclock() : () -> f64
+
+  %Q_val = arith.constant 3.0 : f32
+  %K_val = arith.constant 2.0 : f32
+  %V_val = arith.constant 8.0 : f32
+  %mask_val = arith.constant 0.0 : f32  // attention mask value (0.0 means no masking)
+
+  %Q = tensor.splat %Q_val : tensor<1x12x40x128xf32>
+
+  %K = tensor.splat %K_val : tensor<1x12x40x128xf32>
+
+  %V = tensor.splat %V_val : tensor<1x12x40x128xf32>
+
+  %Mask = tensor.splat %mask_val : tensor<1x1x40x40xf32>
+
+  %flash_result = call @kernel(%Q, %K, %V, %Mask) : (tensor<1x12x40x128xf32>, tensor<1x12x40x128xf32>, tensor<1x12x40x128xf32>, tensor<1x1x40x40xf32>) -> tensor<1x12x40x128xf32>
+
+  %t_end = call @rtclock() : () -> f64
+  %time = arith.subf %t_end, %t_start : f64
+
+  %tensor_unranked = tensor.cast %flash_result : tensor<1x12x40x128xf32> to tensor<*xf32>
+
+
+  call @printMemrefF32(%tensor_unranked) : (tensor<*xf32>) -> ()
+
+  // Print timings.
+  vector.print %time : f64
+  // CHECK: {{[0-9]+\.[0-9]+}}
+
+  return
+}
+  func.func private @printMemrefF32(%ptr : tensor<*xf32>)

--- a/frontend/Python/ops/tosa.py
+++ b/frontend/Python/ops/tosa.py
@@ -24,7 +24,8 @@ import numpy
 import sys
 
 import mlir.ir as ir
-from mlir.dialects import tensor, tosa, arith, linalg, math
+from mlir.ir import IndexType, F32Type
+from mlir.dialects import tensor, tosa, arith, linalg, math, affine ,vector,bufferization,memref
 
 from ..graph import TensorDType
 from ..graph import (
@@ -1619,214 +1620,200 @@ def argmax_op(node: ArgMaxOp, symbol_table):
 
 
 def scaled_dot_product_flash_attention_for_cpu_op(
-    node: ScaledDotProductFlashAttentionForCpuOp, symbol_table
+    node: "ScaledDotProductFlashAttentionForCpuOp", symbol_table
 ):
     """
-    Perform scaled dot-product attention computation.
-    Args:
-        node (ScaledDotProductFlashAttentionForCpuOp): The scaled dot-product attention operation node with metadata.
-        symbol_table: Mapping of variable names to tensor references.
+    Lower ScaledDotProductFlashAttentionForCpuOp into MLIR affine+vector IR.
     Returns:
-        result_reshape_op: Reshaped result tensor of the attention operation.
-        log_sumexp_op: Log-sum-exp constant operation.
+        result_tensor: Final attention output tensor
+        log_sumexp_reshape: Placeholder log-sum-exp (can be reshaped as needed)
     """
+    loc = ir.Location.unknown()
+    f32 = F32Type.get()
+    index = IndexType.get()
+    v16 = ir.VectorType.get([16], f32)
+
+    # === input parse ===
     query = symbol_table.get((str(node.args[0]), 0), node.args[0])
     key = symbol_table.get((str(node.args[1]), 0), node.args[1])
     value = symbol_table.get((str(node.args[2]), 0), node.args[2])
-
-    if len(node.args) == 4:
-        dropout_p = node.args[3]
-        assert dropout_p != 0.0
-    if len(node.args) == 5:
-        dropout_p = node.args[3]
-        is_causal = node.args[4]
-        assert dropout_p != 0.0
-        assert is_causal == True
-
     attn_mask = node.kwargs.get("attn_mask", None)
     scale = node.kwargs.get("scale", None)
 
+    c0 = arith.ConstantOp(index, 0, loc=loc)
     query_shape = query.type.shape
     key_shape = key.type.shape
     value_shape = value.type.shape
     output_shape = list(node.tensor_meta["shape"])
-    L, S = query_shape[-2], key_shape[-2]
-    scale_factor = (
+
+    one = arith.ConstantOp(f32, 1.0).result   
+                    
+
+    # scale = 1/sqrt(H)     
+    scale_val = (
         1 / numpy.sqrt(query.type.shape[-1]) if scale is None else scale
     )
+    scale_val = arith.ConstantOp(f32, float(scale_val)).result
 
-    # Initialize attention bias
-    dtype = node.tensor_meta["dtype"][0]
-    attn_bias_shape = [L, S]
-    mlir_dtype = mlir_element_type_get(dtype)
-    attn_bias_type = ir.RankedTensorType.get(attn_bias_shape, mlir_dtype)
-    zero_constant = arith.ConstantOp(mlir_dtype, 0.0)
-    attn_bias = tensor.SplatOp(attn_bias_type, zero_constant, [])
+    zero_f32 = arith.ConstantOp(f32, 0.0, loc=loc).result
+    neg_inf = arith.ConstantOp(f32, -1.0e30, loc=loc).result
+
+    # === bufferization ===
+    Q_memref = bufferization.ToMemrefOp(
+        memref.MemRefType.get(query_shape, f32), query, loc=loc
+    )
+    K_memref = bufferization.ToMemrefOp(
+        memref.MemRefType.get(key_shape, f32), key, loc=loc
+    )
+    V_memref = bufferization.ToMemrefOp(
+        memref.MemRefType.get(value_shape, f32), value, loc=loc
+    )
+
+    mask_memref = None
     if attn_mask is not None:
         attn_mask = symbol_table.get((str(attn_mask), 0), attn_mask)
-        if attn_mask.type.element_type == ir.IntegerType.get_signless(1):
-            assert attn_mask.type.element_type == ir.IntegerType.get_signless(1)
-            tensor_type = ir.RankedTensorType.get(
-                attn_mask.type.shape, ir.IntegerType.get_signless(1)
-            )
-            true_tensor = arith.ConstantOp(
-                tensor_type,
-                ir.DenseElementsAttr.get_splat(
-                    tensor_type, ir.BoolAttr.get(True)
-                ),
-            )
-            attn_mask = arith.XOrIOp(attn_mask, true_tensor)
-            minus_inf_tensor = arith.ConstantOp(
-                attn_mask.type,
-                ir.DenseElementsAttr.get_splat(
-                    attn_mask.type, ir.FloatAttr.get(f32_type, float("-inf"))
-                ),
-            )
-            attn_bias = tensor.SelectOp(attn_mask, minus_inf_tensor, attn_bias)
-        else:
-            if attn_mask.type.shape != attn_bias.result.type.shape:
-                attn_mask = tosa.ReshapeOp(
-                    attn_mask,
-                    memoryview(array.array("i", attn_bias.result.type.shape)),
+        mask_memref = bufferization.ToMemrefOp(
+            memref.MemRefType.get(attn_mask.type.shape, f32), attn_mask, loc=loc
+        )
+
+    batch_dim = arith.ConstantOp(index, query_shape[0], loc=loc)
+    q_dim0 = arith.ConstantOp(index, query_shape[1], loc=loc)
+    q_dim1 = arith.ConstantOp(index, query_shape[2], loc=loc)
+    q_dim2 = arith.ConstantOp(index, query_shape[3], loc=loc)
+
+    out_memref = memref.AllocOp(
+        memref.MemRefType.get(list(output_shape[0]), f32), [], [], loc=loc
+    )
+    out_exp_sum_memref = memref.AllocOp(
+        memref.MemRefType.get([query_shape[0],query_shape[1],query_shape[2]], f32), [], [], loc=loc
+    )
+
+    accum = memref.AllocOp(
+        memref.MemRefType.get([query_shape[-1]], f32), [], [], loc=loc
+    )
+    # batch loop
+    loop_batch = affine.AffineForOp(0, batch_dim.result, 1)
+    with ir.InsertionPoint(loop_batch.body):
+        batch = loop_batch.induction_variable
+
+        # h loop
+        loop_h = affine.AffineForOp(0, q_dim0.result, 1)
+        with ir.InsertionPoint(loop_h.body):
+            h = loop_h.induction_variable
+
+            # i loop
+            loop_i = affine.AffineForOp(0, q_dim1.result, 1)
+            with ir.InsertionPoint(loop_i.body):
+                i = loop_i.induction_variable
+
+                # initialize accum to zero
+                loop_init = affine.AffineForOp(0, q_dim2.result, 16)
+                temp_h = loop_init.induction_variable
+                with ir.InsertionPoint(loop_init.body):
+                    zv = vector.SplatOp(v16, zero_f32, loc=loc)
+                    identity_map = ir.AffineMap.get_identity(1)
+                    in_bounds = [True]
+                    vector.TransferWriteOp(None, zv, accum, [temp_h], identity_map, in_bounds)
+                    affine.yield_([])
+
+                # attention j loop
+                loop_js = affine.AffineForOp(
+                    0, q_dim1.result, iter_args=[neg_inf, zero_f32]
                 )
-            attn_bias = tosa.AddOp(attn_bias.result.type, attn_bias, attn_mask)
+                j = loop_js.induction_variable
+                iter_args = loop_js.inner_iter_args
+                with ir.InsertionPoint(loop_js.body):
+                    max_iter = iter_args[0]
+                    sum_exp_iter = iter_args[1]
 
-    # Transpose key tensor
-    key_shape = list(key.type.shape)
-    perm_list = list(range(len(key_shape)))
-    perm_list[-1], perm_list[-2] = perm_list[-2], perm_list[-1]
-    perm_const_op = tosa.ConstOp(
-        ir.DenseElementsAttr.get(memoryview(array.array("i", perm_list)))
-    )
-    perm_shape = []
-    perm_shape.append(key_shape[0])
-    perm_shape.append(key_shape[1])
-    perm_shape.append(key_shape[3])
-    perm_shape.append(key_shape[2])
-    permute_result_type = ir.RankedTensorType.get(perm_shape, mlir_dtype)
-    key = tosa.TransposeOp(
-        permute_result_type, key, perm_const_op.results[0]
-    ).result
+                    # ========== 1. calculate q·k ==========
+                    loop_qk = affine.AffineForOp(0, q_dim2.result, 16, [zero_f32])
+                    s = loop_qk.induction_variable
+                    temp_s = loop_qk.inner_iter_args[0]
+                    with ir.InsertionPoint(loop_qk.body):
+                        identity_1d = ir.AffineMap.get(len(query_shape), 0, [ir.AffineDimExpr.get(3)])  
+                        qv = vector.TransferReadOp(v16,Q_memref,[batch, h, i, s],identity_1d,zero_f32,[True],)
+                        kv = vector.TransferReadOp(v16,K_memref,[batch, h, j, s],identity_1d,zero_f32,[True],)
+                        mulv = arith.MulFOp(qv.result, kv.result, loc=loc).result
+                        sumv = vector.ReductionOp(f32, "add", mulv).result
+                        ns = arith.AddFOp(temp_s, sumv, loc=loc).result
+                        affine.yield_([ns])
 
-    # Matrix multiplication of query and key
-    query_reshape_op = tosa.ReshapeOp(
-        query,
-        memoryview(
-            array.array(
-                "i",
-                [
-                    query_shape[0] * query_shape[1],
-                    query_shape[2],
-                    query_shape[3],
-                ],
-            )
-        ),
-    )
-    key_reshape_op = tosa.ReshapeOp(
-        key,
-        memoryview(
-            array.array(
-                "i", [key_shape[0] * key_shape[1], key_shape[3], key_shape[2]]
-            )
-        ),
-    )
-    matmul_result_shp = [
-        key_shape[0] * key_shape[1],
-        query_shape[2],
-        key_shape[2],
-    ]
-    matmul_result_type = ir.RankedTensorType.get(matmul_result_shp, mlir_dtype)
-    matmul_op = tosa.MatMulOp(
-        matmul_result_type, query_reshape_op.result, key_reshape_op.result
-    )
-    if mlir_dtype == ir.F16Type.get():
-        f16_max_val = 65504.0
-        f16_min_val = -65504.0
-        min_int_attr = ir.IntegerAttr.get(
-            ir.IntegerType.get_signless(64), -sys.maxsize
-        )
-        max_int_attr = ir.IntegerAttr.get(
-            ir.IntegerType.get_signless(64), sys.maxsize
-        )
-        min_fp_attr = ir.FloatAttr.get(ir.F32Type.get(), f16_min_val)
-        max_fp_attr = ir.FloatAttr.get(ir.F32Type.get(), f16_max_val)
+                    score = loop_qk.result
+                    normalized = arith.MulFOp(score, scale_val, loc=loc).result
 
-        matmul_op = tosa.ClampOp(
-            matmul_op.result.type,
-            matmul_op,
-            min_int_attr,
-            max_int_attr,
-            min_fp_attr,
-            max_fp_attr,
-        )
-    # Multiply result by scale factor
-    scale_factor_constant = arith.ConstantOp(mlir_dtype, scale_factor)
-    scale_factor = tensor.SplatOp(matmul_result_type, scale_factor_constant, [])
-    mul_op = tosa.MulOp(
-        matmul_result_type,
-        matmul_op,
-        scale_factor,
-    )
+                    if mask_memref is not None:
+                        map4 = ir.AffineMap.get_identity(4)
+                        mask_val = affine.load(f32, mask_memref, [batch, c0.result, i, j], map4)
+                        score_masked = arith.AddFOp(normalized, mask_val, loc=loc).result
+                    else:
+                        score_masked = normalized
 
-    # Add attention bias to the result
-    add_op = _gen_arith_binary_op(mul_op.result, attn_bias.result, tosa.AddOp)
-    # add_op = tosa.AddOp(matmul_result_type, mul_op.result, attn_bias)
-    # Apply softmax to the result
-    softmax_output_shape = list(add_op.result.type.shape)
-    softmax_dim = len(softmax_output_shape) - 1
+                    # === FlashAttention online softmax ===
+                    cond_max = arith.CmpFOp(arith.CmpFPredicate.OGT, score_masked, max_iter, loc=loc)
+                    new_max = arith.SelectOp(cond_max, score_masked, max_iter, loc=loc)
 
-    # Subtract the maximum value along the dimension where softmax is applied to
-    # prevent overflow during the exp operation.
-    max_vals = tosa.ReduceMaxOp(add_op.result, softmax_dim)
-    sub_op = tosa.SubOp(add_op.result.type, add_op, max_vals)
-    exp_op = math.ExpOp(sub_op.result)
-    reduce_sum_op = tosa.ReduceSumOp(exp_op, softmax_dim)
-    log_op = tosa.LogOp(reduce_sum_op.result.type, reduce_sum_op)
-    log_sumexp = tosa.AddOp(max_vals.result.type, max_vals, log_op)
-    log_weights = tosa.SubOp(add_op.result.type, add_op, log_sumexp)
-    softmax_result = math.ExpOp(log_weights.result)
-    log_sumexp = tosa.ReshapeOp(
-        log_sumexp,
-        memoryview(
-            array.array(
-                "i",
-                output_shape[1],
-            )
-        ),
-    )
+                    sub1 = arith.SubFOp(max_iter, score_masked, loc=loc).result
+                    exp1 = math.ExpOp(sub1, loc=loc).result
+                    mul1 = arith.MulFOp(exp1, sum_exp_iter, loc=loc).result
+                    add1 = arith.AddFOp(mul1, one, loc=loc).result   
 
-    # This step includes dropout during training.
-    # Multiply the result by the value tensor.
-    value_reshape_op = tosa.ReshapeOp(
-        value,
-        memoryview(
-            array.array(
-                "i",
-                [key_shape[0] * key_shape[1], value_shape[2], value_shape[3]],
-            )
-        ),
-    )
-    matmul_result_shp = matmul_result_shp = [
-        key_shape[0] * key_shape[1],
-        query_shape[2],
-        value_shape[3],
-    ]
-    matmul_result_type = ir.RankedTensorType.get(matmul_result_shp, mlir_dtype)
-    matmul_op = tosa.MatMulOp(
-        matmul_result_type, softmax_result.result, value_reshape_op.result
-    )
+                    sub2 = arith.SubFOp(score_masked, max_iter, loc=loc).result
+                    exp2 = math.ExpOp(sub2, loc=loc).result
+                    add2 = arith.AddFOp(sum_exp_iter, exp2, loc=loc).result   
 
-    result_reshape_op = tosa.ReshapeOp(
-        matmul_op.result,
-        memoryview(
-            array.array(
-                "i",
-                [key_shape[0], key_shape[1], query_shape[2], value_shape[3]],
-            )
-        ),
-    )
+                    sum_exp_update = arith.SelectOp(
+                        cond_max, add1, add2, loc=loc
+                    )
+                    # === V accumulate ===
+                    loop_d = affine.AffineForOp(0, q_dim2.result, 16)
+                    d = loop_d.induction_variable
+                    with ir.InsertionPoint(loop_d.body):
+                        identity_map = ir.AffineMap.get(len(value_shape), 0, [ir.AffineDimExpr.get(3)])
+                        vvec = vector.TransferReadOp(v16,V_memref,[batch, h, j, d],identity_map,zero_f32,[True],).result
+                        identity_map = ir.AffineMap.get_identity(1)
+                        acc_old = vector.TransferReadOp(v16,accum,[d],identity_map,zero_f32,[True],).result
 
-    return result_reshape_op, log_sumexp
+                        v_exp1 = vector.SplatOp(v16, exp1, loc=loc).result
+                        accum_mul1 = arith.MulFOp(acc_old, v_exp1, loc=loc).result
+                        r1 = arith.AddFOp(accum_mul1, vvec).result
+
+                        v_exp2 = vector.SplatOp(v16, exp2, loc=loc).result
+                        accum_mul2 = arith.MulFOp(v_exp2, vvec, loc=loc).result
+                        r2 = arith.AddFOp(accum_mul2, acc_old, loc=loc).result
+                        acc_new = arith.SelectOp(cond_max, r1, r2, loc=loc).result
+
+                        vector.TransferWriteOp(None, acc_new, accum, [d], identity_map, [True])
+                        affine.yield_([])
+
+                    affine.yield_([new_max.result, sum_exp_update.result])
+
+                final_sum = loop_js.results[1]
+
+                identity_map = ir.AffineMap.get_identity(3)
+                affine.store(final_sum, out_exp_sum_memref, [batch, h, i],identity_map)
+
+                # === write back result ===
+                loop_back = affine.AffineForOp(0, q_dim2.result, 16)
+                d_back = loop_back.induction_variable
+                with ir.InsertionPoint(loop_back.body):
+                    identity_map = ir.AffineMap.get_identity(1)
+                    accv = vector.TransferReadOp(v16,accum,[d_back],identity_map,zero_f32,[True],).result
+                    final_sum_vec = vector.SplatOp(v16, final_sum, loc=loc).result
+                    outv = arith.DivFOp(accv, final_sum_vec, loc=loc)
+                    identity_map = ir.AffineMap.get(len(list(output_shape[0])), 0, [ir.AffineDimExpr.get(3)])
+                    vector.TransferWriteOp(None, outv, out_memref, [batch, h, i, d_back], identity_map, [True])
+                    affine.yield_([])
+
+                affine.yield_([])
+            affine.yield_([])
+        affine.yield_([])
+
+    tensor_ty = ir.RankedTensorType.get(list(output_shape[0]), f32)
+    result_tensor = bufferization.ToTensorOp(tensor_ty, out_memref, restrict=ir.BoolAttr.get(True))
+    tensor_lg = ir.RankedTensorType.get([query_shape[0],query_shape[1],query_shape[2]], f32)
+    log_sumexp = bufferization.ToTensorOp(tensor_lg, out_exp_sum_memref, restrict=ir.BoolAttr.get(True))
+    return result_tensor, log_sumexp
 
 
 ops_registry = {


### PR DESCRIPTION
1. Implement FlashAttention kernel in MLIR using affine loops + vector ops.

2. Replace the existing Attention → TOSA lowering path with Attention → FlashAttention kernel in MLIR using affine loops + vector ops.