### PR TITLE
[midend/lib/Conversion/MatMulOptimization] Fixi bug in batchmatmul optimization pass.

### DIFF
--- a/examples/BuddyMatmul/linalg-batchmatmul-f32.mlir
+++ b/examples/BuddyMatmul/linalg-batchmatmul-f32.mlir
@@ -1,4 +1,5 @@
 // RUN: buddy-opt %s \
+// RUN:     -batchmatmul-optimize \
 // RUN:     -convert-linalg-to-affine-loops \
 // RUN:     -lower-affine \
 // RUN:     -convert-vector-to-scf \

--- a/examples/MLIRLinalg/linalg-batch-matmul-f32.mlir
+++ b/examples/MLIRLinalg/linalg-batch-matmul-f32.mlir
@@ -1,4 +1,4 @@
-// RUN: buddy-opt -convert-linalg-to-loops -verify-diagnostics -expand-strided-metadata -lower-affine -convert-vector-to-llvm \
+// RUN: buddy-opt -batchmatmul-optimize -verify-diagnostics -expand-strided-metadata -lower-affine -convert-vector-to-llvm \
 // RUN:   -finalize-memref-to-llvm -convert-scf-to-cf -convert-linalg-to-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-arith-to-llvm -llvm-request-c-wrappers \
 // RUN:   -convert-func-to-llvm -reconcile-unrealized-casts %s \
 // RUN: | mlir-runner -O0 -e buddy_batchmatmul_f32 -entry-point-result=void \

--- a/examples/MLIRLinalg/linalg-batch-matmul-i8.mlir
+++ b/examples/MLIRLinalg/linalg-batch-matmul-i8.mlir
@@ -1,4 +1,4 @@
-// RUN: buddy-opt -convert-linalg-to-loops -verify-diagnostics -expand-strided-metadata -lower-affine \
+// RUN: buddy-opt -batchmatmul-optimize -verify-diagnostics -expand-strided-metadata -lower-affine \
 // RUN:   -convert-vector-to-llvm -finalize-memref-to-llvm -convert-scf-to-cf -convert-linalg-to-loops -convert-scf-to-cf -convert-cf-to-llvm -convert-arith-to-llvm \
 // RUN:   -llvm-request-c-wrappers -convert-func-to-llvm -reconcile-unrealized-casts %s \
 // RUN: | mlir-runner -O0 -e buddy_batchmatmul_i8 -entry-point-result=void \

--- a/midend/lib/Conversion/MatMulOptimization/BatchMatMulOptimize.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/BatchMatMulOptimize.cpp
@@ -80,362 +80,171 @@ public:
     Type elementType = A.getType().cast<MemRefType>().getElementType();
     VectorType vectorTy = mlir::VectorType::get({vecSize}, elementType);
 
-    const AffineExpr d0 = rewriter.getAffineDimExpr(0);
-    const AffineExpr d1 = rewriter.getAffineDimExpr(1);
-    const AffineExpr d2 = rewriter.getAffineDimExpr(2);
+    AffineExpr d0 = rewriter.getAffineDimExpr(0);
+    AffineExpr d1 = rewriter.getAffineDimExpr(1);
 
     // Define constants.
-    const Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    const Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    const Value c2 = rewriter.create<arith::ConstantIndexOp>(loc, 2);
-    const Value c3 = rewriter.create<arith::ConstantIndexOp>(loc, 3);
-    const Value c4 = rewriter.create<arith::ConstantIndexOp>(loc, 4);
-    const Value c5 = rewriter.create<arith::ConstantIndexOp>(loc, 5);
-    const Value c6 = rewriter.create<arith::ConstantIndexOp>(loc, 6);
-    const Value c7 = rewriter.create<arith::ConstantIndexOp>(loc, 7);
-    const Value unroll = rewriter.create<arith::ConstantIndexOp>(loc, 8);
-    const Value vlStep = rewriter.create<arith::ConstantIndexOp>(loc, vecSize);
+    llvm::SmallVector<Value, 8> constantVals;
+    for (int i = 0; i <= 8; ++i) {
+      auto val =
+          rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(i));
+      constantVals.push_back(val);
+    }
+    Value vlStep = rewriter.create<arith::ConstantIndexOp>(loc, vecSize);
 
     // Get dimensions of input tensors.
-    Value batch = rewriter.create<memref::DimOp>(loc, A, c0);
-    Value aRow = rewriter.create<memref::DimOp>(loc, A, c1);
-    Value aCol = rewriter.create<memref::DimOp>(loc, A, c2);
-    Value bCol = rewriter.create<memref::DimOp>(loc, C, c2);
+    Value batch = rewriter.create<memref::DimOp>(loc, A, constantVals[0]);
+    Value aRow = rewriter.create<memref::DimOp>(loc, A, constantVals[1]);
+    Value aCol = rewriter.create<memref::DimOp>(loc, A, constantVals[2]);
+    Value bCol = rewriter.create<memref::DimOp>(loc, C, constantVals[2]);
 
-    Value upperBound_tmp = rewriter.create<arith::SubIOp>(loc, bCol, vlStep);
-    Value upperBound = rewriter.create<arith::AddIOp>(loc, upperBound_tmp, c1);
+    AffineMap unrollMap = AffineMap::get(
+        /*dimCount=*/1,
+        /*symbolCount=*/0, {d0 % rewriter.getAffineConstantExpr(8)}, ctx);
+    AffineMap tailMap = AffineMap::get(
+        /*dimCount=*/2,
+        /*symbolCount=*/0, {d0 - d1}, ctx);
+    AffineMap affineMapVec = AffineMap::get(
+        /*dimCount=*/2,
+        /*symbolCount=*/0, {d0 - d1 + rewriter.getAffineConstantExpr(1)}, ctx);
 
-    // Create the primary parallel batch level loop.
-    auto parOp = rewriter.create<scf::ParallelOp>(
-        loc,
-        /*lowerBounds=*/ValueRange{c0, c0},
-        /*upperBounds=*/ValueRange{batch, aRow},
-        /*steps=*/ValueRange{c1, unroll},
-        [&](OpBuilder &builder, Location loc, ValueRange ivs) {
-          auto aRowIdx1 = rewriter.create<arith::AddIOp>(loc, ivs[1], c1);
-          auto aRowIdx2 = rewriter.create<arith::AddIOp>(loc, ivs[1], c2);
-          auto aRowIdx3 = rewriter.create<arith::AddIOp>(loc, ivs[1], c3);
-          auto aRowIdx4 = rewriter.create<arith::AddIOp>(loc, ivs[1], c4);
-          auto aRowIdx5 = rewriter.create<arith::AddIOp>(loc, ivs[1], c5);
-          auto aRowIdx6 = rewriter.create<arith::AddIOp>(loc, ivs[1], c6);
-          auto aRowIdx7 = rewriter.create<arith::AddIOp>(loc, ivs[1], c7);
+    Value tailSize =
+        rewriter.create<AffineApplyOp>(loc, unrollMap, ValueRange{aRow});
+    Value parallelSize = rewriter.create<AffineApplyOp>(
+        loc, tailMap, ValueRange{aRow, tailSize});
 
-          auto iter_idx = rewriter.create<scf::ForOp>(
-              loc, c0, upperBound,
-              /*Step=*/vlStep, ValueRange{c0},
-              [&](OpBuilder &builder, Location loc, Value iv0,
-                  ValueRange iterArgs0) {
-                auto cVec0 = rewriter.create<vector::LoadOp>(
-                    loc, vectorTy, C, ValueRange{ivs[0], ivs[1], iv0});
-                auto cVec1 = rewriter.create<vector::LoadOp>(
-                    loc, vectorTy, C, ValueRange{ivs[0], aRowIdx1, iv0});
-                auto cVec2 = rewriter.create<vector::LoadOp>(
-                    loc, vectorTy, C, ValueRange{ivs[0], aRowIdx2, iv0});
-                auto cVec3 = rewriter.create<vector::LoadOp>(
-                    loc, vectorTy, C, ValueRange{ivs[0], aRowIdx3, iv0});
-                auto cVec4 = rewriter.create<vector::LoadOp>(
-                    loc, vectorTy, C, ValueRange{ivs[0], aRowIdx4, iv0});
-                auto cVec5 = rewriter.create<vector::LoadOp>(
-                    loc, vectorTy, C, ValueRange{ivs[0], aRowIdx5, iv0});
-                auto cVec6 = rewriter.create<vector::LoadOp>(
-                    loc, vectorTy, C, ValueRange{ivs[0], aRowIdx6, iv0});
-                auto cVec7 = rewriter.create<vector::LoadOp>(
-                    loc, vectorTy, C, ValueRange{ivs[0], aRowIdx7, iv0});
-                auto sumIterVecs = builder.create<scf::ForOp>(
-                    loc, c0, aCol, /*Step=*/c1,
-                    ValueRange{cVec0, cVec1, cVec2, cVec3, cVec4, cVec5, cVec6,
-                               cVec7},
-                    [&](OpBuilder &builder, Location loc, Value iv1,
-                        ValueRange iterArgs1) {
-                      auto aEle0 = builder.create<memref::LoadOp>(
-                          loc, A, ValueRange{ivs[0], ivs[1], iv1});
-                      auto aEle1 = rewriter.create<memref::LoadOp>(
-                          loc, A, ValueRange{ivs[0], aRowIdx1, iv1});
-                      auto aEle2 = rewriter.create<memref::LoadOp>(
-                          loc, A, ValueRange{ivs[0], aRowIdx2, iv1});
-                      auto aEle3 = rewriter.create<memref::LoadOp>(
-                          loc, A, ValueRange{ivs[0], aRowIdx3, iv1});
-                      auto aEle4 = rewriter.create<memref::LoadOp>(
-                          loc, A, ValueRange{ivs[0], aRowIdx4, iv1});
-                      auto aEle5 = rewriter.create<memref::LoadOp>(
-                          loc, A, ValueRange{ivs[0], aRowIdx5, iv1});
-                      auto aEle6 = rewriter.create<memref::LoadOp>(
-                          loc, A, ValueRange{ivs[0], aRowIdx6, iv1});
-                      auto aEle7 = rewriter.create<memref::LoadOp>(
-                          loc, A, ValueRange{ivs[0], aRowIdx7, iv1});
-                      auto aVec0 = rewriter.create<vector::BroadcastOp>(
-                          loc, vectorTy, aEle0);
-                      auto aVec1 = rewriter.create<vector::BroadcastOp>(
-                          loc, vectorTy, aEle1);
-                      auto aVec2 = rewriter.create<vector::BroadcastOp>(
-                          loc, vectorTy, aEle2);
-                      auto aVec3 = rewriter.create<vector::BroadcastOp>(
-                          loc, vectorTy, aEle3);
-                      auto aVec4 = rewriter.create<vector::BroadcastOp>(
-                          loc, vectorTy, aEle4);
-                      auto aVec5 = rewriter.create<vector::BroadcastOp>(
-                          loc, vectorTy, aEle5);
-                      auto aVec6 = rewriter.create<vector::BroadcastOp>(
-                          loc, vectorTy, aEle6);
-                      auto aVec7 = rewriter.create<vector::BroadcastOp>(
-                          loc, vectorTy, aEle7);
-                      auto bVec = rewriter.create<vector::LoadOp>(
-                          loc, vectorTy, B, ValueRange{ivs[0], iv1, iv0});
-                      Value computedVec0;
-                      Value computedVec1;
-                      Value computedVec2;
-                      Value computedVec3;
-                      Value computedVec4;
-                      Value computedVec5;
-                      Value computedVec6;
-                      Value computedVec7;
-                      if (isa<IntegerType>(elementType)) {
-                        Value mulVec0 =
-                            builder.create<arith::MulIOp>(loc, aVec0, bVec);
-                        computedVec0 = builder.create<arith::AddIOp>(
-                            loc, mulVec0, iterArgs1[0]);
-                        Value mulVec1 =
-                            builder.create<arith::MulIOp>(loc, aVec1, bVec);
-                        computedVec1 = builder.create<arith::AddIOp>(
-                            loc, mulVec1, iterArgs1[1]);
-                        Value mulVec2 =
-                            builder.create<arith::MulIOp>(loc, aVec2, bVec);
-                        computedVec2 = builder.create<arith::AddIOp>(
-                            loc, mulVec2, iterArgs1[2]);
-                        Value mulVec3 =
-                            builder.create<arith::MulIOp>(loc, aVec3, bVec);
-                        computedVec3 = builder.create<arith::AddIOp>(
-                            loc, mulVec3, iterArgs1[3]);
-                        Value mulVec4 =
-                            builder.create<arith::MulIOp>(loc, aVec4, bVec);
-                        computedVec4 = builder.create<arith::AddIOp>(
-                            loc, mulVec4, iterArgs1[4]);
-                        Value mulVec5 =
-                            builder.create<arith::MulIOp>(loc, aVec5, bVec);
-                        computedVec5 = builder.create<arith::AddIOp>(
-                            loc, mulVec5, iterArgs1[5]);
-                        Value mulVec6 =
-                            builder.create<arith::MulIOp>(loc, aVec6, bVec);
-                        computedVec6 = builder.create<arith::AddIOp>(
-                            loc, mulVec6, iterArgs1[6]);
-                        Value mulVec7 =
-                            builder.create<arith::MulIOp>(loc, aVec7, bVec);
-                        computedVec7 = builder.create<arith::AddIOp>(
-                            loc, mulVec7, iterArgs1[7]);
-                      } else {
-                        computedVec0 = builder.create<vector::FMAOp>(
-                            loc, aVec0, bVec, iterArgs1[0]);
-                        computedVec1 = builder.create<vector::FMAOp>(
-                            loc, aVec1, bVec, iterArgs1[1]);
-                        computedVec2 = builder.create<vector::FMAOp>(
-                            loc, aVec2, bVec, iterArgs1[2]);
-                        computedVec3 = builder.create<vector::FMAOp>(
-                            loc, aVec3, bVec, iterArgs1[3]);
-                        computedVec4 = builder.create<vector::FMAOp>(
-                            loc, aVec4, bVec, iterArgs1[4]);
-                        computedVec5 = builder.create<vector::FMAOp>(
-                            loc, aVec5, bVec, iterArgs1[5]);
-                        computedVec6 = builder.create<vector::FMAOp>(
-                            loc, aVec6, bVec, iterArgs1[6]);
-                        computedVec7 = builder.create<vector::FMAOp>(
-                            loc, aVec7, bVec, iterArgs1[7]);
-                      }
-                      builder.create<scf::YieldOp>(
-                          loc,
-                          ValueRange{computedVec0, computedVec1, computedVec2,
-                                     computedVec3, computedVec4, computedVec5,
-                                     computedVec6, computedVec7});
-                    });
-                auto sumIterVec0 = rewriter.create<vector::StoreOp>(
-                    loc, sumIterVecs.getResult(0), C,
-                    ValueRange{ivs[0], ivs[1], iv0});
-                auto sumIterVec1 = rewriter.create<vector::StoreOp>(
-                    loc, sumIterVecs.getResult(1), C,
-                    ValueRange{ivs[0], aRowIdx1, iv0});
-                auto sumIterVec2 = rewriter.create<vector::StoreOp>(
-                    loc, sumIterVecs.getResult(2), C,
-                    ValueRange{ivs[0], aRowIdx2, iv0});
-                auto sumIterVec3 = rewriter.create<vector::StoreOp>(
-                    loc, sumIterVecs.getResult(3), C,
-                    ValueRange{ivs[0], aRowIdx3, iv0});
-                auto sumIterVec4 = rewriter.create<vector::StoreOp>(
-                    loc, sumIterVecs.getResult(4), C,
-                    ValueRange{ivs[0], aRowIdx4, iv0});
-                auto sumIterVec5 = rewriter.create<vector::StoreOp>(
-                    loc, sumIterVecs.getResult(5), C,
-                    ValueRange{ivs[0], aRowIdx5, iv0});
-                auto sumIterVec6 = rewriter.create<vector::StoreOp>(
-                    loc, sumIterVecs.getResult(6), C,
-                    ValueRange{ivs[0], aRowIdx6, iv0});
-                auto sumIterVec7 = rewriter.create<vector::StoreOp>(
-                    loc, sumIterVecs.getResult(7), C,
-                    ValueRange{ivs[0], aRowIdx7, iv0});
+    Value nUpperBound = rewriter.create<AffineApplyOp>(
+        loc, affineMapVec, ValueRange{bCol, vlStep});
 
-                auto nextIdx = rewriter.create<arith::AddIOp>(loc, iv0, vlStep);
-                builder.create<scf::YieldOp>(loc, ValueRange{nextIdx});
-              });
-          // Compute the tail size and Process the remaining elements
-          // using masked vector operations.
-          Value idx = iter_idx.getResult(0);
-          rewriter.create<scf::ForOp>(
-              loc, idx, bCol,
-              /*Step=*/c1, std::nullopt,
-              [&](OpBuilder &builder, Location loc, Value iv0,
-                  ValueRange itrArgs0) {
-                auto cEle0 = rewriter.create<memref::LoadOp>(
-                    loc, C, ValueRange{ivs[0], ivs[1], iv0});
-                auto cEle1 = rewriter.create<memref::LoadOp>(
-                    loc, C, ValueRange{ivs[0], aRowIdx1, iv0});
-                auto cEle2 = rewriter.create<memref::LoadOp>(
-                    loc, C, ValueRange{ivs[0], aRowIdx2, iv0});
-                auto cEle3 = rewriter.create<memref::LoadOp>(
-                    loc, C, ValueRange{ivs[0], aRowIdx3, iv0});
-                auto cEle4 = rewriter.create<memref::LoadOp>(
-                    loc, C, ValueRange{ivs[0], aRowIdx4, iv0});
-                auto cEle5 = rewriter.create<memref::LoadOp>(
-                    loc, C, ValueRange{ivs[0], aRowIdx5, iv0});
-                auto cEle6 = rewriter.create<memref::LoadOp>(
-                    loc, C, ValueRange{ivs[0], aRowIdx6, iv0});
-                auto cEle7 = rewriter.create<memref::LoadOp>(
-                    loc, C, ValueRange{ivs[0], aRowIdx7, iv0});
-                auto sumIterVecs = rewriter.create<scf::ForOp>(
-                    loc, c0, aCol, c1,
-                    ValueRange{cEle0, cEle1, cEle2, cEle3, cEle4, cEle5, cEle6,
-                               cEle7},
-                    [&](OpBuilder &builder, Location loc, Value iv1,
-                        ValueRange iterArgs1) {
-                      auto aEle0 = builder.create<memref::LoadOp>(
-                          loc, A, ValueRange{ivs[0], ivs[1], iv1});
-                      auto aEle1 = rewriter.create<memref::LoadOp>(
-                          loc, A, ValueRange{ivs[0], aRowIdx1, iv1});
-                      auto aEle2 = rewriter.create<memref::LoadOp>(
-                          loc, A, ValueRange{ivs[0], aRowIdx2, iv1});
-                      auto aEle3 = rewriter.create<memref::LoadOp>(
-                          loc, A, ValueRange{ivs[0], aRowIdx3, iv1});
-                      auto aEle4 = rewriter.create<memref::LoadOp>(
-                          loc, A, ValueRange{ivs[0], aRowIdx4, iv1});
-                      auto aEle5 = rewriter.create<memref::LoadOp>(
-                          loc, A, ValueRange{ivs[0], aRowIdx5, iv1});
-                      auto aEle6 = rewriter.create<memref::LoadOp>(
-                          loc, A, ValueRange{ivs[0], aRowIdx6, iv1});
-                      auto aEle7 = rewriter.create<memref::LoadOp>(
-                          loc, A, ValueRange{ivs[0], aRowIdx7, iv1});
-                      auto bEle = rewriter.create<memref::LoadOp>(
-                          loc, B, ValueRange{ivs[0], iv1, iv0});
+    auto createUnrollParallel = [&](int unrollSize, Value lowerBound,
+                                    Value upperBound) {
+      // Create the primary parallel batch level loop.
+      auto parOp = rewriter.create<scf::ParallelOp>(
+          loc,
+          /*lowerBounds=*/ValueRange{constantVals[0], lowerBound},
+          /*upperBounds=*/ValueRange{batch, upperBound},
+          /*steps=*/ValueRange{constantVals[1], constantVals[unrollSize]},
+          [&](OpBuilder &builder, Location loc, ValueRange ivs) {
+            llvm::SmallVector<Value, 8> mIndices;
+            for (int i = 0; i < unrollSize; ++i) {
+              auto mIndex =
+                  rewriter.create<arith::AddIOp>(loc, ivs[1], constantVals[i]);
+              mIndices.push_back(mIndex);
+            }
 
-                      Value computedVal0;
-                      Value computedVal1;
-                      Value computedVal2;
-                      Value computedVal3;
-                      Value computedVal4;
-                      Value computedVal5;
-                      Value computedVal6;
-                      Value computedVal7;
-                      if (isa<IntegerType>(elementType)) {
-                        auto tmpEle0 =
-                            rewriter.create<arith::MulIOp>(loc, aEle0, bEle);
-                        auto tmpEle1 =
-                            rewriter.create<arith::MulIOp>(loc, aEle1, bEle);
-                        auto tmpEle2 =
-                            rewriter.create<arith::MulIOp>(loc, aEle2, bEle);
-                        auto tmpEle3 =
-                            rewriter.create<arith::MulIOp>(loc, aEle3, bEle);
-                        auto tmpEle4 =
-                            rewriter.create<arith::MulIOp>(loc, aEle4, bEle);
-                        auto tmpEle5 =
-                            rewriter.create<arith::MulIOp>(loc, aEle5, bEle);
-                        auto tmpEle6 =
-                            rewriter.create<arith::MulIOp>(loc, aEle6, bEle);
-                        auto tmpEle7 =
-                            rewriter.create<arith::MulIOp>(loc, aEle7, bEle);
+            auto iter_idx = rewriter.create<scf::ForOp>(
+                loc, constantVals[0], nUpperBound,
+                /*Step=*/vlStep, ValueRange{constantVals[0]},
+                [&](OpBuilder &builder, Location loc, Value iv0,
+                    ValueRange iterArgs0) {
+                  SmallVector<Value> cVecs;
+                  for (auto mIndex : mIndices) {
+                    auto cInitVec = rewriter.create<vector::LoadOp>(
+                        loc, vectorTy, C, ValueRange{ivs[0], mIndex, iv0});
+                    cVecs.push_back(cInitVec);
+                  }
+                  auto sumIterVecs = builder.create<scf::ForOp>(
+                      loc, constantVals[0], aCol, /*Step=*/constantVals[1],
+                      ValueRange{cVecs},
+                      [&](OpBuilder &builder, Location loc, Value iv1,
+                          ValueRange iterArgs1) {
+                        auto bVec = rewriter.create<vector::LoadOp>(
+                            loc, vectorTy, B, ValueRange{ivs[0], iv1, iv0});
+                        SmallVector<Value> resSumVecs;
+                        if (isa<IntegerType>(elementType)) {
+                          for (int i = 0; i < unrollSize; ++i) {
+                            auto aEle = rewriter.create<memref::LoadOp>(
+                                loc, A, ValueRange{ivs[0], mIndices[i], iv1});
+                            auto aVec = rewriter.create<vector::BroadcastOp>(
+                                loc, vectorTy, aEle);
+                            Value mulVec =
+                                builder.create<arith::MulIOp>(loc, aVec, bVec);
+                            Value resSumVec = builder.create<arith::AddIOp>(
+                                loc, mulVec, iterArgs1[0]);
+                            resSumVecs.push_back(resSumVec);
+                          }
+                        } else {
+                          for (int i = 0; i < unrollSize; ++i) {
+                            auto aEle = rewriter.create<memref::LoadOp>(
+                                loc, A, ValueRange{ivs[0], mIndices[i], iv1});
+                            auto aVec = rewriter.create<vector::BroadcastOp>(
+                                loc, vectorTy, aEle);
+                            Value resSumVec = rewriter.create<vector::FMAOp>(
+                                loc, aVec, bVec, iterArgs1[i]);
+                            resSumVecs.push_back(resSumVec);
+                          }
+                        }
+                        builder.create<scf::YieldOp>(loc,
+                                                     ValueRange{resSumVecs});
+                      });
+                  for (int i = 0; i < unrollSize; ++i) {
+                    rewriter.create<vector::StoreOp>(
+                        loc, sumIterVecs.getResult(i), C,
+                        ValueRange{ivs[0], mIndices[i], iv0});
+                  }
 
-                        computedVal0 = rewriter.create<arith::AddIOp>(
-                            loc, tmpEle0, iterArgs1[0]);
-                        computedVal1 = rewriter.create<arith::AddIOp>(
-                            loc, tmpEle1, iterArgs1[1]);
-                        computedVal2 = rewriter.create<arith::AddIOp>(
-                            loc, tmpEle2, iterArgs1[2]);
-                        computedVal3 = rewriter.create<arith::AddIOp>(
-                            loc, tmpEle3, iterArgs1[3]);
-                        computedVal4 = rewriter.create<arith::AddIOp>(
-                            loc, tmpEle4, iterArgs1[4]);
-                        computedVal5 = rewriter.create<arith::AddIOp>(
-                            loc, tmpEle5, iterArgs1[5]);
-                        computedVal6 = rewriter.create<arith::AddIOp>(
-                            loc, tmpEle6, iterArgs1[6]);
-                        computedVal7 = rewriter.create<arith::AddIOp>(
-                            loc, tmpEle7, iterArgs1[7]);
-                      } else {
-                        auto tmpEle0 =
-                            rewriter.create<arith::MulFOp>(loc, aEle0, bEle);
-                        auto tmpEle1 =
-                            rewriter.create<arith::MulFOp>(loc, aEle1, bEle);
-                        auto tmpEle2 =
-                            rewriter.create<arith::MulFOp>(loc, aEle2, bEle);
-                        auto tmpEle3 =
-                            rewriter.create<arith::MulFOp>(loc, aEle3, bEle);
-                        auto tmpEle4 =
-                            rewriter.create<arith::MulFOp>(loc, aEle4, bEle);
-                        auto tmpEle5 =
-                            rewriter.create<arith::MulFOp>(loc, aEle5, bEle);
-                        auto tmpEle6 =
-                            rewriter.create<arith::MulFOp>(loc, aEle6, bEle);
-                        auto tmpEle7 =
-                            rewriter.create<arith::MulFOp>(loc, aEle7, bEle);
+                  auto nextIdx =
+                      rewriter.create<arith::AddIOp>(loc, iv0, vlStep);
+                  builder.create<scf::YieldOp>(loc, ValueRange{nextIdx});
+                });
+            // Compute the tail size and Process the remaining elements
+            // using masked vector operations.
+            Value idx = iter_idx.getResult(0);
+            rewriter.create<scf::ForOp>(
+                loc, idx, bCol,
+                /*Step=*/constantVals[1], std::nullopt,
+                [&](OpBuilder &builder, Location loc, Value iv0,
+                    ValueRange itrArgs0) {
+                  SmallVector<Value> cEles;
+                  for (auto mIndex : mIndices) {
+                    auto cInit = rewriter.create<memref::LoadOp>(
+                        loc, C, ValueRange{ivs[0], mIndex, iv0});
+                    cEles.push_back(cInit);
+                  }
+                  auto sumIterVecs = rewriter.create<scf::ForOp>(
+                      loc, constantVals[0], aCol, constantVals[1],
+                      ValueRange{cEles},
+                      [&](OpBuilder &builder, Location loc, Value iv1,
+                          ValueRange iterArgs1) {
+                        auto bEle = rewriter.create<memref::LoadOp>(
+                            loc, B, ValueRange{ivs[0], iv1, iv0});
+                        SmallVector<Value> resSums;
+                        if (isa<IntegerType>(elementType)) {
+                          for (int i = 0; i < unrollSize; ++i) {
+                            auto aEle = rewriter.create<memref::LoadOp>(
+                                loc, A, ValueRange{ivs[0], mIndices[i], iv1});
+                            auto tmpEle =
+                                rewriter.create<arith::MulIOp>(loc, aEle, bEle);
+                            auto resSum = rewriter.create<arith::AddIOp>(
+                                loc, tmpEle, iterArgs1[i]);
+                            resSums.push_back(resSum);
+                          }
+                        } else {
+                          for (int i = 0; i < unrollSize; ++i) {
+                            auto aEle = rewriter.create<memref::LoadOp>(
+                                loc, A, ValueRange{ivs[0], mIndices[i], iv1});
+                            auto tmpEle =
+                                rewriter.create<arith::MulFOp>(loc, aEle, bEle);
+                            auto resSum = rewriter.create<arith::AddFOp>(
+                                loc, tmpEle, iterArgs1[i]);
+                            resSums.push_back(resSum);
+                          }
+                        }
 
-                        computedVal0 = rewriter.create<arith::AddFOp>(
-                            loc, tmpEle0, iterArgs1[0]);
-                        computedVal1 = rewriter.create<arith::AddFOp>(
-                            loc, tmpEle1, iterArgs1[1]);
-                        computedVal2 = rewriter.create<arith::AddFOp>(
-                            loc, tmpEle2, iterArgs1[2]);
-                        computedVal3 = rewriter.create<arith::AddFOp>(
-                            loc, tmpEle3, iterArgs1[3]);
-                        computedVal4 = rewriter.create<arith::AddFOp>(
-                            loc, tmpEle4, iterArgs1[4]);
-                        computedVal5 = rewriter.create<arith::AddFOp>(
-                            loc, tmpEle5, iterArgs1[5]);
-                        computedVal6 = rewriter.create<arith::AddFOp>(
-                            loc, tmpEle6, iterArgs1[6]);
-                        computedVal7 = rewriter.create<arith::AddFOp>(
-                            loc, tmpEle7, iterArgs1[7]);
-                      }
-
-                      builder.create<scf::YieldOp>(
-                          loc,
-                          ValueRange{computedVal0, computedVal1, computedVal2,
-                                     computedVal3, computedVal4, computedVal5,
-                                     computedVal6, computedVal7});
-                    });
-
-                auto sumIter0 = rewriter.create<memref::StoreOp>(
-                    loc, sumIterVecs.getResult(0), C,
-                    ValueRange{ivs[0], ivs[1], iv0});
-                auto sumIter1 = rewriter.create<memref::StoreOp>(
-                    loc, sumIterVecs.getResult(1), C,
-                    ValueRange{ivs[0], aRowIdx1, iv0});
-                auto sumIter2 = rewriter.create<memref::StoreOp>(
-                    loc, sumIterVecs.getResult(2), C,
-                    ValueRange{ivs[0], aRowIdx2, iv0});
-                auto sumIter3 = rewriter.create<memref::StoreOp>(
-                    loc, sumIterVecs.getResult(3), C,
-                    ValueRange{ivs[0], aRowIdx3, iv0});
-                auto sumIter4 = rewriter.create<memref::StoreOp>(
-                    loc, sumIterVecs.getResult(4), C,
-                    ValueRange{ivs[0], aRowIdx4, iv0});
-                auto sumIter5 = rewriter.create<memref::StoreOp>(
-                    loc, sumIterVecs.getResult(5), C,
-                    ValueRange{ivs[0], aRowIdx5, iv0});
-                auto sumIter6 = rewriter.create<memref::StoreOp>(
-                    loc, sumIterVecs.getResult(6), C,
-                    ValueRange{ivs[0], aRowIdx6, iv0});
-                auto sumIter7 = rewriter.create<memref::StoreOp>(
-                    loc, sumIterVecs.getResult(7), C,
-                    ValueRange{ivs[0], aRowIdx7, iv0});
-
-                builder.create<scf::YieldOp>(loc);
-              });
-        });
+                        builder.create<scf::YieldOp>(loc, ValueRange{resSums});
+                      });
+                  
+                  for (int i = 0; i < unrollSize; i++) {
+                    rewriter.create<memref::StoreOp>(
+                        loc, sumIterVecs.getResult(i), C,
+                        ValueRange{ivs[0], mIndices[i], iv0});
+                  }
+                  builder.create<scf::YieldOp>(loc);
+                });
+          });
+    };
+    createUnrollParallel(8, constantVals[0], parallelSize);
+    createUnrollParallel(1, parallelSize, aRow);
 
     rewriter.eraseOp(op);
     return success();


### PR DESCRIPTION
Add tail processing for m-dim(unroll dimension) and support unrolling for any size.

Adjust the pass code structure for improved readability.