### PR TITLE
[frontend] add new Operator fusion

### DIFF
--- a/frontend/Python/graph/operation.py
+++ b/frontend/Python/graph/operation.py
@@ -162,6 +162,12 @@ class TransposeMatmulFusedOp(Op):
         self._op_type = OpType.ReduceType
 
 
+class MatmulWithAccOp(Op):
+    def __init__(self) -> None:
+        super().__init__()
+        self._op_type = OpType.ReduceType
+
+
 class GetItemOp(Op):
     def __init__(self) -> None:
         super().__init__()


### PR DESCRIPTION
Operator fusion of residual networks has been added to the front end.
# Before fusion：
```
    %cst_26 = arith.constant dense<0.000000e+00> : tensor<1x1536xf32>
    %129 = linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%128, %arg14 : tensor<1x1536xf32>, tensor<1536x1536xf32>) outs(%cst_26 : tensor<1x1536xf32>) -> tensor<1x1536xf32>
    %130 = tosa.reshape %129 {new_shape = array<i64: 1, 1, 1536>} : (tensor<1x1536xf32>) -> tensor<1x1x1536xf32>
    %131 = tosa.add %2, %130 : (tensor<1x1x1536xf32>, tensor<1x1x1536xf32>) -> tensor<1x1x1536xf32>
```
# After fusion
```
    %129 = tosa.reshape %2 {new_shape = array<i64: 1, 1536>} : (tensor<1x1x1536xf32>) -> tensor<1x1536xf32>
    %130 = linalg.matmul {cast = #linalg.type_fn<cast_signed>} ins(%128, %arg14 : tensor<1x1536xf32>, tensor<1536x1536xf32>) outs(%129 : tensor<1x1536xf32>) -> tensor<1x1536xf32>
    %131 = tosa.reshape %130 {new_shape = array<i64: 1, 1, 1536>} : (tensor<1x1536xf32>) -> tensor<1x1x1536xf32>
```