### PR TITLE
BuddyDeepSeekR1 supports riscv cross compilation and update LLVM construction method

### DIFF
--- a/docs/RVVEnvironment.md
+++ b/docs/RVVEnvironment.md
@@ -38,7 +38,7 @@ $ cmake -G Ninja ../llvm \
     -DCMAKE_BUILD_TYPE=RELEASE \
     -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
     -DPython3_EXECUTABLE=$(which python3)
-$ ninja check-clang check-mlir omp
+$ ninja check-clang check-mlir 
 $ export BUILD_LOCAL_LLVM_DIR=$PWD
 ```
 

--- a/examples/BuddyDeepSeekR1/CMakeLists.txt
+++ b/examples/BuddyDeepSeekR1/CMakeLists.txt
@@ -3,6 +3,10 @@ set(BUFFERIZE_FULL_OPTS "unknown-type-conversion=identity-layout-map function-bo
 set(BUFFERIZE_SIMPLE_OPTS "bufferize-function-boundaries")
 set(TOSA_PIPELINE "builtin.module(func.func(tosa-to-linalg-named),func.func(tosa-to-linalg),func.func(tosa-to-tensor),func.func(tosa-to-arith))")
 
+if(IS_RVV_CROSSCOMPILING)
+set(CMAKE_C_COMPILER ${BUDDY_MLIR_BUILD_DIR}/../llvm/build/bin/clang)
+set(CMAKE_CXX_COMPILER ${BUDDY_MLIR_BUILD_DIR}/../llvm/build/bin/clang++)
+endif()
 # Detect RISC-V Vector (RVV) platform
 # Use HAVE_LOCAL_RVV from check_simd.cmake which is already called in the main CMakeLists.txt
 if(HAVE_LOCAL_RVV)
@@ -19,6 +23,24 @@ if(IS_RVV_PLATFORM)
 else()
   set(OPENMP_NUM_THREADS "num-threads=48")
   set(LLC_RISCV_ATTRS "-mcpu=native")
+endif()
+
+if(IS_RVV_CROSSCOMPILING)
+  message(STATUS "CROSSCOMPILING RISC-V Vector (RVV) platform")
+  set(OPENMP_NUM_THREADS "num-threads=8")
+  set(LLC_RISCV_ATTRS "-march=riscv64;-mattr=+m,+d,+v")
+  set(RISCV_COMPILE_OPTS
+      -march=rv64gcv
+      --target=riscv64-unknown-linux-gnu
+      --sysroot=${RISCV_GNU_TOOLCHAIN}/sysroot
+      --gcc-toolchain=${RISCV_GNU_TOOLCHAIN}
+      -fPIC
+  )
+  set(RISCV_LINK_OPTS
+    --target=riscv64-unknown-linux-gnu
+    --sysroot=${RISCV_GNU_TOOLCHAIN}/sysroot
+    --gcc-toolchain=${RISCV_GNU_TOOLCHAIN}
+  )
 endif()
 
 # Skip import commands on RVV platform
@@ -689,8 +711,13 @@ add_executable(buddy-deepseek-r1-f16-run buddy-deepseek-r1-f16-main.cpp)
 add_executable(buddy-deepseek-r1-bf16-run buddy-deepseek-r1-bf16-main.cpp)
 add_executable(buddy-deepseek-r1-cli buddy-deepseek-r1-cli.cpp)
 
-set(DEEPSEEKR1_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
-set(DEEPSEEKR1_EXAMPLE_BUILD_PATH ${CMAKE_CURRENT_BINARY_DIR})
+if(IS_RVV_CROSSCOMPILING)
+  set(DEEPSEEKR1_EXAMPLE_PATH ${DEEPSEEKR1_EXAMPLE_PATH})
+  set(DEEPSEEKR1_EXAMPLE_BUILD_PATH ${DEEPSEEKR1_EXAMPLE_BUILD_PATH})
+else()
+  set(DEEPSEEKR1_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
+  set(DEEPSEEKR1_EXAMPLE_BUILD_PATH ${CMAKE_CURRENT_BINARY_DIR})
+endif()
 
 target_compile_definitions(buddy-deepseek-r1-run PRIVATE
   DEEPSEEKR1_EXAMPLE_PATH="${DEEPSEEKR1_EXAMPLE_PATH}/"
@@ -711,9 +738,16 @@ target_compile_definitions(buddy-deepseek-r1-cli PRIVATE
 target_compile_options(buddy-deepseek-r1-cli PRIVATE -fno-rtti)
 
 # Add RISC-V specific compile and link options for the main executable
-if(IS_RVV_PLATFORM)
+if(IS_RVV_PLATFORM OR IS_RVV_CROSSCOMPILING)
   target_compile_options(buddy-deepseek-r1-run PRIVATE ${RISCV_COMPILE_OPTS})
+  target_compile_options(buddy-deepseek-r1-f16-run PRIVATE ${RISCV_COMPILE_OPTS})
+  target_compile_options(buddy-deepseek-r1-bf16-run PRIVATE ${RISCV_COMPILE_OPTS})
+  target_compile_options(buddy-deepseek-r1-cli PRIVATE ${RISCV_COMPILE_OPTS})
+
   target_link_options(buddy-deepseek-r1-run PRIVATE ${RISCV_LINK_OPTS})
+  target_link_options(buddy-deepseek-r1-f16-run PRIVATE ${RISCV_LINK_OPTS})
+  target_link_options(buddy-deepseek-r1-bf16-run PRIVATE ${RISCV_LINK_OPTS})
+  target_link_options(buddy-deepseek-r1-cli PRIVATE ${RISCV_LINK_OPTS})
 endif()
 
 target_link_directories(buddy-deepseek-r1-run PRIVATE ${LLVM_LIBRARY_DIR})
@@ -721,21 +755,40 @@ target_link_directories(buddy-deepseek-r1-f16-run PRIVATE ${LLVM_LIBRARY_DIR})
 target_link_directories(buddy-deepseek-r1-bf16-run PRIVATE ${LLVM_LIBRARY_DIR})
 target_link_directories(buddy-deepseek-r1-cli PRIVATE ${LLVM_LIBRARY_DIR})
 
-set(BUDDY_DEEPSEEKR1_LIBS
-  DEEPSEEKR1
-  mlir_c_runner_utils
-  omp
-)
-set(BUDDY_DEEPSEEKR1_F16_LIBS
-  DEEPSEEKR1_F16
-  mlir_c_runner_utils
-  omp
-)
-set(BUDDY_DEEPSEEKR1_BF16_LIBS
-  DEEPSEEKR1_BF16
-  mlir_c_runner_utils
-  omp
-)
+if(IS_RVV_CROSSCOMPILING)
+  set(BUDDY_DEEPSEEKR1_LIBS
+    DEEPSEEKR1
+    ${RISCV_MLIR_C_RUNNER_UTILS}
+    ${RISCV_OMP_SHARED}
+  )
+  set(BUDDY_DEEPSEEKR1_F16_LIBS
+    DEEPSEEKR1_F16
+    ${RISCV_MLIR_C_RUNNER_UTILS}
+    ${RISCV_OMP_SHARED}
+  )
+  set(BUDDY_DEEPSEEKR1_BF16_LIBS
+    DEEPSEEKR1_BF16
+    ${RISCV_MLIR_C_RUNNER_UTILS}
+    ${RISCV_OMP_SHARED}
+  )
+else()
+  set(BUDDY_DEEPSEEKR1_LIBS
+    DEEPSEEKR1
+    mlir_c_runner_utils
+    omp
+  )
+  set(BUDDY_DEEPSEEKR1_F16_LIBS
+    DEEPSEEKR1_F16
+    mlir_c_runner_utils
+    omp
+  )
+  set(BUDDY_DEEPSEEKR1_BF16_LIBS
+    DEEPSEEKR1_BF16
+    mlir_c_runner_utils
+    omp
+  )
+endif()
+
 if(BUDDY_MLIR_USE_MIMALLOC)
   list(APPEND BUDDY_DEEPSEEKR1_LIBS mimalloc)
   list(APPEND BUDDY_DEEPSEEKR1_F16_LIBS mimalloc)
@@ -745,7 +798,16 @@ endif()
 target_link_libraries(buddy-deepseek-r1-run ${BUDDY_DEEPSEEKR1_LIBS})
 target_link_libraries(buddy-deepseek-r1-f16-run ${BUDDY_DEEPSEEKR1_F16_LIBS})
 target_link_libraries(buddy-deepseek-r1-bf16-run ${BUDDY_DEEPSEEKR1_BF16_LIBS})
-target_link_libraries(buddy-deepseek-r1-cli ${BUDDY_DEEPSEEKR1_LIBS} LLVMOption)
+if(IS_RVV_CROSSCOMPILING)
+  target_link_libraries(buddy-deepseek-r1-cli
+                        ${BUDDY_DEEPSEEKR1_LIBS}
+                        ${BUILD_CROSS_MLIR_DIR}/lib/libLLVMOption.a
+                        ${BUILD_CROSS_MLIR_DIR}/lib/libLLVMSupport.a
+                        ${BUILD_CROSS_MLIR_DIR}/lib/libLLVMDemangle.a)
+else()
+  target_link_libraries(buddy-deepseek-r1-cli ${BUDDY_DEEPSEEKR1_LIBS} LLVMOption)
+endif()
+
 
 # Create a distributable package
 set(DIST_PACKAGE_NAME "buddy-deepseek-r1")
@@ -771,6 +833,128 @@ add_custom_target(buddy-deepseek-r1-package
     ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_prefill.mlir
     ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode.mlir
     ${CMAKE_CURRENT_BINARY_DIR}/arg0.data
+  USES_TERMINAL
+  VERBATIM
+)
+
+set(R1_RVV_PKG_NAME "buddy-deepseek-r1-rvv-package")
+set(R1_RVV_PKG_DIR ${CMAKE_CURRENT_BINARY_DIR}/${R1_RVV_PKG_NAME})
+set(R1_RVV_PKG_ARCHIVE ${CMAKE_CURRENT_BINARY_DIR}/${R1_RVV_PKG_NAME}.tgz)
+add_custom_target(buddy-deepseek-r1-rvv-package DEPENDS ${R1_RVV_PKG_ARCHIVE})
+add_custom_command(
+  OUTPUT ${R1_RVV_PKG_ARCHIVE}
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${R1_RVV_PKG_DIR}
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${BUILD_CROSS_MLIR_DIR}/lib/libmlir_float16_utils.so.22.0git
+    ${CMAKE_CURRENT_BINARY_DIR}/arg0.data
+    ${CMAKE_BINARY_DIR}/bin/buddy-deepseek-r1-run
+    ${CMAKE_SOURCE_DIR}/examples/BuddyDeepSeekR1/vocab.txt
+    ${RISCV_MLIR_C_RUNNER_UTILS}
+    ${RISCV_OMP_SHARED}
+    ${R1_RVV_PKG_DIR}/
+  COMMAND sh -c "tar -czf ${R1_RVV_PKG_ARCHIVE} ${R1_RVV_PKG_NAME}"
+  COMMAND ${CMAKE_COMMAND} -E remove_directory ${R1_RVV_PKG_DIR}
+  COMMENT "Creating RVV package: ${R1_RVV_PKG_ARCHIVE}"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS
+    ${BUILD_CROSS_MLIR_DIR}/lib/libmlir_float16_utils.so.22.0git
+    ${CMAKE_CURRENT_BINARY_DIR}/arg0.data
+    ${CMAKE_BINARY_DIR}/bin/buddy-deepseek-r1-run
+    ${CMAKE_SOURCE_DIR}/examples/BuddyDeepSeekR1/vocab.txt
+    ${RISCV_MLIR_C_RUNNER_UTILS}
+    ${RISCV_OMP_SHARED}
+  USES_TERMINAL
+  VERBATIM
+)
+
+set(R1F16_RVV_PKG_NAME "buddy-deepseek-r1-f16-rvv-package")
+set(R1F16_RVV_PKG_DIR ${CMAKE_CURRENT_BINARY_DIR}/${R1F16_RVV_PKG_NAME})
+set(R1F16_RVV_PKG_ARCHIVE ${CMAKE_CURRENT_BINARY_DIR}/${R1F16_RVV_PKG_NAME}.tgz)
+add_custom_target(buddy-deepseek-r1-f16-rvv-package DEPENDS ${R1F16_RVV_PKG_ARCHIVE})
+add_custom_command(
+  OUTPUT ${R1F16_RVV_PKG_ARCHIVE}
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${R1F16_RVV_PKG_DIR}
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${BUILD_CROSS_MLIR_DIR}/lib/libmlir_float16_utils.so.22.0git
+    ${CMAKE_CURRENT_BINARY_DIR}/arg0-f16.data
+    ${CMAKE_BINARY_DIR}/bin/buddy-deepseek-r1-f16-run
+    ${CMAKE_SOURCE_DIR}/examples/BuddyDeepSeekR1/vocab.txt
+    ${RISCV_MLIR_C_RUNNER_UTILS}
+    ${RISCV_OMP_SHARED}
+    ${R1F16_RVV_PKG_DIR}/
+  COMMAND sh -c "tar -czf ${R1F16_RVV_PKG_ARCHIVE} ${R1F16_RVV_PKG_NAME}"
+  COMMAND ${CMAKE_COMMAND} -E remove_directory ${R1F16_RVV_PKG_DIR}
+  COMMENT "Creating RVV package: ${R1F16_RVV_PKG_ARCHIVE}"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS
+    ${BUILD_CROSS_MLIR_DIR}/lib/libmlir_float16_utils.so.22.0git
+    ${CMAKE_CURRENT_BINARY_DIR}/arg0-f16.data
+    ${CMAKE_BINARY_DIR}/bin/buddy-deepseek-r1-f16-run
+    ${CMAKE_SOURCE_DIR}/examples/BuddyDeepSeekR1/vocab.txt
+    ${RISCV_MLIR_C_RUNNER_UTILS}
+    ${RISCV_OMP_SHARED}
+  USES_TERMINAL
+  VERBATIM
+)
+
+set(R1BF16_RVV_PKG_NAME "buddy-deepseek-r1-bf16-rvv-package")
+set(R1BF16_RVV_PKG_DIR ${CMAKE_CURRENT_BINARY_DIR}/${R1BF16_RVV_PKG_NAME})
+set(R1BF16_RVV_PKG_ARCHIVE ${CMAKE_CURRENT_BINARY_DIR}/${R1BF16_RVV_PKG_NAME}.tgz)
+add_custom_target(buddy-deepseek-r1-bf16-rvv-package DEPENDS ${R1BF16_RVV_PKG_ARCHIVE})
+add_custom_command(
+  OUTPUT ${R1BF16_RVV_PKG_ARCHIVE}
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${R1BF16_RVV_PKG_DIR}
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${BUILD_CROSS_MLIR_DIR}/lib/libmlir_float16_utils.so.22.0git
+    ${CMAKE_CURRENT_BINARY_DIR}/arg0-bf16.data
+    ${CMAKE_BINARY_DIR}/bin/buddy-deepseek-r1-bf16-run
+    ${CMAKE_SOURCE_DIR}/examples/BuddyDeepSeekR1/vocab.txt
+    ${RISCV_MLIR_C_RUNNER_UTILS}
+    ${RISCV_OMP_SHARED}
+    ${R1F16_RVV_PKG_DIR}/
+  COMMAND sh -c "tar -czf ${R1BF16_RVV_PKG_ARCHIVE} ${R1BF16_RVV_PKG_NAME}"
+  COMMAND ${CMAKE_COMMAND} -E remove_directory ${R1BF16_RVV_PKG_DIR}
+  COMMENT "Creating RVV package: ${R1BF16_RVV_PKG_ARCHIVE}"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS
+    ${BUILD_CROSS_MLIR_DIR}/lib/libmlir_float16_utils.so.22.0git
+    ${CMAKE_CURRENT_BINARY_DIR}/arg0-bf16.data
+    ${CMAKE_BINARY_DIR}/bin/buddy-deepseek-r1-bf16-run
+    ${CMAKE_SOURCE_DIR}/examples/BuddyDeepSeekR1/vocab.txt
+    ${RISCV_MLIR_C_RUNNER_UTILS}
+    ${RISCV_OMP_SHARED}
+  USES_TERMINAL
+  VERBATIM
+)
+
+
+
+set(R1CLI_RVV_PKG_NAME "buddy-deepseek-r1-cli-rvv-package")
+set(R1CLI_RVV_PKG_DIR ${CMAKE_CURRENT_BINARY_DIR}/${R1CLI_RVV_PKG_NAME})
+set(R1CLI_RVV_PKG_ARCHIVE ${CMAKE_CURRENT_BINARY_DIR}/${R1CLI_RVV_PKG_NAME}.tgz)
+add_custom_target(buddy-deepseek-r1-cli-rvv-package DEPENDS ${R1CLI_RVV_PKG_ARCHIVE})
+add_custom_command(
+  OUTPUT ${R1CLI_RVV_PKG_ARCHIVE}
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${R1CLI_RVV_PKG_DIR}
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${BUILD_CROSS_MLIR_DIR}/lib/libmlir_float16_utils.so.22.0git
+    ${CMAKE_CURRENT_BINARY_DIR}/arg0.data
+    ${CMAKE_BINARY_DIR}/bin/buddy-deepseek-r1-cli
+    ${CMAKE_SOURCE_DIR}/examples/BuddyDeepSeekR1/vocab.txt
+    ${RISCV_MLIR_C_RUNNER_UTILS}
+    ${RISCV_OMP_SHARED}
+    ${R1CLI_RVV_PKG_DIR}/
+  COMMAND sh -c "tar -czf ${R1CLI_RVV_PKG_ARCHIVE} ${R1CLI_RVV_PKG_NAME}"
+  COMMAND ${CMAKE_COMMAND} -E remove_directory ${R1CLI_RVV_PKG_DIR}
+  COMMENT "Creating RVV package: ${R1CLI_RVV_PKG_ARCHIVE}"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS
+    ${BUILD_CROSS_MLIR_DIR}/lib/libmlir_float16_utils.so.22.0git
+    ${CMAKE_CURRENT_BINARY_DIR}/arg0.data
+    ${CMAKE_BINARY_DIR}/bin/buddy-deepseek-r1-cli
+    ${CMAKE_SOURCE_DIR}/examples/BuddyDeepSeekR1/vocab.txt
+    ${RISCV_MLIR_C_RUNNER_UTILS}
+    ${RISCV_OMP_SHARED}
   USES_TERMINAL
   VERBATIM
 )
@@ -901,7 +1085,7 @@ foreach(CACHE_SIZE ${KV_CACHE_SIZES})
               -reconcile-unrealized-casts |
             ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
             ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
-            ${LLVM_TOOLS_BINARY_DIR}/llc -filetype=obj -relocation-model=pic -O3
+            ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} -filetype=obj -relocation-model=pic -O3
               -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph_decode_${CACHE_SIZE}.o
     DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode_${CACHE_SIZE}.mlir
     COMMENT "Building subgraph_decode_${CACHE_SIZE}.o"
@@ -1037,7 +1221,7 @@ target_compile_definitions(buddy-deepseek-r1-tiered-kv-cache-run PRIVATE
   DEEPSEEKR1_EXAMPLE_BUILD_PATH="${DEEPSEEKR1_EXAMPLE_BUILD_PATH}/"
 )
 
-if(IS_RVV_PLATFORM)
+if(IS_RVV_PLATFORM OR IS_RVV_CROSSCOMPILING)
   target_compile_options(buddy-deepseek-r1-tiered-kv-cache-run PRIVATE ${RISCV_COMPILE_OPTS})
   target_link_options(buddy-deepseek-r1-tiered-kv-cache-run PRIVATE ${RISCV_LINK_OPTS})
 endif()
@@ -1048,11 +1232,20 @@ target_link_directories(buddy-deepseek-r1-tiered-kv-cache-run PRIVATE ${LLVM_LIB
 # bufferization-lower-deallocations; allow multiple definitions when linking.
 target_link_options(buddy-deepseek-r1-tiered-kv-cache-run PRIVATE -Wl,--allow-multiple-definition)
 
-set(BUDDY_DEEPSEEKR1_TIERED_KV_CACHE_LIBS
-  DEEPSEEKR1_TIERED_KV_CACHE
-  mlir_c_runner_utils
-  omp
-)
+if(IS_RVV_CROSSCOMPILING)
+  set(BUDDY_DEEPSEEKR1_TIERED_KV_CACHE_LIBS
+    DEEPSEEKR1_TIERED_KV_CACHE
+    ${RISCV_MLIR_C_RUNNER_UTILS}
+    ${RISCV_OMP_SHARED}
+  )
+else()
+ set(BUDDY_DEEPSEEKR1_TIERED_KV_CACHE_LIBS
+   DEEPSEEKR1_TIERED_KV_CACHE
+   mlir_c_runner_utils
+   omp
+ )
+endif()
+
 if(BUDDY_MLIR_USE_MIMALLOC)
   list(APPEND BUDDY_DEEPSEEKR1_TIERED_KV_CACHE_LIBS mimalloc)
 endif()
@@ -1065,3 +1258,33 @@ add_custom_target(deepseekr1-tiered-kv-cache
 )
 
 message(STATUS "DeepSeekR1 Multi-Cache: Building prefill and decode subgraphs for cache sizes: ${KV_CACHE_SIZES}")
+
+set(R1KV_CACHE_RVV_PKG_NAME "buddy-deepseek-r1-tiered-kv-cache-run-rvv-pkg")
+set(R1KV_CACHE_RVV_PKG_DIR ${CMAKE_CURRENT_BINARY_DIR}/${R1KV_CACHE_RVV_PKG_NAME})
+set(R1KV_CACHE_RVV_PKG_ARCHIVE ${CMAKE_CURRENT_BINARY_DIR}/${R1KV_CACHE_RVV_PKG_NAME}.tgz)
+add_custom_target(buddy-deepseek-r1-tiered-kv-cache-run-rvv-package DEPENDS ${R1KV_CACHE_RVV_PKG_ARCHIVE})
+add_custom_command(
+  OUTPUT ${R1KV_CACHE_RVV_PKG_ARCHIVE}
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${R1KV_CACHE_RVV_PKG_DIR}
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${BUILD_CROSS_MLIR_DIR}/lib/libmlir_float16_utils.so.22.0git
+    ${CMAKE_CURRENT_BINARY_DIR}/arg0_mc.data
+    ${CMAKE_BINARY_DIR}/bin/buddy-deepseek-r1-tiered-kv-cache-run
+    ${CMAKE_SOURCE_DIR}/examples/BuddyDeepSeekR1/vocab.txt
+    ${RISCV_MLIR_C_RUNNER_UTILS}
+    ${RISCV_OMP_SHARED}
+    ${R1KV_CACHE_RVV_PKG_DIR}/
+  COMMAND sh -c "tar -czf ${R1KV_CACHE_RVV_PKG_ARCHIVE} ${R1KV_CACHE_RVV_PKG_NAME}"
+  COMMAND ${CMAKE_COMMAND} -E remove_directory ${R1KV_CACHE_RVV_PKG_DIR}
+  COMMENT "Creating RVV package: ${R1KV_CACHE_RVV_PKG_ARCHIVE}"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS
+    ${BUILD_CROSS_MLIR_DIR}/lib/libmlir_float16_utils.so.22.0git
+    ${CMAKE_CURRENT_BINARY_DIR}/arg0_mc.data
+    ${CMAKE_BINARY_DIR}/bin/buddy-deepseek-r1-tiered-kv-cache-run
+    ${CMAKE_SOURCE_DIR}/examples/BuddyDeepSeekR1/vocab.txt
+    ${RISCV_MLIR_C_RUNNER_UTILS}
+    ${RISCV_OMP_SHARED}
+  USES_TERMINAL
+  VERBATIM
+)

--- a/examples/BuddyDeepSeekR1/README.md
+++ b/examples/BuddyDeepSeekR1/README.md
@@ -205,3 +205,93 @@ cd buddy-mlir/build/
 ninja buddy-deepseek-r1-run
 ./bin/buddy-deepseek-r1-run
 ```
+
+## How to cross compile RISC-V target on x86_64 machine
+
+0. Clone code and initialize
+  Refer to steps 0. Prepare `buddy-mlir` and Submodules in the [docs/RVVEnvironment.md](https://github.com/buddy-compiler/buddy-mlir/blob/main/docs/RVVEnvironment.md).
+
+1. Build and test LLVM/MLIR
+  Refer to steps 1. Build Local LLVM/MLIR in the [docs/RVVEnvironment.md](https://github.com/buddy-compiler/buddy-mlir/blob/main/docs/RVVEnvironment.md).
+
+2. Build buddy-mlir
+  Refer to steps 2. Build Local `buddy-mlir` in the [docs/RVVEnvironment.md](https://github.com/buddy-compiler/buddy-mlir/blob/main/docs/RVVEnvironment.md) and add `export BUDDY_MLIR_BUILD_DIR=$PWD` `export PYTHONPATH=${BUILD_LOCAL_LLVM_DIR}/tools/mlir/python_packages/mlir_core:${BUDDY_MLIR_BUILD_DIR}/python_packages:${PYTHONPATH}` after execution.
+
+3. Build Cross-Compiled MLIR
+  Refer to steps 4. Build Cross-Compiled MLIR in the [docs/RVVEnvironment.md](https://github.com/buddy-compiler/buddy-mlir/blob/main/docs/RVVEnvironment.md).
+  Note: Add the `-DMLIR_IRDL_TO_CPP_EXE=${BUILD_LOCAL_LLVM_DIR}/bin/mlir-irdl-to-cpp` parameter at the end of cmake.
+       Add `export BUDDY_DEEPSEEKR1_LLVMOPT=${BUILD_CROSS_MLIR_DIR}/lib/libLLVMSupport.a` `export RISCV_MLIR_C_RUNNER_UTILS=${BUILD_CROSS_MLIR_DIR}/lib/libmlir_c_runner_utils.so.22.0git` parameter after execution.
+
+4. Pull the OpenMP shared library of RISC-V
+   Since the repository depends on OpenMP shared libraries, follow the steps below to set up the OpenMP dependency:
+```bash
+$ cd ${BUILD_LOCAL_LLVM_DIR}/../
+$ wget --no-check-certificate 'https://docs.google.com/uc?export=download&id=1XEsAhOcMioN9gdufuyO9OrHIdR0UtHh2' -O build-omp-shared-rv.tar.gz
+$ mkdir build-omp-shared-rv && tar -xzf build-omp-shared-rv.tar.gz -C build-omp-shared-rv && rm build-omp-shared-rv.tar.gz
+$ export RISCV_OMP_SHARED=${BUILD_LOCAL_LLVM_DIR}/../build-omp-shared-rv/libomp.so
+```
+
+5. Build for the target platform
+
+```bash
+$ cd buddy-mlir/build
+$ cmake -G Ninja .. \
+-DRISCV_GNU_TOOLCHAIN=${BUILD_RISCV_GNU_TOOLCHAIN_DIR} \
+-DDEEPSEEKR1_EXAMPLE_PATH=. \
+-DDEEPSEEKR1_EXAMPLE_BUILD_PATH=. \
+-DBUDDY_DEEPSEEKR1_EXAMPLES=ON \
+-DIS_RVV_CROSSCOMPILING=ON \
+-DRISCV_OMP_SHARED=${RISCV_OMP_SHARED} \
+-DRISCV_MLIR_C_RUNNER_UTILS=${RISCV_MLIR_C_RUNNER_UTILS} \
+-DBUILD_CROSS_MLIR_DIR=${BUILD_CROSS_MLIR_DIR} \
+-DBUDDY_MLIR_BUILD_DIR=${BUDDY_MLIR_BUILD_DIR}
+$ ninja <target> # For example: `ninja buddy-deepseek-r1-run`
+```
+
+Compile, package, and run
+```bash
+# f32
+$ ninja buddy-deepseek-r1-run
+$ ninja buddy-deepseek-r1-rvv-package
+$ scp ./examples/BuddyDeepSeekR1/buddy-deepseek-r1-rvv-package.tgz user@risc-v-host:
+# On risc-v-host
+rv-user$ tar xzf buddy-deepseek-r1-rvv-package.tgz && cd buddy-deepseek-r1-rvv-package
+rv-user$ export LD_LIBRARY_PATH=${PWD}:$LD_LIBRARY_PATH
+rv-user$ ./buddy-deepseek-r1-run
+
+# f16
+$ ninja buddy-deepseek-r1-f16-run
+$ ninja buddy-deepseek-r1-f16-rvv-package
+$ scp ./examples/BuddyDeepSeekR1/buddy-deepseek-r1-f16-rvv-package.tgz user@risc-v-host:
+# On risc-v-host
+rv-user$ tar xzf buddy-deepseek-r1-f16-rvv-package.tgz && cd buddy-deepseek-r1-f16-rvv-package
+rv-user$ export LD_LIBRARY_PATH=${PWD}:$LD_LIBRARY_PATH
+rv-user$ ./buddy-deepseek-r1-f16-run
+
+# bf16
+$ ninja buddy-deepseek-r1-bf16-run
+$ ninja buddy-deepseek-r1-bf16-rvv-package
+$ scp ./examples/BuddyDeepSeekR1/buddy-deepseek-r1-bf16-rvv-package.tgz user@risc-v-host:
+# On risc-v-host
+rv-user$ tar xzf buddy-deepseek-r1-bf16-rvv-package.tgz && cd buddy-deepseek-r1-bf16-rvv-package
+rv-user$ export LD_LIBRARY_PATH=${PWD}:$LD_LIBRARY_PATH
+rv-user$ ./buddy-deepseek-r1-bf16-run
+
+# cli
+$ ninja buddy-deepseek-r1-cli
+$ ninja buddy-deepseek-r1-cli-rvv-package
+$ scp ./examples/BuddyDeepSeekR1/buddy-deepseek-r1-cli-rvv-package.tgz user@risc-v-host:
+# On risc-v-host
+rv-user:~$ tar xzf buddy-deepseek-r1-cli-rvv-package.tgz && cd buddy-deepseek-r1-cli-rvv-package
+rv-user:~$ export LD_LIBRARY_PATH=${PWD}:$LD_LIBRARY_PATH
+rv-user:~$ echo "Hello." | ./buddy-deepseek-r1-cli --no-stats 
+
+# kv
+$ ninja buddy-deepseek-r1-tiered-kv-cache-run
+$ ninja buddy-deepseek-r1-tiered-kv-cache-run-rvv-package
+$ scp /examples/BuddyDeepSeekR1/buddy-deepseek-r1-tiered-kv-cache-run-rvv-pkg.tgz user@risc-v-host:
+# On risc-v-host
+rv-user:~$ tar xzf buddy-deepseek-r1-tiered-kv-cache-run-rvv-pkg.tgz && cd buddy-deepseek-r1-tiered-kv-cache-run-rvv-pkg
+rv-user:~$ export LD_LIBRARY_PATH=${PWD}:$LD_LIBRARY_PATH
+rv-user:~$ ./buddy-deepseek-r1-tiered-kv-cache-run
+```


### PR DESCRIPTION
## Summary

- BuddyDeepSeekR1 supports riscv cross compilation
- README.md -> How to cross compile RISC-V target on x86_64 machine
- Update LLVM construction method in docs/RVVEnvironment.md

## Checklist

- [ OK] The code builds successfully
- [ OK] Existing tests pass
- [ OK] New tests are added where appropriate
- [OK ] Code follows the project coding style
- [ OK] Documentation is updated if needed
