### PR TITLE
[ci] Enable check-buddy on x64

### DIFF
--- a/.github/actions/ci-common/action.yml
+++ b/.github/actions/ci-common/action.yml
@@ -71,7 +71,9 @@ runs:
       shell: bash
       run: |
         LLVM_COMMIT=$(git ls-tree HEAD llvm | awk '{print $3}')
-        LLVM_BUILD_DIR=$LLVM_BUILD_ROOT/$LLVM_COMMIT
+        PATCH_HASH=$(shasum ./riscv-jitlink.patch | cut -d' ' -f1)
+
+        LLVM_BUILD_DIR=$LLVM_BUILD_ROOT/$LLVM_COMMIT-${PATCH_HASH:0:12}
 
         mkdir -p $LLVM_BUILD_ROOT
 
@@ -83,6 +85,8 @@ runs:
         git -C $LLVM_SRC reset --hard
         git -C $LLVM_SRC clean -fdx
         git -C $LLVM_SRC checkout $LLVM_COMMIT
+
+        git -C $LLVM_SRC apply $GITHUB_WORKSPACE/riscv-jitlink.patch
 
         echo "LLVM_SRC=$LLVM_SRC" >> $GITHUB_ENV
         echo "LLVM_COMMIT=$LLVM_COMMIT" >> $GITHUB_ENV

--- a/.github/workflows/TestBuild.yml
+++ b/.github/workflows/TestBuild.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main, ci, ci-test ]
   pull_request:
     branches: [ main, ci, ci-test ]
+  workflow_dispatch:
 
 jobs:
   test:
@@ -68,7 +69,15 @@ jobs:
           venv_deactivate: ${{ matrix.venv_deactivate }}
 
       - name: Run check-buddy
+        if: matrix.arch == 'x64'
         run: |
           ${{ matrix.venv_activate }}
-          ninja -C build check-buddy || true
+          ninja -C build check-buddy
+          ${{ matrix.venv_deactivate }}
+
+      - name: Run check-buddy
+        if: matrix.arch != 'x64'
+        run: |
+          ${{ matrix.venv_activate }}
+          ninja -C build check-buddy | true
           ${{ matrix.venv_deactivate }}

--- a/examples/lit.cfg.py
+++ b/examples/lit.cfg.py
@@ -81,6 +81,9 @@ config.buddy_tools_dir = os.path.join(config.buddy_obj_root, "bin")
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment("PATH", config.llvm_tools_dir, append_path=True)
 
+# So The execution engine in frontend can find out-of-tree llvm librarys
+config.environment["LLVM_LIBS_DIR"] = config.mlir_runner_utils_dir
+
 # Add the python path for both upstream MLIR and Buddy Compiler python packages.
 if config.buddy_mlir_enable_python_packages:
     llvm_config.with_environment(

--- a/frontend/Python/frontend.py
+++ b/frontend/Python/frontend.py
@@ -35,7 +35,6 @@ import torch
 import torch._dynamo as dynamo
 from buddy_mlir import runtime as rt
 from buddy_mlir.execution_engine import ExecutionEngine
-from buddy_mlir.passmanager import *
 from torch._functorch.aot_autograd import aot_module_simplified
 from torch.fx.experimental.proxy_tensor import make_fx
 
@@ -45,7 +44,6 @@ from .graph.transform import (
     RUNTIME_RNG_TRANSFORMS,
     maxpool2d_simplify,
 )
-from .graph.type import *
 from .ops.func import ops_registry as func_ops_registry
 from .ops.linalg import ops_registry as linalg_ops_registry
 from .ops.math import ops_registry as math_ops_registry
@@ -838,7 +836,8 @@ class DynamoCompiler:
             elif isinstance(arg, torch.dtype):
                 buddy_node.add_argument(self._torch_dtype_translate(str(arg)))
             elif isinstance(arg, (list, tuple)):
-                # Traverse elements to collect parent nodes but keep the container as a single argument
+                # Traverse elements to collect parent nodes
+                # but keep the container as a single argument
                 for item in arg:
                     if isinstance(item, torch.fx.Node):
                         buddy_node.add_parent(str(item))
@@ -869,7 +868,7 @@ class DynamoCompiler:
 
         Args:
             gm (torch.fx.GraphModule): The GraphModule to be compiled.
-            inputs (List[torch.Tensor]): The input tensors.
+            inputs (list[torch.Tensor]): The input tensors.
             return_type (str): Controls the compiled callable that AOTAutograd
                 receives from the Buddy compiler.
                 - "eager": return the FX graph forward (legacy behavior).
@@ -1119,7 +1118,7 @@ class DynamoCompiler:
 
         Args:
             gm (torch.fx.GraphModule): The GraphModule to be compiled.
-            inputs (List[torch.Tensor]): The input tensors.
+            inputs (list[torch.Tensor]): The input tensors.
 
         Returns:
             dynamo_run: The function of the ahead-of-time compiled module,
@@ -1257,12 +1256,23 @@ class DynamoCompiler:
             return os.path.join(lib_base_path, "libomp" + lib_extension)
 
         graph.compile()
+
         # Collect dependency libraries.
         lib_extension = get_lib_extension()
         lib_names = ["libmlir_runner_utils", "libmlir_c_runner_utils"]
         path_prefix = os.path.dirname(os.path.abspath(__file__))
-        lib_base_path = os.path.join(path_prefix, "../../../../llvm/build/lib/")
-        lib_base_path = os.path.abspath(lib_base_path)
+
+        LLVM_LIBS_DIR = os.getenv("LLVM_LIBS_DIR")
+        if LLVM_LIBS_DIR:
+            # Out-of-Tree LLVM
+            lib_base_path = LLVM_LIBS_DIR
+        else:
+            # Local LLVM
+            lib_base_path = os.path.join(
+                path_prefix, "../../../../llvm/build/lib/"
+            )
+            lib_base_path = os.path.abspath(lib_base_path)
+
         shared_libs = [
             os.path.join(lib_base_path, lib_name + lib_extension)
             for lib_name in lib_names
@@ -1280,6 +1290,7 @@ class DynamoCompiler:
                 shared_libs.append(
                     os.path.join(buddy_lib_base_path, lib_name + lib_extension)
                 )
+
         # Define execution engine.
         ee = ExecutionEngine(
             graph._imported_module, opt_level=3, shared_libs=shared_libs
@@ -1290,11 +1301,11 @@ class DynamoCompiler:
             Execute a graph using TorchDynamo with the provided input tensors.
 
             Args:
-                *args: List[torch.Tensor]
+                *args: list[torch.Tensor]
                 Input tensors to be passed to the graph's function.
 
             Returns:
-            List[torch.Tensor]
+            list[torch.Tensor]
                 The result of executing the graph, represented as a list of
                 output tensors.
             """

--- a/frontend/Python/graph/graph.py
+++ b/frontend/Python/graph/graph.py
@@ -27,8 +27,7 @@ import buddy_mlir.dialects.func as func
 import buddy_mlir.ir as ir
 import numpy as np
 from buddy_mlir import runtime as rt
-from buddy_mlir.execution_engine import *
-from buddy_mlir.passmanager import *
+from buddy_mlir.passmanager import PassManager
 
 from .operation import *
 from .type import *
@@ -39,9 +38,9 @@ def make_output_memref_descriptor(ranks, dtypes):
     Make an output memref descriptor for the given memref ranks and dtypes.
 
     Parameters:
-    - ranks: List[int]
+    - ranks: list[int]
         A list of integers representing the ranks of each memref.
-    - dtypes: List[str]
+    - dtypes: list[str]
         A list of strings representing the data types of each memref.
 
     Returns:
@@ -81,11 +80,11 @@ class Graph:
     MLIR module.
 
     Attributes:
-    - _body: List[Op]
+    - _body: list[Op]
         The sequence of operation nodes in the graph.
-    - _inputs: List[TensorMeta]
+    - _inputs: list[TensorMeta]
         The model inputs represented as TensorMeta objects.
-    - _fake_params: List[TensorMeta]
+    - _fake_params: list[TensorMeta]
         The fake parameters represented as TensorMeta objects.
     - device: str
         The hardware for graph runtime.
@@ -117,9 +116,9 @@ class Graph:
         Initializes the Graph.
 
         Args:
-            inputs: List[TensorMeta]
+            inputs: list[TensorMeta]
                 The model inputs represented as TensorMeta objects.
-            fake_params: List[TensorMeta]
+            fake_params: list[TensorMeta]
                 The fake parameters represented as TensorMeta objects.
             ops_registry: dict
                 The ops lower strategy for the graph.
@@ -254,7 +253,7 @@ class Graph:
 
         Args:
             node (Op): The operation node to be deleted from the graph.
-            parents (List[Op]): A list of parent operation nodes that reference the node to be deleted.
+            parents (list[Op]): A list of parent operation nodes that reference the node to be deleted.
 
         Returns:
             None
@@ -435,7 +434,7 @@ class Graph:
         Fuse operations in the graph based on provided fusion patterns.
 
         Args:
-        - pattern_list (List[FunctionType]): A list of functions representing
+        - pattern_list (list[FunctionType]): A list of functions representing
         fusion patterns.
 
         Returns:
@@ -455,7 +454,7 @@ class Graph:
         of functions.
 
         Args:
-        - func_list (List[FunctionType]): A list of functions representing
+        - func_list (list[FunctionType]): A list of functions representing
         transformations to be applied to the graph.
 
         Returns:
@@ -607,9 +606,9 @@ class GraphImporter:
 
     Attributes:
         _symbol_table (dict): A dictionary to keep track of the symbols.
-        _body (List[Op]): The FX graph module to be imported.
+        _body (list[Op]): The FX graph module to be imported.
         _func_name (str): Name of the generated MLIR function.
-        _inputs (List[TensorMeta]): Input tensor(s) of the FX graph.
+        _inputs (list[TensorMeta]): Input tensor(s) of the FX graph.
         _num_input_visited (int): Number of input nodes that have been visited.
         _module (buddy_mlir.ir.Module): The generated MLIR module.
         _ops_registry (dict): Registry for the candidate operations.
@@ -632,7 +631,7 @@ class GraphImporter:
 
         Args:
             gm (Graph): The buddy graph that will be imported.
-            inputs (List[TensorMeta]): Input tensor(s) of the buddy graph.
+            inputs (list[TensorMeta]): Input tensor(s) of the buddy graph.
             func_name (str): Name of the generated MLIR function.
             ops_registry (dict): Registry for the candidate operations.
             enable_external_calls (bool): Enable external function call support (for oneDNN, etc.)
@@ -859,7 +858,7 @@ class GraphImporter:
         Parameters:
         - node (PlaceholderOp): The PlaceholderOp node representing the
         placeholder.
-        - args_list (List[buddy_mlir.ir.BlockArgument]): List of input memrefs.
+        - args_list (list[buddy_mlir.ir.BlockArgument]): list of input memrefs.
 
         Returns:
         None
@@ -915,7 +914,7 @@ class GraphImporter:
 
         # Build argument types from CallOp's arguments
         arg_types = []
-        for i, arg in enumerate(call_node.args):
+        for _, arg in enumerate(call_node.args):
             # Get the node that produces this argument
             arg_node = None
             for node in self._body:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
-  "setuptools>=69",
-  "wheel",
-  "build>=1.2",
+    "setuptools>=69",
+    "wheel",
+    "build>=1.2"
 ]
 build-backend = "setuptools.build_meta"
 
@@ -16,10 +16,12 @@ dynamic = ["entry-points", "scripts", "version"]
 include-package-data = true
 
 [tool.setuptools.dynamic]
-version = {attr = "buddy.__version__"}
+version = { attr = "buddy.__version__" }
 
 [tool.ruff]
 line-length = 80
+
+[tool.ruff.lint]
 
 select = [
     "E",   # pycodestyle errors
@@ -33,9 +35,13 @@ select = [
 ]
 
 ignore = [
-    # "F821", # Undefined name
-    # "F403", # from module import *
-    # "F405", # Name may be undefined
+    "B905", # zip-without-explicit-strict
+    "B007",
+    "B011",
+    "F821", # Undefined name
+    "F403", # from module import *
+    "F405", # Name may be undefined
+    "E501", # Line too long
     # "F401", # Unused import
     # "E203", # Whitespace before ':'
     # "E402", # Module level import not at top of file
@@ -43,41 +49,25 @@ ignore = [
     # "E401", # Multiple imports on one line
     # "W605", # Invalid escape sequence
     # "E712", # Comparison to True/False
-    # "E711", # Comparison to None
-    # "F841", # Unused variable
+    "E711", # Comparison to None
+    "E712", # true-false-comparison
+    "F841", # Unused variable
+    "C403", # unnecessary-list-comprehension-set
+    "C416", # unnecessary-comprehension
+    "E741",
+    "SIM101",
+    "SIM102",
+    "SIM103",
+    "SIM105",
+    "SIM108",
+    "SIM118",
+    "UP031",
 ]
 
-# lit.cfg.py: `config` is injected by lit when loading the file, not defined
-# in-module.
-# frontend/Python/ops/: star imports + verbose MLIR builders (per-directory
-# ignores below).
-[tool.ruff.lint.per-file-ignores]
-"examples/lit.cfg.py" = ["F821"]
-"tests/lit.cfg.py" = ["F821"]
-"frontend/Python/ops/**" = [
-    "B007", "B011", "B905",
-    "C416",
-    "E501",
-    "E711", "E712", "E741",
-    "F403", "F405", "F841",
-    "SIM101", "SIM102", "SIM105", "SIM108",
-    "UP031",
-]
-# graph.py: same star-import / MLIR builder style as ops/
-"frontend/Python/graph/**" = [
-    "B007", "B011", "B905",
-    "C403", "C416",
-    "E501",
-    "E711", "E712", "E741",
-    "F403", "F405", "F841",
-    "SIM101", "SIM102", "SIM103", "SIM105", "SIM108",
-    "UP031",
-]
-# frontend.py: large aten→Op map via `from .graph.operation import *`
-"frontend/Python/frontend.py" = ["F403", "F405"]
 
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
+docstring-code-format = true

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# ===- setup.py -----------------------------------------------------------------
+# ===- setup.py ----------------------------------------------------------------
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# ===---------------------------------------------------------------------------
+# ===--------------------------------------------------------------------------
 
 from __future__ import annotations
 
@@ -21,16 +21,17 @@ import shutil
 from pathlib import Path
 
 from setuptools import find_namespace_packages, find_packages, setup
-from setuptools.dist import Distribution
-from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 from setuptools.command.build import build as _build
 from setuptools.command.build_py import build_py as _build_py
+from setuptools.dist import Distribution
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
 ROOT = Path(__file__).parent.resolve()
 
 
 def _resolve_build_dir() -> Path:
-    """Resolve the CMake build directory that already contains compiled outputs."""
+    """Resolve the CMake build directory
+    that already contains compiled outputs."""
     build_dir = Path(os.environ.get("BUDDY_BUILD_DIR", "build"))
     if not build_dir.is_absolute():
         build_dir = ROOT / build_dir
@@ -52,17 +53,19 @@ if not PYTHON_PACKAGES_DIR.exists():
 REL_PYTHON_PACKAGES_DIR = os.path.relpath(PYTHON_PACKAGES_DIR, ROOT)
 if REL_PYTHON_PACKAGES_DIR.startswith(".."):
     raise SystemExit(
-        f"BUDDY_BUILD_DIR must reside inside the project root ({ROOT}) so packaging "
-        f"can use relative paths. Current: {PYTHON_PACKAGES_DIR}"
+        f"BUDDY_BUILD_DIR must reside inside the project root ({ROOT}) "
+        f"so packaging can use relative paths. Current: {PYTHON_PACKAGES_DIR}"
     )
 
-# Stage python packages into the build tree so setuptools never sees absolute paths.
+# Stage python packages into the build tree so setuptools
+# never sees absolute paths.
 STAGING_ROOT = CMAKE_BUILD / "py-stage"
 if STAGING_ROOT.exists():
     shutil.rmtree(STAGING_ROOT)
 STAGING_ROOT.mkdir(parents=True, exist_ok=True)
 STAGING_SRC = STAGING_ROOT / "python_packages"
-# Copy python outputs but drop any pre-existing egg-info that may carry absolute paths.
+# Copy python outputs but drop any pre-existing egg-info that may carry
+# absolute paths.
 shutil.copytree(
     PYTHON_PACKAGES_DIR,
     STAGING_SRC,
@@ -115,12 +118,14 @@ class build_py(_build_py):
         try:
             if dst.resolve().is_relative_to(src.resolve()):
                 raise SystemExit(f"Refusing to copy {src} into itself ({dst})")
-        except AttributeError:
+        except AttributeError as err:
             # Python <3.9 compatibility: manual check
             src_resolved = src.resolve()
             dst_resolved = dst.resolve()
             if str(dst_resolved).startswith(str(src_resolved)):
-                raise SystemExit(f"Refusing to copy {src} into itself ({dst})")
+                raise SystemExit(
+                    f"Refusing to copy {src} into itself ({dst})"
+                ) from err
 
         for path in src.rglob("*"):
             if not path.is_file():
@@ -139,9 +144,6 @@ ENTRY_POINTS = {
         "buddy-llc=buddy_tools.cli:buddy_llc",
         "buddy-lsp-server=buddy_tools.cli:buddy_lsp_server",
         "buddy-frontendgen=buddy_tools.cli:buddy_frontendgen",
-        "buddy-audio-container-test=buddy_tools.cli:buddy_audio_container_test",
-        "buddy-text-container-test=buddy_tools.cli:buddy_text_container_test",
-        "buddy-container-test=buddy_tools.cli:buddy_container_test",
     ]
 }
 

--- a/tests/Models/BuddyLLMGraphImport/lit.local.cfg.py
+++ b/tests/Models/BuddyLLMGraphImport/lit.local.cfg.py
@@ -1,6 +1,6 @@
 import os
 
-config.excludes = getattr(config, "excludes", []) + ["set_model_env.sh"]
+config.excludes = list(getattr(config, "excludes", [])) + ["set_model_env.sh"]
 
 config.excludes.extend(
     name

--- a/tests/Python/JIT/conv2d_relu.py
+++ b/tests/Python/JIT/conv2d_relu.py
@@ -31,7 +31,6 @@ def test_conv2d_relu():
     expect = model(x, w)
 
     # CHECK: Is MLIR equal to Torch? True
-    print(
-        f"Is MLIR equal to Torch? {torch.allclose(actual, expect, atol=1e-05, rtol=1e-05)}"
-    )
-    assert torch.allclose(actual, expect, atol=1e-05, rtol=1e-05)
+    equal = torch.allclose(actual, expect, atol=1e-05, rtol=1e-05)
+    print(f"Is MLIR equal to Torch? {equal}")
+    assert equal

--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -38,7 +38,6 @@ llvm_config.use_default_substitutions()
 config.excludes = [
     "Inputs",
     "Examples",
-    "Models",
     "CMakeLists.txt",
     "README.txt",
     "LICENSE.txt",
@@ -56,6 +55,9 @@ config.test_exec_root = os.path.join(config.buddy_obj_root, "tests")
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment("PATH", config.llvm_tools_dir, append_path=True)
 
+# So The execution engine in frontend can find out-of-tree llvm librarys
+config.environment["LLVM_LIBS_DIR"] = config.mlir_runner_utils_dir
+
 tool_dirs = [config.buddy_tools_dir, config.llvm_tools_dir]
 tools = [
     "buddy-opt",
@@ -64,8 +66,8 @@ tools = [
     "buddy-audio-container-test",
     "buddy-text-container-test",
     "mlir-runner",
-    "buddy-lenet-run-test-cpu",
 ]
+
 tools.extend(
     [
         ToolSubst(
@@ -122,5 +124,10 @@ if config.buddy_mlir_enable_dip_lib == "ON":
     tools.append("buddy-new-image-container-test-bmp")
     if config.buddy_enable_png == "ON":
         tools.append("buddy-new-image-container-test-png")
+# Ignore Models if e2e not enabled
+if config.buddy_enable_e2e_test == "ON":
+    tools.append("buddy-lenet-run-test-cpu")
+else:
+    config.excludes.append("Models")
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/tests/lit.site.cfg.py.in
+++ b/tests/lit.site.cfg.py.in
@@ -42,6 +42,9 @@ config.mlir_runner_utils_dir = "@LLVM_LIBS_DIR@"
 config.have_amx = "@HAVE_AMX@"
 config.have_scalable_vector = "@HAVE_SCALABLE_VECTOR@"
 
+# E2E test binary are not available when BUDDY_ENABLE_E2E_TESTS=OFF
+config.buddy_enable_e2e_test = "@BUDDY_ENABLE_E2E_TESTS@"
+
 if str(config.have_amx).lower() in ("1", "on", "true", "yes"):
     config.available_features.add("has_amx")
 


### PR DESCRIPTION
## Summary

1. Fix ninja check-buddy buddy-lenet-run-test-cpu not found even if `DBUDDY_ENABLE_E2E_TESTS=OFF`
2. The current frontend hardcodes the search paths for the three libraries `libomp`, `libmlir_runner_util`, and `libmlir_c_runner_util`, causing one of the lit tests to fail when using LLVM build out-of-tree. The current solution is to add a new environment variable `LLVM_LIBS_DIR` to the frontend to discover LLVM libraries.