### PR TITLE
[IME] Add sliding-window matrix multiply-accumulate instructions

### DIFF
--- a/backend/include/llvm/IR/IntrinsicsRISCVBuddyExt.td
+++ b/backend/include/llvm/IR/IntrinsicsRISCVBuddyExt.td
@@ -120,3 +120,103 @@ let TargetPrefix = "riscv" in
 def int_riscv_ime_vfmadot : Intrinsic<[llvm_anyvector_ty],
                                       [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty],
                                       [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vmadot1 : Intrinsic<[llvm_anyvector_ty],
+                                      [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty],
+                                      [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vmadot1u : Intrinsic<[llvm_anyvector_ty],
+                                       [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty],
+                                       [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vmadot1su : Intrinsic<[llvm_anyvector_ty],
+                                        [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty],
+                                        [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vmadot1us : Intrinsic<[llvm_anyvector_ty],
+                                        [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty],
+                                        [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vmadot2 : Intrinsic<[llvm_anyvector_ty],
+                                      [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty],
+                                      [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vmadot2u : Intrinsic<[llvm_anyvector_ty],
+                                       [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty],
+                                       [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vmadot2su : Intrinsic<[llvm_anyvector_ty],
+                                        [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty],
+                                        [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vmadot2us : Intrinsic<[llvm_anyvector_ty],
+                                        [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty],
+                                        [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vmadot3 : Intrinsic<[llvm_anyvector_ty],
+                                      [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty],
+                                      [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vmadot3u : Intrinsic<[llvm_anyvector_ty],
+                                       [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty],
+                                       [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vmadot3su : Intrinsic<[llvm_anyvector_ty],
+                                        [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty],
+                                        [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vmadot3us : Intrinsic<[llvm_anyvector_ty],
+                                        [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty],
+                                        [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vmadotn : Intrinsic<[llvm_anyvector_ty],
+                                      [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty, llvm_i64_ty],
+                                      [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vmadotnu : Intrinsic<[llvm_anyvector_ty],
+                                       [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty, llvm_i64_ty],
+                                       [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vmadotnsu : Intrinsic<[llvm_anyvector_ty],
+                                        [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty, llvm_i64_ty],
+                                        [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vmadotnus : Intrinsic<[llvm_anyvector_ty],
+                                        [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty, llvm_i64_ty],
+                                        [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vfmadot1 : Intrinsic<[llvm_anyvector_ty],
+                                       [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty],
+                                       [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vfmadot2 : Intrinsic<[llvm_anyvector_ty],
+                                       [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty],
+                                       [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vfmadot3 : Intrinsic<[llvm_anyvector_ty],
+                                       [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty],
+                                       [IntrNoMem]>;
+
+let TargetPrefix = "riscv" in
+def int_riscv_ime_vfmadotn : Intrinsic<[llvm_anyvector_ty],
+                                       [LLVMMatchType<0>, llvm_anyvector_ty, llvm_anyvector_ty, llvm_i64_ty],
+                                       [IntrNoMem]>;

--- a/backend/llvm/lib/Target/RISCV/RISCVInstrInfoBuddyExt.td
+++ b/backend/llvm/lib/Target/RISCV/RISCVInstrInfoBuddyExt.td
@@ -240,6 +240,134 @@ def IME_VFMADOT : RVInstIME<0b1110101, 0b000,
   let Constraints = "$vd = $vd_in";
 }
 
+//===----------------------------------------------------------------------===//
+// IME Sliding-Window Instructions
+//===----------------------------------------------------------------------===//
+
+// Integer slide-1 instructions
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VMADOT1 : RVInstIME<0b1110010, 0b000,
+                            (outs VRM4:$vd),
+                            (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2),
+                            "vmadot1", "$vd, $vs1, $vs2"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VMADOT1U : RVInstIME<0b1110010, 0b011,
+                             (outs VRM4:$vd),
+                             (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2),
+                             "vmadot1u", "$vd, $vs1, $vs2"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VMADOT1SU : RVInstIME<0b1110010, 0b001,
+                              (outs VRM4:$vd),
+                              (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2),
+                              "vmadot1su", "$vd, $vs1, $vs2"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VMADOT1US : RVInstIME<0b1110010, 0b010,
+                              (outs VRM4:$vd),
+                              (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2),
+                              "vmadot1us", "$vd, $vs1, $vs2"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+// Integer slide-2 instructions
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VMADOT2 : RVInstIME<0b1110011, 0b000,
+                            (outs VRM4:$vd),
+                            (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2),
+                            "vmadot2", "$vd, $vs1, $vs2"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VMADOT2U : RVInstIME<0b1110011, 0b011,
+                             (outs VRM4:$vd),
+                             (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2),
+                             "vmadot2u", "$vd, $vs1, $vs2"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VMADOT2SU : RVInstIME<0b1110011, 0b001,
+                              (outs VRM4:$vd),
+                              (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2),
+                              "vmadot2su", "$vd, $vs1, $vs2"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VMADOT2US : RVInstIME<0b1110011, 0b010,
+                              (outs VRM4:$vd),
+                              (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2),
+                              "vmadot2us", "$vd, $vs1, $vs2"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+// Integer slide-3 instructions
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VMADOT3 : RVInstIME<0b1110100, 0b000,
+                            (outs VRM4:$vd),
+                            (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2),
+                            "vmadot3", "$vd, $vs1, $vs2"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VMADOT3U : RVInstIME<0b1110100, 0b011,
+                             (outs VRM4:$vd),
+                             (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2),
+                             "vmadot3u", "$vd, $vs1, $vs2"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VMADOT3SU : RVInstIME<0b1110100, 0b001,
+                              (outs VRM4:$vd),
+                              (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2),
+                              "vmadot3su", "$vd, $vs1, $vs2"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VMADOT3US : RVInstIME<0b1110100, 0b010,
+                              (outs VRM4:$vd),
+                              (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2),
+                              "vmadot3us", "$vd, $vs1, $vs2"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+// Floating-point slide instructions
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VFMADOT1 : RVInstIME<0b1110110, 0b000,
+                             (outs VRM4:$vd),
+                             (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2),
+                             "vfmadot1", "$vd, $vs1, $vs2"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VFMADOT2 : RVInstIME<0b1110111, 0b000,
+                             (outs VRM4:$vd),
+                             (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2),
+                             "vfmadot2", "$vd, $vs1, $vs2"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VFMADOT3 : RVInstIME<0b1111000, 0b000,
+                             (outs VRM4:$vd),
+                             (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2),
+                             "vfmadot3", "$vd, $vs1, $vs2"> {
+  let Constraints = "$vd = $vd_in";
+}
+
 let Predicates = [HasBuddyExt] in 
 def : Pat<(int_riscv_mvin GPR:$rs1, GPR:$rs2), (MVIN GPR:$rs1, GPR:$rs2)>;
 
@@ -342,4 +470,161 @@ let Predicates = [HasBuddyExt] in {
 let Predicates = [HasBuddyExt] in {
   def : Pat<(nxv16f16 (int_riscv_ime_vfmadot nxv16f16:$vd, nxv16f16:$vs1, nxv16f16:$vs2)),
             (IME_VFMADOT VRM4:$vd, VRM4:$vs1, VRM4:$vs2)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv8i32 (int_riscv_ime_vmadot1 nxv8i32:$vd, nxv64i8:$vs1, nxv32i8:$vs2)),
+            (IME_VMADOT1 VRM4:$vd, VRM8:$vs1, VRM4:$vs2)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv8i32 (int_riscv_ime_vmadot1u nxv8i32:$vd, nxv64i8:$vs1, nxv32i8:$vs2)),
+            (IME_VMADOT1U VRM4:$vd, VRM8:$vs1, VRM4:$vs2)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv8i32 (int_riscv_ime_vmadot1su nxv8i32:$vd, nxv64i8:$vs1, nxv32i8:$vs2)),
+            (IME_VMADOT1SU VRM4:$vd, VRM8:$vs1, VRM4:$vs2)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv8i32 (int_riscv_ime_vmadot1us nxv8i32:$vd, nxv64i8:$vs1, nxv32i8:$vs2)),
+            (IME_VMADOT1US VRM4:$vd, VRM8:$vs1, VRM4:$vs2)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv8i32 (int_riscv_ime_vmadot2 nxv8i32:$vd, nxv64i8:$vs1, nxv32i8:$vs2)),
+            (IME_VMADOT2 VRM4:$vd, VRM8:$vs1, VRM4:$vs2)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv8i32 (int_riscv_ime_vmadot2u nxv8i32:$vd, nxv64i8:$vs1, nxv32i8:$vs2)),
+            (IME_VMADOT2U VRM4:$vd, VRM8:$vs1, VRM4:$vs2)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv8i32 (int_riscv_ime_vmadot2su nxv8i32:$vd, nxv64i8:$vs1, nxv32i8:$vs2)),
+            (IME_VMADOT2SU VRM4:$vd, VRM8:$vs1, VRM4:$vs2)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv8i32 (int_riscv_ime_vmadot2us nxv8i32:$vd, nxv64i8:$vs1, nxv32i8:$vs2)),
+            (IME_VMADOT2US VRM4:$vd, VRM8:$vs1, VRM4:$vs2)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv8i32 (int_riscv_ime_vmadot3 nxv8i32:$vd, nxv64i8:$vs1, nxv32i8:$vs2)),
+            (IME_VMADOT3 VRM4:$vd, VRM8:$vs1, VRM4:$vs2)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv8i32 (int_riscv_ime_vmadot3u nxv8i32:$vd, nxv64i8:$vs1, nxv32i8:$vs2)),
+            (IME_VMADOT3U VRM4:$vd, VRM8:$vs1, VRM4:$vs2)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv8i32 (int_riscv_ime_vmadot3su nxv8i32:$vd, nxv64i8:$vs1, nxv32i8:$vs2)),
+            (IME_VMADOT3SU VRM4:$vd, VRM8:$vs1, VRM4:$vs2)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv8i32 (int_riscv_ime_vmadot3us nxv8i32:$vd, nxv64i8:$vs1, nxv32i8:$vs2)),
+            (IME_VMADOT3US VRM4:$vd, VRM8:$vs1, VRM4:$vs2)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv16f16 (int_riscv_ime_vfmadot1 nxv16f16:$vd, nxv32f16:$vs1, nxv16f16:$vs2)),
+            (IME_VFMADOT1 VRM4:$vd, VRM8:$vs1, VRM4:$vs2)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv16f16 (int_riscv_ime_vfmadot2 nxv16f16:$vd, nxv32f16:$vs1, nxv16f16:$vs2)),
+            (IME_VFMADOT2 VRM4:$vd, VRM8:$vs1, VRM4:$vs2)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv16f16 (int_riscv_ime_vfmadot3 nxv16f16:$vd, nxv32f16:$vs1, nxv16f16:$vs2)),
+            (IME_VFMADOT3 VRM4:$vd, VRM8:$vs1, VRM4:$vs2)>;
+}
+
+class RVInstIMEN<bits<7> funct7, bits<3> funct3, dag outs, dag ins,
+                 string opcodestr, string argstr>
+    : RVInst<outs, ins, opcodestr, argstr, [], InstFormatR> {
+  bits<5> vs2;
+  bits<5> rs1;  // GPR for dynamic slide value
+  bits<5> vd;
+
+  let Inst{31-25} = funct7;
+  let Inst{24-20} = vs2;
+  let Inst{19-15} = rs1;
+  let Inst{14-12} = funct3;
+  let Inst{11-7} = vd;
+  let Inst{6-0} = OPC_CUSTOM_1.Value;
+
+  let Uses = [VTYPE, VL];
+}
+
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VMADOTN : RVInstIMEN<0b1111001, 0b000,
+                             (outs VRM4:$vd),
+                             (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2, GPR:$rs1),
+                             "vmadotn", "$vd, $vs1, $vs2, $rs1"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VMADOTNU : RVInstIMEN<0b1111001, 0b011,
+                              (outs VRM4:$vd),
+                              (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2, GPR:$rs1),
+                              "vmadotnu", "$vd, $vs1, $vs2, $rs1"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VMADOTNSU : RVInstIMEN<0b1111001, 0b001,
+                               (outs VRM4:$vd),
+                               (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2, GPR:$rs1),
+                               "vmadotnsu", "$vd, $vs1, $vs2, $rs1"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VMADOTNUS : RVInstIMEN<0b1111001, 0b010,
+                               (outs VRM4:$vd),
+                               (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2, GPR:$rs1),
+                               "vmadotnus", "$vd, $vs1, $vs2, $rs1"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+let Predicates = [HasBuddyExt], hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def IME_VFMADOTN : RVInstIMEN<0b1111010, 0b000,
+                              (outs VRM4:$vd),
+                              (ins VRM4:$vd_in, VRM8:$vs1, VRM4:$vs2, GPR:$rs1),
+                              "vfmadotn", "$vd, $vs1, $vs2, $rs1"> {
+  let Constraints = "$vd = $vd_in";
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv8i32 (int_riscv_ime_vmadotn nxv8i32:$vd, nxv64i8:$vs1, nxv32i8:$vs2, GPR:$rs1)),
+            (IME_VMADOTN VRM4:$vd, VRM8:$vs1, VRM4:$vs2, GPR:$rs1)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv8i32 (int_riscv_ime_vmadotnu nxv8i32:$vd, nxv64i8:$vs1, nxv32i8:$vs2, GPR:$rs1)),
+            (IME_VMADOTNU VRM4:$vd, VRM8:$vs1, VRM4:$vs2, GPR:$rs1)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv8i32 (int_riscv_ime_vmadotnsu nxv8i32:$vd, nxv64i8:$vs1, nxv32i8:$vs2, GPR:$rs1)),
+            (IME_VMADOTNSU VRM4:$vd, VRM8:$vs1, VRM4:$vs2, GPR:$rs1)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv8i32 (int_riscv_ime_vmadotnus nxv8i32:$vd, nxv64i8:$vs1, nxv32i8:$vs2, GPR:$rs1)),
+            (IME_VMADOTNUS VRM4:$vd, VRM8:$vs1, VRM4:$vs2, GPR:$rs1)>;
+}
+
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv16f16 (int_riscv_ime_vfmadotn nxv16f16:$vd, nxv32f16:$vs1, nxv16f16:$vs2, GPR:$rs1)),
+            (IME_VFMADOTN VRM4:$vd, VRM8:$vs1, VRM4:$vs2, GPR:$rs1)>;
 }

--- a/backend/llvm/lib/Target/RISCV/RISCVInstrInfoBuddyExt.td
+++ b/backend/llvm/lib/Target/RISCV/RISCVInstrInfoBuddyExt.td
@@ -452,6 +452,12 @@ let Predicates = [HasBuddyExt] in {
             (IME_VMADOT VRM4:$vd, VRM4:$vs1, VRM4:$vs2)>;
 }
 
+// int16 vmadot patterns
+let Predicates = [HasBuddyExt] in {
+  def : Pat<(nxv8i32 (int_riscv_ime_vmadot nxv8i32:$vd, nxv16i16:$vs1, nxv16i16:$vs2)),
+            (IME_VMADOT VRM4:$vd, VRM4:$vs1, VRM4:$vs2)>;
+}
+
 let Predicates = [HasBuddyExt] in {
   def : Pat<(nxv8i32 (int_riscv_ime_vmadotu nxv8i32:$vd, nxv32i8:$vs1, nxv32i8:$vs2)),
             (IME_VMADOTU VRM4:$vd, VRM4:$vs1, VRM4:$vs2)>;

--- a/examples/IMEDialect/.gitignore
+++ b/examples/IMEDialect/.gitignore
@@ -10,3 +10,4 @@ vmadot-variants.mlir
 *.o
 *.s
 *_test
+test_instructions.sh

--- a/examples/IMEDialect/README.md
+++ b/examples/IMEDialect/README.md
@@ -14,7 +14,10 @@ This document provides a comprehensive guide for using the IME (Integrated Matri
 The IMEDialect example folder contains the following key files:
 
 **MLIR Source Files:**
-- **`vmadot.mlir`, `vmadotu.mlir`, `vmadotsu.mlir`, `vmadotus.mlir`, `vfmadot.mlir`**: Minimal MLIR files demonstrating each IME operation. Use these to verify assembly code generation.
+- **`vmadot.mlir`, `vmadotu.mlir`, `vmadotsu.mlir`, `vmadotus.mlir`, `vfmadot.mlir`**: Minimal MLIR files demonstrating each basic IME operation. Use these to verify assembly code generation.
+- **`vmadot1.mlir`, `vmadot2.mlir`, `vmadot3.mlir`**: Fixed sliding-window integer operations with slide=1, 2, 3.
+- **`vfmadot1.mlir`, `vfmadot2.mlir`, `vfmadot3.mlir`**: Fixed sliding-window floating-point operations with slide=1, 2, 3.
+- **`vmadotn.mlir`, `vmadotnu.mlir`, `vmadotnsu.mlir`, `vmadotnus.mlir`, `vfmadotn.mlir`**: Minimal MLIR files for dynamic sliding-window operations with runtime slide parameter.
 - **`vmadot_print_test.mlir`, `vmadotu_print_test.mlir`, etc.**: Extended test MLIR files with additional code for printing input/output matrices on hardware. Use these for hardware validation with visible results.
 
 **Runtime and Build Files:**
@@ -84,21 +87,48 @@ Use this option to verify that IME operations are correctly lowered to RISC-V as
 
 **Generate Lowered MLIR:**
 ```bash
-make vmadot-lower
+make vmadot-lower      # Basic integer operations
+make vmadot1-lower     # Fixed sliding-window (slide=1)
+make vmadotn-lower     # Dynamic sliding-window
+make vfmadot-lower     # Floating-point
+make vfmadot1-lower    # Floating-point fixed sliding-window
+make vfmadotn-lower    # Floating-point dynamic sliding-window
 ```
 This generates `log.mlir` containing the lowered representation.
 
 **Generate LLVM IR:**
 ```bash
 make vmadot-translate
+make vmadot1-translate
+make vmadotn-translate
+# ... and similarly for other variants
 ```
 This generates `log.ll` containing LLVM IR code.
 
 **Generate Assembly:**
 ```bash
-make vmadot-asm
+make vmadot-asm        # Basic: vmadot, vmadotu, vmadotsu, vmadotus
+make vmadot1-asm       # Fixed slide: vmadot1, vmadot2, vmadot3
+make vmadotn-asm       # Dynamic slide: vmadotn, vmadotnu, vmadotnsu, vmadotnus
+make vfmadot-asm       # Float basic
+make vfmadot1-asm      # Float fixed slide: vfmadot1, vfmadot2, vfmadot3
+make vfmadotn-asm      # Float dynamic slide
 ```
 This generates `log.s` containing RISC-V assembly. You can inspect this file to verify correct IME instruction generation.
+
+**Available Make Targets Summary:**
+
+| Category | Instructions | Make Targets |
+|----------|-------------|--------------|
+| Basic Integer | vmadot, vmadotu, vmadotsu, vmadotus | `vmadot{,u,su,us}-{lower,translate,asm,run}` |
+| Fixed Slide Integer (signed) | vmadot1, vmadot2, vmadot3 | `vmadot{1,2,3}-{lower,translate,asm,run}` |
+| Fixed Slide Integer (unsigned) | vmadot1u, vmadot2u, vmadot3u | `vmadot{1,2,3}u-{lower,translate,asm}` |
+| Fixed Slide Integer (signed×unsigned) | vmadot1su, vmadot2su, vmadot3su | `vmadot{1,2,3}su-{lower,translate,asm}` |
+| Fixed Slide Integer (unsigned×signed) | vmadot1us, vmadot2us, vmadot3us | `vmadot{1,2,3}us-{lower,translate,asm}` |
+| Dynamic Slide Integer | vmadotn, vmadotnu, vmadotnsu, vmadotnus | `vmadotn{,u,su,us}-{lower,translate,asm}` |
+| Basic Float | vfmadot | `vfmadot-{lower,translate,asm,run}` |
+| Fixed Slide Float | vfmadot1, vfmadot2, vfmadot3 | `vfmadot{1,2,3}-{lower,translate,asm,run}` |
+| Dynamic Slide Float | vfmadotn | `vfmadotn-{lower,translate,asm,run}` |
 
 #### Option B: Build Hardware Test Executables (Full Test)
 
@@ -121,6 +151,13 @@ make vmadotus-run  # Generates vmadotus.s and vmadotus_test executable
 This will generate executable binaries: `vmadot_test`, `vmadotu_test`, `vmadotsu_test`, `vmadotus_test`
 
 > **Note**: The `-run` targets require the SpacemiT cross-compiler (`riscv64-unknown-linux-gnu-gcc`) to be in your PATH.
+
+> **Toolchain Compatibility Note**: The SpacemiT toolchain (v1.1.2) currently only supports basic IME instructions (`vmadot`, `vmadotu`, `vmadotsu`, `vmadotus`). The following instructions will produce "unrecognized opcode" errors when assembled with SpacemiT's GNU as:
+> - Fixed sliding-window: `vmadot1`, `vmadot2`, `vmadot3`, `vfmadot1`, `vfmadot2`, `vfmadot3`
+> - Dynamic sliding-window: `vmadotn`, `vmadotnu`, `vmadotnsu`, `vmadotnus`, `vfmadotn`
+> - Floating-point basic: `vfmadot`
+>
+> For these unsupported instructions, you can still verify assembly generation using the `-asm` targets, but hardware testing requires SpacemiT to update their toolchain.
 
 ---
 
@@ -154,7 +191,19 @@ Each test will output:
 - Expected and computed results
 - Verification status (PASS/FAIL)
 
-**Note**: `vfmadot` floating-point instruction tests cannot yet be executed as standalone binaries and are available only for assembly generation and inspection.
+**Current Hardware Test Status:**
+
+| Instruction | Assembly Gen | Hardware Test | Notes |
+|-------------|-------------|---------------|-------|
+| vmadot | ✅ | ✅ | Fully working |
+| vmadotu | ✅ | ✅ | Fully working |
+| vmadotsu | ✅ | ✅ | Fully working |
+| vmadotus | ✅ | ✅ | Fully working |
+| vmadot1/2/3 | ✅ | ⏳ | Waiting for funct7 fix |
+| vmadotn/nu/nsu/nus | ✅ | ⏳ | Waiting for toolchain support |
+| vfmadot | ✅ | ⏳ | Waiting for toolchain support |
+| vfmadot1/2/3 | ✅ | ⏳ | Waiting for toolchain support |
+| vfmadotn | ✅ | ⏳ | Waiting for toolchain support |
 
 
 
@@ -215,39 +264,187 @@ vfmadot vd, vs1, vs2    # vd(C) += vs1(A) × vs2(B)
 - `vs2` (source 2): Input matrix B
 - Result is stored in a single register (different from integer instructions)
 
+#### 3. Fixed Sliding-Window Instructions (vmadot1/2/3, vfmadot1/2/3)
+
+These instructions have a **fixed slide amount encoded in the instruction**. They read from VS1 and VS1+1 (64 elements for int8, forming a 2M×K matrix), then slide by a fixed number of rows (1, 2, or 3) to select an M×K submatrix.
+
+**Integer Fixed Sliding-Window Instructions:**
+
+| Category | Instructions | Operand A Type | Operand B Type | Accumulator Type | Description |
+|----------|-------------|---|---|---|---|
+| slide-1 | `vmadot1` | int8 | int8 | int32 | signed × signed |
+|         | `vmadot1u` | uint8 | uint8 | int32 | unsigned × unsigned |
+|         | `vmadot1su` | int8 | uint8 | int32 | signed × unsigned |
+|         | `vmadot1us` | uint8 | int8 | int32 | unsigned × signed |
+| slide-2 | `vmadot2` | int8 | int8 | int32 | signed × signed |
+|         | `vmadot2u` | uint8 | uint8 | int32 | unsigned × unsigned |
+|         | `vmadot2su` | int8 | uint8 | int32 | signed × unsigned |
+|         | `vmadot2us` | uint8 | int8 | int32 | unsigned × signed |
+| slide-3 | `vmadot3` | int8 | int8 | int32 | signed × signed |
+|         | `vmadot3u` | uint8 | uint8 | int32 | unsigned × unsigned |
+|         | `vmadot3su` | int8 | uint8 | int32 | signed × unsigned |
+|         | `vmadot3us` | uint8 | int8 | int32 | unsigned × signed |
+
+**Floating-Point Fixed Sliding-Window Instructions:**
+
+| Instruction | Operand A Type | Operand B Type | Accumulator Type | Description |
+|-------------|---|---|---|---|
+| `vfmadot1` | fp16 | fp16 | fp16 | floating-point, slide=1 |
+| `vfmadot2` | fp16 | fp16 | fp16 | floating-point, slide=2 |
+| `vfmadot3` | fp16 | fp16 | fp16 | floating-point, slide=3 |
+
+**Assembly Format**:
+```assembly
+# Integer slide-1
+vmadot1   vd, vs1, vs2    # vd(C) += slide(vs1, 1)(A) × vs2(B) - signed × signed
+vmadot1u  vd, vs1, vs2    # unsigned × unsigned
+vmadot1su vd, vs1, vs2    # signed × unsigned
+vmadot1us vd, vs1, vs2    # unsigned × signed
+
+# Integer slide-2
+vmadot2   vd, vs1, vs2
+vmadot2u  vd, vs1, vs2
+vmadot2su vd, vs1, vs2
+vmadot2us vd, vs1, vs2
+
+# Integer slide-3
+vmadot3   vd, vs1, vs2
+vmadot3u  vd, vs1, vs2
+vmadot3su vd, vs1, vs2
+vmadot3us vd, vs1, vs2
+
+# Floating-point
+vfmadot1 vd, vs1, vs2
+vfmadot2 vd, vs1, vs2
+vfmadot3 vd, vs1, vs2
+```
+
+**Register Constraints**:
+- `vd` (destination): Target register for result matrix C
+- `vs1` (source 1): Input matrix A (reads VS1 and VS1+1, 64 elements for sliding)
+- `vs2` (source 2): Input matrix B
+
+> **Note**: The `vmadot1/2/3` instructions currently have a funct7 encoding issue (see [SpacemiT Issue #2](https://github.com/user/repo/issues/2)). Assembly generation works, but machine code may be incorrect until resolved.
+
+#### 4. Dynamic Sliding-Window Instructions (vmadotn/vfmadotn)
+
+These instructions support a **dynamic slide parameter** passed at runtime, allowing flexible row selection from the source matrix. The sliding window reads from VS1 and VS1+1 (64 elements for int8, forming a 2M×K matrix), then slides by n rows to select an M×K submatrix.
+
+| Instruction | Operand A Type | Operand B Type | Accumulator Type | Description |
+|-------------|---|---|---|---|
+| `vmadotn` | int8 | int8 | int32 | signed × signed with dynamic slide |
+| `vmadotnu` | uint8 | uint8 | int32 | unsigned × unsigned with dynamic slide |
+| `vmadotnsu` | int8 | uint8 | int32 | signed × unsigned with dynamic slide |
+| `vmadotnus` | uint8 | int8 | int32 | unsigned × signed with dynamic slide |
+| `vfmadotn` | fp16 | fp16 | fp16 | floating-point with dynamic slide |
+
+**Assembly Format**:
+```assembly
+vmadotn   vd, vs1, vs2, rs1    # vd(C) += slide(vs1, rs1)(A) × vs2(B)
+vmadotnu  vd, vs1, vs2, rs1
+vmadotnsu vd, vs1, vs2, rs1
+vmadotnus vd, vs1, vs2, rs1
+vfmadotn  vd, vs1, vs2, rs1
+```
+
+**Register Constraints**:
+- `vd` (destination): Target register for result matrix C
+- `vs1` (source 1): Input matrix A (reads VS1 and VS1+1, 64 elements for sliding)
+- `vs2` (source 2): Input matrix B
+- `rs1` (scalar): Slide amount (0-3 for int8 with VLEN=256)
+
+**Sliding Window Mechanism**:
+```
+For VLEN=256, int8:
+- VS1 loads 64 elements (8 rows × 8 cols)
+- slide=0: use rows [0,1,2,3]
+- slide=1: use rows [1,2,3,4]
+- slide=2: use rows [2,3,4,5]
+- slide=3: use rows [3,4,5,6]
+```
+
 ### MLIR Operation Syntax
 
 All IME operations in MLIR follow this pattern:
 
 ```mlir
+// Basic operations (without slide)
 ime.vmadot %accumulator, %matrix_a, %matrix_b : memref<...>, memref<...>, memref<...>
+
+// Dynamic sliding-window operations (with slide parameter)
+ime.vmadotn %accumulator, %matrix_a, %matrix_b, %slide : memref<...>, memref<...>, memref<...>, i64
 ```
 
 Where:
 - `%accumulator`: Destination memref (2D, element type matches result type)
 - `%matrix_a`: Left operand matrix A memref (2D)
 - `%matrix_b`: Right operand matrix B memref (2D)
+- `%slide`: (for vmadotn variants) Slide amount as i64 scalar
 
 ### Example MLIR Code
 
 Complete example showing IME operations in MLIR:
 
 ```mlir
+// Basic integer matrix multiply-accumulate
 func.func @vmadot_example(%arg0: memref<4x4xi32>, %arg1: memref<4x8xi8>, %arg2: memref<8x4xi8>) {
   // Perform matrix multiply-accumulate: arg0 += arg1 × arg2
   ime.vmadot %arg0, %arg1, %arg2 : memref<4x4xi32>, memref<4x8xi8>, memref<8x4xi8>
   return
 }
 
+// Unsigned integer version
 func.func @vmadotu_example(%arg0: memref<4x4xi32>, %arg1: memref<4x8xui8>, %arg2: memref<8x4xui8>) {
-  // Unsigned integer version
   ime.vmadotu %arg0, %arg1, %arg2 : memref<4x4xi32>, memref<4x8xui8>, memref<8x4xui8>
   return
 }
 
+// Floating-point version
 func.func @vfmadot_example(%arg0: memref<4x4xf16>, %arg1: memref<4x4xf16>, %arg2: memref<4x4xf16>) {
-  // Floating-point version
   ime.vfmadot %arg0, %arg1, %arg2 : memref<4x4xf16>, memref<4x4xf16>, memref<4x4xf16>
+  return
+}
+
+// Fixed sliding-window: A is 8x8 (2M×K), slide=1 selects rows [1,2,3,4]
+// Signed × Signed variants
+func.func @vmadot1_example(%arg0: memref<4x4xi32>, %arg1: memref<8x8xi8>, %arg2: memref<8x4xi8>) {
+  ime.vmadot1 %arg0, %arg1, %arg2 : memref<4x4xi32>, memref<8x8xi8>, memref<8x4xi8>
+  return
+}
+
+// Unsigned × Unsigned variants
+func.func @vmadot1u_example(%arg0: memref<4x4xi32>, %arg1: memref<8x8xui8>, %arg2: memref<8x4xui8>) {
+  ime.vmadot1u %arg0, %arg1, %arg2 : memref<4x4xi32>, memref<8x8xui8>, memref<8x4xui8>
+  return
+}
+
+// Signed × Unsigned variants
+func.func @vmadot1su_example(%arg0: memref<4x4xi32>, %arg1: memref<8x8xi8>, %arg2: memref<8x4xui8>) {
+  ime.vmadot1su %arg0, %arg1, %arg2 : memref<4x4xi32>, memref<8x8xi8>, memref<8x4xui8>
+  return
+}
+
+// Unsigned × Signed variants
+func.func @vmadot1us_example(%arg0: memref<4x4xi32>, %arg1: memref<8x8xui8>, %arg2: memref<8x4xi8>) {
+  ime.vmadot1us %arg0, %arg1, %arg2 : memref<4x4xi32>, memref<8x8xui8>, memref<8x4xi8>
+  return
+}
+
+// Fixed sliding-window floating-point
+func.func @vfmadot1_example(%arg0: memref<4x4xf16>, %arg1: memref<8x4xf16>, %arg2: memref<4x4xf16>) {
+  ime.vfmadot1 %arg0, %arg1, %arg2 : memref<4x4xf16>, memref<8x4xf16>, memref<4x4xf16>
+  return
+}
+
+// Dynamic sliding-window: slide amount passed at runtime
+func.func @vmadotn_example(%arg0: memref<4x4xi32>, %arg1: memref<8x8xi8>, %arg2: memref<8x4xi8>, %slide: i64) {
+  ime.vmadotn %arg0, %arg1, %arg2, %slide : memref<4x4xi32>, memref<8x8xi8>, memref<8x4xi8>, i64
+  return
+}
+
+// Dynamic sliding-window floating-point
+func.func @vfmadotn_example(%arg0: memref<4x4xf16>, %arg1: memref<8x4xf16>, %arg2: memref<4x4xf16>, %slide: i64) {
+  ime.vfmadotn %arg0, %arg1, %arg2, %slide : memref<4x4xf16>, memref<8x4xf16>, memref<4x4xf16>, i64
   return
 }
 ```

--- a/examples/IMEDialect/build_all_tests.sh
+++ b/examples/IMEDialect/build_all_tests.sh
@@ -58,6 +58,21 @@ build_test "vmadotus" "vmadotus_print_test.mlir" "runtime_vmadotus.c"
 # Build vfmadot (floating-point) - uses different print function
 # build_test "vfmadot" "vfmadot_print_test.mlir" "runtime_vfmadot.c"
 
+# Build vmadotn (signed x signed, dynamic slide)
+build_test "vmadotn" "vmadotn_print_test.mlir" "runtime_vmadotn.c"
+
+# Build vmadotnu (unsigned x unsigned, dynamic slide)
+build_test "vmadotnu" "vmadotnu_print_test.mlir" "runtime_vmadotnu.c"
+
+# Build vmadotnsu (signed x unsigned, dynamic slide)
+build_test "vmadotnsu" "vmadotnsu_print_test.mlir" "runtime_vmadotnsu.c"
+
+# Build vmadotnus (unsigned x signed, dynamic slide)
+build_test "vmadotnus" "vmadotnus_print_test.mlir" "runtime_vmadotnus.c"
+
+# Build vfmadotn (floating-point, dynamic slide) - uses different print function
+# build_test "vfmadotn" "vfmadotn_print_test.mlir" "runtime_vfmadotn.c"
+
 echo ""
 echo "All builds complete. Executables:"
 ls -la *_test 2>/dev/null || echo "No test executables found"

--- a/examples/IMEDialect/makefile
+++ b/examples/IMEDialect/makefile
@@ -8,9 +8,30 @@ BUDDY_LLC := ../../build/bin/buddy-llc
         vmadotu-lower vmadotu-translate vmadotu-asm vmadotu-run \
         vmadotsu-lower vmadotsu-translate vmadotsu-asm vmadotsu-run \
         vmadotus-lower vmadotus-translate vmadotus-asm vmadotus-run \
-        vfmadot-lower vfmadot-translate vfmadot-asm
+        vfmadot-lower vfmadot-translate vfmadot-asm vfmadot-run \
+        vmadotn vmadotnu vmadotnsu vmadotnus vfmadotn \
+        vmadotn-lower vmadotn-translate vmadotn-asm vmadotn-run \
+        vmadotnu-lower vmadotnu-translate vmadotnu-asm vmadotnu-run \
+        vmadotnsu-lower vmadotnsu-translate vmadotnsu-asm vmadotnsu-run \
+        vmadotnus-lower vmadotnus-translate vmadotnus-asm vmadotnus-run \
+        vfmadotn-lower vfmadotn-translate vfmadotn-asm vfmadotn-run \
+        vmadot1-lower vmadot1-translate vmadot1-asm vmadot1-run \
+        vmadot1u-lower vmadot1u-translate vmadot1u-asm \
+        vmadot1su-lower vmadot1su-translate vmadot1su-asm \
+        vmadot1us-lower vmadot1us-translate vmadot1us-asm \
+        vmadot2-lower vmadot2-translate vmadot2-asm vmadot2-run \
+        vmadot2u-lower vmadot2u-translate vmadot2u-asm \
+        vmadot2su-lower vmadot2su-translate vmadot2su-asm \
+        vmadot2us-lower vmadot2us-translate vmadot2us-asm \
+        vmadot3-lower vmadot3-translate vmadot3-asm vmadot3-run \
+        vmadot3u-lower vmadot3u-translate vmadot3u-asm \
+        vmadot3su-lower vmadot3su-translate vmadot3su-asm \
+        vmadot3us-lower vmadot3us-translate vmadot3us-asm \
+        vfmadot1-lower vfmadot1-translate vfmadot1-asm vfmadot1-run \
+        vfmadot2-lower vfmadot2-translate vfmadot2-asm vfmadot2-run \
+        vfmadot3-lower vfmadot3-translate vfmadot3-asm vfmadot3-run
 
-all: vmadot vmadotu vmadotsu vmadotus vfmadot
+all: vmadot vmadotu vmadotsu vmadotus vfmadot vmadotn vmadotnu vmadotnsu vmadotnus vfmadotn
 
 
 vmadot: vmadot.mlir
@@ -27,6 +48,21 @@ vmadotus: vmadotus.mlir
 
 vfmadot: vfmadot.mlir
 	$(BUDDY_OPT) $< -o vfmadot-out.mlir
+
+vmadotn: vmadotn.mlir
+	$(BUDDY_OPT) $< -o vmadotn-out.mlir
+
+vmadotnu: vmadotnu.mlir
+	$(BUDDY_OPT) $< -o vmadotnu-out.mlir
+
+vmadotnsu: vmadotnsu.mlir
+	$(BUDDY_OPT) $< -o vmadotnsu-out.mlir
+
+vmadotnus: vmadotnus.mlir
+	$(BUDDY_OPT) $< -o vmadotnus-out.mlir
+
+vfmadotn: vfmadotn.mlir
+	$(BUDDY_OPT) $< -o vfmadotn-out.mlir
 
 clean:
 	rm -f *-out.mlir
@@ -332,5 +368,1147 @@ vfmadot-asm:
 		-reconcile-unrealized-casts | \
 	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
 	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+zvfh,+buddyext \
+		-o log.s
+
+vfmadot-run:
+	@${BUDDY_OPT} ./vfmadot_print_test.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+zvfh,+buddyext \
+		-o vfmadot.s
+	riscv64-unknown-linux-gnu-gcc -march=rv64gcv -static vfmadot.s runtime_vfmadot.c -o vfmadot_test
+
+
+vmadot1-lower:
+	@${BUDDY_OPT} ./vmadot1.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vmadot1-translate:
+	@${BUDDY_OPT} ./vmadot1.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vmadot1-asm:
+	@${BUDDY_OPT} ./vmadot1.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
 		-mattr=+m,+v,+buddyext \
 		-o log.s
+
+vmadot2-lower:
+	@${BUDDY_OPT} ./vmadot2.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vmadot2-translate:
+	@${BUDDY_OPT} ./vmadot2.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vmadot2-asm:
+	@${BUDDY_OPT} ./vmadot2.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o log.s
+
+vmadot3-lower:
+	@${BUDDY_OPT} ./vmadot3.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vmadot3-translate:
+	@${BUDDY_OPT} ./vmadot3.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vmadot3-asm:
+	@${BUDDY_OPT} ./vmadot3.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o log.s
+
+vmadot1-run:
+	@${BUDDY_OPT} ./vmadot1_print_test.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o vmadot1.s
+	riscv64-unknown-linux-gnu-gcc -march=rv64gcv -static vmadot1.s runtime_vmadot1.c -o vmadot1_test
+
+vmadot2-run:
+	@${BUDDY_OPT} ./vmadot2_print_test.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o vmadot2.s
+	riscv64-unknown-linux-gnu-gcc -march=rv64gcv -static vmadot2.s runtime_vmadot2.c -o vmadot2_test
+
+vmadot3-run:
+	@${BUDDY_OPT} ./vmadot3_print_test.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o vmadot3.s
+	riscv64-unknown-linux-gnu-gcc -march=rv64gcv -static vmadot3.s runtime_vmadot3.c -o vmadot3_test
+
+vmadot1u-lower:
+	@${BUDDY_OPT} ./vmadot1u.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vmadot1u-translate:
+	@${BUDDY_OPT} ./vmadot1u.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vmadot1u-asm:
+	@${BUDDY_OPT} ./vmadot1u.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o log.s
+
+vmadot1su-lower:
+	@${BUDDY_OPT} ./vmadot1su.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vmadot1su-translate:
+	@${BUDDY_OPT} ./vmadot1su.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vmadot1su-asm:
+	@${BUDDY_OPT} ./vmadot1su.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o log.s
+
+vmadot1us-lower:
+	@${BUDDY_OPT} ./vmadot1us.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vmadot1us-translate:
+	@${BUDDY_OPT} ./vmadot1us.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vmadot1us-asm:
+	@${BUDDY_OPT} ./vmadot1us.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o log.s
+
+vmadot2u-lower:
+	@${BUDDY_OPT} ./vmadot2u.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vmadot2u-translate:
+	@${BUDDY_OPT} ./vmadot2u.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vmadot2u-asm:
+	@${BUDDY_OPT} ./vmadot2u.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o log.s
+
+vmadot2su-lower:
+	@${BUDDY_OPT} ./vmadot2su.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vmadot2su-translate:
+	@${BUDDY_OPT} ./vmadot2su.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vmadot2su-asm:
+	@${BUDDY_OPT} ./vmadot2su.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o log.s
+
+vmadot2us-lower:
+	@${BUDDY_OPT} ./vmadot2us.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vmadot2us-translate:
+	@${BUDDY_OPT} ./vmadot2us.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vmadot2us-asm:
+	@${BUDDY_OPT} ./vmadot2us.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o log.s
+
+vmadot3u-lower:
+	@${BUDDY_OPT} ./vmadot3u.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vmadot3u-translate:
+	@${BUDDY_OPT} ./vmadot3u.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vmadot3u-asm:
+	@${BUDDY_OPT} ./vmadot3u.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o log.s
+
+vmadot3su-lower:
+	@${BUDDY_OPT} ./vmadot3su.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vmadot3su-translate:
+	@${BUDDY_OPT} ./vmadot3su.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vmadot3su-asm:
+	@${BUDDY_OPT} ./vmadot3su.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o log.s
+
+vmadot3us-lower:
+	@${BUDDY_OPT} ./vmadot3us.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vmadot3us-translate:
+	@${BUDDY_OPT} ./vmadot3us.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vmadot3us-asm:
+	@${BUDDY_OPT} ./vmadot3us.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o log.s
+
+vmadotn-lower:
+	@${BUDDY_OPT} ./vmadotn.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vmadotn-translate:
+	@${BUDDY_OPT} ./vmadotn.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vmadotn-asm:
+	@${BUDDY_OPT} ./vmadotn.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o log.s
+
+vmadotn-run:
+	@${BUDDY_OPT} ./vmadotn_print_test.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o vmadotn.s
+	riscv64-unknown-linux-gnu-gcc -march=rv64gcv -static vmadotn.s runtime_vmadotn.c -o vmadotn_test
+
+
+vmadotnu-lower:
+	@${BUDDY_OPT} ./vmadotnu.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vmadotnu-translate:
+	@${BUDDY_OPT} ./vmadotnu.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vmadotnu-asm:
+	@${BUDDY_OPT} ./vmadotnu.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o log.s
+
+vmadotnu-run:
+	@${BUDDY_OPT} ./vmadotnu_print_test.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o vmadotnu.s
+	riscv64-unknown-linux-gnu-gcc -march=rv64gcv -static vmadotnu.s runtime_vmadotnu.c -o vmadotnu_test
+
+
+vmadotnsu-lower:
+	@${BUDDY_OPT} ./vmadotnsu.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vmadotnsu-translate:
+	@${BUDDY_OPT} ./vmadotnsu.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vmadotnsu-asm:
+	@${BUDDY_OPT} ./vmadotnsu.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o log.s
+
+vmadotnsu-run:
+	@${BUDDY_OPT} ./vmadotnsu_print_test.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o vmadotnsu.s
+	riscv64-unknown-linux-gnu-gcc -march=rv64gcv -static vmadotnsu.s runtime_vmadotnsu.c -o vmadotnsu_test
+
+
+vmadotnus-lower:
+	@${BUDDY_OPT} ./vmadotnus.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vmadotnus-translate:
+	@${BUDDY_OPT} ./vmadotnus.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vmadotnus-asm:
+	@${BUDDY_OPT} ./vmadotnus.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o log.s
+
+vmadotnus-run:
+	@${BUDDY_OPT} ./vmadotnus_print_test.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+buddyext \
+		-o vmadotnus.s
+	riscv64-unknown-linux-gnu-gcc -march=rv64gcv -static vmadotnus.s runtime_vmadotnus.c -o vmadotnus_test
+
+
+vfmadot1-lower:
+	@${BUDDY_OPT} ./vfmadot1.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vfmadot1-translate:
+	@${BUDDY_OPT} ./vfmadot1.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vfmadot1-asm:
+	@${BUDDY_OPT} ./vfmadot1.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+zvfh,+buddyext \
+		-o log.s
+
+vfmadot2-lower:
+	@${BUDDY_OPT} ./vfmadot2.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vfmadot2-translate:
+	@${BUDDY_OPT} ./vfmadot2.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vfmadot2-asm:
+	@${BUDDY_OPT} ./vfmadot2.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+zvfh,+buddyext \
+		-o log.s
+
+vfmadot3-lower:
+	@${BUDDY_OPT} ./vfmadot3.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vfmadot3-translate:
+	@${BUDDY_OPT} ./vfmadot3.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vfmadot3-asm:
+	@${BUDDY_OPT} ./vfmadot3.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+zvfh,+buddyext \
+		-o log.s
+
+vfmadot1-run:
+	@${BUDDY_OPT} ./vfmadot1_print_test.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+zvfh,+buddyext \
+		-o vfmadot1.s
+	riscv64-unknown-linux-gnu-gcc -march=rv64gcv -static vfmadot1.s runtime_vfmadot1.c -o vfmadot1_test
+
+vfmadot2-run:
+	@${BUDDY_OPT} ./vfmadot2_print_test.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+zvfh,+buddyext \
+		-o vfmadot2.s
+	riscv64-unknown-linux-gnu-gcc -march=rv64gcv -static vfmadot2.s runtime_vfmadot2.c -o vfmadot2_test
+
+vfmadot3-run:
+	@${BUDDY_OPT} ./vfmadot3_print_test.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+zvfh,+buddyext \
+		-o vfmadot3.s
+	riscv64-unknown-linux-gnu-gcc -march=rv64gcv -static vfmadot3.s runtime_vfmadot3.c -o vfmadot3_test
+
+vfmadotn-lower:
+	@${BUDDY_OPT} ./vfmadotn.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts \
+		-o log.mlir
+
+vfmadotn-translate:
+	@${BUDDY_OPT} ./vfmadotn.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir \
+		-o log.ll
+
+vfmadotn-asm:
+	@${BUDDY_OPT} ./vfmadotn.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+zvfh,+buddyext \
+		-o log.s
+
+vfmadotn-run:
+	@${BUDDY_OPT} ./vfmadotn_print_test.mlir \
+		-lower-ime \
+		-convert-linalg-to-loops \
+		-lower-affine \
+		-convert-scf-to-cf \
+		-convert-cf-to-llvm \
+		-convert-arith-to-llvm \
+		-convert-math-to-llvm \
+		-convert-func-to-llvm \
+		-finalize-memref-to-llvm \
+		-reconcile-unrealized-casts | \
+	${BUDDY_TRANSLATE} -buddy-to-llvmir | \
+	${BUDDY_LLC} -filetype=asm -mtriple=riscv64 \
+		-mattr=+m,+v,+zvfh,+buddyext \
+		-o vfmadotn.s
+	riscv64-unknown-linux-gnu-gcc -march=rv64gcv -static vfmadotn.s runtime_vfmadotn.c -o vfmadotn_test
+

--- a/examples/IMEDialect/runtime_vfmadot1.c
+++ b/examples/IMEDialect/runtime_vfmadot1.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+
+void print_header() {
+  printf("=== vfmadot1 (fp16 x fp16, fixed slide=1) ===");
+  printf("\n\nMatrix A (8x4, fp16, sliding source):\n");
+  printf("  [1.0, 2.0, 3.0, 4.0]   row 0\n");
+  printf("  [2.0, 3.0, 4.0, 5.0]   row 1 <- slide=1 starts here\n");
+  printf("  [3.0, 4.0, 5.0, 6.0]   row 2\n");
+  printf("  [4.0, 5.0, 6.0, 7.0]   row 3\n");
+  printf("  [5.0, 6.0, 7.0, 8.0]   row 4\n");
+  printf("  [6.0, 7.0, 8.0, 9.0]   row 5\n");
+  printf("  [7.0, 8.0, 9.0, 10.0]  row 6\n");
+  printf("  [8.0, 9.0, 10.0, 11.0] row 7\n");
+  printf("\nMatrix B (4x4, fp16, packed):\n");
+  printf("  [1.0, 1.0, 1.0, 1.0]\n");
+  printf("  [1.0, 1.0, 1.0, 1.0]\n");
+  printf("  [1.0, 1.0, 1.0, 1.0]\n");
+  printf("  [1.0, 1.0, 1.0, 1.0]\n");
+  printf("\nFixed slide: 1\n");
+  printf("Rows used after slide: [1,2,3,4] -> sums [14,18,22,26]\n");
+  printf("\nResult matrix C (4x4, fp16):\n");
+  printf("Expected: [[14,14,14,14], [18,18,18,18], [22,22,22,22], "
+         "[26,26,26,26]]\n");
+}
+
+void print_row_f16(int row, float v0, float v1, float v2, float v3) {
+  printf("Row %d: [%.1f, %.1f, %.1f, %.1f]\n", row, v0, v1, v2, v3);
+}

--- a/examples/IMEDialect/runtime_vfmadot2.c
+++ b/examples/IMEDialect/runtime_vfmadot2.c
@@ -1,0 +1,64 @@
+// Runtime support for vfmadot2_print_test
+// Prints matrix results in human-readable format (fp16 version)
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+
+// Convert half-precision float to single-precision
+// Based on IEEE 754 half-precision format
+static float f16_to_f32(uint16_t h) {
+  uint32_t sign = (h >> 15) & 0x1;
+  uint32_t exp = (h >> 10) & 0x1f;
+  uint32_t mant = h & 0x3ff;
+
+  uint32_t f;
+  if (exp == 0) {
+    if (mant == 0) {
+      f = sign << 31;
+    } else {
+      // Denormalized
+      while (!(mant & 0x400)) {
+        mant <<= 1;
+        exp--;
+      }
+      exp++;
+      mant &= ~0x400;
+      exp = exp + (127 - 15);
+      f = (sign << 31) | (exp << 23) | (mant << 13);
+    }
+  } else if (exp == 31) {
+    f = (sign << 31) | 0x7f800000 | (mant << 13);
+  } else {
+    exp = exp + (127 - 15);
+    f = (sign << 31) | (exp << 23) | (mant << 13);
+  }
+
+  union {
+    uint32_t u;
+    float f;
+  } u;
+  u.u = f;
+  return u.f;
+}
+
+void print_header() {
+  printf("======================================\n");
+  printf("   vfmadot2 Result Matrix (fp16)\n");
+  printf("   slide=2 fixed sliding window\n");
+  printf("======================================\n");
+  printf("Expected (slide=2): all 18s in row 0,\n");
+  printf("                    all 22s in row 1,\n");
+  printf("                    all 26s in row 2,\n");
+  printf("                    all 30s in row 3\n");
+  printf("--------------------------------------\n");
+}
+
+void print_row_f16(int32_t row, uint16_t v0, uint16_t v1, uint16_t v2,
+                   uint16_t v3) {
+  float f0 = f16_to_f32(v0);
+  float f1 = f16_to_f32(v1);
+  float f2 = f16_to_f32(v2);
+  float f3 = f16_to_f32(v3);
+  printf("Row %d: [%6.2f, %6.2f, %6.2f, %6.2f]\n", row, f0, f1, f2, f3);
+}

--- a/examples/IMEDialect/runtime_vfmadot3.c
+++ b/examples/IMEDialect/runtime_vfmadot3.c
@@ -1,0 +1,64 @@
+// Runtime support for vfmadot3_print_test
+// Prints matrix results in human-readable format (fp16 version)
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+
+// Convert half-precision float to single-precision
+// Based on IEEE 754 half-precision format
+static float f16_to_f32(uint16_t h) {
+  uint32_t sign = (h >> 15) & 0x1;
+  uint32_t exp = (h >> 10) & 0x1f;
+  uint32_t mant = h & 0x3ff;
+
+  uint32_t f;
+  if (exp == 0) {
+    if (mant == 0) {
+      f = sign << 31;
+    } else {
+      // Denormalized
+      while (!(mant & 0x400)) {
+        mant <<= 1;
+        exp--;
+      }
+      exp++;
+      mant &= ~0x400;
+      exp = exp + (127 - 15);
+      f = (sign << 31) | (exp << 23) | (mant << 13);
+    }
+  } else if (exp == 31) {
+    f = (sign << 31) | 0x7f800000 | (mant << 13);
+  } else {
+    exp = exp + (127 - 15);
+    f = (sign << 31) | (exp << 23) | (mant << 13);
+  }
+
+  union {
+    uint32_t u;
+    float f;
+  } u;
+  u.u = f;
+  return u.f;
+}
+
+void print_header() {
+  printf("======================================\n");
+  printf("   vfmadot3 Result Matrix (fp16)\n");
+  printf("   slide=3 fixed sliding window\n");
+  printf("======================================\n");
+  printf("Expected (slide=3): all 22s in row 0,\n");
+  printf("                    all 26s in row 1,\n");
+  printf("                    all 30s in row 2,\n");
+  printf("                    all 34s in row 3\n");
+  printf("--------------------------------------\n");
+}
+
+void print_row_f16(int32_t row, uint16_t v0, uint16_t v1, uint16_t v2,
+                   uint16_t v3) {
+  float f0 = f16_to_f32(v0);
+  float f1 = f16_to_f32(v1);
+  float f2 = f16_to_f32(v2);
+  float f3 = f16_to_f32(v3);
+  printf("Row %d: [%6.2f, %6.2f, %6.2f, %6.2f]\n", row, f0, f1, f2, f3);
+}

--- a/examples/IMEDialect/runtime_vfmadotn.c
+++ b/examples/IMEDialect/runtime_vfmadotn.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+
+void print_header() {
+  printf("=== vfmadotn (fp16 x fp16, dynamic slide) ===");
+  printf("\n\nMatrix A (8x4, fp16, sliding source):\n");
+  printf("  [1.0, 2.0, 3.0, 4.0]   row 0\n");
+  printf("  [2.0, 3.0, 4.0, 5.0]   row 1 <- slide=1 starts here\n");
+  printf("  [3.0, 4.0, 5.0, 6.0]   row 2\n");
+  printf("  [4.0, 5.0, 6.0, 7.0]   row 3\n");
+  printf("  [5.0, 6.0, 7.0, 8.0]   row 4\n");
+  printf("  [6.0, 7.0, 8.0, 9.0]   row 5\n");
+  printf("  [7.0, 8.0, 9.0, 10.0]  row 6\n");
+  printf("  [8.0, 9.0, 10.0, 11.0] row 7\n");
+  printf("\nMatrix B (4x4, fp16, packed):\n");
+  printf("  [1.0, 1.0, 1.0, 1.0]\n");
+  printf("  [1.0, 1.0, 1.0, 1.0]\n");
+  printf("  [1.0, 1.0, 1.0, 1.0]\n");
+  printf("  [1.0, 1.0, 1.0, 1.0]\n");
+  printf("\nSlide parameter: 1\n");
+  printf("Rows used after slide: [1,2,3,4] -> sums [14,18,22,26]\n");
+  printf("\nResult matrix C (4x4, fp16):\n");
+  printf("Expected: [[14,14,14,14], [18,18,18,18], [22,22,22,22], "
+         "[26,26,26,26]]\n");
+}
+
+void print_row_f16(int row, float v0, float v1, float v2, float v3) {
+  printf("Row %d: [%.1f, %.1f, %.1f, %.1f]\n", row, v0, v1, v2, v3);
+}

--- a/examples/IMEDialect/runtime_vmadot1.c
+++ b/examples/IMEDialect/runtime_vmadot1.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+
+void print_header() {
+  printf("=== vmadot1 (signed x signed, fixed slide=1) ===");
+  printf("\n\nMatrix A (8x8, int8, signed, sliding source):\n");
+  printf("  [1, 2, 3, 4, 5, 6, 7, 8]      row 0\n");
+  printf("  [2, 3, 4, 5, 6, 7, 8, 9]      row 1 <- slide=1 starts here\n");
+  printf("  [3, 4, 5, 6, 7, 8, 9, 10]     row 2\n");
+  printf("  [4, 5, 6, 7, 8, 9, 10, 11]    row 3\n");
+  printf("  [5, 6, 7, 8, 9, 10, 11, 12]   row 4\n");
+  printf("  [6, 7, 8, 9, 10, 11, 12, 13]  row 5\n");
+  printf("  [7, 8, 9, 10, 11, 12, 13, 14] row 6\n");
+  printf("  [8, 9, 10, 11, 12, 13, 14, 15] row 7\n");
+  printf("\nMatrix B (4x8, int8, signed, packed):\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("\nFixed slide: 1\n");
+  printf("Rows used after slide: [1,2,3,4] -> sums [44,52,60,68]\n");
+  printf("\nResult matrix C (4x4, int32):\n");
+  printf("Expected: [[44,44,44,44], [52,52,52,52], [60,60,60,60], "
+         "[68,68,68,68]]\n");
+}
+
+void print_row(int row, int v0, int v1, int v2, int v3) {
+  printf("Row %d: [%d, %d, %d, %d]\n", row, v0, v1, v2, v3);
+}

--- a/examples/IMEDialect/runtime_vmadot2.c
+++ b/examples/IMEDialect/runtime_vmadot2.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+
+void print_header() {
+  printf("=== vmadot2 (signed x signed, fixed slide=2) ===");
+  printf("\n\nMatrix A (8x8, int8, signed, sliding source):\n");
+  printf("  [1, 2, 3, 4, 5, 6, 7, 8]      row 0\n");
+  printf("  [2, 3, 4, 5, 6, 7, 8, 9]      row 1\n");
+  printf("  [3, 4, 5, 6, 7, 8, 9, 10]     row 2 <- slide=2 starts here\n");
+  printf("  [4, 5, 6, 7, 8, 9, 10, 11]    row 3\n");
+  printf("  [5, 6, 7, 8, 9, 10, 11, 12]   row 4\n");
+  printf("  [6, 7, 8, 9, 10, 11, 12, 13]  row 5\n");
+  printf("  [7, 8, 9, 10, 11, 12, 13, 14] row 6\n");
+  printf("  [8, 9, 10, 11, 12, 13, 14, 15] row 7\n");
+  printf("\nMatrix B (4x8, int8, signed, packed):\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("\nFixed slide: 2\n");
+  printf("Rows used after slide: [2,3,4,5] -> sums [52,60,68,76]\n");
+  printf("\nResult matrix C (4x4, int32):\n");
+  printf("Expected: [[52,52,52,52], [60,60,60,60], [68,68,68,68], "
+         "[76,76,76,76]]\n");
+}
+
+void print_row(int row, int v0, int v1, int v2, int v3) {
+  printf("Row %d: [%d, %d, %d, %d]\n", row, v0, v1, v2, v3);
+}

--- a/examples/IMEDialect/runtime_vmadot3.c
+++ b/examples/IMEDialect/runtime_vmadot3.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+
+void print_header() {
+  printf("=== vmadot3 (signed x signed, fixed slide=3) ===");
+  printf("\n\nMatrix A (8x8, int8, signed, sliding source):\n");
+  printf("  [1, 2, 3, 4, 5, 6, 7, 8]      row 0\n");
+  printf("  [2, 3, 4, 5, 6, 7, 8, 9]      row 1\n");
+  printf("  [3, 4, 5, 6, 7, 8, 9, 10]     row 2\n");
+  printf("  [4, 5, 6, 7, 8, 9, 10, 11]    row 3 <- slide=3 starts here\n");
+  printf("  [5, 6, 7, 8, 9, 10, 11, 12]   row 4\n");
+  printf("  [6, 7, 8, 9, 10, 11, 12, 13]  row 5\n");
+  printf("  [7, 8, 9, 10, 11, 12, 13, 14] row 6\n");
+  printf("  [8, 9, 10, 11, 12, 13, 14, 15] row 7\n");
+  printf("\nMatrix B (4x8, int8, signed, packed):\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("\nFixed slide: 3\n");
+  printf("Rows used after slide: [3,4,5,6] -> sums [60,68,76,84]\n");
+  printf("\nResult matrix C (4x4, int32):\n");
+  printf("Expected: [[60,60,60,60], [68,68,68,68], [76,76,76,76], "
+         "[84,84,84,84]]\n");
+}
+
+void print_row(int row, int v0, int v1, int v2, int v3) {
+  printf("Row %d: [%d, %d, %d, %d]\n", row, v0, v1, v2, v3);
+}

--- a/examples/IMEDialect/runtime_vmadotn.c
+++ b/examples/IMEDialect/runtime_vmadotn.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+
+void print_header() {
+  printf("=== vmadotn (signed x signed, dynamic slide) ===");
+  printf("\n\nMatrix A (8x8, int8, signed, sliding source):\n");
+  printf("  [1, 2, 3, 4, 5, 6, 7, 8]      row 0\n");
+  printf("  [2, 3, 4, 5, 6, 7, 8, 9]      row 1 <- slide=1 starts here\n");
+  printf("  [3, 4, 5, 6, 7, 8, 9, 10]     row 2\n");
+  printf("  [4, 5, 6, 7, 8, 9, 10, 11]    row 3\n");
+  printf("  [5, 6, 7, 8, 9, 10, 11, 12]   row 4\n");
+  printf("  [6, 7, 8, 9, 10, 11, 12, 13]  row 5\n");
+  printf("  [7, 8, 9, 10, 11, 12, 13, 14] row 6\n");
+  printf("  [8, 9, 10, 11, 12, 13, 14, 15] row 7\n");
+  printf("\nMatrix B (4x8, int8, signed, packed):\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("\nSlide parameter: 1\n");
+  printf("Rows used after slide: [1,2,3,4] -> sums [44,52,60,68]\n");
+  printf("\nResult matrix C (4x4, int32):\n");
+  printf("Expected: [[44,44,44,44], [52,52,52,52], [60,60,60,60], "
+         "[68,68,68,68]]\n");
+}
+
+void print_row(int row, int v0, int v1, int v2, int v3) {
+  printf("Row %d: [%d, %d, %d, %d]\n", row, v0, v1, v2, v3);
+}

--- a/examples/IMEDialect/runtime_vmadotnsu.c
+++ b/examples/IMEDialect/runtime_vmadotnsu.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+
+void print_header() {
+  printf("=== vmadotnsu (signed x unsigned, dynamic slide) ===");
+  printf("\n\nMatrix A (8x8, int8, signed, sliding source):\n");
+  printf("  [-1, -2, -3, -4, -5, -6, -7, -8]       row 0\n");
+  printf("  [-2, -3, -4, -5, -6, -7, -8, -9]       row 1 <- slide=1 starts "
+         "here\n");
+  printf("  [-3, -4, -5, -6, -7, -8, -9, -10]      row 2\n");
+  printf("  [-4, -5, -6, -7, -8, -9, -10, -11]     row 3\n");
+  printf("  [-5, -6, -7, -8, -9, -10, -11, -12]    row 4\n");
+  printf("  [-6, -7, -8, -9, -10, -11, -12, -13]   row 5\n");
+  printf("  [-7, -8, -9, -10, -11, -12, -13, -14]  row 6\n");
+  printf("  [-8, -9, -10, -11, -12, -13, -14, -15] row 7\n");
+  printf("\nMatrix B (4x8, uint8, unsigned, packed):\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("\nSlide parameter: 1\n");
+  printf("Rows used after slide: [1,2,3,4] -> sums [-44,-52,-60,-68]\n");
+  printf("\nResult matrix C (4x4, int32):\n");
+  printf("Expected: [[-44,-44,-44,-44], [-52,-52,-52,-52], [-60,-60,-60,-60], "
+         "[-68,-68,-68,-68]]\n");
+}
+
+void print_row(int row, int v0, int v1, int v2, int v3) {
+  printf("Row %d: [%d, %d, %d, %d]\n", row, v0, v1, v2, v3);
+}

--- a/examples/IMEDialect/runtime_vmadotnu.c
+++ b/examples/IMEDialect/runtime_vmadotnu.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+
+void print_header() {
+  printf("=== vmadotnu (unsigned x unsigned, dynamic slide) ===");
+  printf("\n\nMatrix A (8x8, uint8, unsigned, sliding source):\n");
+  printf("  [1, 2, 3, 4, 5, 6, 7, 8]      row 0\n");
+  printf("  [2, 3, 4, 5, 6, 7, 8, 9]      row 1\n");
+  printf("  [3, 4, 5, 6, 7, 8, 9, 10]     row 2 <- slide=2 starts here\n");
+  printf("  [4, 5, 6, 7, 8, 9, 10, 11]    row 3\n");
+  printf("  [5, 6, 7, 8, 9, 10, 11, 12]   row 4\n");
+  printf("  [6, 7, 8, 9, 10, 11, 12, 13]  row 5\n");
+  printf("  [7, 8, 9, 10, 11, 12, 13, 14] row 6\n");
+  printf("  [8, 9, 10, 11, 12, 13, 14, 15] row 7\n");
+  printf("\nMatrix B (4x8, uint8, unsigned, packed):\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("  [1, 1, 1, 1, 1, 1, 1, 1]\n");
+  printf("\nSlide parameter: 2\n");
+  printf("Rows used after slide: [2,3,4,5] -> sums [52,60,68,76]\n");
+  printf("\nResult matrix C (4x4, int32):\n");
+  printf("Expected: [[52,52,52,52], [60,60,60,60], [68,68,68,68], "
+         "[76,76,76,76]]\n");
+}
+
+void print_row(int row, int v0, int v1, int v2, int v3) {
+  printf("Row %d: [%d, %d, %d, %d]\n", row, v0, v1, v2, v3);
+}

--- a/examples/IMEDialect/runtime_vmadotnus.c
+++ b/examples/IMEDialect/runtime_vmadotnus.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+
+void print_header() {
+  printf("=== vmadotnus (unsigned x signed, dynamic slide) ===");
+  printf("\n\nMatrix A (8x8, uint8, unsigned, sliding source):\n");
+  printf("  [1, 2, 3, 4, 5, 6, 7, 8]      row 0\n");
+  printf("  [2, 3, 4, 5, 6, 7, 8, 9]      row 1\n");
+  printf("  [3, 4, 5, 6, 7, 8, 9, 10]     row 2\n");
+  printf("  [4, 5, 6, 7, 8, 9, 10, 11]    row 3 <- slide=3 starts here\n");
+  printf("  [5, 6, 7, 8, 9, 10, 11, 12]   row 4\n");
+  printf("  [6, 7, 8, 9, 10, 11, 12, 13]  row 5\n");
+  printf("  [7, 8, 9, 10, 11, 12, 13, 14] row 6\n");
+  printf("  [8, 9, 10, 11, 12, 13, 14, 15] row 7\n");
+  printf("\nMatrix B (4x8, int8, signed, packed):\n");
+  printf("  [-1, -1, -1, -1, -1, -1, -1, -1]\n");
+  printf("  [-1, -1, -1, -1, -1, -1, -1, -1]\n");
+  printf("  [-1, -1, -1, -1, -1, -1, -1, -1]\n");
+  printf("  [-1, -1, -1, -1, -1, -1, -1, -1]\n");
+  printf("\nSlide parameter: 3\n");
+  printf("Rows used after slide: [3,4,5,6] -> sums [-60,-68,-76,-84]\n");
+  printf("\nResult matrix C (4x4, int32):\n");
+  printf("Expected: [[-60,-60,-60,-60], [-68,-68,-68,-68], [-76,-76,-76,-76], "
+         "[-84,-84,-84,-84]]\n");
+}
+
+void print_row(int row, int v0, int v1, int v2, int v3) {
+  printf("Row %d: [%d, %d, %d, %d]\n", row, v0, v1, v2, v3);
+}

--- a/examples/IMEDialect/vfmadot1.mlir
+++ b/examples/IMEDialect/vfmadot1.mlir
@@ -1,0 +1,49 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vfmadot1 operation (slide=1).
+// vfmadot1 performs: C += slide(A, 1) × B where A, B are fp16 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (32 fp16 elements), slides by 1 row.
+// Matrix dimensions for VLEN=256, SEW=16 (fp16):
+// A: 8×4 (2M×K) source, sliding selects 4×4 (M×K) starting from row 1
+// B: 4×4 (K×N) - fp16
+// C: 4×4 (M×N) - fp16 accumulator
+
+memref.global "private" @matA : memref<8x4xf16> = dense<[
+  [1.0, 2.0, 3.0, 4.0],
+  [2.0, 3.0, 4.0, 5.0],
+  [3.0, 4.0, 5.0, 6.0],
+  [4.0, 5.0, 6.0, 7.0],
+  [5.0, 6.0, 7.0, 8.0],
+  [6.0, 7.0, 8.0, 9.0],
+  [7.0, 8.0, 9.0, 10.0],
+  [8.0, 9.0, 10.0, 11.0]
+]>
+
+memref.global "private" @matB : memref<4x4xf16> = dense<[
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x4xf16>
+  %b = memref.get_global @matB : memref<4x4xf16>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xf16>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0.0 : f16
+  linalg.fill ins(%zero : f16) outs(%c : memref<4x4xf16>)
+  
+  // Perform floating-point matrix multiply-accumulate with slide=1
+  // CHECK: ime.vfmadot1
+  ime.vfmadot1 %c, %a, %b : memref<4x4xf16>, memref<8x4xf16>, memref<4x4xf16>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vfmadot1_print_test.mlir
+++ b/examples/IMEDialect/vfmadot1_print_test.mlir
@@ -1,0 +1,95 @@
+// IME vfmadot1 test: floating-point matrix multiply-accumulate with fixed slide=1
+//
+// vfmadot1 computes: C[i,j] += sum_k(A[1+i,k] * B[j,k])
+//
+// Sliding window reads 64 fp16 elements from VS1 (8 rows), then slides by 1 row.
+// A (8x4): fp16, source matrix
+// B (4x4): fp16, packed form
+//
+// With slide=1:
+// A rows used = [1,2,3,4] (after sliding by 1)
+// Row 1 = [2,3,4,5], sum = 14
+// Row 2 = [3,4,5,6], sum = 18
+// Row 3 = [4,5,6,7], sum = 22
+// Row 4 = [5,6,7,8], sum = 26
+
+memref.global "private" @matA : memref<8x4xf16> = dense<[
+  [1.0, 2.0, 3.0, 4.0],
+  [2.0, 3.0, 4.0, 5.0],
+  [3.0, 4.0, 5.0, 6.0],
+  [4.0, 5.0, 6.0, 7.0],
+  [5.0, 6.0, 7.0, 8.0],
+  [6.0, 7.0, 8.0, 9.0],
+  [7.0, 8.0, 9.0, 10.0],
+  [8.0, 9.0, 10.0, 11.0]
+]>
+
+// Packed B (4x4): all ones for easy verification
+memref.global "private" @matB : memref<4x4xf16> = dense<[
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0]
+]>
+
+// With slide=1: Expected C = [[14,14,14,14], [18,18,18,18], [22,22,22,22], [26,26,26,26]]
+
+func.func private @print_row_f16(i32, f16, f16, f16, f16)
+func.func private @print_header()
+
+func.func @main() -> i32 {
+  %a = memref.get_global @matA : memref<8x4xf16>
+  %b = memref.get_global @matB : memref<4x4xf16>
+  
+  %c = memref.alloc() : memref<4x4xf16>
+  
+  // Initialize to zero
+  %zero = arith.constant 0.0 : f16
+  linalg.fill ins(%zero : f16) outs(%c : memref<4x4xf16>)
+  
+  // Perform vfmadot1 (fixed slide=1)
+  ime.vfmadot1 %c, %a, %b : memref<4x4xf16>, memref<8x4xf16>, memref<4x4xf16>
+  
+  // Print results
+  call @print_header() : () -> ()
+  
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %i0 = arith.constant 0 : i32
+  %i1 = arith.constant 1 : i32
+  %i2 = arith.constant 2 : i32
+  %i3 = arith.constant 3 : i32
+  
+  // Row 0
+  %v00 = memref.load %c[%c0, %c0] : memref<4x4xf16>
+  %v01 = memref.load %c[%c0, %c1] : memref<4x4xf16>
+  %v02 = memref.load %c[%c0, %c2] : memref<4x4xf16>
+  %v03 = memref.load %c[%c0, %c3] : memref<4x4xf16>
+  call @print_row_f16(%i0, %v00, %v01, %v02, %v03) : (i32, f16, f16, f16, f16) -> ()
+  
+  // Row 1
+  %v10 = memref.load %c[%c1, %c0] : memref<4x4xf16>
+  %v11 = memref.load %c[%c1, %c1] : memref<4x4xf16>
+  %v12 = memref.load %c[%c1, %c2] : memref<4x4xf16>
+  %v13 = memref.load %c[%c1, %c3] : memref<4x4xf16>
+  call @print_row_f16(%i1, %v10, %v11, %v12, %v13) : (i32, f16, f16, f16, f16) -> ()
+  
+  // Row 2
+  %v20 = memref.load %c[%c2, %c0] : memref<4x4xf16>
+  %v21 = memref.load %c[%c2, %c1] : memref<4x4xf16>
+  %v22 = memref.load %c[%c2, %c2] : memref<4x4xf16>
+  %v23 = memref.load %c[%c2, %c3] : memref<4x4xf16>
+  call @print_row_f16(%i2, %v20, %v21, %v22, %v23) : (i32, f16, f16, f16, f16) -> ()
+  
+  // Row 3
+  %v30 = memref.load %c[%c3, %c0] : memref<4x4xf16>
+  %v31 = memref.load %c[%c3, %c1] : memref<4x4xf16>
+  %v32 = memref.load %c[%c3, %c2] : memref<4x4xf16>
+  %v33 = memref.load %c[%c3, %c3] : memref<4x4xf16>
+  call @print_row_f16(%i3, %v30, %v31, %v32, %v33) : (i32, f16, f16, f16, f16) -> ()
+  
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vfmadot1_print_test.mlir
+++ b/examples/IMEDialect/vfmadot1_print_test.mlir
@@ -1,4 +1,5 @@
-// IME vfmadot1 test: floating-point matrix multiply-accumulate with fixed slide=1
+// RUN: buddy-opt %s | FileCheck %s
+// CHECK: func.func @main
 //
 // vfmadot1 computes: C[i,j] += sum_k(A[1+i,k] * B[j,k])
 //

--- a/examples/IMEDialect/vfmadot2.mlir
+++ b/examples/IMEDialect/vfmadot2.mlir
@@ -1,0 +1,49 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vfmadot2 operation (slide=2).
+// vfmadot2 performs: C += slide(A, 2) × B where A, B are fp16 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (32 fp16 elements), slides by 2 rows.
+// Matrix dimensions for VLEN=256, SEW=16 (fp16):
+// A: 8×4 (2M×K) source, sliding selects 4×4 (M×K) starting from row 2
+// B: 4×4 (K×N) - fp16
+// C: 4×4 (M×N) - fp16 accumulator
+
+memref.global "private" @matA : memref<8x4xf16> = dense<[
+  [1.0, 2.0, 3.0, 4.0],
+  [2.0, 3.0, 4.0, 5.0],
+  [3.0, 4.0, 5.0, 6.0],
+  [4.0, 5.0, 6.0, 7.0],
+  [5.0, 6.0, 7.0, 8.0],
+  [6.0, 7.0, 8.0, 9.0],
+  [7.0, 8.0, 9.0, 10.0],
+  [8.0, 9.0, 10.0, 11.0]
+]>
+
+memref.global "private" @matB : memref<4x4xf16> = dense<[
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x4xf16>
+  %b = memref.get_global @matB : memref<4x4xf16>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xf16>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0.0 : f16
+  linalg.fill ins(%zero : f16) outs(%c : memref<4x4xf16>)
+  
+  // Perform floating-point matrix multiply-accumulate with slide=2
+  // CHECK: ime.vfmadot2
+  ime.vfmadot2 %c, %a, %b : memref<4x4xf16>, memref<8x4xf16>, memref<4x4xf16>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vfmadot2_print_test.mlir
+++ b/examples/IMEDialect/vfmadot2_print_test.mlir
@@ -1,0 +1,95 @@
+// IME vfmadot2 test: floating-point matrix multiply-accumulate with fixed slide=2
+//
+// vfmadot2 computes: C[i,j] += sum_k(A[2+i,k] * B[j,k])
+//
+// Sliding window reads 64 fp16 elements from VS1 (8 rows), then slides by 2 rows.
+// A (8x4): fp16, source matrix
+// B (4x4): fp16, packed form
+//
+// With slide=2:
+// A rows used = [2,3,4,5] (after sliding by 2)
+// Row 2 = [3,4,5,6], sum = 18
+// Row 3 = [4,5,6,7], sum = 22
+// Row 4 = [5,6,7,8], sum = 26
+// Row 5 = [6,7,8,9], sum = 30
+
+memref.global "private" @matA : memref<8x4xf16> = dense<[
+  [1.0, 2.0, 3.0, 4.0],
+  [2.0, 3.0, 4.0, 5.0],
+  [3.0, 4.0, 5.0, 6.0],
+  [4.0, 5.0, 6.0, 7.0],
+  [5.0, 6.0, 7.0, 8.0],
+  [6.0, 7.0, 8.0, 9.0],
+  [7.0, 8.0, 9.0, 10.0],
+  [8.0, 9.0, 10.0, 11.0]
+]>
+
+// Packed B (4x4): all ones for easy verification
+memref.global "private" @matB : memref<4x4xf16> = dense<[
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0]
+]>
+
+// With slide=2: Expected C = [[18,18,18,18], [22,22,22,22], [26,26,26,26], [30,30,30,30]]
+
+func.func private @print_row_f16(i32, f16, f16, f16, f16)
+func.func private @print_header()
+
+func.func @main() -> i32 {
+  %a = memref.get_global @matA : memref<8x4xf16>
+  %b = memref.get_global @matB : memref<4x4xf16>
+  
+  %c = memref.alloc() : memref<4x4xf16>
+  
+  // Initialize to zero
+  %zero = arith.constant 0.0 : f16
+  linalg.fill ins(%zero : f16) outs(%c : memref<4x4xf16>)
+  
+  // Perform vfmadot2 (fixed slide=2)
+  ime.vfmadot2 %c, %a, %b : memref<4x4xf16>, memref<8x4xf16>, memref<4x4xf16>
+  
+  // Print results
+  call @print_header() : () -> ()
+  
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %i0 = arith.constant 0 : i32
+  %i1 = arith.constant 1 : i32
+  %i2 = arith.constant 2 : i32
+  %i3 = arith.constant 3 : i32
+  
+  // Row 0
+  %v00 = memref.load %c[%c0, %c0] : memref<4x4xf16>
+  %v01 = memref.load %c[%c0, %c1] : memref<4x4xf16>
+  %v02 = memref.load %c[%c0, %c2] : memref<4x4xf16>
+  %v03 = memref.load %c[%c0, %c3] : memref<4x4xf16>
+  call @print_row_f16(%i0, %v00, %v01, %v02, %v03) : (i32, f16, f16, f16, f16) -> ()
+  
+  // Row 1
+  %v10 = memref.load %c[%c1, %c0] : memref<4x4xf16>
+  %v11 = memref.load %c[%c1, %c1] : memref<4x4xf16>
+  %v12 = memref.load %c[%c1, %c2] : memref<4x4xf16>
+  %v13 = memref.load %c[%c1, %c3] : memref<4x4xf16>
+  call @print_row_f16(%i1, %v10, %v11, %v12, %v13) : (i32, f16, f16, f16, f16) -> ()
+  
+  // Row 2
+  %v20 = memref.load %c[%c2, %c0] : memref<4x4xf16>
+  %v21 = memref.load %c[%c2, %c1] : memref<4x4xf16>
+  %v22 = memref.load %c[%c2, %c2] : memref<4x4xf16>
+  %v23 = memref.load %c[%c2, %c3] : memref<4x4xf16>
+  call @print_row_f16(%i2, %v20, %v21, %v22, %v23) : (i32, f16, f16, f16, f16) -> ()
+  
+  // Row 3
+  %v30 = memref.load %c[%c3, %c0] : memref<4x4xf16>
+  %v31 = memref.load %c[%c3, %c1] : memref<4x4xf16>
+  %v32 = memref.load %c[%c3, %c2] : memref<4x4xf16>
+  %v33 = memref.load %c[%c3, %c3] : memref<4x4xf16>
+  call @print_row_f16(%i3, %v30, %v31, %v32, %v33) : (i32, f16, f16, f16, f16) -> ()
+  
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vfmadot2_print_test.mlir
+++ b/examples/IMEDialect/vfmadot2_print_test.mlir
@@ -1,4 +1,5 @@
-// IME vfmadot2 test: floating-point matrix multiply-accumulate with fixed slide=2
+// RUN: buddy-opt %s | FileCheck %s
+// CHECK: func.func @main
 //
 // vfmadot2 computes: C[i,j] += sum_k(A[2+i,k] * B[j,k])
 //

--- a/examples/IMEDialect/vfmadot3.mlir
+++ b/examples/IMEDialect/vfmadot3.mlir
@@ -1,0 +1,49 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vfmadot3 operation (slide=3).
+// vfmadot3 performs: C += slide(A, 3) × B where A, B are fp16 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (32 fp16 elements), slides by 3 rows.
+// Matrix dimensions for VLEN=256, SEW=16 (fp16):
+// A: 8×4 (2M×K) source, sliding selects 4×4 (M×K) starting from row 3
+// B: 4×4 (K×N) - fp16
+// C: 4×4 (M×N) - fp16 accumulator
+
+memref.global "private" @matA : memref<8x4xf16> = dense<[
+  [1.0, 2.0, 3.0, 4.0],
+  [2.0, 3.0, 4.0, 5.0],
+  [3.0, 4.0, 5.0, 6.0],
+  [4.0, 5.0, 6.0, 7.0],
+  [5.0, 6.0, 7.0, 8.0],
+  [6.0, 7.0, 8.0, 9.0],
+  [7.0, 8.0, 9.0, 10.0],
+  [8.0, 9.0, 10.0, 11.0]
+]>
+
+memref.global "private" @matB : memref<4x4xf16> = dense<[
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x4xf16>
+  %b = memref.get_global @matB : memref<4x4xf16>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xf16>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0.0 : f16
+  linalg.fill ins(%zero : f16) outs(%c : memref<4x4xf16>)
+  
+  // Perform floating-point matrix multiply-accumulate with slide=3
+  // CHECK: ime.vfmadot3
+  ime.vfmadot3 %c, %a, %b : memref<4x4xf16>, memref<8x4xf16>, memref<4x4xf16>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vfmadot3_print_test.mlir
+++ b/examples/IMEDialect/vfmadot3_print_test.mlir
@@ -1,0 +1,95 @@
+// IME vfmadot3 test: floating-point matrix multiply-accumulate with fixed slide=3
+//
+// vfmadot3 computes: C[i,j] += sum_k(A[3+i,k] * B[j,k])
+//
+// Sliding window reads 64 fp16 elements from VS1 (8 rows), then slides by 3 rows.
+// A (8x4): fp16, source matrix
+// B (4x4): fp16, packed form
+//
+// With slide=3:
+// A rows used = [3,4,5,6] (after sliding by 3)
+// Row 3 = [4,5,6,7], sum = 22
+// Row 4 = [5,6,7,8], sum = 26
+// Row 5 = [6,7,8,9], sum = 30
+// Row 6 = [7,8,9,10], sum = 34
+
+memref.global "private" @matA : memref<8x4xf16> = dense<[
+  [1.0, 2.0, 3.0, 4.0],
+  [2.0, 3.0, 4.0, 5.0],
+  [3.0, 4.0, 5.0, 6.0],
+  [4.0, 5.0, 6.0, 7.0],
+  [5.0, 6.0, 7.0, 8.0],
+  [6.0, 7.0, 8.0, 9.0],
+  [7.0, 8.0, 9.0, 10.0],
+  [8.0, 9.0, 10.0, 11.0]
+]>
+
+// Packed B (4x4): all ones for easy verification
+memref.global "private" @matB : memref<4x4xf16> = dense<[
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0]
+]>
+
+// With slide=3: Expected C = [[22,22,22,22], [26,26,26,26], [30,30,30,30], [34,34,34,34]]
+
+func.func private @print_row_f16(i32, f16, f16, f16, f16)
+func.func private @print_header()
+
+func.func @main() -> i32 {
+  %a = memref.get_global @matA : memref<8x4xf16>
+  %b = memref.get_global @matB : memref<4x4xf16>
+  
+  %c = memref.alloc() : memref<4x4xf16>
+  
+  // Initialize to zero
+  %zero = arith.constant 0.0 : f16
+  linalg.fill ins(%zero : f16) outs(%c : memref<4x4xf16>)
+  
+  // Perform vfmadot3 (fixed slide=3)
+  ime.vfmadot3 %c, %a, %b : memref<4x4xf16>, memref<8x4xf16>, memref<4x4xf16>
+  
+  // Print results
+  call @print_header() : () -> ()
+  
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %i0 = arith.constant 0 : i32
+  %i1 = arith.constant 1 : i32
+  %i2 = arith.constant 2 : i32
+  %i3 = arith.constant 3 : i32
+  
+  // Row 0
+  %v00 = memref.load %c[%c0, %c0] : memref<4x4xf16>
+  %v01 = memref.load %c[%c0, %c1] : memref<4x4xf16>
+  %v02 = memref.load %c[%c0, %c2] : memref<4x4xf16>
+  %v03 = memref.load %c[%c0, %c3] : memref<4x4xf16>
+  call @print_row_f16(%i0, %v00, %v01, %v02, %v03) : (i32, f16, f16, f16, f16) -> ()
+  
+  // Row 1
+  %v10 = memref.load %c[%c1, %c0] : memref<4x4xf16>
+  %v11 = memref.load %c[%c1, %c1] : memref<4x4xf16>
+  %v12 = memref.load %c[%c1, %c2] : memref<4x4xf16>
+  %v13 = memref.load %c[%c1, %c3] : memref<4x4xf16>
+  call @print_row_f16(%i1, %v10, %v11, %v12, %v13) : (i32, f16, f16, f16, f16) -> ()
+  
+  // Row 2
+  %v20 = memref.load %c[%c2, %c0] : memref<4x4xf16>
+  %v21 = memref.load %c[%c2, %c1] : memref<4x4xf16>
+  %v22 = memref.load %c[%c2, %c2] : memref<4x4xf16>
+  %v23 = memref.load %c[%c2, %c3] : memref<4x4xf16>
+  call @print_row_f16(%i2, %v20, %v21, %v22, %v23) : (i32, f16, f16, f16, f16) -> ()
+  
+  // Row 3
+  %v30 = memref.load %c[%c3, %c0] : memref<4x4xf16>
+  %v31 = memref.load %c[%c3, %c1] : memref<4x4xf16>
+  %v32 = memref.load %c[%c3, %c2] : memref<4x4xf16>
+  %v33 = memref.load %c[%c3, %c3] : memref<4x4xf16>
+  call @print_row_f16(%i3, %v30, %v31, %v32, %v33) : (i32, f16, f16, f16, f16) -> ()
+  
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vfmadot3_print_test.mlir
+++ b/examples/IMEDialect/vfmadot3_print_test.mlir
@@ -1,4 +1,5 @@
-// IME vfmadot3 test: floating-point matrix multiply-accumulate with fixed slide=3
+// RUN: buddy-opt %s | FileCheck %s
+// CHECK: func.func @main
 //
 // vfmadot3 computes: C[i,j] += sum_k(A[3+i,k] * B[j,k])
 //

--- a/examples/IMEDialect/vfmadot_print_test.mlir
+++ b/examples/IMEDialect/vfmadot_print_test.mlir
@@ -1,4 +1,5 @@
-// IME vfmadot test - floating-point matrix multiply-accumulate (fp16)
+// RUN: buddy-opt %s | FileCheck %s
+// CHECK: func.func @main
 //
 // vfmadot computes: C[i,j] += sum_k(A[i,k] * B[j,k]) for fp16 values
 //

--- a/examples/IMEDialect/vfmadotn.mlir
+++ b/examples/IMEDialect/vfmadotn.mlir
@@ -1,0 +1,52 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vfmadotn operation with dynamic slide parameter.
+// vfmadotn performs: C += slide(A, n) × B where A, B are fp16 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (64 elements), slides by n rows.
+// Matrix dimensions for VLEN=256, SEW=16 (fp16):
+// A: 8×4 (2M×K) source, sliding selects 4×4 (M×K) - fp16
+// B: 4×4 (K×N) - fp16
+// C: 4×4 (M×N) - fp16 accumulator
+
+memref.global "private" @matA : memref<8x4xf16> = dense<[
+  [1.0, 2.0, 3.0, 4.0],
+  [2.0, 3.0, 4.0, 5.0],
+  [3.0, 4.0, 5.0, 6.0],
+  [4.0, 5.0, 6.0, 7.0],
+  [5.0, 6.0, 7.0, 8.0],
+  [6.0, 7.0, 8.0, 9.0],
+  [7.0, 8.0, 9.0, 10.0],
+  [8.0, 9.0, 10.0, 11.0]
+]>
+
+memref.global "private" @matB : memref<4x4xf16> = dense<[
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x4xf16>
+  %b = memref.get_global @matB : memref<4x4xf16>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xf16>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0.0 : f16
+  linalg.fill ins(%zero : f16) outs(%c : memref<4x4xf16>)
+  
+  // Slide parameter (0-3)
+  %slide = arith.constant 1 : i64
+  
+  // Perform floating-point matrix multiply-accumulate with dynamic slide
+  // CHECK: ime.vfmadotn
+  ime.vfmadotn %c, %a, %b, %slide : memref<4x4xf16>, memref<8x4xf16>, memref<4x4xf16>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vfmadotn_print_test.mlir
+++ b/examples/IMEDialect/vfmadotn_print_test.mlir
@@ -1,4 +1,5 @@
-// IME vfmadotn test: floating-point matrix multiply-accumulate with dynamic slide
+// RUN: buddy-opt %s | FileCheck %s
+// CHECK: func.func @main
 //
 // vfmadotn computes: C[i,j] += sum_k(A[slide+i,k] * B[j,k])
 //

--- a/examples/IMEDialect/vfmadotn_print_test.mlir
+++ b/examples/IMEDialect/vfmadotn_print_test.mlir
@@ -1,0 +1,98 @@
+// IME vfmadotn test: floating-point matrix multiply-accumulate with dynamic slide
+//
+// vfmadotn computes: C[i,j] += sum_k(A[slide+i,k] * B[j,k])
+//
+// Sliding window reads 64 fp16 elements from VS1 (8 rows), then slides by n rows.
+// A (8x4): fp16, source matrix
+// B (4x4): fp16, packed form
+//
+// With slide=1:
+// A rows used = [1,2,3,4] (after sliding by 1)
+// Row 1 = [2,3,4,5], sum = 14
+// Row 2 = [3,4,5,6], sum = 18
+// Row 3 = [4,5,6,7], sum = 22
+// Row 4 = [5,6,7,8], sum = 26
+
+memref.global "private" @matA : memref<8x4xf16> = dense<[
+  [1.0, 2.0, 3.0, 4.0],
+  [2.0, 3.0, 4.0, 5.0],
+  [3.0, 4.0, 5.0, 6.0],
+  [4.0, 5.0, 6.0, 7.0],
+  [5.0, 6.0, 7.0, 8.0],
+  [6.0, 7.0, 8.0, 9.0],
+  [7.0, 8.0, 9.0, 10.0],
+  [8.0, 9.0, 10.0, 11.0]
+]>
+
+// Packed B (4x4): all ones for easy verification
+memref.global "private" @matB : memref<4x4xf16> = dense<[
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0],
+  [1.0, 1.0, 1.0, 1.0]
+]>
+
+// With slide=1: Expected C = [[14,14,14,14], [18,18,18,18], [22,22,22,22], [26,26,26,26]]
+
+func.func private @print_row_f16(i32, f16, f16, f16, f16)
+func.func private @print_header()
+
+func.func @main() -> i32 {
+  %a = memref.get_global @matA : memref<8x4xf16>
+  %b = memref.get_global @matB : memref<4x4xf16>
+  
+  %c = memref.alloc() : memref<4x4xf16>
+  
+  // Initialize to zero
+  %zero = arith.constant 0.0 : f16
+  linalg.fill ins(%zero : f16) outs(%c : memref<4x4xf16>)
+  
+  // Slide parameter = 1
+  %slide = arith.constant 1 : i64
+  
+  // Perform vfmadotn with slide=1
+  ime.vfmadotn %c, %a, %b, %slide : memref<4x4xf16>, memref<8x4xf16>, memref<4x4xf16>
+  
+  // Print results
+  call @print_header() : () -> ()
+  
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %i0 = arith.constant 0 : i32
+  %i1 = arith.constant 1 : i32
+  %i2 = arith.constant 2 : i32
+  %i3 = arith.constant 3 : i32
+  
+  // Row 0
+  %v00 = memref.load %c[%c0, %c0] : memref<4x4xf16>
+  %v01 = memref.load %c[%c0, %c1] : memref<4x4xf16>
+  %v02 = memref.load %c[%c0, %c2] : memref<4x4xf16>
+  %v03 = memref.load %c[%c0, %c3] : memref<4x4xf16>
+  call @print_row_f16(%i0, %v00, %v01, %v02, %v03) : (i32, f16, f16, f16, f16) -> ()
+  
+  // Row 1
+  %v10 = memref.load %c[%c1, %c0] : memref<4x4xf16>
+  %v11 = memref.load %c[%c1, %c1] : memref<4x4xf16>
+  %v12 = memref.load %c[%c1, %c2] : memref<4x4xf16>
+  %v13 = memref.load %c[%c1, %c3] : memref<4x4xf16>
+  call @print_row_f16(%i1, %v10, %v11, %v12, %v13) : (i32, f16, f16, f16, f16) -> ()
+  
+  // Row 2
+  %v20 = memref.load %c[%c2, %c0] : memref<4x4xf16>
+  %v21 = memref.load %c[%c2, %c1] : memref<4x4xf16>
+  %v22 = memref.load %c[%c2, %c2] : memref<4x4xf16>
+  %v23 = memref.load %c[%c2, %c3] : memref<4x4xf16>
+  call @print_row_f16(%i2, %v20, %v21, %v22, %v23) : (i32, f16, f16, f16, f16) -> ()
+  
+  // Row 3
+  %v30 = memref.load %c[%c3, %c0] : memref<4x4xf16>
+  %v31 = memref.load %c[%c3, %c1] : memref<4x4xf16>
+  %v32 = memref.load %c[%c3, %c2] : memref<4x4xf16>
+  %v33 = memref.load %c[%c3, %c3] : memref<4x4xf16>
+  call @print_row_f16(%i3, %v30, %v31, %v32, %v33) : (i32, f16, f16, f16, f16) -> ()
+  
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadot1.mlir
+++ b/examples/IMEDialect/vmadot1.mlir
@@ -1,0 +1,53 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vmadot1 operation (slide=1).
+// vmadot1 performs: C += slide(A, 1) × B where A, B are signed int8 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (64 elements), slides by 1 row.
+// Matrix dimensions for VLEN=256, SEW=8:
+// A: 8×8 (2M×K) source, sliding selects 4×8 (M×K) starting from row 1
+// B: 8×4 (K×N) - signed int8
+// C: 4×4 (M×N) - int32 accumulator
+
+memref.global "private" @matA : memref<8x8xi8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+memref.global "private" @matB : memref<8x4xi8> = dense<[
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x8xi8>
+  %b = memref.get_global @matB : memref<8x4xi8>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Perform signed × signed matrix multiply-accumulate with slide=1
+  // CHECK: ime.vmadot1
+  ime.vmadot1 %c, %a, %b : memref<4x4xi32>, memref<8x8xi8>, memref<8x4xi8>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadot1_print_test.mlir
+++ b/examples/IMEDialect/vmadot1_print_test.mlir
@@ -1,0 +1,95 @@
+// IME vmadot1 test: signed × signed matrix multiply-accumulate with fixed slide=1
+//
+// vmadot1 computes: C[i,j] += sum_k(signed(A[1+i,k]) * signed(B[j,k]))
+//
+// Sliding window reads 64 elements from VS1 (8 rows), then slides by 1 row.
+// A (8x8): signed int8, source matrix (needs 64 elements for sliding)
+// B (4x8): signed int8, packed form
+//
+// With slide=1:
+// A rows used = [1,2,3,4] (after sliding by 1)
+// Row 1 = [2,3,4,5,6,7,8,9], sum = 44
+// Row 2 = [3,4,5,6,7,8,9,10], sum = 52
+// Row 3 = [4,5,6,7,8,9,10,11], sum = 60
+// Row 4 = [5,6,7,8,9,10,11,12], sum = 68
+
+memref.global "private" @matA : memref<8x8xi8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+// Packed B (4x8): all ones for easy verification
+memref.global "private" @matB : memref<4x8xi8> = dense<[
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1]
+]>
+
+// With slide=1: Expected C = [[44,44,44,44], [52,52,52,52], [60,60,60,60], [68,68,68,68]]
+
+func.func private @print_row(i32, i32, i32, i32, i32)
+func.func private @print_header()
+
+func.func @main() -> i32 {
+  %a = memref.get_global @matA : memref<8x8xi8>
+  %b = memref.get_global @matB : memref<4x8xi8>
+  
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Perform vmadot1 (fixed slide=1)
+  ime.vmadot1 %c, %a, %b : memref<4x4xi32>, memref<8x8xi8>, memref<4x8xi8>
+  
+  // Print results
+  call @print_header() : () -> ()
+  
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %i0 = arith.constant 0 : i32
+  %i1 = arith.constant 1 : i32
+  %i2 = arith.constant 2 : i32
+  %i3 = arith.constant 3 : i32
+  
+  // Row 0
+  %v00 = memref.load %c[%c0, %c0] : memref<4x4xi32>
+  %v01 = memref.load %c[%c0, %c1] : memref<4x4xi32>
+  %v02 = memref.load %c[%c0, %c2] : memref<4x4xi32>
+  %v03 = memref.load %c[%c0, %c3] : memref<4x4xi32>
+  call @print_row(%i0, %v00, %v01, %v02, %v03) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 1
+  %v10 = memref.load %c[%c1, %c0] : memref<4x4xi32>
+  %v11 = memref.load %c[%c1, %c1] : memref<4x4xi32>
+  %v12 = memref.load %c[%c1, %c2] : memref<4x4xi32>
+  %v13 = memref.load %c[%c1, %c3] : memref<4x4xi32>
+  call @print_row(%i1, %v10, %v11, %v12, %v13) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 2
+  %v20 = memref.load %c[%c2, %c0] : memref<4x4xi32>
+  %v21 = memref.load %c[%c2, %c1] : memref<4x4xi32>
+  %v22 = memref.load %c[%c2, %c2] : memref<4x4xi32>
+  %v23 = memref.load %c[%c2, %c3] : memref<4x4xi32>
+  call @print_row(%i2, %v20, %v21, %v22, %v23) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 3
+  %v30 = memref.load %c[%c3, %c0] : memref<4x4xi32>
+  %v31 = memref.load %c[%c3, %c1] : memref<4x4xi32>
+  %v32 = memref.load %c[%c3, %c2] : memref<4x4xi32>
+  %v33 = memref.load %c[%c3, %c3] : memref<4x4xi32>
+  call @print_row(%i3, %v30, %v31, %v32, %v33) : (i32, i32, i32, i32, i32) -> ()
+  
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadot1_print_test.mlir
+++ b/examples/IMEDialect/vmadot1_print_test.mlir
@@ -1,4 +1,5 @@
-// IME vmadot1 test: signed × signed matrix multiply-accumulate with fixed slide=1
+// RUN: buddy-opt %s | FileCheck %s
+// CHECK: func.func @main
 //
 // vmadot1 computes: C[i,j] += sum_k(signed(A[1+i,k]) * signed(B[j,k]))
 //

--- a/examples/IMEDialect/vmadot1su.mlir
+++ b/examples/IMEDialect/vmadot1su.mlir
@@ -1,0 +1,53 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vmadot1su operation (slide=1, signed × unsigned).
+// vmadot1su performs: C += slide(A, 1) × B where A is signed, B is unsigned int8 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (64 elements), slides by 1 row.
+// Matrix dimensions for VLEN=256, SEW=8:
+// A: 8×8 (2M×K) source, sliding selects 4×8 (M×K) starting from row 1 - signed int8
+// B: 8×4 (K×N) - unsigned int8
+// C: 4×4 (M×N) - int32 accumulator
+
+memref.global "private" @matA : memref<8x8xi8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+memref.global "private" @matB : memref<8x4xui8> = dense<[
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x8xi8>
+  %b = memref.get_global @matB : memref<8x4xui8>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Perform signed × unsigned matrix multiply-accumulate with slide=1
+  // CHECK: ime.vmadot1su
+  ime.vmadot1su %c, %a, %b : memref<4x4xi32>, memref<8x8xi8>, memref<8x4xui8>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadot1u.mlir
+++ b/examples/IMEDialect/vmadot1u.mlir
@@ -1,0 +1,53 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vmadot1u operation (slide=1, unsigned × unsigned).
+// vmadot1u performs: C += slide(A, 1) × B where A, B are unsigned int8 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (64 elements), slides by 1 row.
+// Matrix dimensions for VLEN=256, SEW=8:
+// A: 8×8 (2M×K) source, sliding selects 4×8 (M×K) starting from row 1
+// B: 8×4 (K×N) - unsigned int8
+// C: 4×4 (M×N) - int32 accumulator
+
+memref.global "private" @matA : memref<8x8xui8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+memref.global "private" @matB : memref<8x4xui8> = dense<[
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x8xui8>
+  %b = memref.get_global @matB : memref<8x4xui8>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Perform unsigned × unsigned matrix multiply-accumulate with slide=1
+  // CHECK: ime.vmadot1u
+  ime.vmadot1u %c, %a, %b : memref<4x4xi32>, memref<8x8xui8>, memref<8x4xui8>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadot1us.mlir
+++ b/examples/IMEDialect/vmadot1us.mlir
@@ -1,0 +1,53 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vmadot1us operation (slide=1, unsigned × signed).
+// vmadot1us performs: C += slide(A, 1) × B where A is unsigned, B is signed int8 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (64 elements), slides by 1 row.
+// Matrix dimensions for VLEN=256, SEW=8:
+// A: 8×8 (2M×K) source, sliding selects 4×8 (M×K) starting from row 1 - unsigned int8
+// B: 8×4 (K×N) - signed int8
+// C: 4×4 (M×N) - int32 accumulator
+
+memref.global "private" @matA : memref<8x8xui8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+memref.global "private" @matB : memref<8x4xi8> = dense<[
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x8xui8>
+  %b = memref.get_global @matB : memref<8x4xi8>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Perform unsigned × signed matrix multiply-accumulate with slide=1
+  // CHECK: ime.vmadot1us
+  ime.vmadot1us %c, %a, %b : memref<4x4xi32>, memref<8x8xui8>, memref<8x4xi8>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadot2.mlir
+++ b/examples/IMEDialect/vmadot2.mlir
@@ -1,0 +1,53 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vmadot2 operation (slide=2).
+// vmadot2 performs: C += slide(A, 2) × B where A, B are signed int8 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (64 elements), slides by 2 rows.
+// Matrix dimensions for VLEN=256, SEW=8:
+// A: 8×8 (2M×K) source, sliding selects 4×8 (M×K) starting from row 2
+// B: 8×4 (K×N) - signed int8
+// C: 4×4 (M×N) - int32 accumulator
+
+memref.global "private" @matA : memref<8x8xi8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+memref.global "private" @matB : memref<8x4xi8> = dense<[
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x8xi8>
+  %b = memref.get_global @matB : memref<8x4xi8>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Perform signed × signed matrix multiply-accumulate with slide=2
+  // CHECK: ime.vmadot2
+  ime.vmadot2 %c, %a, %b : memref<4x4xi32>, memref<8x8xi8>, memref<8x4xi8>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadot2_print_test.mlir
+++ b/examples/IMEDialect/vmadot2_print_test.mlir
@@ -1,4 +1,5 @@
-// IME vmadot2 test: signed × signed matrix multiply-accumulate with fixed slide=2
+// RUN: buddy-opt %s | FileCheck %s
+// CHECK: func.func @main
 //
 // vmadot2 computes: C[i,j] += sum_k(signed(A[2+i,k]) * signed(B[j,k]))
 //

--- a/examples/IMEDialect/vmadot2_print_test.mlir
+++ b/examples/IMEDialect/vmadot2_print_test.mlir
@@ -1,0 +1,95 @@
+// IME vmadot2 test: signed × signed matrix multiply-accumulate with fixed slide=2
+//
+// vmadot2 computes: C[i,j] += sum_k(signed(A[2+i,k]) * signed(B[j,k]))
+//
+// Sliding window reads 64 elements from VS1 (8 rows), then slides by 2 rows.
+// A (8x8): signed int8, source matrix (needs 64 elements for sliding)
+// B (4x8): signed int8, packed form
+//
+// With slide=2:
+// A rows used = [2,3,4,5] (after sliding by 2)
+// Row 2 = [3,4,5,6,7,8,9,10], sum = 52
+// Row 3 = [4,5,6,7,8,9,10,11], sum = 60
+// Row 4 = [5,6,7,8,9,10,11,12], sum = 68
+// Row 5 = [6,7,8,9,10,11,12,13], sum = 76
+
+memref.global "private" @matA : memref<8x8xi8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+// Packed B (4x8): all ones for easy verification
+memref.global "private" @matB : memref<4x8xi8> = dense<[
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1]
+]>
+
+// With slide=2: Expected C = [[52,52,52,52], [60,60,60,60], [68,68,68,68], [76,76,76,76]]
+
+func.func private @print_row(i32, i32, i32, i32, i32)
+func.func private @print_header()
+
+func.func @main() -> i32 {
+  %a = memref.get_global @matA : memref<8x8xi8>
+  %b = memref.get_global @matB : memref<4x8xi8>
+  
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Perform vmadot2 (fixed slide=2)
+  ime.vmadot2 %c, %a, %b : memref<4x4xi32>, memref<8x8xi8>, memref<4x8xi8>
+  
+  // Print results
+  call @print_header() : () -> ()
+  
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %i0 = arith.constant 0 : i32
+  %i1 = arith.constant 1 : i32
+  %i2 = arith.constant 2 : i32
+  %i3 = arith.constant 3 : i32
+  
+  // Row 0
+  %v00 = memref.load %c[%c0, %c0] : memref<4x4xi32>
+  %v01 = memref.load %c[%c0, %c1] : memref<4x4xi32>
+  %v02 = memref.load %c[%c0, %c2] : memref<4x4xi32>
+  %v03 = memref.load %c[%c0, %c3] : memref<4x4xi32>
+  call @print_row(%i0, %v00, %v01, %v02, %v03) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 1
+  %v10 = memref.load %c[%c1, %c0] : memref<4x4xi32>
+  %v11 = memref.load %c[%c1, %c1] : memref<4x4xi32>
+  %v12 = memref.load %c[%c1, %c2] : memref<4x4xi32>
+  %v13 = memref.load %c[%c1, %c3] : memref<4x4xi32>
+  call @print_row(%i1, %v10, %v11, %v12, %v13) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 2
+  %v20 = memref.load %c[%c2, %c0] : memref<4x4xi32>
+  %v21 = memref.load %c[%c2, %c1] : memref<4x4xi32>
+  %v22 = memref.load %c[%c2, %c2] : memref<4x4xi32>
+  %v23 = memref.load %c[%c2, %c3] : memref<4x4xi32>
+  call @print_row(%i2, %v20, %v21, %v22, %v23) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 3
+  %v30 = memref.load %c[%c3, %c0] : memref<4x4xi32>
+  %v31 = memref.load %c[%c3, %c1] : memref<4x4xi32>
+  %v32 = memref.load %c[%c3, %c2] : memref<4x4xi32>
+  %v33 = memref.load %c[%c3, %c3] : memref<4x4xi32>
+  call @print_row(%i3, %v30, %v31, %v32, %v33) : (i32, i32, i32, i32, i32) -> ()
+  
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadot2su.mlir
+++ b/examples/IMEDialect/vmadot2su.mlir
@@ -1,0 +1,53 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vmadot2su operation (slide=2, signed × unsigned).
+// vmadot2su performs: C += slide(A, 2) × B where A is signed, B is unsigned int8 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (64 elements), slides by 2 rows.
+// Matrix dimensions for VLEN=256, SEW=8:
+// A: 8×8 (2M×K) source, sliding selects 4×8 (M×K) starting from row 2 - signed int8
+// B: 8×4 (K×N) - unsigned int8
+// C: 4×4 (M×N) - int32 accumulator
+
+memref.global "private" @matA : memref<8x8xi8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+memref.global "private" @matB : memref<8x4xui8> = dense<[
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x8xi8>
+  %b = memref.get_global @matB : memref<8x4xui8>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Perform signed × unsigned matrix multiply-accumulate with slide=2
+  // CHECK: ime.vmadot2su
+  ime.vmadot2su %c, %a, %b : memref<4x4xi32>, memref<8x8xi8>, memref<8x4xui8>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadot2u.mlir
+++ b/examples/IMEDialect/vmadot2u.mlir
@@ -1,0 +1,53 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vmadot2u operation (slide=2, unsigned × unsigned).
+// vmadot2u performs: C += slide(A, 2) × B where A, B are unsigned int8 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (64 elements), slides by 2 rows.
+// Matrix dimensions for VLEN=256, SEW=8:
+// A: 8×8 (2M×K) source, sliding selects 4×8 (M×K) starting from row 2
+// B: 8×4 (K×N) - unsigned int8
+// C: 4×4 (M×N) - int32 accumulator
+
+memref.global "private" @matA : memref<8x8xui8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+memref.global "private" @matB : memref<8x4xui8> = dense<[
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x8xui8>
+  %b = memref.get_global @matB : memref<8x4xui8>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Perform unsigned × unsigned matrix multiply-accumulate with slide=2
+  // CHECK: ime.vmadot2u
+  ime.vmadot2u %c, %a, %b : memref<4x4xi32>, memref<8x8xui8>, memref<8x4xui8>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadot2us.mlir
+++ b/examples/IMEDialect/vmadot2us.mlir
@@ -1,0 +1,53 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vmadot2us operation (slide=2, unsigned × signed).
+// vmadot2us performs: C += slide(A, 2) × B where A is unsigned, B is signed int8 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (64 elements), slides by 2 rows.
+// Matrix dimensions for VLEN=256, SEW=8:
+// A: 8×8 (2M×K) source, sliding selects 4×8 (M×K) starting from row 2 - unsigned int8
+// B: 8×4 (K×N) - signed int8
+// C: 4×4 (M×N) - int32 accumulator
+
+memref.global "private" @matA : memref<8x8xui8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+memref.global "private" @matB : memref<8x4xi8> = dense<[
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x8xui8>
+  %b = memref.get_global @matB : memref<8x4xi8>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Perform unsigned × signed matrix multiply-accumulate with slide=2
+  // CHECK: ime.vmadot2us
+  ime.vmadot2us %c, %a, %b : memref<4x4xi32>, memref<8x8xui8>, memref<8x4xi8>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadot3.mlir
+++ b/examples/IMEDialect/vmadot3.mlir
@@ -1,0 +1,53 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vmadot3 operation (slide=3).
+// vmadot3 performs: C += slide(A, 3) × B where A, B are signed int8 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (64 elements), slides by 3 rows.
+// Matrix dimensions for VLEN=256, SEW=8:
+// A: 8×8 (2M×K) source, sliding selects 4×8 (M×K) starting from row 3
+// B: 8×4 (K×N) - signed int8
+// C: 4×4 (M×N) - int32 accumulator
+
+memref.global "private" @matA : memref<8x8xi8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+memref.global "private" @matB : memref<8x4xi8> = dense<[
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x8xi8>
+  %b = memref.get_global @matB : memref<8x4xi8>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Perform signed × signed matrix multiply-accumulate with slide=3
+  // CHECK: ime.vmadot3
+  ime.vmadot3 %c, %a, %b : memref<4x4xi32>, memref<8x8xi8>, memref<8x4xi8>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadot3_print_test.mlir
+++ b/examples/IMEDialect/vmadot3_print_test.mlir
@@ -1,4 +1,5 @@
-// IME vmadot3 test: signed × signed matrix multiply-accumulate with fixed slide=3
+// RUN: buddy-opt %s | FileCheck %s
+// CHECK: func.func @main
 //
 // vmadot3 computes: C[i,j] += sum_k(signed(A[3+i,k]) * signed(B[j,k]))
 //

--- a/examples/IMEDialect/vmadot3_print_test.mlir
+++ b/examples/IMEDialect/vmadot3_print_test.mlir
@@ -1,0 +1,95 @@
+// IME vmadot3 test: signed × signed matrix multiply-accumulate with fixed slide=3
+//
+// vmadot3 computes: C[i,j] += sum_k(signed(A[3+i,k]) * signed(B[j,k]))
+//
+// Sliding window reads 64 elements from VS1 (8 rows), then slides by 3 rows.
+// A (8x8): signed int8, source matrix (needs 64 elements for sliding)
+// B (4x8): signed int8, packed form
+//
+// With slide=3:
+// A rows used = [3,4,5,6] (after sliding by 3)
+// Row 3 = [4,5,6,7,8,9,10,11], sum = 60
+// Row 4 = [5,6,7,8,9,10,11,12], sum = 68
+// Row 5 = [6,7,8,9,10,11,12,13], sum = 76
+// Row 6 = [7,8,9,10,11,12,13,14], sum = 84
+
+memref.global "private" @matA : memref<8x8xi8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+// Packed B (4x8): all ones for easy verification
+memref.global "private" @matB : memref<4x8xi8> = dense<[
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1]
+]>
+
+// With slide=3: Expected C = [[60,60,60,60], [68,68,68,68], [76,76,76,76], [84,84,84,84]]
+
+func.func private @print_row(i32, i32, i32, i32, i32)
+func.func private @print_header()
+
+func.func @main() -> i32 {
+  %a = memref.get_global @matA : memref<8x8xi8>
+  %b = memref.get_global @matB : memref<4x8xi8>
+  
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Perform vmadot3 (fixed slide=3)
+  ime.vmadot3 %c, %a, %b : memref<4x4xi32>, memref<8x8xi8>, memref<4x8xi8>
+  
+  // Print results
+  call @print_header() : () -> ()
+  
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %i0 = arith.constant 0 : i32
+  %i1 = arith.constant 1 : i32
+  %i2 = arith.constant 2 : i32
+  %i3 = arith.constant 3 : i32
+  
+  // Row 0
+  %v00 = memref.load %c[%c0, %c0] : memref<4x4xi32>
+  %v01 = memref.load %c[%c0, %c1] : memref<4x4xi32>
+  %v02 = memref.load %c[%c0, %c2] : memref<4x4xi32>
+  %v03 = memref.load %c[%c0, %c3] : memref<4x4xi32>
+  call @print_row(%i0, %v00, %v01, %v02, %v03) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 1
+  %v10 = memref.load %c[%c1, %c0] : memref<4x4xi32>
+  %v11 = memref.load %c[%c1, %c1] : memref<4x4xi32>
+  %v12 = memref.load %c[%c1, %c2] : memref<4x4xi32>
+  %v13 = memref.load %c[%c1, %c3] : memref<4x4xi32>
+  call @print_row(%i1, %v10, %v11, %v12, %v13) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 2
+  %v20 = memref.load %c[%c2, %c0] : memref<4x4xi32>
+  %v21 = memref.load %c[%c2, %c1] : memref<4x4xi32>
+  %v22 = memref.load %c[%c2, %c2] : memref<4x4xi32>
+  %v23 = memref.load %c[%c2, %c3] : memref<4x4xi32>
+  call @print_row(%i2, %v20, %v21, %v22, %v23) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 3
+  %v30 = memref.load %c[%c3, %c0] : memref<4x4xi32>
+  %v31 = memref.load %c[%c3, %c1] : memref<4x4xi32>
+  %v32 = memref.load %c[%c3, %c2] : memref<4x4xi32>
+  %v33 = memref.load %c[%c3, %c3] : memref<4x4xi32>
+  call @print_row(%i3, %v30, %v31, %v32, %v33) : (i32, i32, i32, i32, i32) -> ()
+  
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadot3su.mlir
+++ b/examples/IMEDialect/vmadot3su.mlir
@@ -1,0 +1,53 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vmadot3su operation (slide=3, signed × unsigned).
+// vmadot3su performs: C += slide(A, 3) × B where A is signed, B is unsigned int8 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (64 elements), slides by 3 rows.
+// Matrix dimensions for VLEN=256, SEW=8:
+// A: 8×8 (2M×K) source, sliding selects 4×8 (M×K) starting from row 3 - signed int8
+// B: 8×4 (K×N) - unsigned int8
+// C: 4×4 (M×N) - int32 accumulator
+
+memref.global "private" @matA : memref<8x8xi8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+memref.global "private" @matB : memref<8x4xui8> = dense<[
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x8xi8>
+  %b = memref.get_global @matB : memref<8x4xui8>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Perform signed × unsigned matrix multiply-accumulate with slide=3
+  // CHECK: ime.vmadot3su
+  ime.vmadot3su %c, %a, %b : memref<4x4xi32>, memref<8x8xi8>, memref<8x4xui8>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadot3u.mlir
+++ b/examples/IMEDialect/vmadot3u.mlir
@@ -1,0 +1,53 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vmadot3u operation (slide=3, unsigned × unsigned).
+// vmadot3u performs: C += slide(A, 3) × B where A, B are unsigned int8 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (64 elements), slides by 3 rows.
+// Matrix dimensions for VLEN=256, SEW=8:
+// A: 8×8 (2M×K) source, sliding selects 4×8 (M×K) starting from row 3
+// B: 8×4 (K×N) - unsigned int8
+// C: 4×4 (M×N) - int32 accumulator
+
+memref.global "private" @matA : memref<8x8xui8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+memref.global "private" @matB : memref<8x4xui8> = dense<[
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x8xui8>
+  %b = memref.get_global @matB : memref<8x4xui8>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Perform unsigned × unsigned matrix multiply-accumulate with slide=3
+  // CHECK: ime.vmadot3u
+  ime.vmadot3u %c, %a, %b : memref<4x4xi32>, memref<8x8xui8>, memref<8x4xui8>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadot3us.mlir
+++ b/examples/IMEDialect/vmadot3us.mlir
@@ -1,0 +1,53 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vmadot3us operation (slide=3, unsigned × signed).
+// vmadot3us performs: C += slide(A, 3) × B where A is unsigned, B is signed int8 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (64 elements), slides by 3 rows.
+// Matrix dimensions for VLEN=256, SEW=8:
+// A: 8×8 (2M×K) source, sliding selects 4×8 (M×K) starting from row 3 - unsigned int8
+// B: 8×4 (K×N) - signed int8
+// C: 4×4 (M×N) - int32 accumulator
+
+memref.global "private" @matA : memref<8x8xui8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+memref.global "private" @matB : memref<8x4xi8> = dense<[
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x8xui8>
+  %b = memref.get_global @matB : memref<8x4xi8>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Perform unsigned × signed matrix multiply-accumulate with slide=3
+  // CHECK: ime.vmadot3us
+  ime.vmadot3us %c, %a, %b : memref<4x4xi32>, memref<8x8xui8>, memref<8x4xi8>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadot_print_test.mlir
+++ b/examples/IMEDialect/vmadot_print_test.mlir
@@ -1,4 +1,5 @@
-// IME vmadot test: signed × signed matrix multiply-accumulate
+// RUN: buddy-opt %s | FileCheck %s
+// CHECK: func.func @main
 //
 // vmadot computes: C[i,j] += sum_k(signed(A[i,k]) * signed(B[j,k]))
 //

--- a/examples/IMEDialect/vmadotn.mlir
+++ b/examples/IMEDialect/vmadotn.mlir
@@ -1,0 +1,56 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vmadotn operation with dynamic slide parameter.
+// vmadotn performs: C += slide(A, n) × B where A, B are signed int8 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (64 elements), slides by n rows.
+// Matrix dimensions for VLEN=256, SEW=8:
+// A: 8×8 (2M×K) source, sliding selects 4×8 (M×K) - signed int8
+// B: 8×4 (K×N) - signed int8
+// C: 4×4 (M×N) - int32 accumulator
+
+memref.global "private" @matA : memref<8x8xi8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+memref.global "private" @matB : memref<8x4xi8> = dense<[
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x8xi8>
+  %b = memref.get_global @matB : memref<8x4xi8>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Slide parameter (0-3)
+  %slide = arith.constant 1 : i64
+  
+  // Perform signed × signed matrix multiply-accumulate with dynamic slide
+  // CHECK: ime.vmadotn
+  ime.vmadotn %c, %a, %b, %slide : memref<4x4xi32>, memref<8x8xi8>, memref<8x4xi8>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadotn_print_test.mlir
+++ b/examples/IMEDialect/vmadotn_print_test.mlir
@@ -1,0 +1,98 @@
+// IME vmadotn test: signed × signed matrix multiply-accumulate with dynamic slide
+//
+// vmadotn computes: C[i,j] += sum_k(signed(A[slide+i,k]) * signed(B[j,k]))
+//
+// Sliding window reads 64 elements from VS1 (8 rows), then slides by n rows.
+// A (8x8): signed int8, source matrix (needs 64 elements for sliding)
+// B (4x8): signed int8, packed form
+//
+// With slide=1:
+// A rows used = [1,2,3,4] (after sliding by 1)
+// Row 1 = [2,3,4,5,6,7,8,9], sum = 44
+// Row 2 = [3,4,5,6,7,8,9,10], sum = 52
+// Row 3 = [4,5,6,7,8,9,10,11], sum = 60
+// Row 4 = [5,6,7,8,9,10,11,12], sum = 68
+
+memref.global "private" @matA : memref<8x8xi8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+// Packed B (4x8): all ones for easy verification
+memref.global "private" @matB : memref<4x8xi8> = dense<[
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1]
+]>
+
+// With slide=1: Expected C = [[44,44,44,44], [52,52,52,52], [60,60,60,60], [68,68,68,68]]
+
+func.func private @print_row(i32, i32, i32, i32, i32)
+func.func private @print_header()
+
+func.func @main() -> i32 {
+  %a = memref.get_global @matA : memref<8x8xi8>
+  %b = memref.get_global @matB : memref<4x8xi8>
+  
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Slide parameter = 1
+  %slide = arith.constant 1 : i64
+  
+  // Perform vmadotn with slide=1
+  ime.vmadotn %c, %a, %b, %slide : memref<4x4xi32>, memref<8x8xi8>, memref<4x8xi8>
+  
+  // Print results
+  call @print_header() : () -> ()
+  
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %i0 = arith.constant 0 : i32
+  %i1 = arith.constant 1 : i32
+  %i2 = arith.constant 2 : i32
+  %i3 = arith.constant 3 : i32
+  
+  // Row 0
+  %v00 = memref.load %c[%c0, %c0] : memref<4x4xi32>
+  %v01 = memref.load %c[%c0, %c1] : memref<4x4xi32>
+  %v02 = memref.load %c[%c0, %c2] : memref<4x4xi32>
+  %v03 = memref.load %c[%c0, %c3] : memref<4x4xi32>
+  call @print_row(%i0, %v00, %v01, %v02, %v03) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 1
+  %v10 = memref.load %c[%c1, %c0] : memref<4x4xi32>
+  %v11 = memref.load %c[%c1, %c1] : memref<4x4xi32>
+  %v12 = memref.load %c[%c1, %c2] : memref<4x4xi32>
+  %v13 = memref.load %c[%c1, %c3] : memref<4x4xi32>
+  call @print_row(%i1, %v10, %v11, %v12, %v13) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 2
+  %v20 = memref.load %c[%c2, %c0] : memref<4x4xi32>
+  %v21 = memref.load %c[%c2, %c1] : memref<4x4xi32>
+  %v22 = memref.load %c[%c2, %c2] : memref<4x4xi32>
+  %v23 = memref.load %c[%c2, %c3] : memref<4x4xi32>
+  call @print_row(%i2, %v20, %v21, %v22, %v23) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 3
+  %v30 = memref.load %c[%c3, %c0] : memref<4x4xi32>
+  %v31 = memref.load %c[%c3, %c1] : memref<4x4xi32>
+  %v32 = memref.load %c[%c3, %c2] : memref<4x4xi32>
+  %v33 = memref.load %c[%c3, %c3] : memref<4x4xi32>
+  call @print_row(%i3, %v30, %v31, %v32, %v33) : (i32, i32, i32, i32, i32) -> ()
+  
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadotn_print_test.mlir
+++ b/examples/IMEDialect/vmadotn_print_test.mlir
@@ -1,4 +1,5 @@
-// IME vmadotn test: signed × signed matrix multiply-accumulate with dynamic slide
+// RUN: buddy-opt %s | FileCheck %s
+// CHECK: func.func @main
 //
 // vmadotn computes: C[i,j] += sum_k(signed(A[slide+i,k]) * signed(B[j,k]))
 //

--- a/examples/IMEDialect/vmadotnsu.mlir
+++ b/examples/IMEDialect/vmadotnsu.mlir
@@ -1,0 +1,56 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vmadotnsu operation with dynamic slide parameter.
+// vmadotnsu performs: C += slide(A, n) × B where A is signed, B is unsigned int8.
+//
+// Sliding window: reads from VS1 and VS1+1 (64 elements), slides by n rows.
+// Matrix dimensions for VLEN=256, SEW=8:
+// A: 8×8 (2M×K) source, sliding selects 4×8 (M×K) - signed int8
+// B: 8×4 (K×N) - unsigned int8
+// C: 4×4 (M×N) - int32 accumulator
+
+memref.global "private" @matA : memref<8x8xi8> = dense<[
+  [-1, -2, -3, -4, -5, -6, -7, -8],
+  [-2, -3, -4, -5, -6, -7, -8, -9],
+  [-3, -4, -5, -6, -7, -8, -9, -10],
+  [-4, -5, -6, -7, -8, -9, -10, -11],
+  [-5, -6, -7, -8, -9, -10, -11, -12],
+  [-6, -7, -8, -9, -10, -11, -12, -13],
+  [-7, -8, -9, -10, -11, -12, -13, -14],
+  [-8, -9, -10, -11, -12, -13, -14, -15]
+]>
+
+memref.global "private" @matB : memref<8x4xui8> = dense<[
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x8xi8>
+  %b = memref.get_global @matB : memref<8x4xui8>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Slide parameter (0-3)
+  %slide = arith.constant 1 : i64
+  
+  // Perform signed × unsigned matrix multiply-accumulate with dynamic slide
+  // CHECK: ime.vmadotnsu
+  ime.vmadotnsu %c, %a, %b, %slide : memref<4x4xi32>, memref<8x8xi8>, memref<8x4xui8>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadotnsu_print_test.mlir
+++ b/examples/IMEDialect/vmadotnsu_print_test.mlir
@@ -26,7 +26,7 @@ memref.global "private" @matA : memref<8x8xi8> = dense<[
 ]>
 
 // Packed B (4x8): all ones (unsigned)
-memref.global "private" @matB : memref<4x8xi8> = dense<[
+memref.global "private" @matB : memref<4x8xui8> = dense<[
   [1, 1, 1, 1, 1, 1, 1, 1],
   [1, 1, 1, 1, 1, 1, 1, 1],
   [1, 1, 1, 1, 1, 1, 1, 1],
@@ -40,7 +40,7 @@ func.func private @print_header()
 
 func.func @main() -> i32 {
   %a = memref.get_global @matA : memref<8x8xi8>
-  %b = memref.get_global @matB : memref<4x8xi8>
+  %b = memref.get_global @matB : memref<4x8xui8>
   
   %c = memref.alloc() : memref<4x4xi32>
   
@@ -52,7 +52,7 @@ func.func @main() -> i32 {
   %slide = arith.constant 1 : i64
   
   // Perform vmadotnsu with slide=1
-  ime.vmadotnsu %c, %a, %b, %slide : memref<4x4xi32>, memref<8x8xi8>, memref<4x8xi8>
+  ime.vmadotnsu %c, %a, %b, %slide : memref<4x4xi32>, memref<8x8xi8>, memref<4x8xui8>
   
   // Print results
   call @print_header() : () -> ()

--- a/examples/IMEDialect/vmadotnsu_print_test.mlir
+++ b/examples/IMEDialect/vmadotnsu_print_test.mlir
@@ -1,4 +1,5 @@
-// IME vmadotnsu test: signed × unsigned matrix multiply-accumulate with dynamic slide
+// RUN: buddy-opt %s | FileCheck %s
+// CHECK: func.func @main
 //
 // vmadotnsu computes: C[i,j] += sum_k(signed(A[slide+i,k]) * unsigned(B[j,k]))
 //

--- a/examples/IMEDialect/vmadotnsu_print_test.mlir
+++ b/examples/IMEDialect/vmadotnsu_print_test.mlir
@@ -1,0 +1,98 @@
+// IME vmadotnsu test: signed × unsigned matrix multiply-accumulate with dynamic slide
+//
+// vmadotnsu computes: C[i,j] += sum_k(signed(A[slide+i,k]) * unsigned(B[j,k]))
+//
+// Sliding window reads 64 elements from VS1 (8 rows), then slides by n rows.
+// A (8x8): signed int8, source matrix (negative values)
+// B (4x8): unsigned int8, packed form
+//
+// With slide=1:
+// A rows used = [1,2,3,4] (after sliding by 1)
+// Row 1 = [-2,-3,-4,-5,-6,-7,-8,-9], sum = -44
+// Row 2 = [-3,-4,-5,-6,-7,-8,-9,-10], sum = -52
+// Row 3 = [-4,-5,-6,-7,-8,-9,-10,-11], sum = -60
+// Row 4 = [-5,-6,-7,-8,-9,-10,-11,-12], sum = -68
+
+memref.global "private" @matA : memref<8x8xi8> = dense<[
+  [-1, -2, -3, -4, -5, -6, -7, -8],
+  [-2, -3, -4, -5, -6, -7, -8, -9],
+  [-3, -4, -5, -6, -7, -8, -9, -10],
+  [-4, -5, -6, -7, -8, -9, -10, -11],
+  [-5, -6, -7, -8, -9, -10, -11, -12],
+  [-6, -7, -8, -9, -10, -11, -12, -13],
+  [-7, -8, -9, -10, -11, -12, -13, -14],
+  [-8, -9, -10, -11, -12, -13, -14, -15]
+]>
+
+// Packed B (4x8): all ones (unsigned)
+memref.global "private" @matB : memref<4x8xi8> = dense<[
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1]
+]>
+
+// With slide=1: Expected C = [[-44,-44,-44,-44], [-52,-52,-52,-52], [-60,-60,-60,-60], [-68,-68,-68,-68]]
+
+func.func private @print_row(i32, i32, i32, i32, i32)
+func.func private @print_header()
+
+func.func @main() -> i32 {
+  %a = memref.get_global @matA : memref<8x8xi8>
+  %b = memref.get_global @matB : memref<4x8xi8>
+  
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Slide parameter = 1
+  %slide = arith.constant 1 : i64
+  
+  // Perform vmadotnsu with slide=1
+  ime.vmadotnsu %c, %a, %b, %slide : memref<4x4xi32>, memref<8x8xi8>, memref<4x8xi8>
+  
+  // Print results
+  call @print_header() : () -> ()
+  
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %i0 = arith.constant 0 : i32
+  %i1 = arith.constant 1 : i32
+  %i2 = arith.constant 2 : i32
+  %i3 = arith.constant 3 : i32
+  
+  // Row 0
+  %v00 = memref.load %c[%c0, %c0] : memref<4x4xi32>
+  %v01 = memref.load %c[%c0, %c1] : memref<4x4xi32>
+  %v02 = memref.load %c[%c0, %c2] : memref<4x4xi32>
+  %v03 = memref.load %c[%c0, %c3] : memref<4x4xi32>
+  call @print_row(%i0, %v00, %v01, %v02, %v03) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 1
+  %v10 = memref.load %c[%c1, %c0] : memref<4x4xi32>
+  %v11 = memref.load %c[%c1, %c1] : memref<4x4xi32>
+  %v12 = memref.load %c[%c1, %c2] : memref<4x4xi32>
+  %v13 = memref.load %c[%c1, %c3] : memref<4x4xi32>
+  call @print_row(%i1, %v10, %v11, %v12, %v13) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 2
+  %v20 = memref.load %c[%c2, %c0] : memref<4x4xi32>
+  %v21 = memref.load %c[%c2, %c1] : memref<4x4xi32>
+  %v22 = memref.load %c[%c2, %c2] : memref<4x4xi32>
+  %v23 = memref.load %c[%c2, %c3] : memref<4x4xi32>
+  call @print_row(%i2, %v20, %v21, %v22, %v23) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 3
+  %v30 = memref.load %c[%c3, %c0] : memref<4x4xi32>
+  %v31 = memref.load %c[%c3, %c1] : memref<4x4xi32>
+  %v32 = memref.load %c[%c3, %c2] : memref<4x4xi32>
+  %v33 = memref.load %c[%c3, %c3] : memref<4x4xi32>
+  call @print_row(%i3, %v30, %v31, %v32, %v33) : (i32, i32, i32, i32, i32) -> ()
+  
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadotnu.mlir
+++ b/examples/IMEDialect/vmadotnu.mlir
@@ -1,0 +1,56 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vmadotnu operation with dynamic slide parameter.
+// vmadotnu performs: C += slide(A, n) × B where A, B are unsigned int8 matrices.
+//
+// Sliding window: reads from VS1 and VS1+1 (64 elements), slides by n rows.
+// Matrix dimensions for VLEN=256, SEW=8:
+// A: 8×8 (2M×K) source, sliding selects 4×8 (M×K) - unsigned int8
+// B: 8×4 (K×N) - unsigned int8
+// C: 4×4 (M×N) - int32 accumulator
+
+memref.global "private" @matA : memref<8x8xui8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+memref.global "private" @matB : memref<8x4xui8> = dense<[
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 1]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x8xui8>
+  %b = memref.get_global @matB : memref<8x4xui8>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Slide parameter (0-3)
+  %slide = arith.constant 2 : i64
+  
+  // Perform unsigned × unsigned matrix multiply-accumulate with dynamic slide
+  // CHECK: ime.vmadotnu
+  ime.vmadotnu %c, %a, %b, %slide : memref<4x4xi32>, memref<8x8xui8>, memref<8x4xui8>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadotnu_print_test.mlir
+++ b/examples/IMEDialect/vmadotnu_print_test.mlir
@@ -1,4 +1,5 @@
-// IME vmadotnu test: unsigned × unsigned matrix multiply-accumulate with dynamic slide
+// RUN: buddy-opt %s | FileCheck %s
+// CHECK: func.func @main
 //
 // vmadotnu computes: C[i,j] += sum_k(unsigned(A[slide+i,k]) * unsigned(B[j,k]))
 //

--- a/examples/IMEDialect/vmadotnu_print_test.mlir
+++ b/examples/IMEDialect/vmadotnu_print_test.mlir
@@ -1,0 +1,98 @@
+// IME vmadotnu test: unsigned × unsigned matrix multiply-accumulate with dynamic slide
+//
+// vmadotnu computes: C[i,j] += sum_k(unsigned(A[slide+i,k]) * unsigned(B[j,k]))
+//
+// Sliding window reads 64 elements from VS1 (8 rows), then slides by n rows.
+// A (8x8): unsigned int8, source matrix
+// B (4x8): unsigned int8, packed form
+//
+// With slide=2:
+// A rows used = [2,3,4,5] (after sliding by 2)
+// Row 2 = [3,4,5,6,7,8,9,10], sum = 52
+// Row 3 = [4,5,6,7,8,9,10,11], sum = 60
+// Row 4 = [5,6,7,8,9,10,11,12], sum = 68
+// Row 5 = [6,7,8,9,10,11,12,13], sum = 76
+
+memref.global "private" @matA : memref<8x8xi8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+// Packed B (4x8): all ones for easy verification
+memref.global "private" @matB : memref<4x8xi8> = dense<[
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1]
+]>
+
+// With slide=2: Expected C = [[52,52,52,52], [60,60,60,60], [68,68,68,68], [76,76,76,76]]
+
+func.func private @print_row(i32, i32, i32, i32, i32)
+func.func private @print_header()
+
+func.func @main() -> i32 {
+  %a = memref.get_global @matA : memref<8x8xi8>
+  %b = memref.get_global @matB : memref<4x8xi8>
+  
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Slide parameter = 2
+  %slide = arith.constant 2 : i64
+  
+  // Perform vmadotnu with slide=2
+  ime.vmadotnu %c, %a, %b, %slide : memref<4x4xi32>, memref<8x8xi8>, memref<4x8xi8>
+  
+  // Print results
+  call @print_header() : () -> ()
+  
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %i0 = arith.constant 0 : i32
+  %i1 = arith.constant 1 : i32
+  %i2 = arith.constant 2 : i32
+  %i3 = arith.constant 3 : i32
+  
+  // Row 0
+  %v00 = memref.load %c[%c0, %c0] : memref<4x4xi32>
+  %v01 = memref.load %c[%c0, %c1] : memref<4x4xi32>
+  %v02 = memref.load %c[%c0, %c2] : memref<4x4xi32>
+  %v03 = memref.load %c[%c0, %c3] : memref<4x4xi32>
+  call @print_row(%i0, %v00, %v01, %v02, %v03) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 1
+  %v10 = memref.load %c[%c1, %c0] : memref<4x4xi32>
+  %v11 = memref.load %c[%c1, %c1] : memref<4x4xi32>
+  %v12 = memref.load %c[%c1, %c2] : memref<4x4xi32>
+  %v13 = memref.load %c[%c1, %c3] : memref<4x4xi32>
+  call @print_row(%i1, %v10, %v11, %v12, %v13) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 2
+  %v20 = memref.load %c[%c2, %c0] : memref<4x4xi32>
+  %v21 = memref.load %c[%c2, %c1] : memref<4x4xi32>
+  %v22 = memref.load %c[%c2, %c2] : memref<4x4xi32>
+  %v23 = memref.load %c[%c2, %c3] : memref<4x4xi32>
+  call @print_row(%i2, %v20, %v21, %v22, %v23) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 3
+  %v30 = memref.load %c[%c3, %c0] : memref<4x4xi32>
+  %v31 = memref.load %c[%c3, %c1] : memref<4x4xi32>
+  %v32 = memref.load %c[%c3, %c2] : memref<4x4xi32>
+  %v33 = memref.load %c[%c3, %c3] : memref<4x4xi32>
+  call @print_row(%i3, %v30, %v31, %v32, %v33) : (i32, i32, i32, i32, i32) -> ()
+  
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadotnu_print_test.mlir
+++ b/examples/IMEDialect/vmadotnu_print_test.mlir
@@ -14,7 +14,7 @@
 // Row 4 = [5,6,7,8,9,10,11,12], sum = 68
 // Row 5 = [6,7,8,9,10,11,12,13], sum = 76
 
-memref.global "private" @matA : memref<8x8xi8> = dense<[
+memref.global "private" @matA : memref<8x8xui8> = dense<[
   [1, 2, 3, 4, 5, 6, 7, 8],
   [2, 3, 4, 5, 6, 7, 8, 9],
   [3, 4, 5, 6, 7, 8, 9, 10],
@@ -26,7 +26,7 @@ memref.global "private" @matA : memref<8x8xi8> = dense<[
 ]>
 
 // Packed B (4x8): all ones for easy verification
-memref.global "private" @matB : memref<4x8xi8> = dense<[
+memref.global "private" @matB : memref<4x8xui8> = dense<[
   [1, 1, 1, 1, 1, 1, 1, 1],
   [1, 1, 1, 1, 1, 1, 1, 1],
   [1, 1, 1, 1, 1, 1, 1, 1],
@@ -39,8 +39,8 @@ func.func private @print_row(i32, i32, i32, i32, i32)
 func.func private @print_header()
 
 func.func @main() -> i32 {
-  %a = memref.get_global @matA : memref<8x8xi8>
-  %b = memref.get_global @matB : memref<4x8xi8>
+  %a = memref.get_global @matA : memref<8x8xui8>
+  %b = memref.get_global @matB : memref<4x8xui8>
   
   %c = memref.alloc() : memref<4x4xi32>
   
@@ -52,7 +52,7 @@ func.func @main() -> i32 {
   %slide = arith.constant 2 : i64
   
   // Perform vmadotnu with slide=2
-  ime.vmadotnu %c, %a, %b, %slide : memref<4x4xi32>, memref<8x8xi8>, memref<4x8xi8>
+  ime.vmadotnu %c, %a, %b, %slide : memref<4x4xi32>, memref<8x8xui8>, memref<4x8xui8>
   
   // Print results
   call @print_header() : () -> ()

--- a/examples/IMEDialect/vmadotnus.mlir
+++ b/examples/IMEDialect/vmadotnus.mlir
@@ -1,0 +1,56 @@
+// RUN: buddy-opt %s | FileCheck %s
+
+// This example demonstrates the IME vmadotnus operation with dynamic slide parameter.
+// vmadotnus performs: C += slide(A, n) × B where A is unsigned, B is signed int8.
+//
+// Sliding window: reads from VS1 and VS1+1 (64 elements), slides by n rows.
+// Matrix dimensions for VLEN=256, SEW=8:
+// A: 8×8 (2M×K) source, sliding selects 4×8 (M×K) - unsigned int8
+// B: 8×4 (K×N) - signed int8
+// C: 4×4 (M×N) - int32 accumulator
+
+memref.global "private" @matA : memref<8x8xui8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+memref.global "private" @matB : memref<8x4xi8> = dense<[
+  [-1, -1, -1, -1],
+  [-1, -1, -1, -1],
+  [-1, -1, -1, -1],
+  [-1, -1, -1, -1],
+  [-1, -1, -1, -1],
+  [-1, -1, -1, -1],
+  [-1, -1, -1, -1],
+  [-1, -1, -1, -1]
+]>
+
+func.func @main() -> i32 {
+  // Get input matrices
+  %a = memref.get_global @matA : memref<8x8xui8>
+  %b = memref.get_global @matB : memref<8x4xi8>
+  
+  // Allocate output matrix (accumulator)
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize accumulator to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Slide parameter (0-3)
+  %slide = arith.constant 3 : i64
+  
+  // Perform unsigned × signed matrix multiply-accumulate with dynamic slide
+  // CHECK: ime.vmadotnus
+  ime.vmadotnus %c, %a, %b, %slide : memref<4x4xi32>, memref<8x8xui8>, memref<8x4xi8>
+  
+  // Return success
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadotnus_print_test.mlir
+++ b/examples/IMEDialect/vmadotnus_print_test.mlir
@@ -1,4 +1,5 @@
-// IME vmadotnus test: unsigned × signed matrix multiply-accumulate with dynamic slide
+// RUN: buddy-opt %s | FileCheck %s
+// CHECK: func.func @main
 //
 // vmadotnus computes: C[i,j] += sum_k(unsigned(A[slide+i,k]) * signed(B[j,k]))
 //

--- a/examples/IMEDialect/vmadotnus_print_test.mlir
+++ b/examples/IMEDialect/vmadotnus_print_test.mlir
@@ -1,0 +1,98 @@
+// IME vmadotnus test: unsigned × signed matrix multiply-accumulate with dynamic slide
+//
+// vmadotnus computes: C[i,j] += sum_k(unsigned(A[slide+i,k]) * signed(B[j,k]))
+//
+// Sliding window reads 64 elements from VS1 (8 rows), then slides by n rows.
+// A (8x8): unsigned int8, source matrix
+// B (4x8): signed int8, packed form (negative values)
+//
+// With slide=3:
+// A rows used = [3,4,5,6] (after sliding by 3)
+// Row 3 = [4,5,6,7,8,9,10,11], sum with B=-1 each: -60
+// Row 4 = [5,6,7,8,9,10,11,12], sum = -68
+// Row 5 = [6,7,8,9,10,11,12,13], sum = -76
+// Row 6 = [7,8,9,10,11,12,13,14], sum = -84
+
+memref.global "private" @matA : memref<8x8xi8> = dense<[
+  [1, 2, 3, 4, 5, 6, 7, 8],
+  [2, 3, 4, 5, 6, 7, 8, 9],
+  [3, 4, 5, 6, 7, 8, 9, 10],
+  [4, 5, 6, 7, 8, 9, 10, 11],
+  [5, 6, 7, 8, 9, 10, 11, 12],
+  [6, 7, 8, 9, 10, 11, 12, 13],
+  [7, 8, 9, 10, 11, 12, 13, 14],
+  [8, 9, 10, 11, 12, 13, 14, 15]
+]>
+
+// Packed B (4x8): all -1 (signed)
+memref.global "private" @matB : memref<4x8xi8> = dense<[
+  [-1, -1, -1, -1, -1, -1, -1, -1],
+  [-1, -1, -1, -1, -1, -1, -1, -1],
+  [-1, -1, -1, -1, -1, -1, -1, -1],
+  [-1, -1, -1, -1, -1, -1, -1, -1]
+]>
+
+// With slide=3: Expected C = [[-60,-60,-60,-60], [-68,-68,-68,-68], [-76,-76,-76,-76], [-84,-84,-84,-84]]
+
+func.func private @print_row(i32, i32, i32, i32, i32)
+func.func private @print_header()
+
+func.func @main() -> i32 {
+  %a = memref.get_global @matA : memref<8x8xi8>
+  %b = memref.get_global @matB : memref<4x8xi8>
+  
+  %c = memref.alloc() : memref<4x4xi32>
+  
+  // Initialize to zero
+  %zero = arith.constant 0 : i32
+  linalg.fill ins(%zero : i32) outs(%c : memref<4x4xi32>)
+  
+  // Slide parameter = 3
+  %slide = arith.constant 3 : i64
+  
+  // Perform vmadotnus with slide=3
+  ime.vmadotnus %c, %a, %b, %slide : memref<4x4xi32>, memref<8x8xi8>, memref<4x8xi8>
+  
+  // Print results
+  call @print_header() : () -> ()
+  
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %i0 = arith.constant 0 : i32
+  %i1 = arith.constant 1 : i32
+  %i2 = arith.constant 2 : i32
+  %i3 = arith.constant 3 : i32
+  
+  // Row 0
+  %v00 = memref.load %c[%c0, %c0] : memref<4x4xi32>
+  %v01 = memref.load %c[%c0, %c1] : memref<4x4xi32>
+  %v02 = memref.load %c[%c0, %c2] : memref<4x4xi32>
+  %v03 = memref.load %c[%c0, %c3] : memref<4x4xi32>
+  call @print_row(%i0, %v00, %v01, %v02, %v03) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 1
+  %v10 = memref.load %c[%c1, %c0] : memref<4x4xi32>
+  %v11 = memref.load %c[%c1, %c1] : memref<4x4xi32>
+  %v12 = memref.load %c[%c1, %c2] : memref<4x4xi32>
+  %v13 = memref.load %c[%c1, %c3] : memref<4x4xi32>
+  call @print_row(%i1, %v10, %v11, %v12, %v13) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 2
+  %v20 = memref.load %c[%c2, %c0] : memref<4x4xi32>
+  %v21 = memref.load %c[%c2, %c1] : memref<4x4xi32>
+  %v22 = memref.load %c[%c2, %c2] : memref<4x4xi32>
+  %v23 = memref.load %c[%c2, %c3] : memref<4x4xi32>
+  call @print_row(%i2, %v20, %v21, %v22, %v23) : (i32, i32, i32, i32, i32) -> ()
+  
+  // Row 3
+  %v30 = memref.load %c[%c3, %c0] : memref<4x4xi32>
+  %v31 = memref.load %c[%c3, %c1] : memref<4x4xi32>
+  %v32 = memref.load %c[%c3, %c2] : memref<4x4xi32>
+  %v33 = memref.load %c[%c3, %c3] : memref<4x4xi32>
+  call @print_row(%i3, %v30, %v31, %v32, %v33) : (i32, i32, i32, i32, i32) -> ()
+  
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}

--- a/examples/IMEDialect/vmadotnus_print_test.mlir
+++ b/examples/IMEDialect/vmadotnus_print_test.mlir
@@ -14,7 +14,7 @@
 // Row 5 = [6,7,8,9,10,11,12,13], sum = -76
 // Row 6 = [7,8,9,10,11,12,13,14], sum = -84
 
-memref.global "private" @matA : memref<8x8xi8> = dense<[
+memref.global "private" @matA : memref<8x8xui8> = dense<[
   [1, 2, 3, 4, 5, 6, 7, 8],
   [2, 3, 4, 5, 6, 7, 8, 9],
   [3, 4, 5, 6, 7, 8, 9, 10],
@@ -39,7 +39,7 @@ func.func private @print_row(i32, i32, i32, i32, i32)
 func.func private @print_header()
 
 func.func @main() -> i32 {
-  %a = memref.get_global @matA : memref<8x8xi8>
+  %a = memref.get_global @matA : memref<8x8xui8>
   %b = memref.get_global @matB : memref<4x8xi8>
   
   %c = memref.alloc() : memref<4x4xi32>
@@ -52,7 +52,7 @@ func.func @main() -> i32 {
   %slide = arith.constant 3 : i64
   
   // Perform vmadotnus with slide=3
-  ime.vmadotnus %c, %a, %b, %slide : memref<4x4xi32>, memref<8x8xi8>, memref<4x8xi8>
+  ime.vmadotnus %c, %a, %b, %slide : memref<4x4xi32>, memref<8x8xui8>, memref<4x8xi8>
   
   // Print results
   call @print_header() : () -> ()

--- a/examples/IMEDialect/vmadotsu_print_test.mlir
+++ b/examples/IMEDialect/vmadotsu_print_test.mlir
@@ -1,4 +1,5 @@
-// IME vmadotsu test: signed × unsigned matrix multiply-accumulate
+// RUN: buddy-opt %s | FileCheck %s
+// CHECK: func.func @main
 //
 // vmadotsu computes: C[i,j] += sum_k(signed(A[i,k]) * unsigned(B[j,k]))
 //

--- a/examples/IMEDialect/vmadotu_print_test.mlir
+++ b/examples/IMEDialect/vmadotu_print_test.mlir
@@ -1,4 +1,5 @@
-// IME vmadotu test: unsigned × unsigned matrix multiply-accumulate
+// RUN: buddy-opt %s | FileCheck %s
+// CHECK: func.func @main
 //
 // vmadotu computes: C[i,j] += sum_k(unsigned(A[i,k]) * unsigned(B[j,k]))
 //

--- a/examples/IMEDialect/vmadotus_print_test.mlir
+++ b/examples/IMEDialect/vmadotus_print_test.mlir
@@ -1,4 +1,5 @@
-// IME vmadotus test: unsigned × signed matrix multiply-accumulate
+// RUN: buddy-opt %s | FileCheck %s
+// CHECK: func.func @main
 //
 // vmadotus computes: C[i,j] += sum_k(unsigned(A[i,k]) * signed(B[j,k]))
 //

--- a/examples/lit.cfg.py
+++ b/examples/lit.cfg.py
@@ -76,11 +76,6 @@ config.excludes = [
     "log.mlir",
     "lit.cfg.py",
     "BuddyPython",
-    "vmadot_print_test.mlir",
-    "vmadotu_print_test.mlir",
-    "vmadotsu_print_test.mlir",
-    "vmadotus_print_test.mlir",
-    "vfmadot_print_test.mlir",
 ]
 
 config.buddy_tools_dir = os.path.join(config.buddy_obj_root, "bin")

--- a/midend/include/Dialect/IME/IME.td
+++ b/midend/include/Dialect/IME/IME.td
@@ -95,6 +95,233 @@ def VfmadotOp : IME_Op<"vfmadot"> {
 }
 
 //===----------------------------------------------------------------------===//
+// Sliding-window Integer Matrix Multiply-Accumulate Operations
+//===----------------------------------------------------------------------===//
+// These operations select values from VS1 and VS1+1 using a sliding window.
+// slide-1/2/3 use fixed slide values, while slide-n uses a dynamic value.
+
+// slide-1 operations
+def Vmadot1Op : IME_Op<"vmadot1"> {
+  let summary = "Sliding-window integer MMA (signed × signed, slide=1)";
+  let description = [{
+    Performs sliding-window matrix multiply-accumulate with slide=1.
+    Input A is selected from VS1 and VS1+1 with a slide offset of 1*K elements.
+  }];
+  let arguments = (ins
+    MemRefRankOf<[I32], [2]>:$vd,
+    MemRefRankOf<[I8], [2]>:$vs1,
+    MemRefRankOf<[I8], [2]>:$vs2
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+def Vmadot1uOp : IME_Op<"vmadot1u"> {
+  let summary = "Sliding-window integer MMA (unsigned × unsigned, slide=1)";
+  let arguments = (ins
+    MemRefRankOf<[I32], [2]>:$vd,
+    MemRefRankOf<[UI8], [2]>:$vs1,
+    MemRefRankOf<[UI8], [2]>:$vs2
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+def Vmadot1suOp : IME_Op<"vmadot1su"> {
+  let summary = "Sliding-window integer MMA (signed × unsigned, slide=1)";
+  let arguments = (ins
+    MemRefRankOf<[I32], [2]>:$vd,
+    MemRefRankOf<[I8], [2]>:$vs1,
+    MemRefRankOf<[UI8], [2]>:$vs2
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+def Vmadot1usOp : IME_Op<"vmadot1us"> {
+  let summary = "Sliding-window integer MMA (unsigned × signed, slide=1)";
+  let arguments = (ins
+    MemRefRankOf<[I32], [2]>:$vd,
+    MemRefRankOf<[UI8], [2]>:$vs1,
+    MemRefRankOf<[I8], [2]>:$vs2
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+// slide-2 operations
+def Vmadot2Op : IME_Op<"vmadot2"> {
+  let summary = "Sliding-window integer MMA (signed × signed, slide=2)";
+  let arguments = (ins
+    MemRefRankOf<[I32], [2]>:$vd,
+    MemRefRankOf<[I8], [2]>:$vs1,
+    MemRefRankOf<[I8], [2]>:$vs2
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+def Vmadot2uOp : IME_Op<"vmadot2u"> {
+  let summary = "Sliding-window integer MMA (unsigned × unsigned, slide=2)";
+  let arguments = (ins
+    MemRefRankOf<[I32], [2]>:$vd,
+    MemRefRankOf<[UI8], [2]>:$vs1,
+    MemRefRankOf<[UI8], [2]>:$vs2
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+def Vmadot2suOp : IME_Op<"vmadot2su"> {
+  let summary = "Sliding-window integer MMA (signed × unsigned, slide=2)";
+  let arguments = (ins
+    MemRefRankOf<[I32], [2]>:$vd,
+    MemRefRankOf<[I8], [2]>:$vs1,
+    MemRefRankOf<[UI8], [2]>:$vs2
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+def Vmadot2usOp : IME_Op<"vmadot2us"> {
+  let summary = "Sliding-window integer MMA (unsigned × signed, slide=2)";
+  let arguments = (ins
+    MemRefRankOf<[I32], [2]>:$vd,
+    MemRefRankOf<[UI8], [2]>:$vs1,
+    MemRefRankOf<[I8], [2]>:$vs2
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+// slide-3 operations
+def Vmadot3Op : IME_Op<"vmadot3"> {
+  let summary = "Sliding-window integer MMA (signed × signed, slide=3)";
+  let arguments = (ins
+    MemRefRankOf<[I32], [2]>:$vd,
+    MemRefRankOf<[I8], [2]>:$vs1,
+    MemRefRankOf<[I8], [2]>:$vs2
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+def Vmadot3uOp : IME_Op<"vmadot3u"> {
+  let summary = "Sliding-window integer MMA (unsigned × unsigned, slide=3)";
+  let arguments = (ins
+    MemRefRankOf<[I32], [2]>:$vd,
+    MemRefRankOf<[UI8], [2]>:$vs1,
+    MemRefRankOf<[UI8], [2]>:$vs2
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+def Vmadot3suOp : IME_Op<"vmadot3su"> {
+  let summary = "Sliding-window integer MMA (signed × unsigned, slide=3)";
+  let arguments = (ins
+    MemRefRankOf<[I32], [2]>:$vd,
+    MemRefRankOf<[I8], [2]>:$vs1,
+    MemRefRankOf<[UI8], [2]>:$vs2
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+def Vmadot3usOp : IME_Op<"vmadot3us"> {
+  let summary = "Sliding-window integer MMA (unsigned × signed, slide=3)";
+  let arguments = (ins
+    MemRefRankOf<[I32], [2]>:$vd,
+    MemRefRankOf<[UI8], [2]>:$vs1,
+    MemRefRankOf<[I8], [2]>:$vs2
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+// slide-n operations (dynamic slide value)
+def VmadotnOp : IME_Op<"vmadotn"> {
+  let summary = "Sliding-window integer MMA (signed × signed, slide=n)";
+  let description = [{
+    Performs sliding-window matrix multiply-accumulate with dynamic slide value.
+    The slide value is passed as an additional operand.
+  }];
+  let arguments = (ins
+    MemRefRankOf<[I32], [2]>:$vd,
+    MemRefRankOf<[I8], [2]>:$vs1,
+    MemRefRankOf<[I8], [2]>:$vs2,
+    I64:$slide
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 `,` $slide attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+def VmadotnuOp : IME_Op<"vmadotnu"> {
+  let summary = "Sliding-window integer MMA (unsigned × unsigned, slide=n)";
+  let arguments = (ins
+    MemRefRankOf<[I32], [2]>:$vd,
+    MemRefRankOf<[UI8], [2]>:$vs1,
+    MemRefRankOf<[UI8], [2]>:$vs2,
+    I64:$slide
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 `,` $slide attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+def VmadotnsuOp : IME_Op<"vmadotnsu"> {
+  let summary = "Sliding-window integer MMA (signed × unsigned, slide=n)";
+  let arguments = (ins
+    MemRefRankOf<[I32], [2]>:$vd,
+    MemRefRankOf<[I8], [2]>:$vs1,
+    MemRefRankOf<[UI8], [2]>:$vs2,
+    I64:$slide
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 `,` $slide attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+def VmadotnusOp : IME_Op<"vmadotnus"> {
+  let summary = "Sliding-window integer MMA (unsigned × signed, slide=n)";
+  let arguments = (ins
+    MemRefRankOf<[I32], [2]>:$vd,
+    MemRefRankOf<[UI8], [2]>:$vs1,
+    MemRefRankOf<[I8], [2]>:$vs2,
+    I64:$slide
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 `,` $slide attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+//===----------------------------------------------------------------------===//
+// Sliding-window Floating-Point Matrix Multiply-Accumulate Operations
+//===----------------------------------------------------------------------===//
+
+def Vfmadot1Op : IME_Op<"vfmadot1"> {
+  let summary = "Sliding-window floating-point MMA (slide=1)";
+  let arguments = (ins
+    MemRefRankOf<[F16], [2]>:$vd,
+    MemRefRankOf<[F16], [2]>:$vs1,
+    MemRefRankOf<[F16], [2]>:$vs2
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+def Vfmadot2Op : IME_Op<"vfmadot2"> {
+  let summary = "Sliding-window floating-point MMA (slide=2)";
+  let arguments = (ins
+    MemRefRankOf<[F16], [2]>:$vd,
+    MemRefRankOf<[F16], [2]>:$vs1,
+    MemRefRankOf<[F16], [2]>:$vs2
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+def Vfmadot3Op : IME_Op<"vfmadot3"> {
+  let summary = "Sliding-window floating-point MMA (slide=3)";
+  let arguments = (ins
+    MemRefRankOf<[F16], [2]>:$vd,
+    MemRefRankOf<[F16], [2]>:$vs1,
+    MemRefRankOf<[F16], [2]>:$vs2
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+def VfmadotnOp : IME_Op<"vfmadotn"> {
+  let summary = "Sliding-window floating-point MMA (slide=n)";
+  let arguments = (ins
+    MemRefRankOf<[F16], [2]>:$vd,
+    MemRefRankOf<[F16], [2]>:$vs1,
+    MemRefRankOf<[F16], [2]>:$vs2,
+    I64:$slide
+  );
+  let assemblyFormat = "$vd `,` $vs1 `,` $vs2 `,` $slide attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
+}
+
+//===----------------------------------------------------------------------===//
 // IME Intrinsic operation definitions
 //===----------------------------------------------------------------------===//
 class IME_IntrOpBase<string mnemonic, list<Trait> traits = []> :
@@ -122,5 +349,77 @@ def IME_Vmadotus_IntrOp : IME_IntrOpBase<"vmadotus">,
 // Floating-point matrix multiply-accumulate intrinsic
 def IME_Vfmadot_IntrOp : IME_IntrOpBase<"vfmadot">,
   Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2)>;
+
+//===----------------------------------------------------------------------===//
+// Sliding-window Integer Matrix Multiply-Accumulate Intrinsics
+//===----------------------------------------------------------------------===//
+
+// slide-1 intrinsics
+def IME_Vmadot1_IntrOp : IME_IntrOpBase<"vmadot1">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2)>;
+
+def IME_Vmadot1u_IntrOp : IME_IntrOpBase<"vmadot1u">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2)>;
+
+def IME_Vmadot1su_IntrOp : IME_IntrOpBase<"vmadot1su">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2)>;
+
+def IME_Vmadot1us_IntrOp : IME_IntrOpBase<"vmadot1us">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2)>;
+
+// slide-2 intrinsics
+def IME_Vmadot2_IntrOp : IME_IntrOpBase<"vmadot2">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2)>;
+
+def IME_Vmadot2u_IntrOp : IME_IntrOpBase<"vmadot2u">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2)>;
+
+def IME_Vmadot2su_IntrOp : IME_IntrOpBase<"vmadot2su">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2)>;
+
+def IME_Vmadot2us_IntrOp : IME_IntrOpBase<"vmadot2us">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2)>;
+
+// slide-3 intrinsics
+def IME_Vmadot3_IntrOp : IME_IntrOpBase<"vmadot3">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2)>;
+
+def IME_Vmadot3u_IntrOp : IME_IntrOpBase<"vmadot3u">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2)>;
+
+def IME_Vmadot3su_IntrOp : IME_IntrOpBase<"vmadot3su">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2)>;
+
+def IME_Vmadot3us_IntrOp : IME_IntrOpBase<"vmadot3us">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2)>;
+
+// slide-n intrinsics (with dynamic slide value in GPR)
+def IME_Vmadotn_IntrOp : IME_IntrOpBase<"vmadotn">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2, LLVM_Type:$slide)>;
+
+def IME_Vmadotnu_IntrOp : IME_IntrOpBase<"vmadotnu">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2, LLVM_Type:$slide)>;
+
+def IME_Vmadotnsu_IntrOp : IME_IntrOpBase<"vmadotnsu">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2, LLVM_Type:$slide)>;
+
+def IME_Vmadotnus_IntrOp : IME_IntrOpBase<"vmadotnus">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2, LLVM_Type:$slide)>;
+
+//===----------------------------------------------------------------------===//
+// Sliding-window Floating-Point Matrix Multiply-Accumulate Intrinsics
+//===----------------------------------------------------------------------===//
+
+def IME_Vfmadot1_IntrOp : IME_IntrOpBase<"vfmadot1">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2)>;
+
+def IME_Vfmadot2_IntrOp : IME_IntrOpBase<"vfmadot2">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2)>;
+
+def IME_Vfmadot3_IntrOp : IME_IntrOpBase<"vfmadot3">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2)>;
+
+def IME_Vfmadotn_IntrOp : IME_IntrOpBase<"vfmadotn">,
+  Arguments<(ins LLVM_Type:$vd, LLVM_Type:$vs1, LLVM_Type:$vs2, LLVM_Type:$slide)>;
 
 #endif // IME_DIALECT

--- a/midend/include/Dialect/IME/IME.td
+++ b/midend/include/Dialect/IME/IME.td
@@ -44,12 +44,15 @@ def VmadotOp : IME_Op<"vmadot"> {
   let summary = "Integer matrix multiply-accumulate (signed × signed)";
   let description = [{
     Performs matrix multiply-accumulate: vd += vs1 × vs2
-    where vs1 and vs2 are int8 matrices, and vd is int32 accumulator.
+    where vs1 and vs2 are int8 or int16 matrices, and vd is int32 accumulator.
+    
+    For int8 (SEW=e8): MAC unit 4x4x8, matrices A(4x8), B(8x4), C(4x4)
+    For int16 (SEW=e16): MAC unit 4x4x4, matrices A(4x4), B(4x4), C(4x4)
   }];
   let arguments = (ins
     MemRefRankOf<[I32], [2]>:$vd,
-    MemRefRankOf<[I8], [2]>:$vs1,
-    MemRefRankOf<[I8], [2]>:$vs2
+    MemRefRankOf<[I8, I16], [2]>:$vs1,
+    MemRefRankOf<[I8, I16], [2]>:$vs2
   );
   let assemblyFormat = "$vd `,` $vs1 `,` $vs2 attr-dict `:` type($vd) `,` type($vs1) `,` type($vs2)";
 }

--- a/midend/lib/Dialect/IME/Transforms/LegalizeForLLVMExport.cpp
+++ b/midend/lib/Dialect/IME/Transforms/LegalizeForLLVMExport.cpp
@@ -31,6 +31,107 @@ using namespace buddy::ime;
 
 namespace {
 
+//===----------------------------------------------------------------------===//
+// IME Type Configuration
+//===----------------------------------------------------------------------===//
+
+/// Enumeration of supported IME data types
+enum class IMEDataType {
+  Int8,   // 8-bit integer (signed/unsigned)
+  Int16,  // 16-bit integer (signed/unsigned)
+  FP16    // 16-bit floating point
+};
+
+/// Configuration structure for IME operations based on data type
+struct IMETypeConfig {
+  int64_t targetVL;        // Vector length
+  int64_t sew;             // SEW encoding: 0=e8, 1=e16, 2=e32, 3=e64
+  int64_t lmul;            // LMUL encoding: 0=m1, 1=m2, 2=m4, 3=m8
+  int64_t extendedVL;      // Extended VL for sliding operations (2x targetVL)
+  Type elementType;        // Element type for input vectors
+  Type outputElementType;  // Element type for output vectors
+  VectorType inputVecType; // Input vector type (e.g., nxv32i8)
+  VectorType outputVecType;// Output vector type (e.g., nxv8i32)
+  VectorType extendedInputVecType; // Extended input vector for sliding ops
+  std::string inputVecSuffix;  // e.g., "nxv32i8"
+  std::string outputVecSuffix; // e.g., "nxv8i32"
+  std::string extendedInputVecSuffix; // e.g., "nxv64i8"
+};
+
+/// Get IME type configuration from memref element type
+static IMETypeConfig getIMETypeConfig(MLIRContext *ctx, Type elementType) {
+  IMETypeConfig config;
+  config.lmul = 0; // Always m1 for IME operations
+  
+  if (elementType.isInteger(8)) {
+    // int8: SEW=e8, VL=32, MAC unit 4x4x8
+    config.targetVL = 32;
+    config.sew = 0;  // e8
+    config.extendedVL = 64;
+    config.elementType = IntegerType::get(ctx, 8);
+    config.outputElementType = IntegerType::get(ctx, 32);
+    config.inputVecType = VectorType::get({32}, config.elementType, /*scalableDims=*/true);
+    config.outputVecType = VectorType::get({8}, config.outputElementType, /*scalableDims=*/true);
+    config.extendedInputVecType = VectorType::get({64}, config.elementType, /*scalableDims=*/true);
+    config.inputVecSuffix = "nxv32i8";
+    config.outputVecSuffix = "nxv8i32";
+    config.extendedInputVecSuffix = "nxv64i8";
+  } else if (elementType.isInteger(16)) {
+    // int16: SEW=e16, VL=16, MAC unit 4x4x4
+    config.targetVL = 16;
+    config.sew = 1;  // e16
+    config.extendedVL = 32;
+    config.elementType = IntegerType::get(ctx, 16);
+    config.outputElementType = IntegerType::get(ctx, 32);
+    config.inputVecType = VectorType::get({16}, config.elementType, /*scalableDims=*/true);
+    config.outputVecType = VectorType::get({8}, config.outputElementType, /*scalableDims=*/true);
+    config.extendedInputVecType = VectorType::get({32}, config.elementType, /*scalableDims=*/true);
+    config.inputVecSuffix = "nxv16i16";
+    config.outputVecSuffix = "nxv8i32";
+    config.extendedInputVecSuffix = "nxv32i16";
+  } else if (elementType.isF16()) {
+    // fp16: SEW=e16, VL=16, MAC unit 4x4x4
+    config.targetVL = 16;
+    config.sew = 1;  // e16
+    config.extendedVL = 32;
+    config.elementType = Float16Type::get(ctx);
+    config.outputElementType = Float16Type::get(ctx); // fp16 output is also f16
+    config.inputVecType = VectorType::get({16}, config.elementType, /*scalableDims=*/true);
+    config.outputVecType = VectorType::get({16}, config.outputElementType, /*scalableDims=*/true);
+    config.extendedInputVecType = VectorType::get({32}, config.elementType, /*scalableDims=*/true);
+    config.inputVecSuffix = "nxv16f16";
+    config.outputVecSuffix = "nxv16f16";
+    config.extendedInputVecSuffix = "nxv32f16";
+  } else {
+    // Default to int8 if unknown type
+    config.targetVL = 32;
+    config.sew = 0;
+    config.extendedVL = 64;
+    config.elementType = IntegerType::get(ctx, 8);
+    config.outputElementType = IntegerType::get(ctx, 32);
+    config.inputVecType = VectorType::get({32}, config.elementType, /*scalableDims=*/true);
+    config.outputVecType = VectorType::get({8}, config.outputElementType, /*scalableDims=*/true);
+    config.extendedInputVecType = VectorType::get({64}, config.elementType, /*scalableDims=*/true);
+    config.inputVecSuffix = "nxv32i8";
+    config.outputVecSuffix = "nxv8i32";
+    config.extendedInputVecSuffix = "nxv64i8";
+  }
+  
+  return config;
+}
+
+/// Get element type from a memref value
+static Type getMemRefElementType(Value memref) {
+  if (auto memrefType = dyn_cast<MemRefType>(memref.getType())) {
+    return memrefType.getElementType();
+  }
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// Helper Functions
+//===----------------------------------------------------------------------===//
+
 static FlatSymbolRefAttr
 getOrInsertIntrinsic(ConversionPatternRewriter &rewriter, ModuleOp module,
                      StringRef intrinsicName, LLVM::LLVMFunctionType funcType) {
@@ -47,9 +148,37 @@ getOrInsertIntrinsic(ConversionPatternRewriter &rewriter, ModuleOp module,
   return FlatSymbolRefAttr::get(ctx, intrinsicName);
 }
 
+// Create vsetvli intrinsic call to configure vector type
+// SEW encoding: 0=e8, 1=e16, 2=e32, 3=e64
+// LMUL encoding: 0=m1, 1=m2, 2=m4, 3=m8, 5=mf8, 6=mf4, 7=mf2
+static Value createVsetvli(ConversionPatternRewriter &rewriter, Location loc,
+                           ModuleOp module, int64_t avl, int64_t sew,
+                           int64_t lmul) {
+  auto *ctx = rewriter.getContext();
+  auto i64Type = IntegerType::get(ctx, 64);
+
+  // vsetvli intrinsic: i64 @llvm.riscv.vsetvli.i64(i64 avl, i64 sew, i64 lmul)
+  auto funcType =
+      LLVM::LLVMFunctionType::get(i64Type, {i64Type, i64Type, i64Type}, false);
+  auto funcRef =
+      getOrInsertIntrinsic(rewriter, module, "llvm.riscv.vsetvli.i64", funcType);
+
+  auto avlVal = rewriter.create<LLVM::ConstantOp>(
+      loc, i64Type, rewriter.getI64IntegerAttr(avl));
+  auto sewVal = rewriter.create<LLVM::ConstantOp>(
+      loc, i64Type, rewriter.getI64IntegerAttr(sew));
+  auto lmulVal = rewriter.create<LLVM::ConstantOp>(
+      loc, i64Type, rewriter.getI64IntegerAttr(lmul));
+
+  auto call = rewriter.create<LLVM::CallOp>(loc, TypeRange{i64Type}, funcRef,
+                                            ValueRange{avlVal, sewVal, lmulVal});
+  return call.getResult();
+}
+
 static Value createRVVVectorLoad(ConversionPatternRewriter &rewriter,
                                  Location loc, ModuleOp module, Value pointer,
-                                 Type vectorType, StringRef baseIntrinsicName) {
+                                 Type vectorType, StringRef baseIntrinsicName,
+                                 Value vl) {
   auto *ctx = rewriter.getContext();
   auto i64Type = IntegerType::get(ctx, 64);
   auto ptrType = LLVM::LLVMPointerType::get(ctx);
@@ -58,8 +187,6 @@ static Value createRVVVectorLoad(ConversionPatternRewriter &rewriter,
       vectorType, {vectorType, ptrType, i64Type}, false);
   auto funcRef = getOrInsertIntrinsic(rewriter, module, mangledName, funcType);
   auto undefPassthru = rewriter.create<LLVM::UndefOp>(loc, vectorType);
-  auto vl = rewriter.create<LLVM::ConstantOp>(loc, i64Type,
-                                              rewriter.getI64IntegerAttr(-1));
   auto call =
       rewriter.create<LLVM::CallOp>(loc, TypeRange{vectorType}, funcRef,
                                     ValueRange{undefPassthru, pointer, vl});
@@ -68,7 +195,8 @@ static Value createRVVVectorLoad(ConversionPatternRewriter &rewriter,
 
 static void createRVVVectorStore(ConversionPatternRewriter &rewriter,
                                  Location loc, ModuleOp module, Value vector,
-                                 Value pointer, StringRef baseIntrinsicName) {
+                                 Value pointer, StringRef baseIntrinsicName,
+                                 Value vl) {
   auto *ctx = rewriter.getContext();
   auto i64Type = IntegerType::get(ctx, 64);
   auto ptrType = LLVM::LLVMPointerType::get(ctx);
@@ -78,8 +206,6 @@ static void createRVVVectorStore(ConversionPatternRewriter &rewriter,
   auto funcType = LLVM::LLVMFunctionType::get(
       voidType, {vectorType, ptrType, i64Type}, false);
   auto funcRef = getOrInsertIntrinsic(rewriter, module, mangledName, funcType);
-  auto vl = rewriter.create<LLVM::ConstantOp>(loc, i64Type,
-                                              rewriter.getI64IntegerAttr(-1));
   rewriter.create<LLVM::CallOp>(loc, TypeRange{}, funcRef,
                                 ValueRange{vector, pointer, vl});
 }
@@ -148,26 +274,40 @@ struct IMEVmadotLowering : public ConvertOpToLLVMPattern<VmadotOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs1 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs1());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8VecType = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.inputVecSuffix + "." + config.inputVecSuffix;
 
-    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr, i8VecType,
-                                       "llvm.riscv.vle.nxv32i8");
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr, i8VecType,
-                                       "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr, 
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr, 
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot",
-        ".nxv8i32.nxv32i8.nxv32i8");
+        typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -185,26 +325,40 @@ struct IMEVmadotuLowering : public ConvertOpToLLVMPattern<VmadotuOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs1 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs1());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8VecType = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.inputVecSuffix + "." + config.inputVecSuffix;
 
-    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr, i8VecType,
-                                       "llvm.riscv.vle.nxv32i8");
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr, i8VecType,
-                                       "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr, 
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr, 
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadotu",
-        ".nxv8i32.nxv32i8.nxv32i8");
+        typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -222,26 +376,40 @@ struct IMEVmadotsuLowering : public ConvertOpToLLVMPattern<VmadotsuOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs1 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs1());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8VecType = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.inputVecSuffix + "." + config.inputVecSuffix;
 
-    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr, i8VecType,
-                                       "llvm.riscv.vle.nxv32i8");
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr, i8VecType,
-                                       "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr, 
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr, 
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadotsu",
-        ".nxv8i32.nxv32i8.nxv32i8");
+        typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -259,26 +427,40 @@ struct IMEVmadotusLowering : public ConvertOpToLLVMPattern<VmadotusOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs1 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs1());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8VecType = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.inputVecSuffix + "." + config.inputVecSuffix;
 
-    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr, i8VecType,
-                                       "llvm.riscv.vle.nxv32i8");
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr, i8VecType,
-                                       "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr, 
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr, 
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadotus",
-        ".nxv8i32.nxv32i8.nxv32i8");
+        typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -296,24 +478,40 @@ struct IMEVfmadotLowering : public ConvertOpToLLVMPattern<VfmadotOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs1 memref - should be f16
+    Type elemType = getMemRefElementType(op.getVs1());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type (fp16: vl=16, SEW=e16, LMUL=m1)
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto f16Type = Float16Type::get(ctx);
-    auto f16VecType = VectorType::get({32}, f16Type, /*scalableDims=*/true);
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.inputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       f16VecType, "llvm.riscv.vle.nxv32f16");
+                                       config.inputVecType, loadIntrinsic, vlValue);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       f16VecType, "llvm.riscv.vle.nxv32f16");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, f16VecType,
-                                      "llvm.riscv.vle.nxv32f16");
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vfmadot",
-        ".nxv32f16.nxv32f16.nxv32f16");
+        typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv32f16");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -331,29 +529,45 @@ struct IMEVmadot1Lowering : public ConvertOpToLLVMPattern<Vmadot1Op> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    // For extended loads (2x elements for vs1)
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
-    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
-    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
-
-    // Load 64 i8 elements for VS1 (two consecutive vector registers)
+    // Load extended elements for VS1 (two consecutive vector registers)
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot1",
-        ".nxv8i32.nxv64i8.nxv32i8");
+        typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -371,27 +585,43 @@ struct IMEVmadot1uLowering : public ConvertOpToLLVMPattern<Vmadot1uOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
-    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot1u",
-        ".nxv8i32.nxv64i8.nxv32i8");
+        typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -409,27 +639,43 @@ struct IMEVmadot1suLowering : public ConvertOpToLLVMPattern<Vmadot1suOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
-    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
-        "llvm.riscv.ime.vmadot1su", ".nxv8i32.nxv64i8.nxv32i8");
+        "llvm.riscv.ime.vmadot1su", typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -447,27 +693,43 @@ struct IMEVmadot1usLowering : public ConvertOpToLLVMPattern<Vmadot1usOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
-    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
-        "llvm.riscv.ime.vmadot1us", ".nxv8i32.nxv64i8.nxv32i8");
+        "llvm.riscv.ime.vmadot1us", typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -485,27 +747,43 @@ struct IMEVmadot2Lowering : public ConvertOpToLLVMPattern<Vmadot2Op> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
-    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot2",
-        ".nxv8i32.nxv64i8.nxv32i8");
+        typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -523,27 +801,43 @@ struct IMEVmadot2uLowering : public ConvertOpToLLVMPattern<Vmadot2uOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
-    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot2u",
-        ".nxv8i32.nxv64i8.nxv32i8");
+        typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -561,27 +855,43 @@ struct IMEVmadot2suLowering : public ConvertOpToLLVMPattern<Vmadot2suOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
-    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
-        "llvm.riscv.ime.vmadot2su", ".nxv8i32.nxv64i8.nxv32i8");
+        "llvm.riscv.ime.vmadot2su", typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -599,27 +909,43 @@ struct IMEVmadot2usLowering : public ConvertOpToLLVMPattern<Vmadot2usOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
-    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
-        "llvm.riscv.ime.vmadot2us", ".nxv8i32.nxv64i8.nxv32i8");
+        "llvm.riscv.ime.vmadot2us", typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -637,27 +963,43 @@ struct IMEVmadot3Lowering : public ConvertOpToLLVMPattern<Vmadot3Op> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
-    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot3",
-        ".nxv8i32.nxv64i8.nxv32i8");
+        typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -675,27 +1017,43 @@ struct IMEVmadot3uLowering : public ConvertOpToLLVMPattern<Vmadot3uOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
-    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot3u",
-        ".nxv8i32.nxv64i8.nxv32i8");
+        typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -713,27 +1071,43 @@ struct IMEVmadot3suLowering : public ConvertOpToLLVMPattern<Vmadot3suOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
-    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
-        "llvm.riscv.ime.vmadot3su", ".nxv8i32.nxv64i8.nxv32i8");
+        "llvm.riscv.ime.vmadot3su", typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -751,27 +1125,43 @@ struct IMEVmadot3usLowering : public ConvertOpToLLVMPattern<Vmadot3usOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
-    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
-        "llvm.riscv.ime.vmadot3us", ".nxv8i32.nxv64i8.nxv32i8");
+        "llvm.riscv.ime.vmadot3us", typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -789,27 +1179,43 @@ struct IMEVfmadot1Lowering : public ConvertOpToLLVMPattern<Vfmadot1Op> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref - should be f16
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type (fp16: vl=16, SEW=e16, LMUL=m1)
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto f16Type = Float16Type::get(ctx);
-
-    auto f16Vec32Type = VectorType::get({32}, f16Type, /*scalableDims=*/true);
-
-    auto f16Vec16Type = VectorType::get({16}, f16Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       f16Vec32Type, "llvm.riscv.vle.nxv32f16");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       f16Vec16Type, "llvm.riscv.vle.nxv16f16");
+                                       config.inputVecType, loadIntrinsic, vlValue);
     Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      f16Vec16Type, "llvm.riscv.vle.nxv16f16");
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vfmadot1",
-        ".nxv16f16.nxv32f16.nxv16f16");
+        typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv16f16");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -827,27 +1233,43 @@ struct IMEVfmadot2Lowering : public ConvertOpToLLVMPattern<Vfmadot2Op> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref - should be f16
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type (fp16: vl=16, SEW=e16, LMUL=m1)
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto f16Type = Float16Type::get(ctx);
-
-    auto f16Vec32Type = VectorType::get({32}, f16Type, /*scalableDims=*/true);
-
-    auto f16Vec16Type = VectorType::get({16}, f16Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       f16Vec32Type, "llvm.riscv.vle.nxv32f16");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       f16Vec16Type, "llvm.riscv.vle.nxv16f16");
+                                       config.inputVecType, loadIntrinsic, vlValue);
     Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      f16Vec16Type, "llvm.riscv.vle.nxv16f16");
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vfmadot2",
-        ".nxv16f16.nxv32f16.nxv16f16");
+        typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv16f16");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -865,27 +1287,43 @@ struct IMEVfmadot3Lowering : public ConvertOpToLLVMPattern<Vfmadot3Op> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref - should be f16
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type (fp16: vl=16, SEW=e16, LMUL=m1)
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    auto f16Type = Float16Type::get(ctx);
-
-    auto f16Vec32Type = VectorType::get({32}, f16Type, /*scalableDims=*/true);
-
-    auto f16Vec16Type = VectorType::get({16}, f16Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       f16Vec32Type, "llvm.riscv.vle.nxv32f16");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       f16Vec16Type, "llvm.riscv.vle.nxv16f16");
+                                       config.inputVecType, loadIntrinsic, vlValue);
     Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      f16Vec16Type, "llvm.riscv.vle.nxv16f16");
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vfmadot3",
-        ".nxv16f16.nxv32f16.nxv16f16");
+        typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv16f16");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -903,28 +1341,44 @@ struct IMEVmadotnLowering : public ConvertOpToLLVMPattern<VmadotnOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
     Value slideVal = op.getSlide();
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
-    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotnIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, slideVal,
-        "llvm.riscv.ime.vmadotn", ".nxv8i32.nxv64i8.nxv32i8");
+        "llvm.riscv.ime.vmadotn", typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -942,28 +1396,44 @@ struct IMEVmadotnuLowering : public ConvertOpToLLVMPattern<VmadotnuOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
     Value slideVal = op.getSlide();
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
-    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotnIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, slideVal,
-        "llvm.riscv.ime.vmadotnu", ".nxv8i32.nxv64i8.nxv32i8");
+        "llvm.riscv.ime.vmadotnu", typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -981,28 +1451,44 @@ struct IMEVmadotnsuLowering : public ConvertOpToLLVMPattern<VmadotnsuOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
     Value slideVal = op.getSlide();
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
-    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotnIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, slideVal,
-        "llvm.riscv.ime.vmadotnsu", ".nxv8i32.nxv64i8.nxv32i8");
+        "llvm.riscv.ime.vmadotnsu", typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -1020,28 +1506,44 @@ struct IMEVmadotnusLowering : public ConvertOpToLLVMPattern<VmadotnusOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
     Value slideVal = op.getSlide();
 
-    auto i8Type = IntegerType::get(ctx, 8);
-    auto i32Type = IntegerType::get(ctx, 32);
-    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
-    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
-    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
-                                      "llvm.riscv.vle.nxv8i32");
+                                       config.inputVecType, loadIntrinsic, vlValue);
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, 
+                                      config.outputVecType, outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotnIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, slideVal,
-        "llvm.riscv.ime.vmadotnus", ".nxv8i32.nxv64i8.nxv32i8");
+        "llvm.riscv.ime.vmadotnus", typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv8i32");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -1059,28 +1561,43 @@ struct IMEVfmadotnLowering : public ConvertOpToLLVMPattern<VfmadotnOp> {
     if (!module)
       return failure();
 
+    // Get element type from vs2 memref and configure accordingly
+    Type elemType = getMemRefElementType(op.getVs2());
+    if (!elemType)
+      return failure();
+    
+    IMETypeConfig config = getIMETypeConfig(ctx, elemType);
+    auto i64Type = IntegerType::get(ctx, 64);
+
+    // Configure vtype based on element type
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
+    Value vlValue = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
+        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
     Value slideVal = op.getSlide();
 
-    auto f16Type = Float16Type::get(ctx);
-
-    auto f16Vec32Type = VectorType::get({32}, f16Type, /*scalableDims=*/true);
-
-    auto f16Vec16Type = VectorType::get({16}, f16Type, /*scalableDims=*/true);
+    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
+    std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
+    std::string typeSuffix = "." + config.outputVecSuffix + "." + 
+                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       f16Vec32Type, "llvm.riscv.vle.nxv32f16");
+                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
     Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       f16Vec16Type, "llvm.riscv.vle.nxv16f16");
+                                       config.inputVecType, loadIntrinsic, vlValue);
     Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      f16Vec16Type, "llvm.riscv.vle.nxv16f16");
+                                      config.outputVecType, loadIntrinsic, vlValue);
     Value result = createIMEVmadotnIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, slideVal,
-        "llvm.riscv.ime.vfmadotn", ".nxv16f16.nxv32f16.nxv16f16");
+        "llvm.riscv.ime.vfmadotn", typeSuffix);
     createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         "llvm.riscv.vse.nxv16f16");
+                         storeIntrinsic, vlValue);
     rewriter.eraseOp(op);
     return success();
   }

--- a/midend/lib/Dialect/IME/Transforms/LegalizeForLLVMExport.cpp
+++ b/midend/lib/Dialect/IME/Transforms/LegalizeForLLVMExport.cpp
@@ -103,6 +103,27 @@ static Value createIMEVmadotIntrinsic(ConversionPatternRewriter &rewriter,
   return call.getResult();
 }
 
+static Value createIMEVmadotnIntrinsic(ConversionPatternRewriter &rewriter,
+                                       Location loc, ModuleOp module,
+                                       Value vdVector, Value vs1Vector,
+                                       Value vs2Vector, Value slideVal,
+                                       StringRef baseIntrinsicName,
+                                       StringRef typeSuffix) {
+  auto *ctx = rewriter.getContext();
+  auto vdType = vdVector.getType();
+  auto vs1Type = vs1Vector.getType();
+  auto vs2Type = vs2Vector.getType();
+  auto i64Type = IntegerType::get(ctx, 64);
+  std::string mangledName = (baseIntrinsicName + typeSuffix).str();
+  auto funcType = LLVM::LLVMFunctionType::get(
+      vdType, {vdType, vs1Type, vs2Type, i64Type}, false);
+  auto funcRef = getOrInsertIntrinsic(rewriter, module, mangledName, funcType);
+  auto call = rewriter.create<LLVM::CallOp>(
+      loc, TypeRange{vdType}, funcRef,
+      ValueRange{vdVector, vs1Vector, vs2Vector, slideVal});
+  return call.getResult();
+}
+
 static Value extractPointerFromMemref(ConversionPatternRewriter &rewriter,
                                       Location loc, Value memref) {
   auto *ctx = rewriter.getContext();
@@ -298,6 +319,773 @@ struct IMEVfmadotLowering : public ConvertOpToLLVMPattern<VfmadotOp> {
   }
 };
 
+struct IMEVmadot1Lowering : public ConvertOpToLLVMPattern<Vmadot1Op> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Vmadot1Op op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+
+    auto i8Type = IntegerType::get(ctx, 8);
+    auto i32Type = IntegerType::get(ctx, 32);
+
+    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
+    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
+    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+
+    // Load 64 i8 elements for VS1 (two consecutive vector registers)
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
+                                      "llvm.riscv.vle.nxv8i32");
+    Value result = createIMEVmadotIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot1",
+        ".nxv8i32.nxv64i8.nxv32i8");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv8i32");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVmadot1uLowering : public ConvertOpToLLVMPattern<Vmadot1uOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Vmadot1uOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+
+    auto i8Type = IntegerType::get(ctx, 8);
+    auto i32Type = IntegerType::get(ctx, 32);
+    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
+    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
+    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
+                                      "llvm.riscv.vle.nxv8i32");
+    Value result = createIMEVmadotIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot1u",
+        ".nxv8i32.nxv64i8.nxv32i8");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv8i32");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVmadot1suLowering : public ConvertOpToLLVMPattern<Vmadot1suOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Vmadot1suOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+
+    auto i8Type = IntegerType::get(ctx, 8);
+    auto i32Type = IntegerType::get(ctx, 32);
+    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
+    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
+    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
+                                      "llvm.riscv.vle.nxv8i32");
+    Value result = createIMEVmadotIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+        "llvm.riscv.ime.vmadot1su", ".nxv8i32.nxv64i8.nxv32i8");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv8i32");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVmadot1usLowering : public ConvertOpToLLVMPattern<Vmadot1usOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Vmadot1usOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+
+    auto i8Type = IntegerType::get(ctx, 8);
+    auto i32Type = IntegerType::get(ctx, 32);
+    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
+    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
+    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
+                                      "llvm.riscv.vle.nxv8i32");
+    Value result = createIMEVmadotIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+        "llvm.riscv.ime.vmadot1us", ".nxv8i32.nxv64i8.nxv32i8");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv8i32");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVmadot2Lowering : public ConvertOpToLLVMPattern<Vmadot2Op> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Vmadot2Op op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+
+    auto i8Type = IntegerType::get(ctx, 8);
+    auto i32Type = IntegerType::get(ctx, 32);
+    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
+    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
+    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
+                                      "llvm.riscv.vle.nxv8i32");
+    Value result = createIMEVmadotIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot2",
+        ".nxv8i32.nxv64i8.nxv32i8");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv8i32");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVmadot2uLowering : public ConvertOpToLLVMPattern<Vmadot2uOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Vmadot2uOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+
+    auto i8Type = IntegerType::get(ctx, 8);
+    auto i32Type = IntegerType::get(ctx, 32);
+    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
+    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
+    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
+                                      "llvm.riscv.vle.nxv8i32");
+    Value result = createIMEVmadotIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot2u",
+        ".nxv8i32.nxv64i8.nxv32i8");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv8i32");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVmadot2suLowering : public ConvertOpToLLVMPattern<Vmadot2suOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Vmadot2suOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+
+    auto i8Type = IntegerType::get(ctx, 8);
+    auto i32Type = IntegerType::get(ctx, 32);
+    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
+    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
+    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
+                                      "llvm.riscv.vle.nxv8i32");
+    Value result = createIMEVmadotIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+        "llvm.riscv.ime.vmadot2su", ".nxv8i32.nxv64i8.nxv32i8");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv8i32");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVmadot2usLowering : public ConvertOpToLLVMPattern<Vmadot2usOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Vmadot2usOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+
+    auto i8Type = IntegerType::get(ctx, 8);
+    auto i32Type = IntegerType::get(ctx, 32);
+    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
+    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
+    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
+                                      "llvm.riscv.vle.nxv8i32");
+    Value result = createIMEVmadotIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+        "llvm.riscv.ime.vmadot2us", ".nxv8i32.nxv64i8.nxv32i8");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv8i32");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVmadot3Lowering : public ConvertOpToLLVMPattern<Vmadot3Op> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Vmadot3Op op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+
+    auto i8Type = IntegerType::get(ctx, 8);
+    auto i32Type = IntegerType::get(ctx, 32);
+    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
+    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
+    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
+                                      "llvm.riscv.vle.nxv8i32");
+    Value result = createIMEVmadotIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot3",
+        ".nxv8i32.nxv64i8.nxv32i8");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv8i32");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVmadot3uLowering : public ConvertOpToLLVMPattern<Vmadot3uOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Vmadot3uOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+
+    auto i8Type = IntegerType::get(ctx, 8);
+    auto i32Type = IntegerType::get(ctx, 32);
+    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
+    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
+    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
+                                      "llvm.riscv.vle.nxv8i32");
+    Value result = createIMEVmadotIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot3u",
+        ".nxv8i32.nxv64i8.nxv32i8");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv8i32");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVmadot3suLowering : public ConvertOpToLLVMPattern<Vmadot3suOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Vmadot3suOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+
+    auto i8Type = IntegerType::get(ctx, 8);
+    auto i32Type = IntegerType::get(ctx, 32);
+    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
+    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
+    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
+                                      "llvm.riscv.vle.nxv8i32");
+    Value result = createIMEVmadotIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+        "llvm.riscv.ime.vmadot3su", ".nxv8i32.nxv64i8.nxv32i8");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv8i32");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVmadot3usLowering : public ConvertOpToLLVMPattern<Vmadot3usOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Vmadot3usOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+
+    auto i8Type = IntegerType::get(ctx, 8);
+    auto i32Type = IntegerType::get(ctx, 32);
+    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
+    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
+    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
+                                      "llvm.riscv.vle.nxv8i32");
+    Value result = createIMEVmadotIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+        "llvm.riscv.ime.vmadot3us", ".nxv8i32.nxv64i8.nxv32i8");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv8i32");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVfmadot1Lowering : public ConvertOpToLLVMPattern<Vfmadot1Op> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Vfmadot1Op op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+
+    auto f16Type = Float16Type::get(ctx);
+
+    auto f16Vec32Type = VectorType::get({32}, f16Type, /*scalableDims=*/true);
+
+    auto f16Vec16Type = VectorType::get({16}, f16Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       f16Vec32Type, "llvm.riscv.vle.nxv32f16");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       f16Vec16Type, "llvm.riscv.vle.nxv16f16");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
+                                      f16Vec16Type, "llvm.riscv.vle.nxv16f16");
+    Value result = createIMEVmadotIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vfmadot1",
+        ".nxv16f16.nxv32f16.nxv16f16");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv16f16");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVfmadot2Lowering : public ConvertOpToLLVMPattern<Vfmadot2Op> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Vfmadot2Op op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+
+    auto f16Type = Float16Type::get(ctx);
+
+    auto f16Vec32Type = VectorType::get({32}, f16Type, /*scalableDims=*/true);
+
+    auto f16Vec16Type = VectorType::get({16}, f16Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       f16Vec32Type, "llvm.riscv.vle.nxv32f16");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       f16Vec16Type, "llvm.riscv.vle.nxv16f16");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
+                                      f16Vec16Type, "llvm.riscv.vle.nxv16f16");
+    Value result = createIMEVmadotIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vfmadot2",
+        ".nxv16f16.nxv32f16.nxv16f16");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv16f16");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVfmadot3Lowering : public ConvertOpToLLVMPattern<Vfmadot3Op> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Vfmadot3Op op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+
+    auto f16Type = Float16Type::get(ctx);
+
+    auto f16Vec32Type = VectorType::get({32}, f16Type, /*scalableDims=*/true);
+
+    auto f16Vec16Type = VectorType::get({16}, f16Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       f16Vec32Type, "llvm.riscv.vle.nxv32f16");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       f16Vec16Type, "llvm.riscv.vle.nxv16f16");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
+                                      f16Vec16Type, "llvm.riscv.vle.nxv16f16");
+    Value result = createIMEVmadotIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vfmadot3",
+        ".nxv16f16.nxv32f16.nxv16f16");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv16f16");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVmadotnLowering : public ConvertOpToLLVMPattern<VmadotnOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(VmadotnOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+    Value slideVal = op.getSlide();
+
+    auto i8Type = IntegerType::get(ctx, 8);
+    auto i32Type = IntegerType::get(ctx, 32);
+    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
+    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
+    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
+                                      "llvm.riscv.vle.nxv8i32");
+    Value result = createIMEVmadotnIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, slideVal,
+        "llvm.riscv.ime.vmadotn", ".nxv8i32.nxv64i8.nxv32i8");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv8i32");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVmadotnuLowering : public ConvertOpToLLVMPattern<VmadotnuOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(VmadotnuOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+    Value slideVal = op.getSlide();
+
+    auto i8Type = IntegerType::get(ctx, 8);
+    auto i32Type = IntegerType::get(ctx, 32);
+    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
+    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
+    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
+                                      "llvm.riscv.vle.nxv8i32");
+    Value result = createIMEVmadotnIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, slideVal,
+        "llvm.riscv.ime.vmadotnu", ".nxv8i32.nxv64i8.nxv32i8");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv8i32");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVmadotnsuLowering : public ConvertOpToLLVMPattern<VmadotnsuOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(VmadotnsuOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+    Value slideVal = op.getSlide();
+
+    auto i8Type = IntegerType::get(ctx, 8);
+    auto i32Type = IntegerType::get(ctx, 32);
+    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
+    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
+    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
+                                      "llvm.riscv.vle.nxv8i32");
+    Value result = createIMEVmadotnIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, slideVal,
+        "llvm.riscv.ime.vmadotnsu", ".nxv8i32.nxv64i8.nxv32i8");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv8i32");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVmadotnusLowering : public ConvertOpToLLVMPattern<VmadotnusOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(VmadotnusOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+    Value slideVal = op.getSlide();
+
+    auto i8Type = IntegerType::get(ctx, 8);
+    auto i32Type = IntegerType::get(ctx, 32);
+    auto i8Vec64Type = VectorType::get({64}, i8Type, /*scalableDims=*/true);
+    auto i8Vec32Type = VectorType::get({32}, i8Type, /*scalableDims=*/true);
+    auto i32VecType = VectorType::get({8}, i32Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       i8Vec64Type, "llvm.riscv.vle.nxv64i8");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       i8Vec32Type, "llvm.riscv.vle.nxv32i8");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr, i32VecType,
+                                      "llvm.riscv.vle.nxv8i32");
+    Value result = createIMEVmadotnIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, slideVal,
+        "llvm.riscv.ime.vmadotnus", ".nxv8i32.nxv64i8.nxv32i8");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv8i32");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct IMEVfmadotnLowering : public ConvertOpToLLVMPattern<VfmadotnOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(VfmadotnOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+    auto module = op->getParentOfType<ModuleOp>();
+    if (!module)
+      return failure();
+
+    Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
+    Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
+    Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
+    Value slideVal = op.getSlide();
+
+    auto f16Type = Float16Type::get(ctx);
+
+    auto f16Vec32Type = VectorType::get({32}, f16Type, /*scalableDims=*/true);
+
+    auto f16Vec16Type = VectorType::get({16}, f16Type, /*scalableDims=*/true);
+
+    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
+                                       f16Vec32Type, "llvm.riscv.vle.nxv32f16");
+    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
+                                       f16Vec16Type, "llvm.riscv.vle.nxv16f16");
+    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
+                                      f16Vec16Type, "llvm.riscv.vle.nxv16f16");
+    Value result = createIMEVmadotnIntrinsic(
+        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, slideVal,
+        "llvm.riscv.ime.vfmadotn", ".nxv16f16.nxv32f16.nxv16f16");
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
+                         "llvm.riscv.vse.nxv16f16");
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct LegalizeIMEForLLVMExport
     : public PassWrapper<LegalizeIMEForLLVMExport, OperationPass<ModuleOp>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LegalizeIMEForLLVMExport)
@@ -316,14 +1104,26 @@ struct LegalizeIMEForLLVMExport
     target.addLegalDialect<LLVM::LLVMDialect>();
     target.addLegalDialect<arith::ArithDialect>();
     target.addLegalDialect<memref::MemRefDialect>();
-    target
-        .addIllegalOp<VmadotOp, VmadotuOp, VmadotsuOp, VmadotusOp, VfmadotOp>();
+    target.addIllegalOp<VmadotOp, VmadotuOp, VmadotsuOp, VmadotusOp, VfmadotOp,
+                        Vmadot1Op, Vmadot1uOp, Vmadot1suOp, Vmadot1usOp,
+                        Vmadot2Op, Vmadot2uOp, Vmadot2suOp, Vmadot2usOp,
+                        Vmadot3Op, Vmadot3uOp, Vmadot3suOp, Vmadot3usOp,
+                        Vfmadot1Op, Vfmadot2Op, Vfmadot3Op, VmadotnOp,
+                        VmadotnuOp, VmadotnsuOp, VmadotnusOp, VfmadotnOp>();
 
     LLVMTypeConverter typeConverter(&context);
 
     RewritePatternSet patterns(&context);
-    patterns.add<IMEVmadotLowering, IMEVmadotuLowering, IMEVmadotsuLowering,
-                 IMEVmadotusLowering, IMEVfmadotLowering>(typeConverter);
+    patterns
+        .add<IMEVmadotLowering, IMEVmadotuLowering, IMEVmadotsuLowering,
+             IMEVmadotusLowering, IMEVfmadotLowering, IMEVmadot1Lowering,
+             IMEVmadot1uLowering, IMEVmadot1suLowering, IMEVmadot1usLowering,
+             IMEVmadot2Lowering, IMEVmadot2uLowering, IMEVmadot2suLowering,
+             IMEVmadot2usLowering, IMEVmadot3Lowering, IMEVmadot3uLowering,
+             IMEVmadot3suLowering, IMEVmadot3usLowering, IMEVfmadot1Lowering,
+             IMEVfmadot2Lowering, IMEVfmadot3Lowering, IMEVmadotnLowering,
+             IMEVmadotnuLowering, IMEVmadotnsuLowering, IMEVmadotnusLowering,
+             IMEVfmadotnLowering>(typeConverter);
 
     if (failed(applyPartialConversion(module, target, std::move(patterns))))
       signalPassFailure();
@@ -335,13 +1135,25 @@ struct LegalizeIMEForLLVMExport
 void mlir::populateIMELegalizeForLLVMExportPatterns(
     LLVMTypeConverter &converter, RewritePatternSet &patterns) {
   patterns.add<IMEVmadotLowering, IMEVmadotuLowering, IMEVmadotsuLowering,
-               IMEVmadotusLowering, IMEVfmadotLowering>(converter);
+               IMEVmadotusLowering, IMEVfmadotLowering, IMEVmadot1Lowering,
+               IMEVmadot1uLowering, IMEVmadot1suLowering, IMEVmadot1usLowering,
+               IMEVmadot2Lowering, IMEVmadot2uLowering, IMEVmadot2suLowering,
+               IMEVmadot2usLowering, IMEVmadot3Lowering, IMEVmadot3uLowering,
+               IMEVmadot3suLowering, IMEVmadot3usLowering, IMEVfmadot1Lowering,
+               IMEVfmadot2Lowering, IMEVfmadot3Lowering, IMEVmadotnLowering,
+               IMEVmadotnuLowering, IMEVmadotnsuLowering, IMEVmadotnusLowering,
+               IMEVfmadotnLowering>(converter);
 }
 
 void mlir::configureIMELegalizeForExportTarget(LLVMConversionTarget &target) {
   target.addLegalDialect<arith::ArithDialect>();
   target.addLegalDialect<memref::MemRefDialect>();
-  target.addIllegalOp<VmadotOp, VmadotuOp, VmadotsuOp, VmadotusOp, VfmadotOp>();
+  target.addIllegalOp<VmadotOp, VmadotuOp, VmadotsuOp, VmadotusOp, VfmadotOp,
+                      Vmadot1Op, Vmadot1uOp, Vmadot1suOp, Vmadot1usOp,
+                      Vmadot2Op, Vmadot2uOp, Vmadot2suOp, Vmadot2usOp,
+                      Vmadot3Op, Vmadot3uOp, Vmadot3suOp, Vmadot3usOp,
+                      Vfmadot1Op, Vfmadot2Op, Vfmadot3Op, VmadotnOp, VmadotnuOp,
+                      VmadotnsuOp, VmadotnusOp, VfmadotnOp>();
 }
 
 std::unique_ptr<Pass> buddy::ime::createLegalizeForLLVMExportPass() {


### PR DESCRIPTION
## Summary

This PR adds support for fixed and dynamic sliding-window matrix multiply-accumulate instructions to the IME dialect.

## Changes

### New Instructions

**Fixed Sliding-Window Integer Instructions (12 total)**
| Slide | Signed×Signed | Unsigned×Unsigned | Signed×Unsigned | Unsigned×Signed |
|-------|---------------|-------------------|-----------------|-----------------|
| 1 | vmadot1 | vmadot1u | vmadot1su | vmadot1us |
| 2 | vmadot2 | vmadot2u | vmadot2su | vmadot2us |
| 3 | vmadot3 | vmadot3u | vmadot3su | vmadot3us |

**Fixed Sliding-Window Floating-Point Instructions (3 total)**
- vfmadot1, vfmadot2, vfmadot3

**Dynamic Sliding-Window Instructions (5 total)**
- vmadotn, vmadotnu, vmadotnsu, vmadotnus, vfmadotn

## Testing

```bash
# Build and test assembly generation
cd examples/IMEDialect
make vmadot1-asm    # Generates: vmadot1 v20, v8, v16
make vmadot2u-asm   # Generates: vmadot2u v20, v8, v16
make vmadot3su-asm  # Generates: vmadot3su v20, v8, v16
```