### PR TITLE
[VIR] Fix the linalg.generic bug.

### DIFF
--- a/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
+++ b/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
@@ -1001,6 +1001,23 @@ static LogicalResult transformProjectedPermutationOperands(
       transformedMemRefs[opOperand->get()] = tr;
     }
   }
+
+  // Some named ops such as `linalg.map` only expose DPS inputs as region block
+  // arguments, but `storeYieldValues(...)` still needs every init buffer to be
+  // transformed before creating the final `vir.store`.
+  for (OpOperand &initOpd : linalgOp.getDpsInitsMutable()) {
+    if (transformedMemRefs.count(initOpd.get()))
+      continue;
+    auto indexingMap = linalgOp.getMatchingIndexingMap(&initOpd);
+    if (!indexingMap.isProjectedPermutation(/*allowZeroInResults=*/true)) {
+      return rewriter.notifyMatchFailure(
+          linalgOp, "non-projected permutation outputs not supported yet");
+    }
+    Value tr =
+        transformOutputMemrefForProjectedPermutation(rewriter, loc, &initOpd,
+                                                     indexingMap);
+    transformedMemRefs[initOpd.get()] = tr;
+  }
   return success();
 }
 

--- a/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
+++ b/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
@@ -853,7 +853,8 @@ static bool isSupportedGenericBodyOp(Operation &inner) {
              arith::AndIOp, arith::OrIOp, arith::XOrIOp, arith::ShLIOp,
              arith::ShRUIOp, arith::ShRSIOp, arith::MaximumFOp,
              arith::MinimumFOp, arith::MaxSIOp, arith::MinSIOp, arith::MaxUIOp,
-             arith::MinUIOp, arith::MaxNumFOp, math::ExpOp, math::SqrtOp>(
+             arith::MinUIOp, arith::MaxNumFOp, arith::MinNumFOp, math::ExpOp,
+             math::SqrtOp>(
       inner);
 }
 

--- a/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
+++ b/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
@@ -854,8 +854,7 @@ static bool isSupportedGenericBodyOp(Operation &inner) {
              arith::ShRUIOp, arith::ShRSIOp, arith::MaximumFOp,
              arith::MinimumFOp, arith::MaxSIOp, arith::MinSIOp, arith::MaxUIOp,
              arith::MinUIOp, arith::MaxNumFOp, arith::MinNumFOp, math::ExpOp,
-             math::SqrtOp>(
-      inner);
+             math::SqrtOp>(inner);
 }
 
 static buddy::vir::SetVLOp createSetVLRegion(PatternRewriter &rewriter,
@@ -1014,9 +1013,8 @@ static LogicalResult transformProjectedPermutationOperands(
       return rewriter.notifyMatchFailure(
           linalgOp, "non-projected permutation outputs not supported yet");
     }
-    Value tr =
-        transformOutputMemrefForProjectedPermutation(rewriter, loc, &initOpd,
-                                                     indexingMap);
+    Value tr = transformOutputMemrefForProjectedPermutation(
+        rewriter, loc, &initOpd, indexingMap);
     transformedMemRefs[initOpd.get()] = tr;
   }
   return success();

--- a/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
+++ b/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
@@ -52,8 +52,9 @@ using namespace buddy;
 
 namespace {
 
-/// Helper function to check leading static dims then return vector shape with
-/// trailing dynamic dim (if any).
+/// Helper function to check leading static dims, build a VIR vector type shape
+/// whose last dimension is always dynamic, and preserve the concrete logical
+/// iteration extents in `ofrCommon` for downstream VL derivation.
 static LogicalResult
 buildVIRVectorShape(linalg::LinalgOp op, SmallVectorImpl<int64_t> &shapeOut,
                     SmallVectorImpl<OpFoldResult> &ofrCommon, OpBuilder &b) {
@@ -88,16 +89,17 @@ buildVIRVectorShape(linalg::LinalgOp op, SmallVectorImpl<int64_t> &shapeOut,
     }
   }
 
-  // Build VIR vector shape: copy loop sizes, but convert the last to dynamic
-  // if it is dynamic, otherwise keep static.
+  // Keep leading dimensions unchanged, but always model the vectorized last
+  // dimension as dynamic in `shapeOut`. The concrete last extent is preserved
+  // separately in `commonShape`/`ofrCommon`, so callers must use
+  // `ofrCommon.back()` rather than `shapeOut.back()` when deriving VL.
   shapeOut.clear();
   shapeOut.reserve(staticLoopSizes.size());
   for (int64_t i = 0, e = op.getNumLoops(); i < e; ++i) {
-    int64_t sz = staticLoopSizes[i];
-    if (i == e - 1 && ShapedType::isDynamic(sz)) {
+    if (i == e - 1) {
       shapeOut.push_back(ShapedType::kDynamic);
     } else {
-      shapeOut.push_back(sz);
+      shapeOut.push_back(staticLoopSizes[i]);
     }
   }
 

--- a/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
+++ b/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
@@ -86,6 +86,50 @@ static bool hasStaticallyUnitStrideInVectorizedDim(Value base) {
   return strides.back() == 1;
 }
 
+// Downstream LLVM lowering may pack vector<...xi1> memory operations, which
+// breaks round-tripping through scalar i1 loads/stores. Keep i1 memref accesses
+// scalarized even inside the vectorized loop.
+static bool shouldScalarizeI1VectorMemoryOp(VectorType vecTy) {
+  return vecTy && !vecTy.isScalable() && vecTy.getRank() == 1 &&
+         vecTy.getElementType().isInteger(1);
+}
+
+static Value buildScalarizedI1VectorLoad(OpBuilder &builder, Location loc,
+                                         VectorType vecTy, Value base,
+                                         ArrayRef<Value> baseIndices) {
+  assert(!baseIndices.empty() && "expected at least one memref index");
+  auto zero = builder.create<arith::ConstantOp>(
+      loc, vecTy,
+      DenseElementsAttr::get(vecTy, builder.getZeroAttr(vecTy.getElementType())));
+  Value result = zero.getResult();
+  for (int64_t lane = 0, e = vecTy.getNumElements(); lane < e; ++lane) {
+    auto laneIdx = builder.create<arith::ConstantIndexOp>(loc, lane);
+    SmallVector<Value> laneIndices(baseIndices.begin(), baseIndices.end());
+    laneIndices.back() =
+        builder.create<arith::AddIOp>(loc, laneIndices.back(), laneIdx);
+    Value scalar = builder.create<memref::LoadOp>(loc, base, laneIndices);
+    result =
+        builder.create<vector::InsertElementOp>(loc, scalar, result, laneIdx);
+  }
+  return result;
+}
+
+static void buildScalarizedI1VectorStore(OpBuilder &builder, Location loc,
+                                         Value vectorValue, Value base,
+                                         ArrayRef<Value> baseIndices) {
+  assert(!baseIndices.empty() && "expected at least one memref index");
+  auto vecTy = cast<VectorType>(vectorValue.getType());
+  for (int64_t lane = 0, e = vecTy.getNumElements(); lane < e; ++lane) {
+    auto laneIdx = builder.create<arith::ConstantIndexOp>(loc, lane);
+    SmallVector<Value> laneIndices(baseIndices.begin(), baseIndices.end());
+    laneIndices.back() =
+        builder.create<arith::AddIOp>(loc, laneIndices.back(), laneIdx);
+    Value scalar =
+        builder.create<vector::ExtractElementOp>(loc, vectorValue, laneIdx);
+    builder.create<memref::StoreOp>(loc, scalar, base, laneIndices);
+  }
+}
+
 VectorType vectorTypeHelper(Region &srcRegion, Type anchorType,
                             bool useScalable, bool verbose) {
 #define VERBOSE_ANALYSIS_INFO(info)                                            \
@@ -399,6 +443,12 @@ private:
                 op.emitError("failed to derive vector type for vir.load");
                 return;
               }
+              if (shouldScalarizeI1VectorMemoryOp(*vecTyOr)) {
+                virSymbolTable[op.getResult()] =
+                    buildScalarizedI1VectorLoad(builder, loc, *vecTyOr, base,
+                                                destIndices);
+                return;
+              }
               if (hasStaticallyUnitStrideInVectorizedDim(base)) {
                 auto vectorLoadOp = builder.create<vector::LoadOp>(
                     loc, *vecTyOr, base, destIndices);
@@ -454,6 +504,12 @@ private:
               builder.create<memref::StoreOp>(loc, valueToStore, base,
                                               destIndices);
             } else {
+              if (auto vecTy = dyn_cast<VectorType>(valueToStore.getType());
+                  shouldScalarizeI1VectorMemoryOp(vecTy)) {
+                buildScalarizedI1VectorStore(builder, loc, valueToStore, base,
+                                             destIndices);
+                return;
+              }
               if (hasStaticallyUnitStrideInVectorizedDim(base)) {
                 builder.create<vector::StoreOp>(loc, valueToStore, base,
                                                 destIndices);

--- a/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
+++ b/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
@@ -965,6 +965,18 @@ private:
             auto newOp = builder.create<arith::MinimumFOp>(loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
+          .Case<arith::MaxNumFOp>([&](arith::MaxNumFOp op) {
+            Value lhs = findValue(op.getLhs());
+            Value rhs = findValue(op.getRhs());
+            auto newOp = builder.create<arith::MaxNumFOp>(loc, lhs, rhs);
+            virSymbolTable[op.getResult()] = newOp.getResult();
+          })
+          .Case<arith::MinNumFOp>([&](arith::MinNumFOp op) {
+            Value lhs = findValue(op.getLhs());
+            Value rhs = findValue(op.getRhs());
+            auto newOp = builder.create<arith::MinNumFOp>(loc, lhs, rhs);
+            virSymbolTable[op.getResult()] = newOp.getResult();
+          })
           .Case<arith::MaxSIOp>([&](arith::MaxSIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());

--- a/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
+++ b/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
@@ -100,7 +100,8 @@ static Value buildScalarizedI1VectorLoad(OpBuilder &builder, Location loc,
   assert(!baseIndices.empty() && "expected at least one memref index");
   auto zero = builder.create<arith::ConstantOp>(
       loc, vecTy,
-      DenseElementsAttr::get(vecTy, builder.getZeroAttr(vecTy.getElementType())));
+      DenseElementsAttr::get(vecTy,
+                             builder.getZeroAttr(vecTy.getElementType())));
   Value result = zero.getResult();
   for (int64_t lane = 0, e = vecTy.getNumElements(); lane < e; ++lane) {
     auto laneIdx = builder.create<arith::ConstantIndexOp>(loc, lane);
@@ -444,9 +445,8 @@ private:
                 return;
               }
               if (shouldScalarizeI1VectorMemoryOp(*vecTyOr)) {
-                virSymbolTable[op.getResult()] =
-                    buildScalarizedI1VectorLoad(builder, loc, *vecTyOr, base,
-                                                destIndices);
+                virSymbolTable[op.getResult()] = buildScalarizedI1VectorLoad(
+                    builder, loc, *vecTyOr, base, destIndices);
                 return;
               }
               if (hasStaticallyUnitStrideInVectorizedDim(base)) {

--- a/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
+++ b/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
@@ -70,6 +70,22 @@ namespace {
 static constexpr int DEFAULT_VECTOR_WIDTH = 4;
 static constexpr bool DEFAULT_USE_SCALABLE = false;
 
+// This pass vectorizes along the memref's most-minor dimension, so the
+// vector.load/vector.store fast path is only valid when that specific stride is
+// statically known to be 1.
+static bool hasStaticallyUnitStrideInVectorizedDim(Value base) {
+  auto memrefTy = dyn_cast<MemRefType>(base.getType());
+  if (!memrefTy || memrefTy.getRank() == 0)
+    return false;
+
+  SmallVector<int64_t> strides;
+  int64_t offset;
+  if (failed(memrefTy.getStridesAndOffset(strides, offset)) || strides.empty())
+    return false;
+
+  return strides.back() == 1;
+}
+
 VectorType vectorTypeHelper(Region &srcRegion, Type anchorType,
                             bool useScalable, bool verbose) {
 #define VERBOSE_ANALYSIS_INFO(info)                                            \
@@ -383,9 +399,17 @@ private:
                 op.emitError("failed to derive vector type for vir.load");
                 return;
               }
-              auto vectorLoadOp = builder.create<vector::LoadOp>(
-                  loc, *vecTyOr, base, destIndices);
-              virSymbolTable[op.getResult()] = vectorLoadOp.getResult();
+              if (hasStaticallyUnitStrideInVectorizedDim(base)) {
+                auto vectorLoadOp = builder.create<vector::LoadOp>(
+                    loc, *vecTyOr, base, destIndices);
+                virSymbolTable[op.getResult()] = vectorLoadOp.getResult();
+              } else {
+                auto padding = builder.create<arith::ConstantOp>(
+                    loc, builder.getZeroAttr((*vecTyOr).getElementType()));
+                auto transferReadOp = builder.create<vector::TransferReadOp>(
+                    loc, *vecTyOr, base, destIndices, padding);
+                virSymbolTable[op.getResult()] = transferReadOp.getResult();
+              }
             }
           })
           .Case<vir::StoreOp>([&](vir::StoreOp op) {
@@ -430,8 +454,13 @@ private:
               builder.create<memref::StoreOp>(loc, valueToStore, base,
                                               destIndices);
             } else {
-              builder.create<vector::StoreOp>(loc, valueToStore, base,
-                                              destIndices);
+              if (hasStaticallyUnitStrideInVectorizedDim(base)) {
+                builder.create<vector::StoreOp>(loc, valueToStore, base,
+                                                destIndices);
+              } else {
+                builder.create<vector::TransferWriteOp>(loc, valueToStore, base,
+                                                        destIndices);
+              }
             }
           })
           .Case<vir::ConstantOp>([&](vir::ConstantOp op) {

--- a/tests/Conversion/LinalgToVIR/linalg-i1-zero-broadcast-roundtrip-to-vir-to-vector.mlir
+++ b/tests/Conversion/LinalgToVIR/linalg-i1-zero-broadcast-roundtrip-to-vir-to-vector.mlir
@@ -1,0 +1,62 @@
+// RUN: buddy-opt %s -lower-linalg-to-vir -lower-vir-to-vector="vector-width=4" -cse --convert-vector-to-scf --expand-strided-metadata --lower-affine --convert-scf-to-cf --convert-cf-to-llvm --convert-vector-to-llvm --finalize-memref-to-llvm --convert-arith-to-llvm --convert-func-to-llvm --reconcile-unrealized-casts | mlir-runner -O0 -e main -entry-point-result=i32 -shared-libs=%mlir_runner_utils_dir/libmlir_runner_utils%shlibext,%mlir_runner_utils_dir/libmlir_c_runner_utils%shlibext | FileCheck %s
+
+// Regression test for mask values that are materialized as i1 memrefs,
+// broadcast through a zero-stride view, and later consumed by scalar code.
+// This matches the pattern behind Triton's gather_column_ld_mask failure.
+
+#broadcast_row = affine_map<(d0, d1) -> (d0, 0)>
+#id = affine_map<(d0, d1) -> (d0, d1)>
+
+module {
+  func.func @main() -> i32 {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c4 = arith.constant 4 : index
+    %zero = arith.constant 0 : i32
+    %one = arith.constant 1 : i32
+
+    %src = memref.alloc() : memref<2xi32>
+    %mask1 = memref.alloc() : memref<2x1xi1>
+    %mask2 = memref.alloc() : memref<2x4xi1>
+
+    affine.for %i = 0 to 2 {
+      %iv = arith.index_cast %i : index to i32
+      memref.store %iv, %src[%i] : memref<2xi32>
+    }
+
+    %expanded = memref.expand_shape %src [[0, 1]] output_shape [2, 1]
+      : memref<2xi32> into memref<2x1xi32>
+    linalg.generic
+        {indexing_maps = [#id, #id], iterator_types = ["parallel", "parallel"]}
+        ins(%expanded : memref<2x1xi32>)
+        outs(%mask1 : memref<2x1xi1>) {
+      ^bb0(%a: i32, %m: i1):
+        %pred = arith.cmpi slt, %a, %one : i32
+        linalg.yield %pred : i1
+    }
+
+    linalg.generic
+        {indexing_maps = [#broadcast_row, #id],
+         iterator_types = ["parallel", "parallel"]}
+        ins(%mask1 : memref<2x1xi1>)
+        outs(%mask2 : memref<2x4xi1>) attrs = {broadcastDims = array<i64: 1>} {
+      ^bb0(%m_in: i1, %m_out: i1):
+        linalg.yield %m_in : i1
+    }
+
+    %sum = scf.for %i = %c0 to %c2 step %c1 iter_args(%acc0 = %zero) -> (i32) {
+      %row = scf.for %j = %c0 to %c4 step %c1 iter_args(%acc1 = %acc0) -> (i32) {
+        %m = memref.load %mask2[%i, %j] : memref<2x4xi1>
+        %inc = arith.select %m, %one, %zero : i32
+        %next = arith.addi %acc1, %inc : i32
+        scf.yield %next : i32
+      }
+      scf.yield %row : i32
+    }
+
+    return %sum : i32
+  }
+}
+
+// CHECK: 4

--- a/tests/Conversion/LinalgToVIR/linalg-map-to-vir-regression.mlir
+++ b/tests/Conversion/LinalgToVIR/linalg-map-to-vir-regression.mlir
@@ -1,0 +1,15 @@
+// RUN: buddy-opt %s -lower-linalg-to-vir | FileCheck %s
+
+func.func @map_scalar_defined_above(%out: memref<4xi32>, %seed: i32) {
+  linalg.map outs(%out : memref<4xi32>)
+    () {
+      linalg.yield %seed : i32
+    }
+  return
+}
+
+// CHECK-LABEL: func.func @map_scalar_defined_above
+// CHECK: vir.set_vl %[[VL:.*]] : index {
+// CHECK:   %[[TOUT:.*]] = memref.transpose %arg0 (d0) -> (d0) : memref<4xi32> to memref<4xi32, strided<[1]>>
+// CHECK:   %[[V:.*]] = vir.broadcast %arg1 : i32 -> !vir.vec<?xi32>
+// CHECK:   vir.store %[[V]], %[[TOUT]][]

--- a/tests/Conversion/LinalgToVIR/linalg-maxnumf-minnumf-clamp-to-vir.mlir
+++ b/tests/Conversion/LinalgToVIR/linalg-maxnumf-minnumf-clamp-to-vir.mlir
@@ -1,0 +1,29 @@
+// RUN: buddy-opt %s -lower-linalg-to-vir | FileCheck %s
+
+func.func @clamp_with_maxnumf_minnumf(%arg0: memref<?xf32>, %arg1: memref<?xf32>) {
+  linalg.generic
+      { indexing_maps = [affine_map<(i)->(i)>, affine_map<(i)->(i)>],
+        iterator_types = ["parallel"] }
+      ins(%arg0 : memref<?xf32>)
+      outs(%arg1 : memref<?xf32>) {
+    ^bb0(%a: f32, %b: f32):
+      %lo = arith.constant -1.0 : f32
+      %hi = arith.constant 1.0 : f32
+      %m0 = arith.maxnumf %a, %lo : f32
+      %m1 = arith.minnumf %m0, %hi : f32
+      linalg.yield %m1 : f32
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @clamp_with_maxnumf_minnumf
+// CHECK: %[[VL:.*]] = memref.dim %arg1, %{{.*}} : memref<?xf32>
+// CHECK: vir.set_vl %[[VL]] : index {
+// CHECK:   %[[A:.*]] = vir.load %{{.*}}[] : memref<?xf32, strided<[1]>> -> !vir.vec<?xf32>
+// CHECK:   %[[LO:.*]] = vir.broadcast %{{.*}} : f32 -> !vir.vec<?xf32>
+// CHECK:   %[[HI:.*]] = vir.broadcast %{{.*}} : f32 -> !vir.vec<?xf32>
+// CHECK:   %[[M0:.*]] = arith.maxnumf %[[A]], %[[LO]] : !vir.vec<?xf32>
+// CHECK:   %[[M1:.*]] = arith.minnumf %[[M0]], %[[HI]] : !vir.vec<?xf32>
+// CHECK:   vir.store %[[M1]], %{{.*}}[] : !vir.vec<?xf32> -> memref<?xf32, strided<[1]>>
+// CHECK: }
+// CHECK-NOT: linalg.generic

--- a/tests/Conversion/LinalgToVIR/linalg-to-vir-index-broadcast-regression.mlir
+++ b/tests/Conversion/LinalgToVIR/linalg-to-vir-index-broadcast-regression.mlir
@@ -33,5 +33,6 @@ func.func @index_and_zero_broadcast_regression(%src: memref<2xf32>, %out: memref
 // CHECK:   %[[TEXP:.*]] = memref.transpose %[[EXP]] (d0, d1) -> (d0, d1) : memref<2x1xf32> to memref<2x1xf32, strided<[1, 1]>>
 // CHECK:   %[[SV:.*]] = memref.subview %[[TEXP]][0, 0] [2, 2] [1, 0] : memref<2x1xf32, strided<[1, 1]>> to memref<2x2xf32, strided<[1, 0]>>
 // CHECK:   %[[TOUT:.*]] = memref.transpose %{{.*}} (d0, d1) -> (d0, d1) : memref<2x2xf32> to memref<2x2xf32, strided<[2, 1]>>
-// CHECK:   %[[V:.*]] = vir.load %[[SV]][] : memref<2x2xf32, strided<[1, 0]>> -> !vir.vec<2x2xf32>
+// CHECK:   %[[V:.*]] = vir.load %[[SV]][] : memref<2x2xf32, strided<[1, 0]>> -> !vir.vec<2x?xf32>
+// CHECK-NOT: !vir.vec<2x2xf32>
 // CHECK:   vir.store %[[V]], %[[TOUT]][]

--- a/tests/Conversion/LinalgToVIR/linalg-to-vir.mlir
+++ b/tests/Conversion/LinalgToVIR/linalg-to-vir.mlir
@@ -147,7 +147,8 @@ func.func @permute_input(%A: memref<8x4xf32>, %B: memref<4x8xf32>) {
 // CHECK: vir.set_vl %[[C8_P]] : index {
 // CHECK:   %[[TA:.*]] = memref.transpose %arg0 (d0, d1) -> (d1, d0) : memref<8x4xf32> to memref<4x8xf32, strided<[1, 4]>>
 // CHECK:   %[[TB:.*]] = memref.transpose %arg1 (d0, d1) -> (d0, d1) : memref<4x8xf32> to memref<4x8xf32, strided<[8, 1]>>
-// CHECK:   %[[VA:.*]] = vir.load %[[TA]][] : memref<4x8xf32, strided<[1, 4]>> -> !vir.vec<4x8xf32>
+// CHECK:   %[[VA:.*]] = vir.load %[[TA]][] : memref<4x8xf32, strided<[1, 4]>> -> !vir.vec<4x?xf32>
+// CHECK-NOT: !vir.vec<4x8xf32>
 // CHECK:   vir.store %[[VA]], %[[TB]]
 
 // -----

--- a/tests/Conversion/linalg-non-unit-stride-to-vir-to-vector.mlir
+++ b/tests/Conversion/linalg-non-unit-stride-to-vir-to-vector.mlir
@@ -1,0 +1,35 @@
+// RUN: buddy-opt %s -lower-linalg-to-vir -lower-vir-to-vector='vector-width=4' | FileCheck %s
+
+#map0 = affine_map<(d0, d1) -> (d0, 0)>
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+#map2 = affine_map<(d0, d1) -> (d1, d0)>
+
+func.func @zero_broadcast_uses_transfer_read(%src: memref<2xf32>, %out: memref<2x2xf32>) {
+  %expanded = memref.expand_shape %src [[0, 1]] output_shape [2, 1] : memref<2xf32> into memref<2x1xf32>
+  linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%expanded : memref<2x1xf32>) outs(%out : memref<2x2xf32>) attrs = {broadcastDims = array<i64: 1>} {
+  ^bb0(%in: f32, %out_elem: f32):
+    linalg.yield %in : f32
+  }
+  return
+}
+
+func.func @transposed_output_uses_transfer_write(%src: memref<2x2xf32>, %out: memref<2x2xf32>) {
+  linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins(%src : memref<2x2xf32>) outs(%out : memref<2x2xf32>) {
+  ^bb0(%in: f32, %out_elem: f32):
+    linalg.yield %in : f32
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @zero_broadcast_uses_transfer_read
+// CHECK: %[[SV:.*]] = memref.subview
+// CHECK: %[[READ:.*]] = vector.transfer_read %[[SV]]
+// CHECK-NOT: vector.load %[[SV]]
+// CHECK: vector.store %[[READ]],
+
+// CHECK-LABEL: func.func @transposed_output_uses_transfer_write
+// CHECK: %[[SRC:.*]] = memref.transpose %arg0
+// CHECK: %[[DST:.*]] = memref.transpose %arg1
+// CHECK: %[[V:.*]] = vector.load %[[SRC]]
+// CHECK: vector.transfer_write %[[V]], %[[DST]]
+// CHECK-NOT: vector.store %[[V]], %[[DST]]

--- a/tests/Conversion/vir-maxnumf-minnumf-to-vector.mlir
+++ b/tests/Conversion/vir-maxnumf-minnumf-to-vector.mlir
@@ -1,0 +1,33 @@
+// RUN: buddy-opt %s -lower-vir-to-vector='vector-width=4' -cse | FileCheck %s
+
+func.func @vir_maxnumf_to_vector(%arg0: memref<128xf32>, %arg1: memref<128xf32>) {
+  %c128 = arith.constant 128 : index
+  vir.set_vl %c128 : index {
+    %a = vir.load %arg0[] : memref<128xf32> -> !vir.vec<?xf32>
+    %b = vir.load %arg1[] : memref<128xf32> -> !vir.vec<?xf32>
+    %max = arith.maxnumf %a, %b : !vir.vec<?xf32>
+    vir.store %max, %arg0[] : !vir.vec<?xf32> -> memref<128xf32>
+    vector.yield
+  }
+  return
+}
+
+func.func @vir_minnumf_to_vector(%arg0: memref<128xf32>, %arg1: memref<128xf32>) {
+  %c128 = arith.constant 128 : index
+  vir.set_vl %c128 : index {
+    %a = vir.load %arg0[] : memref<128xf32> -> !vir.vec<?xf32>
+    %b = vir.load %arg1[] : memref<128xf32> -> !vir.vec<?xf32>
+    %min = arith.minnumf %a, %b : !vir.vec<?xf32>
+    vir.store %min, %arg0[] : !vir.vec<?xf32> -> memref<128xf32>
+    vector.yield
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @vir_maxnumf_to_vector
+// CHECK: arith.maxnumf {{.*}} : vector<4xf32>
+// CHECK: arith.maxnumf {{.*}} : f32
+
+// CHECK-LABEL: func.func @vir_minnumf_to_vector
+// CHECK: arith.minnumf {{.*}} : vector<4xf32>
+// CHECK: arith.minnumf {{.*}} : f32


### PR DESCRIPTION
…mension, and change the lowering target for non-unit-stride vir.vec

## Summary

- Force the last dimension of VIR to be generated as a dynamic dimension
- Set the lowering target for non-unit-stride vir.vec to vector.transfer_read/write


