### PR TITLE
[VIR] Support Reduce 3D And Transpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ $ cmake -G Ninja .. \
     -DLLVM_DIR=$PWD/../llvm/build/lib/cmake/llvm \
     -DLLVM_ENABLE_ASSERTIONS=ON \
     -DCMAKE_BUILD_TYPE=RELEASE \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
     -DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON \
     -DPython3_EXECUTABLE=$(which python3)
 $ ninja

--- a/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
+++ b/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
@@ -382,6 +382,7 @@ static LogicalResult lowerReduceToScalarLoop(linalg::ReduceOp reduceOp,
   };
 
   // Case A: rank-1 -> rank-0, dimensions = [0].
+  // Reduce the full 1D buffer into a scalar accumulator.
   if (inTy.getRank() == 1 && outTy.getRank() == 0) {
     if (dims.size() != 1 || dims[0] != 0)
       return rewriter.notifyMatchFailure(
@@ -420,60 +421,240 @@ static LogicalResult lowerReduceToScalarLoop(linalg::ReduceOp reduceOp,
   }
 
   // Case B: rank-2 -> rank-1, dimensions = [1].
+  // Reduce each row of the MxN input into one output element.
   if (inTy.getRank() == 2 && outTy.getRank() == 1) {
-    if (dims.size() != 1 || dims[0] != 1)
+    if (dims.size() != 1)
       return rewriter.notifyMatchFailure(
-          reduceOp, "rank-2 -> rank-1 reduction requires dimensions=[1]");
+          reduceOp, "rank-2 -> rank-1 reduction requires one dimension");
 
     int64_t inStaticM = inTy.getShape()[0];
+    int64_t inStaticN = inTy.getShape()[1];
     int64_t outStaticM = outTy.getShape()[0];
-    if (!ShapedType::isDynamic(inStaticM) && !ShapedType::isDynamic(outStaticM) &&
-        inStaticM != outStaticM) {
-      return rewriter.notifyMatchFailure(
-          reduceOp, "input/output leading dimension mismatch");
+    Type elemTy = inTy.getElementType();
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+
+    if (dims[0] == 1) {
+      if (!ShapedType::isDynamic(inStaticM) &&
+          !ShapedType::isDynamic(outStaticM) && inStaticM != outStaticM) {
+        return rewriter.notifyMatchFailure(
+            reduceOp, "input/output leading dimension mismatch");
+      }
+
+      Value upperM = rewriter.create<memref::DimOp>(loc, input, 0);
+      Value upperN = rewriter.create<memref::DimOp>(loc, input, 1);
+      auto outerLoop = rewriter.create<scf::ForOp>(loc, lower, upperM, step);
+
+      {
+        OpBuilder::InsertionGuard g(rewriter);
+        rewriter.setInsertionPointToStart(outerLoop.getBody());
+        Value i = outerLoop.getInductionVar();
+        auto accBufTy = MemRefType::get({}, elemTy);
+        Value accBuf = rewriter.create<memref::AllocaOp>(loc, accBufTy);
+        Value initVal = rewriter.create<memref::LoadOp>(loc, init, ValueRange{i});
+        rewriter.create<memref::StoreOp>(loc, initVal, accBuf, ValueRange{});
+
+        auto setVl = rewriter.create<buddy::vir::SetVLOp>(
+            loc, /*results=*/TypeRange{}, /*operands=*/ValueRange{upperN});
+        Region &region = setVl.getRegion();
+        Block &block = region.emplaceBlock();
+        rewriter.setInsertionPointToStart(&block);
+
+        auto vecTy =
+            buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
+        Value row = rewriter
+                        .create<buddy::vir::LoadOp>(loc, vecTy, input,
+                                                    ValueRange{i, c0})
+                        .getResult();
+        Value acc = rewriter.create<memref::LoadOp>(loc, accBuf, ValueRange{});
+        Value reduced =
+            rewriter
+                .create<buddy::vir::ReduceOp>(
+                    loc, elemTy, row, acc,
+                    rewriter.getStringAttr(kindToString(*combinerKind)))
+                .getResult();
+        rewriter.create<memref::StoreOp>(loc, reduced, accBuf, ValueRange{});
+        rewriter.create<vector::YieldOp>(loc);
+
+        rewriter.setInsertionPointAfter(setVl);
+        Value finalVal =
+            rewriter.create<memref::LoadOp>(loc, accBuf, ValueRange{});
+        rewriter.create<memref::StoreOp>(loc, finalVal, init, ValueRange{i});
+      }
+
+      rewriter.eraseOp(reduceOp);
+      return success();
     }
 
+    // Case C: rank-2 -> rank-1, dimensions = [0].
+    // First transpose MxN -> NxM so reducing the original leading dimension
+    // becomes a reduction across one transposed row. The transpose view has a
+    // non-unit stride on the minor dimension, so we materialize it into a
+    // contiguous NxM scratch buffer before lowering further; otherwise
+    // -lower-vir-to-vector would reject the eventual vector.load because the
+    // innermost dimension would not be unit-stride.
+    if (dims[0] == 0) {
+      int64_t outStaticN = outTy.getShape()[0];
+      if (ShapedType::isDynamic(inStaticM) || ShapedType::isDynamic(inStaticN) ||
+          ShapedType::isDynamic(outStaticN)) {
+        return rewriter.notifyMatchFailure(
+            reduceOp, "rank-2 -> rank-1 dimensions=[0] requires static M/N");
+      }
+      if (inStaticN != outStaticN)
+        return rewriter.notifyMatchFailure(
+            reduceOp, "input/output trailing dimension mismatch");
+
+      Value upperN = rewriter.create<arith::ConstantIndexOp>(loc, inStaticN);
+      Value upperM = rewriter.create<arith::ConstantIndexOp>(loc, inStaticM);
+      SmallVector<int64_t> permutation = {1, 0};
+      auto permutationMap =
+          AffineMap::getPermutationMap(permutation, rewriter.getContext());
+      auto scope = rewriter.create<memref::AllocaScopeOp>(loc, TypeRange{});
+      Block *scopeBlock = rewriter.createBlock(&scope.getBodyRegion());
+      rewriter.setInsertionPointToStart(scopeBlock);
+
+      Value transposed = rewriter.create<memref::TransposeOp>(
+          loc, input, AffineMapAttr::get(permutationMap));
+      auto scratchTy = MemRefType::get({inStaticN, inStaticM}, elemTy);
+      Value scratch = rewriter.create<memref::AllocaOp>(loc, scratchTy);
+      rewriter.create<memref::CopyOp>(loc, transposed, scratch);
+      auto outerLoop = rewriter.create<scf::ForOp>(loc, lower, upperN, step);
+
+      {
+        OpBuilder::InsertionGuard g(rewriter);
+        rewriter.setInsertionPointToStart(outerLoop.getBody());
+        Value j = outerLoop.getInductionVar();
+        auto accBufTy = MemRefType::get({}, elemTy);
+        Value accBuf = rewriter.create<memref::AllocaOp>(loc, accBufTy);
+        Value initVal = rewriter.create<memref::LoadOp>(loc, init, ValueRange{j});
+        rewriter.create<memref::StoreOp>(loc, initVal, accBuf, ValueRange{});
+
+        auto setVl = rewriter.create<buddy::vir::SetVLOp>(
+            loc, /*results=*/TypeRange{}, /*operands=*/ValueRange{upperM});
+        Region &region = setVl.getRegion();
+        Block &block = region.emplaceBlock();
+        rewriter.setInsertionPointToStart(&block);
+
+        auto vecTy =
+            buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
+        Value col =
+            rewriter
+                .create<buddy::vir::LoadOp>(loc, vecTy, scratch, ValueRange{j, c0})
+                .getResult();
+        Value acc = rewriter.create<memref::LoadOp>(loc, accBuf, ValueRange{});
+        Value reduced =
+            rewriter
+                .create<buddy::vir::ReduceOp>(
+                    loc, elemTy, col, acc,
+                    rewriter.getStringAttr(kindToString(*combinerKind)))
+                .getResult();
+        rewriter.create<memref::StoreOp>(loc, reduced, accBuf, ValueRange{});
+        rewriter.create<vector::YieldOp>(loc);
+
+        rewriter.setInsertionPointAfter(setVl);
+        Value finalVal =
+            rewriter.create<memref::LoadOp>(loc, accBuf, ValueRange{});
+        rewriter.create<memref::StoreOp>(loc, finalVal, init, ValueRange{j});
+      }
+      rewriter.setInsertionPointToEnd(scopeBlock);
+      rewriter.create<memref::AllocaScopeReturnOp>(loc, ValueRange{});
+
+      rewriter.eraseOp(reduceOp);
+      return success();
+    }
+
+    return rewriter.notifyMatchFailure(
+        reduceOp, "rank-2 -> rank-1 reduction requires dimensions=[0] or [1]");
+  }
+
+  // Case D: rank-3 -> rank-2, dimensions = [0].
+  // Transpose MxNxK -> NxKxM so reducing the original leading dimension becomes
+  // a reduction across one contiguous length-M slice per (j, k). The transpose
+  // view is still strided on the minor dimension, so we materialize it into a
+  // contiguous NxKxM scratch buffer; otherwise -lower-vir-to-vector would
+  // reject the eventual vector.load because the innermost dimension would not
+  // be unit-stride.
+  if (inTy.getRank() == 3 && outTy.getRank() == 2) {
+    if (dims.size() != 1 || dims[0] != 0)
+      return rewriter.notifyMatchFailure(
+          reduceOp, "rank-3 -> rank-2 reduction requires dimensions=[0]");
+
+    int64_t inStaticM = inTy.getShape()[0];
+    int64_t inStaticN = inTy.getShape()[1];
+    int64_t inStaticK = inTy.getShape()[2];
+    int64_t outStaticN = outTy.getShape()[0];
+    int64_t outStaticK = outTy.getShape()[1];
+    if (ShapedType::isDynamic(inStaticM) || ShapedType::isDynamic(inStaticN) ||
+        ShapedType::isDynamic(inStaticK) || ShapedType::isDynamic(outStaticN) ||
+        ShapedType::isDynamic(outStaticK)) {
+      return rewriter.notifyMatchFailure(
+          reduceOp, "rank-3 -> rank-2 dimensions=[0] requires static M/N/K");
+    }
+    if (inStaticN != outStaticN || inStaticK != outStaticK)
+      return rewriter.notifyMatchFailure(
+          reduceOp, "input/output trailing dimensions mismatch");
+
     Type elemTy = inTy.getElementType();
-    Value upperM = rewriter.create<memref::DimOp>(loc, input, 0);
-    Value upperN = rewriter.create<memref::DimOp>(loc, input, 1);
     Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    auto outerLoop = rewriter.create<scf::ForOp>(loc, lower, upperM, step);
+    Value upperN = rewriter.create<arith::ConstantIndexOp>(loc, inStaticN);
+    Value upperK = rewriter.create<arith::ConstantIndexOp>(loc, inStaticK);
+    Value upperM = rewriter.create<arith::ConstantIndexOp>(loc, inStaticM);
+    SmallVector<int64_t> permutation = {1, 2, 0};
+    auto permutationMap =
+        AffineMap::getPermutationMap(permutation, rewriter.getContext());
+
+    Value transposed = rewriter.create<memref::TransposeOp>(
+        loc, input, AffineMapAttr::get(permutationMap));
+    auto scratchTy = MemRefType::get({inStaticN, inStaticK, inStaticM}, elemTy);
+    Value scratch = rewriter.create<memref::AllocOp>(loc, scratchTy);
+    rewriter.create<memref::CopyOp>(loc, transposed, scratch);
+    auto outerLoop = rewriter.create<scf::ForOp>(loc, lower, upperN, step);
 
     {
       OpBuilder::InsertionGuard g(rewriter);
       rewriter.setInsertionPointToStart(outerLoop.getBody());
-      Value i = outerLoop.getInductionVar();
-      auto accBufTy = MemRefType::get({}, elemTy);
-      Value accBuf = rewriter.create<memref::AllocaOp>(loc, accBufTy);
-      Value initVal = rewriter.create<memref::LoadOp>(loc, init, ValueRange{i});
-      rewriter.create<memref::StoreOp>(loc, initVal, accBuf, ValueRange{});
+      Value j = outerLoop.getInductionVar();
+      auto innerLoop = rewriter.create<scf::ForOp>(loc, lower, upperK, step);
 
-      auto setVl = rewriter.create<buddy::vir::SetVLOp>(
-          loc, /*results=*/TypeRange{}, /*operands=*/ValueRange{upperN});
-      Region &region = setVl.getRegion();
-      Block &block = region.emplaceBlock();
-      rewriter.setInsertionPointToStart(&block);
+      {
+        OpBuilder::InsertionGuard innerGuard(rewriter);
+        rewriter.setInsertionPointToStart(innerLoop.getBody());
+        Value k = innerLoop.getInductionVar();
+        auto accBufTy = MemRefType::get({}, elemTy);
+        Value accBuf = rewriter.create<memref::AllocaOp>(loc, accBufTy);
+        Value initVal =
+            rewriter.create<memref::LoadOp>(loc, init, ValueRange{j, k});
+        rewriter.create<memref::StoreOp>(loc, initVal, accBuf, ValueRange{});
 
-      auto vecTy =
-          buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
-      Value row = rewriter
-                      .create<buddy::vir::LoadOp>(loc, vecTy, input,
-                                                  ValueRange{i, c0})
-                      .getResult();
-      Value acc = rewriter.create<memref::LoadOp>(loc, accBuf, ValueRange{});
-      Value reduced =
-          rewriter
-              .create<buddy::vir::ReduceOp>(
-                  loc, elemTy, row, acc,
-                  rewriter.getStringAttr(kindToString(*combinerKind)))
-              .getResult();
-      rewriter.create<memref::StoreOp>(loc, reduced, accBuf, ValueRange{});
-      rewriter.create<vector::YieldOp>(loc);
+        auto setVl = rewriter.create<buddy::vir::SetVLOp>(
+            loc, /*results=*/TypeRange{}, /*operands=*/ValueRange{upperM});
+        Region &region = setVl.getRegion();
+        Block &block = region.emplaceBlock();
+        rewriter.setInsertionPointToStart(&block);
 
-      rewriter.setInsertionPointAfter(setVl);
-      Value finalVal = rewriter.create<memref::LoadOp>(loc, accBuf, ValueRange{});
-      rewriter.create<memref::StoreOp>(loc, finalVal, init, ValueRange{i});
+        auto vecTy =
+            buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
+        Value slice =
+            rewriter
+                .create<buddy::vir::LoadOp>(loc, vecTy, scratch,
+                                            ValueRange{j, k, c0})
+                .getResult();
+        Value acc = rewriter.create<memref::LoadOp>(loc, accBuf, ValueRange{});
+        Value reduced =
+            rewriter
+                .create<buddy::vir::ReduceOp>(
+                    loc, elemTy, slice, acc,
+                    rewriter.getStringAttr(kindToString(*combinerKind)))
+                .getResult();
+        rewriter.create<memref::StoreOp>(loc, reduced, accBuf, ValueRange{});
+        rewriter.create<vector::YieldOp>(loc);
+
+        rewriter.setInsertionPointAfter(setVl);
+        Value finalVal =
+            rewriter.create<memref::LoadOp>(loc, accBuf, ValueRange{});
+        rewriter.create<memref::StoreOp>(loc, finalVal, init, ValueRange{j, k});
+      }
     }
+    rewriter.create<memref::DeallocOp>(loc, scratch);
 
     rewriter.eraseOp(reduceOp);
     return success();
@@ -482,7 +663,8 @@ static LogicalResult lowerReduceToScalarLoop(linalg::ReduceOp reduceOp,
   return rewriter.notifyMatchFailure(
       reduceOp,
       "only rank-1 -> rank-0 (dimensions=[0]) and rank-2 -> rank-1 "
-      "(dimensions=[1]) reductions are supported");
+      "(dimensions=[1] or static-shape dimensions=[0]) plus static-shape "
+      "rank-3 -> rank-2 (dimensions=[0]) reductions are supported");
 }
 
 static LogicalResult lowerIndexOnlyGenericToScalarLoop(linalg::LinalgOp linalgOp,
@@ -1097,8 +1279,9 @@ struct LinalgReduceToVIRPattern : public RewritePattern {
       return success();
     reduceOp.emitError(
         "unsupported linalg.reduce for -lower-linalg-to-vir; supported forms "
-        "are rank-1->rank-0 dimensions=[0] and rank-2->rank-1 "
-        "dimensions=[1], both with f32 addf/maxnumf combiner");
+        "are rank-1->rank-0 dimensions=[0], rank-2->rank-1 dimensions=[1], "
+        "static-shape rank-2->rank-1 dimensions=[0], and static-shape "
+        "rank-3->rank-2 dimensions=[0], all with f32 addf/maxnumf combiner");
     return failure();
   }
 };

--- a/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
+++ b/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
@@ -1142,6 +1142,106 @@ static LogicalResult storeYieldValues(linalg::LinalgOp linalgOp,
   return success();
 }
 
+static FailureOr<SmallVector<int64_t>>
+computeTransposedMemRefShape(MemRefType inputType,
+                             ArrayRef<int64_t> permutation) {
+  if (!inputType.hasStaticShape())
+    return failure();
+  if (static_cast<int64_t>(permutation.size()) != inputType.getRank())
+    return failure();
+
+  SmallVector<int64_t> outputShape;
+  outputShape.reserve(permutation.size());
+  for (int64_t dim : permutation) {
+    if (dim < 0 || dim >= inputType.getRank())
+      return failure();
+    outputShape.push_back(inputType.getShape()[dim]);
+  }
+  return outputShape;
+}
+
+static FailureOr<Value> createZeroPaddingValue(OpBuilder &builder, Location loc,
+                                               Type elementType) {
+  TypedAttr zeroAttr = builder.getZeroAttr(elementType);
+  if (!zeroAttr)
+    return failure();
+  return builder.create<arith::ConstantOp>(loc, zeroAttr).getResult();
+}
+
+struct LinalgTransposeToVectorPattern : public RewritePattern {
+  LinalgTransposeToVectorPattern(MLIRContext *ctx)
+      : RewritePattern(linalg::TransposeOp::getOperationName(),
+                       /*benefit=*/4, ctx) {}
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    auto transposeOp = dyn_cast<linalg::TransposeOp>(op);
+    if (!transposeOp)
+      return rewriter.notifyMatchFailure(op, "expected linalg.transpose");
+    if (!transposeOp.hasPureBufferSemantics()) {
+      return rewriter.notifyMatchFailure(op, "expected pure buffer semantics");
+    }
+    if (transposeOp.getNumDpsInputs() != 1 || transposeOp.getNumDpsInits() != 1)
+      return rewriter.notifyMatchFailure(op, "expected one input and one output");
+
+    auto inputType = dyn_cast<MemRefType>(transposeOp.getInput().getType());
+    if (!inputType)
+      return rewriter.notifyMatchFailure(op, "expected memref input");
+    auto outputType = dyn_cast<MemRefType>(transposeOp.getInit().getType());
+    if (!outputType)
+      return rewriter.notifyMatchFailure(op, "expected memref output");
+    if (!inputType.hasStaticShape() || !outputType.hasStaticShape()) {
+      return rewriter.notifyMatchFailure(op, "expected fully static memref shapes");
+    }
+    if (inputType.getRank() != outputType.getRank()) {
+      return rewriter.notifyMatchFailure(op, "expected input/output ranks to match");
+    }
+    if (inputType.getElementType() != outputType.getElementType()) {
+      return rewriter.notifyMatchFailure(
+          op, "expected input/output element types to match");
+    }
+
+    FailureOr<SmallVector<int64_t>> transposedShape =
+        computeTransposedMemRefShape(inputType, transposeOp.getPermutation());
+    if (failed(transposedShape)) {
+      return rewriter.notifyMatchFailure(op, "invalid transpose permutation");
+    }
+    if (ArrayRef<int64_t>(*transposedShape) != outputType.getShape()) {
+      return rewriter.notifyMatchFailure(
+          op, "output shape does not match permuted input shape");
+    }
+    if (llvm::any_of(inputType.getShape(),
+                     [](int64_t dim) { return dim == 0; })) {
+      // Zero-element transposes have no reads or writes to perform.
+      rewriter.eraseOp(transposeOp);
+      return success();
+    }
+
+    Location loc = transposeOp.getLoc();
+    Value zeroIndex = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    SmallVector<Value> indices(inputType.getRank(), zeroIndex);
+    auto vectorType =
+        VectorType::get(inputType.getShape(), inputType.getElementType());
+    FailureOr<Value> padding =
+        createZeroPaddingValue(rewriter, loc, inputType.getElementType());
+    if (failed(padding))
+      return rewriter.notifyMatchFailure(op, "failed to create zero padding");
+
+    AffineMap identityMap = rewriter.getMultiDimIdentityMap(inputType.getRank());
+    SmallVector<bool> inBounds(inputType.getRank(), true);
+    Value read = rewriter.create<vector::TransferReadOp>(
+        loc, vectorType, transposeOp.getInput(), indices, *padding, identityMap,
+        inBounds);
+    Value transposed =
+        rewriter.create<vector::TransposeOp>(loc, read, transposeOp.getPermutation());
+    rewriter.create<vector::TransferWriteOp>(loc, transposed,
+                                             transposeOp.getInit(), indices,
+                                             identityMap);
+    rewriter.eraseOp(transposeOp);
+    return success();
+  }
+};
+
 struct LinalgGenericToVIRPattern : public RewritePattern {
   LinalgGenericToVIRPattern(MLIRContext *ctx)
       : RewritePattern(MatchAnyOpTypeTag(), /*benefit=*/1, ctx) {}
@@ -1314,6 +1414,7 @@ public:
   void runOnOperation() override {
     MLIRContext *ctx = &getContext();
     RewritePatternSet patterns(ctx);
+    patterns.add<LinalgTransposeToVectorPattern>(ctx);
     patterns.add<LinalgReduceToVIRPattern>(ctx);
     patterns.add<LinalgMatmulToVIRPattern>(ctx);
     patterns.add<LinalgGenericToVIRPattern>(ctx);

--- a/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
+++ b/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
@@ -508,14 +508,10 @@ static LogicalResult lowerReduceToScalarLoop(linalg::ReduceOp reduceOp,
       SmallVector<int64_t> permutation = {1, 0};
       auto permutationMap =
           AffineMap::getPermutationMap(permutation, rewriter.getContext());
-      auto scope = rewriter.create<memref::AllocaScopeOp>(loc, TypeRange{});
-      Block *scopeBlock = rewriter.createBlock(&scope.getBodyRegion());
-      rewriter.setInsertionPointToStart(scopeBlock);
-
       Value transposed = rewriter.create<memref::TransposeOp>(
           loc, input, AffineMapAttr::get(permutationMap));
       auto scratchTy = MemRefType::get({inStaticN, inStaticM}, elemTy);
-      Value scratch = rewriter.create<memref::AllocaOp>(loc, scratchTy);
+      Value scratch = rewriter.create<memref::AllocOp>(loc, scratchTy);
       rewriter.create<memref::CopyOp>(loc, transposed, scratch);
       auto outerLoop = rewriter.create<scf::ForOp>(loc, lower, upperN, step);
 
@@ -555,8 +551,7 @@ static LogicalResult lowerReduceToScalarLoop(linalg::ReduceOp reduceOp,
             rewriter.create<memref::LoadOp>(loc, accBuf, ValueRange{});
         rewriter.create<memref::StoreOp>(loc, finalVal, init, ValueRange{j});
       }
-      rewriter.setInsertionPointToEnd(scopeBlock);
-      rewriter.create<memref::AllocaScopeReturnOp>(loc, ValueRange{});
+      rewriter.create<memref::DeallocOp>(loc, scratch);
 
       rewriter.eraseOp(reduceOp);
       return success();

--- a/tests/Conversion/linalg-lowering-to-vir-fallbacks.mlir
+++ b/tests/Conversion/linalg-lowering-to-vir-fallbacks.mlir
@@ -102,14 +102,20 @@ func.func @reduce_2d_dim0_addf(%arg0: memref<4x8xf32>, %arg1: memref<8xf32>) {
 
 // CHECK-LABEL: func.func @reduce_2d_dim0_addf
 // CHECK-NOT: linalg.reduce
-// CHECK: memref.alloca_scope
+// CHECK-NOT: memref.alloca_scope
 // CHECK: memref.transpose %arg0 {{.*}} : memref<4x8xf32> to memref<8x4xf32, {{.*}}>
-// CHECK-COUNT-1: scf.for %[[J:[^ ]+]] =
+// CHECK: %[[SCRATCH:.+]] = memref.alloc() : memref<8x4xf32>
+// CHECK-NEXT: memref.copy %transpose, %[[SCRATCH]] : memref<8x4xf32, {{.*}}> to memref<8x4xf32>
+// CHECK: scf.for %[[J:[^ ]+]] =
 // CHECK: %[[INIT:.+]] = memref.load %arg1[%[[J]]]
 // CHECK: vir.set_vl
 // CHECK: vir.load {{.*}}[%[[J]], {{[^]]+}}]
 // CHECK: vir.reduce
 // CHECK: memref.store
+// CHECK: %[[FINAL:.+]] = memref.load %alloca[] : memref<f32>
+// CHECK-NEXT: memref.store %[[FINAL]], %arg1[%[[J]]]
+// CHECK-NEXT: }
+// CHECK-NEXT: memref.dealloc %[[SCRATCH]] : memref<8x4xf32>
 // CHECK-VEC-REDUCE-LABEL: func.func @reduce_2d_dim0_addf
 // CHECK-VEC-REDUCE: memref.transpose %arg0 {{.*}} : memref<4x8xf32> to memref<8x4xf32, {{.*}}>
 // CHECK-VEC-REDUCE: vector.reduction <add>
@@ -128,14 +134,20 @@ func.func @reduce_2d_dim0_maxnumf(%arg0: memref<4x8xf32>, %arg1: memref<8xf32>) 
 
 // CHECK-LABEL: func.func @reduce_2d_dim0_maxnumf
 // CHECK-NOT: linalg.reduce
-// CHECK: memref.alloca_scope
+// CHECK-NOT: memref.alloca_scope
 // CHECK: memref.transpose %arg0 {{.*}} : memref<4x8xf32> to memref<8x4xf32, {{.*}}>
-// CHECK-COUNT-1: scf.for %[[J:[^ ]+]] =
+// CHECK: %[[SCRATCH:.+]] = memref.alloc() : memref<8x4xf32>
+// CHECK-NEXT: memref.copy %transpose, %[[SCRATCH]] : memref<8x4xf32, {{.*}}> to memref<8x4xf32>
+// CHECK: scf.for %[[J:[^ ]+]] =
 // CHECK: %[[INIT:.+]] = memref.load %arg1[%[[J]]]
 // CHECK: vir.set_vl
 // CHECK: vir.load {{.*}}[%[[J]], {{[^]]+}}]
 // CHECK: vir.reduce
 // CHECK: memref.store
+// CHECK: %[[FINAL:.+]] = memref.load %alloca[] : memref<f32>
+// CHECK-NEXT: memref.store %[[FINAL]], %arg1[%[[J]]]
+// CHECK-NEXT: }
+// CHECK-NEXT: memref.dealloc %[[SCRATCH]] : memref<8x4xf32>
 // CHECK-VEC-REDUCE-LABEL: func.func @reduce_2d_dim0_maxnumf
 // CHECK-VEC-REDUCE: memref.transpose %arg0 {{.*}} : memref<4x8xf32> to memref<8x4xf32, {{.*}}>
 // CHECK-VEC-REDUCE: vector.reduction <maxnumf>

--- a/tests/Conversion/linalg-lowering-to-vir-fallbacks.mlir
+++ b/tests/Conversion/linalg-lowering-to-vir-fallbacks.mlir
@@ -90,6 +90,114 @@ func.func @reduce_2d_to_1d_maxnumf(%arg0: memref<4x8xf32>, %arg1: memref<4xf32>)
 // CHECK-VEC-REDUCE: arith.maxnumf
 
 // -----
+// CASE: linalg-reduce-to-vir-2d-dim0-addf-f32.mlir
+func.func @reduce_2d_dim0_addf(%arg0: memref<4x8xf32>, %arg1: memref<8xf32>) {
+  linalg.reduce ins(%arg0 : memref<4x8xf32>) outs(%arg1 : memref<8xf32>) dimensions = [0]
+    (%in: f32, %init: f32) {
+      %sum = arith.addf %in, %init : f32
+      linalg.yield %sum : f32
+    }
+  return
+}
+
+// CHECK-LABEL: func.func @reduce_2d_dim0_addf
+// CHECK-NOT: linalg.reduce
+// CHECK: memref.alloca_scope
+// CHECK: memref.transpose %arg0 {{.*}} : memref<4x8xf32> to memref<8x4xf32, {{.*}}>
+// CHECK-COUNT-1: scf.for %[[J:[^ ]+]] =
+// CHECK: %[[INIT:.+]] = memref.load %arg1[%[[J]]]
+// CHECK: vir.set_vl
+// CHECK: vir.load {{.*}}[%[[J]], {{[^]]+}}]
+// CHECK: vir.reduce
+// CHECK: memref.store
+// CHECK-VEC-REDUCE-LABEL: func.func @reduce_2d_dim0_addf
+// CHECK-VEC-REDUCE: memref.transpose %arg0 {{.*}} : memref<4x8xf32> to memref<8x4xf32, {{.*}}>
+// CHECK-VEC-REDUCE: vector.reduction <add>
+// CHECK-VEC-REDUCE: arith.addf
+
+// -----
+// CASE: linalg-reduce-to-vir-2d-dim0-maxnumf-f32.mlir
+func.func @reduce_2d_dim0_maxnumf(%arg0: memref<4x8xf32>, %arg1: memref<8xf32>) {
+  linalg.reduce ins(%arg0 : memref<4x8xf32>) outs(%arg1 : memref<8xf32>) dimensions = [0]
+    (%in: f32, %init: f32) {
+      %max = arith.maxnumf %in, %init : f32
+      linalg.yield %max : f32
+    }
+  return
+}
+
+// CHECK-LABEL: func.func @reduce_2d_dim0_maxnumf
+// CHECK-NOT: linalg.reduce
+// CHECK: memref.alloca_scope
+// CHECK: memref.transpose %arg0 {{.*}} : memref<4x8xf32> to memref<8x4xf32, {{.*}}>
+// CHECK-COUNT-1: scf.for %[[J:[^ ]+]] =
+// CHECK: %[[INIT:.+]] = memref.load %arg1[%[[J]]]
+// CHECK: vir.set_vl
+// CHECK: vir.load {{.*}}[%[[J]], {{[^]]+}}]
+// CHECK: vir.reduce
+// CHECK: memref.store
+// CHECK-VEC-REDUCE-LABEL: func.func @reduce_2d_dim0_maxnumf
+// CHECK-VEC-REDUCE: memref.transpose %arg0 {{.*}} : memref<4x8xf32> to memref<8x4xf32, {{.*}}>
+// CHECK-VEC-REDUCE: vector.reduction <maxnumf>
+// CHECK-VEC-REDUCE: arith.maxnumf
+
+// -----
+// CASE: linalg-reduce-to-vir-3d-dim0-addf-f32.mlir
+func.func @reduce_3d_dim0_addf(%arg0: memref<8x4x8xf32>, %arg1: memref<4x8xf32>) {
+  linalg.reduce ins(%arg0 : memref<8x4x8xf32>) outs(%arg1 : memref<4x8xf32>) dimensions = [0]
+    (%in: f32, %init: f32) {
+      %sum = arith.addf %in, %init : f32
+      linalg.yield %sum : f32
+    }
+  return
+}
+
+// CHECK-LABEL: func.func @reduce_3d_dim0_addf
+// CHECK-NOT: linalg.reduce
+// CHECK: memref.transpose %arg0 {{.*}} : memref<8x4x8xf32> to memref<4x8x8xf32, {{.*}}>
+// CHECK: memref.alloc{{.*}} : memref<4x8x8xf32>
+// CHECK: scf.for %[[J:[^ ]+]] =
+// CHECK: scf.for %[[K:[^ ]+]] =
+// CHECK: %[[INIT:.+]] = memref.load %arg1[%[[J]], %[[K]]]
+// CHECK: vir.set_vl
+// CHECK: vir.load {{.*}}[%[[J]], %[[K]], {{[^]]+}}]
+// CHECK: vir.reduce
+// CHECK: memref.store
+// CHECK: memref.dealloc
+// CHECK-VEC-REDUCE-LABEL: func.func @reduce_3d_dim0_addf
+// CHECK-VEC-REDUCE: memref.transpose %arg0 {{.*}} : memref<8x4x8xf32> to memref<4x8x8xf32, {{.*}}>
+// CHECK-VEC-REDUCE: vector.reduction <add>
+// CHECK-VEC-REDUCE: arith.addf
+
+// -----
+// CASE: linalg-reduce-to-vir-3d-dim0-maxnumf-f32.mlir
+func.func @reduce_3d_dim0_maxnumf(%arg0: memref<8x4x8xf32>, %arg1: memref<4x8xf32>) {
+  linalg.reduce ins(%arg0 : memref<8x4x8xf32>) outs(%arg1 : memref<4x8xf32>) dimensions = [0]
+    (%in: f32, %init: f32) {
+      %max = arith.maxnumf %in, %init : f32
+      linalg.yield %max : f32
+    }
+  return
+}
+
+// CHECK-LABEL: func.func @reduce_3d_dim0_maxnumf
+// CHECK-NOT: linalg.reduce
+// CHECK: memref.transpose %arg0 {{.*}} : memref<8x4x8xf32> to memref<4x8x8xf32, {{.*}}>
+// CHECK: memref.alloc{{.*}} : memref<4x8x8xf32>
+// CHECK: scf.for %[[J:[^ ]+]] =
+// CHECK: scf.for %[[K:[^ ]+]] =
+// CHECK: %[[INIT:.+]] = memref.load %arg1[%[[J]], %[[K]]]
+// CHECK: vir.set_vl
+// CHECK: vir.load {{.*}}[%[[J]], %[[K]], {{[^]]+}}]
+// CHECK: vir.reduce
+// CHECK: memref.store
+// CHECK: memref.dealloc
+// CHECK-VEC-REDUCE-LABEL: func.func @reduce_3d_dim0_maxnumf
+// CHECK-VEC-REDUCE: memref.transpose %arg0 {{.*}} : memref<8x4x8xf32> to memref<4x8x8xf32, {{.*}}>
+// CHECK-VEC-REDUCE: vector.reduction <maxnumf>
+// CHECK-VEC-REDUCE: arith.maxnumf
+
+// -----
 // CASE: linalg-index-generic-to-scf-fallback.mlir
 func.func @index_init(%out: memref<16xi32>) {
   linalg.generic {indexing_maps = [affine_map<(i)->(i)>], iterator_types = ["parallel"]}

--- a/tests/Conversion/linalg-reduce-to-vir-strict-failure.mlir
+++ b/tests/Conversion/linalg-reduce-to-vir-strict-failure.mlir
@@ -1,9 +1,35 @@
 // RUN: buddy-opt -verify-diagnostics %s -split-input-file -lower-linalg-to-vir
 
-// Unsupported 2D->1D reduction dimension.
-func.func @reduce_2d_to_1d_bad_dim(%arg0: memref<4x8xf32>, %arg1: memref<8xf32>) {
+// Unsupported 2D->1D dim-0 reduction with non-static shapes.
+func.func @reduce_2d_to_1d_dim0_dynamic_shape(%arg0: memref<?x?xf32>, %arg1: memref<?xf32>) {
   // expected-error @+1 {{unsupported linalg.reduce for -lower-linalg-to-vir}}
-  linalg.reduce ins(%arg0 : memref<4x8xf32>) outs(%arg1 : memref<8xf32>) dimensions = [0]
+  linalg.reduce ins(%arg0 : memref<?x?xf32>) outs(%arg1 : memref<?xf32>) dimensions = [0]
+    (%in: f32, %init: f32) {
+      %sum = arith.addf %in, %init : f32
+      linalg.yield %sum : f32
+    }
+  return
+}
+
+// -----
+
+// Unsupported 2D->1D dim-0 reduction with dynamic M and static N.
+func.func @reduce_2d_to_1d_dim0_dynamic_m(%arg0: memref<?x8xf32>, %arg1: memref<8xf32>) {
+  // expected-error @+1 {{unsupported linalg.reduce for -lower-linalg-to-vir}}
+  linalg.reduce ins(%arg0 : memref<?x8xf32>) outs(%arg1 : memref<8xf32>) dimensions = [0]
+    (%in: f32, %init: f32) {
+      %sum = arith.addf %in, %init : f32
+      linalg.yield %sum : f32
+    }
+  return
+}
+
+// -----
+
+// Unsupported 2D->1D dim-0 reduction with static M and dynamic N.
+func.func @reduce_2d_to_1d_dim0_dynamic_n(%arg0: memref<4x?xf32>, %arg1: memref<?xf32>) {
+  // expected-error @+1 {{unsupported linalg.reduce for -lower-linalg-to-vir}}
+  linalg.reduce ins(%arg0 : memref<4x?xf32>) outs(%arg1 : memref<?xf32>) dimensions = [0]
     (%in: f32, %init: f32) {
       %sum = arith.addf %in, %init : f32
       linalg.yield %sum : f32
@@ -45,6 +71,45 @@ func.func @reduce_3d_to_2d(%arg0: memref<2x4x8xf32>, %arg1: memref<2x4xf32>) {
   linalg.reduce ins(%arg0 : memref<2x4x8xf32>) outs(%arg1 : memref<2x4xf32>) dimensions = [2]
     (%in: f32, %init0: f32) {
       %sum = arith.addf %in, %init0 : f32
+      linalg.yield %sum : f32
+    }
+  return
+}
+
+// -----
+
+// Unsupported 3D->2D dim-0 reduction with dynamic M.
+func.func @reduce_3d_to_2d_dim0_dynamic_m(%arg0: memref<?x4x8xf32>, %arg1: memref<4x8xf32>) {
+  // expected-error @+1 {{unsupported linalg.reduce for -lower-linalg-to-vir}}
+  linalg.reduce ins(%arg0 : memref<?x4x8xf32>) outs(%arg1 : memref<4x8xf32>) dimensions = [0]
+    (%in: f32, %init: f32) {
+      %sum = arith.addf %in, %init : f32
+      linalg.yield %sum : f32
+    }
+  return
+}
+
+// -----
+
+// Unsupported 3D->2D dim-0 reduction with dynamic N.
+func.func @reduce_3d_to_2d_dim0_dynamic_n(%arg0: memref<2x?x8xf32>, %arg1: memref<?x8xf32>) {
+  // expected-error @+1 {{unsupported linalg.reduce for -lower-linalg-to-vir}}
+  linalg.reduce ins(%arg0 : memref<2x?x8xf32>) outs(%arg1 : memref<?x8xf32>) dimensions = [0]
+    (%in: f32, %init: f32) {
+      %sum = arith.addf %in, %init : f32
+      linalg.yield %sum : f32
+    }
+  return
+}
+
+// -----
+
+// Unsupported 3D->2D dim-0 reduction with dynamic K.
+func.func @reduce_3d_to_2d_dim0_dynamic_k(%arg0: memref<2x4x?xf32>, %arg1: memref<4x?xf32>) {
+  // expected-error @+1 {{unsupported linalg.reduce for -lower-linalg-to-vir}}
+  linalg.reduce ins(%arg0 : memref<2x4x?xf32>) outs(%arg1 : memref<4x?xf32>) dimensions = [0]
+    (%in: f32, %init: f32) {
+      %sum = arith.addf %in, %init : f32
       linalg.yield %sum : f32
     }
   return

--- a/tests/Conversion/linalg-transpose-to-vir.mlir
+++ b/tests/Conversion/linalg-transpose-to-vir.mlir
@@ -1,0 +1,85 @@
+// RUN: buddy-opt %s -split-input-file -lower-linalg-to-vir | FileCheck %s
+
+func.func @transpose_smoke_2d(%src: memref<8x4xf32>, %dst: memref<4x8xf32>) {
+  linalg.transpose ins(%src : memref<8x4xf32>)
+                   outs(%dst : memref<4x8xf32>)
+                   permutation = [1, 0]
+  return
+}
+
+// CHECK-LABEL: func.func @transpose_smoke_2d
+// CHECK-NOT: linalg.transpose
+// CHECK-NOT: vir.set_vl
+// CHECK: vector.transfer_read %arg0[%{{.*}}, %{{.*}}], %{{.*}} : memref<8x4xf32>, vector<8x4xf32>
+// CHECK-NOT: linalg.transpose
+// CHECK-NOT: vir.set_vl
+// CHECK: vector.transpose %{{.*}}, [1, 0] : vector<8x4xf32> to vector<4x8xf32>
+// CHECK-NOT: linalg.transpose
+// CHECK-NOT: vir.set_vl
+// CHECK: vector.transfer_write %{{.*}}, %arg1[%{{.*}}, %{{.*}}]{{.*}} : vector<4x8xf32>, memref<4x8xf32>
+// CHECK-NOT: linalg.transpose
+// CHECK-NOT: vir.set_vl
+// CHECK: return
+
+// -----
+
+func.func @transpose_i32_rank3(%src: memref<128x2x4xi32>, %dst: memref<4x128x2xi32>) {
+  linalg.transpose ins(%src : memref<128x2x4xi32>)
+                   outs(%dst : memref<4x128x2xi32>)
+                   permutation = [2, 0, 1]
+  return
+}
+
+// CHECK-LABEL: func.func @transpose_i32_rank3
+// CHECK-NOT: linalg.transpose
+// CHECK-NOT: vir.set_vl
+// CHECK: vector.transfer_read %arg0[%{{.*}}, %{{.*}}, %{{.*}}], %{{.*}} : memref<128x2x4xi32>, vector<128x2x4xi32>
+// CHECK-NOT: linalg.transpose
+// CHECK-NOT: vir.set_vl
+// CHECK: vector.transpose %{{.*}}, [2, 0, 1] : vector<128x2x4xi32> to vector<4x128x2xi32>
+// CHECK-NOT: linalg.transpose
+// CHECK-NOT: vir.set_vl
+// CHECK: vector.transfer_write %{{.*}}, %arg1[%{{.*}}, %{{.*}}, %{{.*}}]{{.*}} : vector<4x128x2xi32>, memref<4x128x2xi32>
+// CHECK-NOT: linalg.transpose
+// CHECK-NOT: vir.set_vl
+// CHECK: return
+
+// -----
+
+func.func @transpose_f32_rank3(%src: memref<128x2x4xf32>, %dst: memref<4x128x2xf32>) {
+  linalg.transpose ins(%src : memref<128x2x4xf32>)
+                   outs(%dst : memref<4x128x2xf32>)
+                   permutation = [2, 0, 1]
+  return
+}
+
+// CHECK-LABEL: func.func @transpose_f32_rank3
+// CHECK-NOT: linalg.transpose
+// CHECK-NOT: vir.set_vl
+// CHECK: vector.transfer_read %arg0[%{{.*}}, %{{.*}}, %{{.*}}], %{{.*}} : memref<128x2x4xf32>, vector<128x2x4xf32>
+// CHECK-NOT: linalg.transpose
+// CHECK-NOT: vir.set_vl
+// CHECK: vector.transpose %{{.*}}, [2, 0, 1] : vector<128x2x4xf32> to vector<4x128x2xf32>
+// CHECK-NOT: linalg.transpose
+// CHECK-NOT: vir.set_vl
+// CHECK: vector.transfer_write %{{.*}}, %arg1[%{{.*}}, %{{.*}}, %{{.*}}]{{.*}} : vector<4x128x2xf32>, memref<4x128x2xf32>
+// CHECK-NOT: linalg.transpose
+// CHECK-NOT: vir.set_vl
+// CHECK: return
+
+// -----
+
+func.func @transpose_zero_extent(%src: memref<0x4xf32>, %dst: memref<4x0xf32>) {
+  linalg.transpose ins(%src : memref<0x4xf32>)
+                   outs(%dst : memref<4x0xf32>)
+                   permutation = [1, 0]
+  return
+}
+
+// CHECK-LABEL: func.func @transpose_zero_extent
+// CHECK-NOT: linalg.transpose
+// CHECK-NOT: vir.set_vl
+// CHECK-NOT: vector.transfer_read
+// CHECK-NOT: vector.transpose
+// CHECK-NOT: vector.transfer_write
+// CHECK: return


### PR DESCRIPTION
## Summary
- Add support for linalg.reduce when rank=2, dim=0 and rank=3, dim=0.
- Add pattern to lower linalg.transpose to vector.transpose.
- Modified and added some test cases.


