### PR TITLE
[tests] Add VIR Python binding and simple tests for it

### DIFF
--- a/midend/lib/CAPI/CMakeLists.txt
+++ b/midend/lib/CAPI/CMakeLists.txt
@@ -28,6 +28,8 @@ add_mlir_public_c_api_library(BuddyMLIRCAPI
   BuddyGemminiTransforms
   BuddyRVV
   BuddyRVVTransforms
+  # TODO: naming consistancy
+  VIR
   VectorExp
   BuddyMLIRInitAll
   BuddyToLLVMIRTranslationRegistration

--- a/midend/lib/CAPI/Dialects.cpp
+++ b/midend/lib/CAPI/Dialects.cpp
@@ -16,6 +16,7 @@
 
 #include "buddy-mlir-c/Dialects.h"
 
+// TODO: Does those inclusion for xxxOps.h necessary?
 #include "Dialect/Bud/BudDialect.h"
 #include "Dialect/Bud/BudOps.h"
 #include "Dialect/DAP/DAPDialect.h"
@@ -25,6 +26,7 @@
 #include "Dialect/Gemmini/GemminiDialect.h"
 #include "Dialect/Gemmini/GemminiOps.h"
 #include "Dialect/RVV/RVVDialect.h"
+#include "Dialect/VIR/VIRDialect.h"
 #include "Dialect/VectorExp/VectorExpDialect.h"
 #include "Dialect/VectorExp/VectorExpOps.h"
 
@@ -38,3 +40,4 @@ MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Gemmini, gemmini,
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(RVV, rvv, buddy::rvv::RVVDialect)
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(VectorExp, vector_exp,
                                       buddy::vector_exp::VectorExpDialect)
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(VIR, vir, buddy::vir::VIRDialect)

--- a/midend/lib/CMakeLists.txt
+++ b/midend/lib/CMakeLists.txt
@@ -21,6 +21,7 @@ set(LinkedLibs
   LowerLinalgToGemminiPass
   LowerRVVPass
   LowerVectorExpPass
+  VIRToVectorPass
   MatMulOptimization
   BatchMatMulOptimization
   MatMulParallelVectorization

--- a/midend/lib/InitAll.cpp
+++ b/midend/lib/InitAll.cpp
@@ -25,6 +25,7 @@
 #include "Dialect/DIP/DIPDialect.h"
 #include "Dialect/Gemmini/GemminiDialect.h"
 #include "Dialect/RVV/RVVDialect.h"
+#include "Dialect/VIR/VIRDialect.h"
 #include "Dialect/VectorExp/VectorExpDialect.h"
 
 namespace mlir {
@@ -45,6 +46,7 @@ void registerMatMulOptimizePass();
 void registerMatMulParallelVectorizationPass();
 void registerMatMulVectorizationPass();
 void registerTransposeOptimizationPass();
+void registerVIRToVectorPass();
 } // namespace buddy
 } // namespace mlir
 
@@ -55,6 +57,7 @@ void mlir::buddy::registerAllDialects(mlir::DialectRegistry &registry) {
   registry.insert<::buddy::gemmini::GemminiDialect>();
   registry.insert<::buddy::rvv::RVVDialect>();
   registry.insert<::buddy::vector_exp::VectorExpDialect>();
+  registry.insert<::buddy::vir::VIRDialect>();
 }
 
 void mlir::buddy::registerAllPasses() {
@@ -74,4 +77,5 @@ void mlir::buddy::registerAllPasses() {
   mlir::buddy::registerMatMulParallelVectorizationPass();
   mlir::buddy::registerMatMulVectorizationPass();
   mlir::buddy::registerTransposeOptimizationPass();
+  mlir::buddy::registerVIRToVectorPass();
 }

--- a/midend/python/CMakeLists.txt
+++ b/midend/python/CMakeLists.txt
@@ -57,7 +57,6 @@ declare_mlir_dialect_python_bindings(
     dialects/rvv.py
   DIALECT_NAME rvv)
 
-
 declare_mlir_dialect_python_bindings(
   ADD_TO_PARENT BuddyMLIRPythonSources.Dialects
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/buddy_mlir"
@@ -65,6 +64,14 @@ declare_mlir_dialect_python_bindings(
   SOURCES
     dialects/vector_exp.py
   DIALECT_NAME vector_exp)
+
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT BuddyMLIRPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/buddy_mlir"
+  TD_FILE dialects/VIRBinding.td
+  SOURCES
+    dialects/vir.py
+  DIALECT_NAME vir)
 
 ################################################################################
 # Python extensions.

--- a/midend/python/buddy_mlir/dialects/VIRBinding.td
+++ b/midend/python/buddy_mlir/dialects/VIRBinding.td
@@ -1,0 +1,22 @@
+//===-------- VIROps.td - Python bindings for VIR --*- tablegen -*--------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef PYTHON_BINDINGS_VIR_OPS
+#define PYTHON_BINDINGS_VIR_OPS
+
+include "VIR/VIROps.td"
+
+#endif

--- a/midend/python/buddy_mlir/dialects/vir.py
+++ b/midend/python/buddy_mlir/dialects/vir.py
@@ -1,0 +1,17 @@
+# ===------------------------ vir.py -------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ===---------------------------------------------------------------------------
+
+from ._vir_ops_gen import *

--- a/tests/Python/dialects/test_vir.py
+++ b/tests/Python/dialects/test_vir.py
@@ -1,0 +1,71 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+from buddy_mlir.dialects import arith, func, vir, memref
+from buddy_mlir import ir
+from buddy_mlir.passmanager import PassManager
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+# CHECK-LABEL: TEST: testVIROperations
+@run
+def testVIROperations():
+    with ir.Context(), ir.Location.unknown():
+        module = ir.Module.parse(
+            """
+            memref.global "private" @gv : memref<10xf32> = dense<[0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0. , 0.]>
+            func.func private @printMemrefF32(memref<*xf32>)
+
+            func.func @main() {
+                %vl = arith.constant 5 : index
+                %f1 = arith.constant 1.0 : f32
+                %mem = memref.get_global @gv : memref<10xf32>
+                %c0 = arith.constant 0 : index
+                %c5 = arith.constant 5 : index
+
+                vir.set_vl %vl : index {
+                    %v1 = vir.constant { value = 2.0 : f32 } : !vir.vec<?xf32>
+                    %v2 = vir.broadcast %f1 : f32 -> !vir.vec<?xf32>
+                    vir.store %v1, %mem[%c0] : !vir.vec<?xf32> -> memref<10xf32>
+                    vir.store %v2, %mem[%c5] : !vir.vec<?xf32> -> memref<10xf32>
+                    vector.yield
+                }
+
+                %print_mem =  memref.cast %mem : memref<10xf32> to memref<*xf32>
+                call @printMemrefF32(%print_mem) : (memref<*xf32>) -> ()
+
+                return
+            }
+            """
+        )
+
+        module.operation.verify()
+
+        pm = PassManager("builtin.module")
+        pm.add("lower-vir-to-vector")
+        pm.run(module.operation)
+        
+        # CHECK: #map = affine_map<(d0) -> (d0)>
+        # CHECK: func.func @main() {
+        # CHECK:   %[[VL:.*]] = arith.constant 5 : index
+        # CHECK:   %[[F1:.*]] = arith.constant 1.000000e+00 : f32
+        # CHECK:   %[[MEM:.*]] = memref.get_global @gv : memref<10xf32>
+        # CHECK:   %[[C0:.*]] = arith.constant 0 : index
+        # CHECK:   %[[C5:.*]] = arith.constant 5 : index
+        # CHECK:   %[[C256:.*]] = arith.constant 256 : index
+        # CHECK:   affine.for %{{.*}} = #map(%{{.*}}) to #map(%{{.*}}) step 256 {
+        # CHECK:     %[[CONST_VEC:.*]] = arith.constant dense<2.000000e+00> : vector<256xf32>
+        # CHECK:     %[[BROADCAST_VEC:.*]] = vector.broadcast %[[F1]] : f32 to vector<256xf32>
+        # CHECK:     vector.store %[[CONST_VEC]], %[[MEM]][%{{.*}}] : memref<10xf32>, vector<256xf32>
+        # CHECK:     vector.store %[[BROADCAST_VEC]], %[[MEM]][%{{.*}}] : memref<10xf32>, vector<256xf32>
+        # CHECK:   }
+        # CHECK:   affine.for %{{.*}} = #map(%{{.*}}) to #map(%[[VL]]) {
+        # CHECK:     %[[SCALAR_CONST:.*]] = arith.constant 2.000000e+00 : f32
+        # CHECK:     memref.store %[[SCALAR_CONST]], %[[MEM]][%{{.*}}] : memref<10xf32>
+        # CHECK:     memref.store %[[F1]], %[[MEM]][%{{.*}}] : memref<10xf32>
+        # CHECK:   }
+        print(module)


### PR DESCRIPTION
There are two minor issue when I add VIR python binding.
1. Naming Consistancy in midend/lib/CAPI/CMakeLists.txt
  For other dialects like rvv, they have a prefix `Buddy`, but for VectorExp dialect, it doesn't.
2. Redundent inclusion in midend/lib/CAPI/Dialects.cpp
  There is no need to include xxxOps.h. I've deleted them all and rebuild, then passed all tests still.

If these two suggestions were to accepted, I'll add a commit to this PR