### PR TITLE
Add traditional optimization pass to subgraph-f16

### DIFF
--- a/examples/BuddyDeepSeekR1/CMakeLists.txt
+++ b/examples/BuddyDeepSeekR1/CMakeLists.txt
@@ -259,6 +259,8 @@ add_custom_command(
             -eliminate-empty-tensors
             -empty-tensor-to-alloc-tensor
             -convert-elementwise-to-linalg
+            -canonicalize
+            -cse
             -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
             -expand-strided-metadata
             -ownership-based-buffer-deallocation
@@ -266,6 +268,9 @@ add_custom_command(
             -bufferization-lower-deallocations
             -matmul-parallel-vectorization-optimize
             -batchmatmul-optimize
+            -canonicalize
+            -cse
+            -sccp
             -convert-linalg-to-affine-loops
             -affine-loop-fusion
             -affine-parallelize
@@ -273,7 +278,10 @@ add_custom_command(
             -lower-affine
             -convert-scf-to-openmp
             -func-bufferize-dynamic-offset
+            -canonicalize
             -cse
+            -sccp
+            -remove-dead-values
             -memref-expand
             -arith-expand
             -convert-vector-to-llvm


### PR DESCRIPTION
Optimized the pipeline for deepseek f16, primarily adding traditional optimization passes: canonicalize sccp remove-dead-values 

Following these additions, the compilation time and maximum memory usage for buddy-opt decreased. Subsequently, the mlir-translate compilation time and maximum memory usage showed significant reductions: from 128.9s to 114.76s, and from 219MB to 189MB.

Although applying traditional optimization methods has little impact on the final program's performance, they can slightly reduce compilation memory and LLVM translation time.
