### PR TITLE
[Examples] Remove affine parallel pass for Deepseek R1 decode phrase 

### DIFF
--- a/examples/BuddyDeepSeekR1/CMakeLists.txt
+++ b/examples/BuddyDeepSeekR1/CMakeLists.txt
@@ -217,7 +217,6 @@ add_custom_command(
             -batchmatmul-transpose-b-vectorization=vector-size=16
             -convert-linalg-to-affine-loops
             -affine-loop-fusion
-            -affine-parallelize
             -convert-vector-to-scf
             -lower-affine
             -convert-scf-to-openmp=${OPENMP_NUM_THREADS}


### PR DESCRIPTION
After remove this pass, the performance of decode phrase achieve 1.6 x speed up.
In the decode stage, most operators are memory-bound. The affine parallel pass automatically converts all affine.for loops into affine.parallel, introducing parallel execution by default. However, for memory-bound operators, parallelization does not alleviate the bottleneck. Instead, it often increases memory contention across multiple cores, resulting in additional memory access overhead and degraded performance.

Therefore, this change removes the affine parallel pass from the pipeline. For operators that truly benefit from parallel execution (e.g., via OpenMP), parallelism should be expressed explicitly using scf.parallel, rather than relying on automatic parallelization through a pass.

Performance before removal:
<img width="1559" height="658" alt="屏幕截图 2025-12-22 170055" src="https://github.com/user-attachments/assets/d0fbe974-c1ed-4ac5-99e2-82aafd29bbbc" />

Performance after removal:
<img width="1509" height="790" alt="image" src="https://github.com/user-attachments/assets/9cd4eda8-3799-418a-8a5b-6c36f19862c7" />

every single operator performance also increase:
before:
<img width="779" height="464" alt="屏幕截图 2025-12-22 205457" src="https://github.com/user-attachments/assets/690102ea-9eb2-4e42-91cc-487beb091423" />
After:
<img width="660" height="478" alt="image" src="https://github.com/user-attachments/assets/56292800-32ad-40e7-b54d-407155630b8c" />

