### PR TITLE
【frontend】Add graph splitting infrastructure compatible with DeepSeek model

### DIFF
--- a/frontend/Python/graph/graph.py
+++ b/frontend/Python/graph/graph.py
@@ -23,6 +23,7 @@ from types import FunctionType
 import ctypes
 import functools
 import numpy as np
+import torch
 
 import mlir.ir as ir
 import mlir.dialects.func as func
@@ -126,6 +127,7 @@ class Graph:
         """
         self._body = []
         self._inputs = inputs
+        self._outputs = None
         self.node_table: Dict[str, Op] = {}
         self._fake_params = fake_params
         self.device = device
@@ -257,6 +259,31 @@ class Graph:
             self.group_map_device[subgraph_name] = DeviceType.CPU
             self.op_groups[subgraph_name] = group
 
+    def infer_graph_inputs(self, op_group: List[Op]) -> List[Op]:
+      inputs = []
+      for op in op_group:
+        for parent in op._parents:
+          op_parent = self.node_table[parent]
+          if (op_parent not in op_group) and (op_parent not in inputs):
+            inputs.append(op_parent)
+      return inputs
+    
+    # Identify outputs for each subgraph and build dependencies between subgraphs
+    def infer_subgraph_outputs(self, op_group: List[Op], 
+                               subgraphs_inputs: Dict, 
+                               output_node: List[Op],
+                               dependencies) -> List[Op]:
+      outputs = []
+      for op in op_group:
+        for key in subgraphs_inputs.keys():
+          if op in subgraphs_inputs[key]:
+            if(op not in outputs):
+              outputs.append(op)
+            dependencies.add(key)
+        if (op.name in output_node) and (op not in outputs):
+          outputs.append(op)
+      return outputs
+    
     def fuse_ops(self, pattern_list: List[FunctionType]):
         """
         Fuse operations in the graph based on provided fusion patterns.
@@ -321,6 +348,7 @@ class Graph:
             )
             self._imported_module = fx_importer.import_graph()
             outputs = fx_importer.get_output_nodes()
+            self._outputs = outputs
         self._output_memref = []
         output_ranks = []
         output_dtypes = []
@@ -448,6 +476,7 @@ class GraphImporter:
         if ops_registry is None:
             ops_registry = {}
         self._symbol_table = {}
+        self._symbol_table_output = {}
         self._body = body
         self._device = device
         self._func_name = func_name
@@ -638,6 +667,8 @@ class GraphImporter:
                         ]
                         self._symbol_table[("output", 0)] = returns
                     elif isinstance(node, PlaceholderOp):
+                        if node._newshape is not None:
+                            node.tensor_meta['shape'] = torch.Size(list(node._newshape)) 
                         self._import_placeholder(node, args_list)
                     elif isinstance(node, GetItemOp):
                         self._symbol_table[(str(node.name), 0)] = (
@@ -791,17 +822,21 @@ class GraphImporter:
                     operation, ir.OpView
                 ):
                     self._symbol_table[(str(node.name), i)] = operation.result
+                    self._symbol_table_output[(str(node.name), i)] = operation.result 
                 elif isinstance(operation, ir.OpResult):
                     self._symbol_table[(str(node.name), i)] = operation
+                    self._symbol_table_output[(str(node.name), i)] = operation  
                 else:
                     raise NotImplementedError
         elif isinstance(op_ret, ir.OpResult):
             self._symbol_table[(str(node.name), 0)] = op_ret
+            self._symbol_table_output[(str(node.name), 0)] = op_ret 
         elif isinstance(op_ret, ir.BlockArgument):
             self._symbol_table[(str(node.name), 0)] = op_ret
         else:
             for i, result in enumerate(op_ret.results):
                 self._symbol_table[(str(node.name), i)] = result
+                self._symbol_table_output[(str(node.name), i)] = result
 
     def get_output_nodes(self):
         """

--- a/frontend/Python/graph/operation.py
+++ b/frontend/Python/graph/operation.py
@@ -119,9 +119,22 @@ class Op:
         """
         self._children.append(child)
 
+    
+    def split_node(self, dim: int, parallel: int):
+        """
+        Split the node into two nodes.
+        """
+        shape = self._tensor_meta["shape"]
+        shape[dim] = shape[dim] / parallel
+        self._tensor_meta["shape"] = shape
+
     @property
     def args(self):
         return self._arguments
+    
+    @property
+    def parents(self):
+        return self._parents
 
     @property
     def kwargs(self):
@@ -141,19 +154,21 @@ class Op:
 
     @tensor_meta.setter
     def tensor_meta(self, new_tensor_meta):
-        self._tensor_meta = new_tensor_meta
+        self._tensor_meta.update(new_tensor_meta)
 
 
 class PlaceholderOp(Op):
     def __init__(self) -> None:
         super().__init__()
         self._op_type = OpType.PlaceholderType
+        self._newshape: list = None
 
 
 class MatmulOp(Op):
     def __init__(self) -> None:
         super().__init__()
         self._op_type = OpType.ReduceType
+        self._newshape: list = None
 
 
 class TransposeMatmulFusedOp(Op):
@@ -190,12 +205,14 @@ class ViewOp(Op):
     def __init__(self) -> None:
         super().__init__()
         self._op_type = OpType.ReshapeType
+        self._newshape: list = None
 
 
 class EmbeddingOp(Op):
     def __init__(self) -> None:
         super().__init__()
         self._op_type = OpType.ReshapeType
+        self._newshape: list = None
 
 
 class OnesOp(Op):

--- a/frontend/Python/graph/type.py
+++ b/frontend/Python/graph/type.py
@@ -54,7 +54,7 @@ class TensorDType(Enum):
     Bool = "bool"
 
 
-class TensorMeta:
+class TensorMeta(dict):
     """
     Store tensor metadata, including shape and data type, while overlooking raw
     data.
@@ -75,7 +75,7 @@ class TensorMeta:
     # Access metadata attributes: meta.shape, meta.dtype
     """
 
-    def __init__(self, shape, dtype) -> None:
+    def __init__(self, shape, dtype):
         """
         Initialize a new instance of the TensorMeta class.
 
@@ -85,8 +85,23 @@ class TensorMeta:
         - dtype: str
             Represents the data type of the tensor.
         """
-        self.shape = shape
-        self.dtype = dtype
+        super().__init__(shape=shape, dtype=dtype)
+
+    @property
+    def shape(self):
+        return self["shape"]
+    
+    @shape.setter
+    def shape(self, value):
+        self["shape"] = value
+    
+    @property
+    def dtype(self):
+        return self["dtype"]
+    
+    @dtype.setter
+    def dtype(self, value):
+        self["dtype"] = value
 
 
 class DeviceType(Enum):

--- a/frontend/Python/ops/linalg.py
+++ b/frontend/Python/ops/linalg.py
@@ -18,6 +18,7 @@
 #
 # ===---------------------------------------------------------------------------
 
+import torch
 from typing import Dict, Tuple, List
 
 import mlir.ir as ir
@@ -829,7 +830,7 @@ def pow_op(
     if input1 is None:
         return
     value = node.args[1]
-    output_shape = list(node.tensor_meta["shape"])
+    output_shape = ir.RankedTensorType(input1.type).shape
     dtype = node.tensor_meta["dtype"]
     dtype = mlir_element_type_get(dtype)
     if not isinstance(value, str):
@@ -1168,7 +1169,9 @@ def matmul_op(
     if input1 is None or input2 is None:
         return
 
-    output_shape = list(node.tensor_meta["shape"])
+    input1_shape = ir.RankedTensorType(input1.type).shape
+    input2_shape = ir.RankedTensorType(input2.type).shape
+    output_shape = [input1_shape[0], input2_shape[1]]
     dtype = node.tensor_meta["dtype"]
     mlir_dtype = mlir_element_type_get(dtype)
     tensor_type = ir.RankedTensorType.get(output_shape, mlir_dtype)
@@ -1442,7 +1445,8 @@ def neg_op(
     input1 = symbol_table.get((str(node.args[0]), 0))
     if input1 is None:
         return
-    output_shape = list(node.tensor_meta["shape"])
+    input1_shape = ir.RankedTensorType(input1.type).shape
+    output_shape = list(input1_shape)
     dtype = node.tensor_meta["dtype"]
     mlir_dtype = mlir_element_type_get(dtype)
     output = tensor.EmptyOp(output_shape, mlir_dtype)
@@ -1476,7 +1480,9 @@ def cat_op(
     if input1 is None or input2 is None:
         return
 
-    output_shape = list(node.tensor_meta["shape"])
+    input1_shape = ir.RankedTensorType(input1.type).shape
+    input2_shape = ir.RankedTensorType(input2.type).shape
+    output_shape = input1_shape[:-1] + [input2_shape[-1] + input1_shape[-1]]
     if dim < 0:
         dim = len(output_shape) + dim
     dtype = node.tensor_meta["dtype"]
@@ -1484,7 +1490,7 @@ def cat_op(
     output = tensor.EmptyOp(output_shape, mlir_dtype)
     offset = [0 for x in output_shape]
     offset_attr = ir._denseI64ArrayAttr(offset, None)
-    input1_shape = ir.RankedTensorType(input1.type).shape
+    # input1_shape = ir.RankedTensorType(input1.type).shape
     size_attr = ir._denseI64ArrayAttr(input1_shape, None)
     stride_attr = ir._denseI64ArrayAttr([1] * len(offset), None)
     insert_input1 = tensor.InsertSliceOp(
@@ -1499,7 +1505,7 @@ def cat_op(
     )
     offset[dim] += input1_shape[dim]
     offset_attr = ir._denseI64ArrayAttr(offset, None)
-    input2_shape = ir.RankedTensorType(input2.type).shape
+    # input2_shape = ir.RankedTensorType(input2.type).shape
     size_attr = ir._denseI64ArrayAttr(input2_shape, None)
     insert_input2 = tensor.InsertSliceOp(
         input2,

--- a/frontend/Python/ops/tosa.py
+++ b/frontend/Python/ops/tosa.py
@@ -500,13 +500,18 @@ def reshape_op(node: ReshapeOp, symbol_table):
     shape will be inferred automatically.
     """
     input1 = symbol_table.get((str(node.args[0]), 0))
-    new_shape = []
-    for i in node.args[1]:
-        new_shape.append(i)
-    total_size = 1
     now_shape = ir.RankedTensorType(input1.type).shape
+    total_size = 1
     for dim_siz in now_shape:
         total_size *= dim_siz
+    
+    new_shape = []
+    if node._newshape is None:
+        for i in node.args[1]:
+            new_shape.append(i)
+    else: 
+        for i in node._newshape:
+            new_shape.append(i)    
 
     neg_one_cnt = 0
     rest_size = 1
@@ -1542,7 +1547,8 @@ def sigmoid_op(node: SigmoidOp, symbol_table):
     input1 = symbol_table.get((str(node.args[0]), 0))
     if input1 is None:
         return
-    output_shape = list(node.tensor_meta["shape"])
+    input_shape = ir.RankedTensorType(input1.type).shape
+    output_shape = list(input_shape)
     dtype = node.tensor_meta["dtype"]
     mlir_dtype = mlir_element_type_get(dtype)
     tensor_type = ir.RankedTensorType.get(output_shape, mlir_dtype)


### PR DESCRIPTION
This PR adds the basic infrastructure for graph splitting in the Python frontend.
The current implementation is compatible with the unsplit DeepSeek model

