### PR TITLE
[CI] Add example ci test

### DIFF
--- a/.github/actions/ci-common/action.yml
+++ b/.github/actions/ci-common/action.yml
@@ -1,0 +1,152 @@
+name: buddy-mlir build
+description: Prepare the environment and build buddy-mlir.
+
+inputs:
+  arch:
+    description: Target runner architecture.
+    required: true
+  venv_activate:
+    description: Command used to activate the Python environment.
+    required: true
+  venv_deactivate:
+    description: Command used to deactivate the Python environment.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Prepare ENV (x64)
+      if: ${{ inputs.arch == 'x64' }}
+      shell: bash
+      run: |
+        echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
+        echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
+        ccache -M 50G
+        echo "CCACHE_MAXSIZE=50G" >> $GITHUB_ENV
+
+        mkdir -p $HOME/actions-runner/workspace
+        echo LLVM_SRC=$HOME/actions-runner/workspace/llvm-project >> $GITHUB_ENV
+        echo LLVM_BUILD_ROOT=$HOME/actions-runner/workspace/llvm-cache >> $GITHUB_ENV
+
+        ${{ inputs.venv_activate }}
+        pip install --upgrade pip
+        pip install -r requirements.txt
+        ${{ inputs.venv_deactivate }}
+
+    - name: Prepare ENV (arm64)
+      if: ${{ inputs.arch == 'arm64' }}
+      shell: bash
+      run: |
+        echo LLVM_SRC=$HOME/actions-runner/workspace/llvm-project >> $GITHUB_ENV
+        echo LLVM_BUILD_ROOT=$HOME/actions-runner/workspace/llvm-cache >> $GITHUB_ENV
+        mkdir -p $HOME/actions-runner/workspace
+
+        ${{ inputs.venv_activate }}
+        pip install --upgrade pip
+        pip install -r requirements.txt
+        ${{ inputs.venv_deactivate }}
+
+    - name: Prepare ENV (riscv64)
+      if: ${{ inputs.arch == 'riscv64' }}
+      shell: bash
+      run: |
+        echo "CCACHE_DIR=/home/jenkins/.ccache" >> $GITHUB_ENV
+        echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
+        ccache -M 50G
+        echo "CCACHE_MAXSIZE=50G" >> $GITHUB_ENV
+        echo LLVM_SRC=/home/jenkins/src/llvm-project >> $GITHUB_ENV
+        echo LLVM_BUILD_ROOT=/home/jenkins/llvm-cache >> $GITHUB_ENV
+        mkdir -p /home/jenkins/src
+
+        ${{ inputs.venv_activate }}
+        pip install -U pip setuptools wheel packaging
+        sed -i \
+          -e '1s/^/# /' \
+          requirements.txt
+        pip install -r requirements.txt
+        ${{ inputs.venv_deactivate }}
+
+    - name: Setup LLVM build
+      id: prepare-llvm-build
+      shell: bash
+      run: |
+        LLVM_COMMIT=$(git ls-tree HEAD llvm | awk '{print $3}')
+        LLVM_BUILD_DIR=$LLVM_BUILD_ROOT/$LLVM_COMMIT
+
+        mkdir -p $LLVM_BUILD_ROOT
+
+        if [ ! -d "$LLVM_SRC" ]; then
+          git clone https://community-ci.openruyi.cn/toolchain/llvm-project.git $LLVM_SRC
+        fi
+
+        git -C $LLVM_SRC fetch --all
+        git -C $LLVM_SRC reset --hard
+        git -C $LLVM_SRC clean -fdx
+        git -C $LLVM_SRC checkout $LLVM_COMMIT
+
+        echo "LLVM_SRC=$LLVM_SRC" >> $GITHUB_ENV
+        echo "LLVM_COMMIT=$LLVM_COMMIT" >> $GITHUB_ENV
+        echo "LLVM_BUILD_DIR=$LLVM_BUILD_DIR" >> $GITHUB_ENV
+
+        if [ -f "$LLVM_BUILD_DIR/build/CMakeCache.txt" ] &&
+          grep -q "$LLVM_SRC" "$LLVM_BUILD_DIR/build/CMakeCache.txt"; then
+          echo "need-rebuild=false" >> $GITHUB_OUTPUT
+        else
+          echo "need-rebuild=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Configure and Build LLVM
+      if: ${{ steps.prepare-llvm-build.outputs.need-rebuild == 'true' }}
+      shell: bash
+      run: |
+        ${{ inputs.venv_activate }}
+        rm -rf $LLVM_BUILD_DIR
+        cmake -G Ninja -S $LLVM_SRC/llvm -B $LLVM_BUILD_DIR/build \
+          -DLLVM_ENABLE_PROJECTS="mlir;clang;openmp" \
+          -DLLVM_TARGETS_TO_BUILD="host;RISCV" \
+          -DLLVM_ENABLE_ASSERTIONS=ON \
+          -DCMAKE_BUILD_TYPE=RELEASE \
+          -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+          -DPython3_EXECUTABLE=$(which python3)
+        ninja -C $LLVM_BUILD_DIR/build check-clang check-mlir omp || true
+        ${{ inputs.venv_deactivate }}
+
+    - name: Show ccache stats
+      if: ${{ runner.os == 'Linux' }}
+      shell: bash
+      run: |
+        ccache -s
+
+    - name: Configure and Build buddy-mlir
+      shell: bash
+      run: |
+        ${{ inputs.venv_activate }}
+        echo "---- CHECK LOCAL SUBMODULE ----"
+        ls -l llvm || true
+        git submodule status || true
+        rm -rf build
+        mkdir build
+        cd build
+
+        cmake -G Ninja .. \
+          -DMLIR_DIR=$LLVM_BUILD_DIR/build/lib/cmake/mlir \
+          -DLLVM_DIR=$LLVM_BUILD_DIR/build/lib/cmake/llvm \
+          -DLLVM_MAIN_SRC_DIR=$LLVM_SRC/llvm \
+          -DMLIR_MAIN_SRC_DIR=$LLVM_SRC/mlir \
+          -DLLVM_ENABLE_ASSERTIONS=ON \
+          -DCMAKE_BUILD_TYPE=RELEASE \
+          -DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON \
+          -DBUDDY_BUILD_DEEPSEEK_R1_MODEL=OFF \
+          -DPython3_EXECUTABLE=$(which python3)
+        ninja
+
+        ${{ inputs.venv_deactivate }}
+
+    - name: Cleanup old LLVM build cache
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        KEEP=3
+
+        cd $LLVM_BUILD_ROOT
+        ls -1dt */ | tail -n +$((KEEP+1)) | xargs -r rm -rf

--- a/.github/workflows/TestBuild.yml
+++ b/.github/workflows/TestBuild.yml
@@ -60,135 +60,15 @@ jobs:
           git fetch github ${{ github.sha }}
           git checkout ${{ github.sha }}
 
-      # 2. Submodule pointer in the superproject (no +/- prefix from submodule status).
-      - name: Get LLVM submodule commit
-        id: llvm-submodule-commit
-        run: |
-          echo "commit=$(git ls-tree HEAD llvm | awk '{print $3}')" >> $GITHUB_OUTPUT
+      - name: Build buddy-mlir
+        uses: ./.github/actions/ci-common
+        with:
+          arch: ${{ matrix.arch }}
+          venv_activate: ${{ matrix.venv_activate }}
+          venv_deactivate: ${{ matrix.venv_deactivate }}
 
-      - name: Prepare ENV (x64)
-        if: matrix.arch == 'x64'
-        run: |
-          echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
-          echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
-          ccache -M 50G
-          echo "CCACHE_MAXSIZE=50G" >> $GITHUB_ENV
-
-          mkdir -p $HOME/actions-runner/workspace
-          echo LLVM_SRC=$HOME/actions-runner/workspace/llvm-project >> $GITHUB_ENV
-          echo LLVM_BUILD_ROOT=$HOME/actions-runner/workspace/llvm-cache >> $GITHUB_ENV
-
-          ${{ matrix.venv_activate }}
-          pip install --upgrade pip
-          pip install -r requirements.txt
-          ${{ matrix.venv_deactivate }}
-      - name: Prepare ENV (arm64)
-        if: matrix.arch == 'arm64'
-        run: |
-          echo LLVM_SRC=$HOME/actions-runner/workspace/llvm-project >> $GITHUB_ENV
-          echo LLVM_BUILD_ROOT=$HOME/actions-runner/workspace/llvm-cache >> $GITHUB_ENV
-          mkdir -p $HOME/actions-runner/workspace
-
-          ${{ matrix.venv_activate }}
-          pip install --upgrade pip
-          pip install -r requirements.txt
-          ${{ matrix.venv_deactivate }}
-      - name: Prepare ENV (riscv64)
-        if: matrix.arch == 'riscv64'
-        run: |
-          echo "CCACHE_DIR=/home/jenkins/.ccache" >> $GITHUB_ENV
-          echo "PATH=/usr/lib/ccache:$PATH" >> $GITHUB_ENV
-          ccache -M 50G
-          echo "CCACHE_MAXSIZE=50G" >> $GITHUB_ENV
-          echo LLVM_SRC=/home/jenkins/src/llvm-project >> $GITHUB_ENV
-          echo LLVM_BUILD_ROOT=/home/jenkins/llvm-cache >> $GITHUB_ENV
-          mkdir -p /home/jenkins/src
-
-          ${{ matrix.venv_activate }}
-          pip install -U pip setuptools wheel packaging
-          sed -i \
-            -e '1s/^/# /' \
-            requirements.txt
-          pip install -r requirements.txt
-          ${{ matrix.venv_deactivate }}
-
-      - name: Setup LLVM build
-        id: prepare-llvm-build
-        run: |
-          LLVM_COMMIT=$(git ls-tree HEAD llvm | awk '{print $3}')
-          LLVM_BUILD_DIR=$LLVM_BUILD_ROOT/$LLVM_COMMIT
-
-          mkdir -p $LLVM_BUILD_ROOT
-
-          # prepare source
-          if [ ! -d "$LLVM_SRC" ]; then
-            git clone https://community-ci.openruyi.cn/toolchain/llvm-project.git $LLVM_SRC
-          fi
-
-          git -C $LLVM_SRC fetch --all
-          git -C $LLVM_SRC reset --hard
-          git -C $LLVM_SRC clean -fdx
-          git -C $LLVM_SRC checkout $LLVM_COMMIT
-
-          echo "LLVM_SRC=$LLVM_SRC" >> $GITHUB_ENV
-          echo "LLVM_COMMIT=$LLVM_COMMIT" >> $GITHUB_ENV
-          echo "LLVM_BUILD_DIR=$LLVM_BUILD_DIR" >> $GITHUB_ENV
-
-          if [ -f "$LLVM_BUILD_DIR/build/CMakeCache.txt" ] &&
-            grep -q "$LLVM_SRC" "$LLVM_BUILD_DIR/build/CMakeCache.txt"; then
-            echo "need-rebuild=false" >> $GITHUB_OUTPUT
-          else
-            echo "need-rebuild=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Configure and Build LLVM
-        if: steps.prepare-llvm-build.outputs.need-rebuild == 'true'
+      - name: Run check-buddy
         run: |
           ${{ matrix.venv_activate }}
-          rm -rf $LLVM_BUILD_DIR
-          cmake -G Ninja -S $LLVM_SRC/llvm  -B $LLVM_BUILD_DIR/build \
-            -DLLVM_ENABLE_PROJECTS="mlir;clang;openmp" \
-            -DLLVM_TARGETS_TO_BUILD="host;RISCV" \
-            -DLLVM_ENABLE_ASSERTIONS=ON \
-            -DCMAKE_BUILD_TYPE=RELEASE \
-            -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-            -DPython3_EXECUTABLE=$(which python3)
-          ninja -C $LLVM_BUILD_DIR/build check-clang check-mlir omp || true
+          ninja -C build check-buddy || true
           ${{ matrix.venv_deactivate }}
-
-      - name: Show ccache stats
-        if: matrix.os == 'linux'
-        run: |
-          ccache -s
-
-      - name: Check buddy-mlir build
-        run: |
-          ${{ matrix.venv_activate }}
-          echo "---- CHECK LOCAL SUBMODULE ----"
-          ls -l llvm || true
-          git submodule status || true
-          rm -rf build
-          mkdir build
-          cd build
-
-          #  It will fail to find source code if no -DLLVM_MAIN_SRC_DIR=$LLVM_SRC/llvm  -DMLIR_MAIN_SRC_DIR=$LLVM_SRC/mlir
-          cmake -G Ninja .. \
-            -DMLIR_DIR=$LLVM_BUILD_DIR/build/lib/cmake/mlir \
-            -DLLVM_DIR=$LLVM_BUILD_DIR/build/lib/cmake/llvm \
-            -DLLVM_MAIN_SRC_DIR=$LLVM_SRC/llvm \
-            -DMLIR_MAIN_SRC_DIR=$LLVM_SRC/mlir \
-            -DLLVM_ENABLE_ASSERTIONS=ON \
-            -DCMAKE_BUILD_TYPE=RELEASE \
-            -DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON \
-            -DBUDDY_BUILD_DEEPSEEK_R1_MODEL=OFF \
-            -DPython3_EXECUTABLE=$(which python3)
-          ninja
-          ninja check-buddy || true
-          ${{ matrix.venv_deactivate }}
-
-      - name: Cleanup old LLVM build cache
-        run: |
-          KEEP=3
-
-          cd $LLVM_BUILD_ROOT
-          ls -1dt */ | tail -n +$((KEEP+1)) | xargs -r rm -rf

--- a/.github/workflows/_pr-comment-commands.yml
+++ b/.github/workflows/_pr-comment-commands.yml
@@ -1,0 +1,76 @@
+name: pr comment commands
+
+on:
+  issue_comment:
+    types: [ created ]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  dispatch:
+    if: >
+      github.event.issue.pull_request &&
+      github.event.issue.state == 'open' &&
+      startsWith(github.event.comment.body, '/run-example') &&
+      contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR head
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }} \
+            --jq '"head_repository=\(.head.repo.full_name)\nhead_ref=\(.head.ref)\nhead_sha=\(.head.sha)\nstatuses_path=\(.statuses_url | ltrimstr("https://api.github.com/"))"' >> "$GITHUB_OUTPUT"
+
+      - name: Mark example tests queued
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for context in \
+            'test-examples (linux-x64)' \
+            'test-examples (macos-arm64)'
+          do
+            gh api --method POST "${{ steps.pr.outputs.statuses_path }}" \
+              -f state='pending' \
+              -f context="$context" \
+              -f description='Example tests queued' \
+              -f target_url="https://github.com/${{ github.repository }}/actions/workflows/test-example.yml"
+          done
+
+      - name: Dispatch example workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dispatch_ref="${{ github.event.repository.default_branch }}"
+          if [ "${{ steps.pr.outputs.head_repository }}" = "${{ github.repository }}" ]; then
+            dispatch_ref="${{ steps.pr.outputs.head_ref }}"
+          fi
+
+          gh workflow run test-example.yml \
+            --ref "$dispatch_ref" \
+            -f source_repository="${{ steps.pr.outputs.head_repository }}" \
+            -f source_ref="${{ steps.pr.outputs.head_ref }}" \
+            -f source_sha="${{ steps.pr.outputs.head_sha }}" \
+            -f status_api_path="${{ steps.pr.outputs.statuses_path }}" \
+            -f status_context='test-examples'
+
+      - name: Mark dispatch failure
+        if: ${{ failure() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for context in \
+            'test-examples (linux-x64)' \
+            'test-examples (macos-arm64)'
+          do
+            gh api --method POST "${{ steps.pr.outputs.statuses_path }}" \
+              -f state='failure' \
+              -f context="$context" \
+              -f description='Failed to dispatch example tests' \
+              -f target_url="https://github.com/${{ github.repository }}/actions/workflows/test-example.yml"
+          done

--- a/.github/workflows/test-example.yml
+++ b/.github/workflows/test-example.yml
@@ -1,0 +1,174 @@
+name: test-examples
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_repository:
+        description: Repository containing the code to test.
+        required: false
+        default: ""
+      source_ref:
+        description: Branch or tag used to fetch the code under test.
+        required: false
+        default: ""
+      source_sha:
+        description: Exact commit SHA to test.
+        required: false
+        default: ""
+      status_api_path:
+        description: REST API path used to update the PR commit status.
+        required: false
+        default: ""
+      status_context:
+        description: Commit status prefix used for per-matrix checks during manual runs.
+        required: false
+        default: "test-examples"
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  test:
+    name: Example Test (${{ matrix.os }}-${{ matrix.arch }})
+    timeout-minutes: 360
+    continue-on-error: ${{ matrix.experimental }}
+    env:
+      CHECKOUT_REPOSITORY: ${{ inputs.source_repository || github.repository }}
+      CHECKOUT_FETCH_REF: ${{ inputs.source_ref || github.ref_name }}
+      CHECKOUT_REF: ${{ inputs.source_sha || github.sha }}
+      STATUS_API_PATH: ${{ inputs.status_api_path }}
+
+    concurrency:
+      group: buddy-mlir-example-${{ matrix.os }}-${{ matrix.arch }}
+      cancel-in-progress: true
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            os: linux
+            experimental: false
+            venv_activate: "source ~/miniforge3/bin/activate buddy"
+            venv_deactivate: "conda deactivate"
+          - arch: arm64
+            os: macos
+            experimental: true
+            venv_activate: "source ~/miniforge3/bin/activate buddy"
+            venv_deactivate: "conda deactivate"
+          # - arch: riscv64
+          #   os: linux
+          #   experimental: true
+          #   venv_activate: "source /home/jenkins/venv/bin/activate"
+          #   venv_deactivate: "deactivate"
+
+    runs-on:
+      - self-hosted
+      - ${{ matrix.arch }}
+
+    steps:
+      - name: Mark example tests in progress
+        if: ${{ env.STATUS_API_PATH != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATRIX_STATUS_CONTEXT: ${{ format('{0} ({1}-{2})', inputs.status_context || 'test-examples', matrix.os, matrix.arch) }}
+        run: |
+          gh api --method POST "$STATUS_API_PATH" \
+            -f state='pending' \
+            -f context="$MATRIX_STATUS_CONTEXT" \
+            -f description='Example tests are running' \
+            -f target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Print target
+        run: |
+          echo "Building on ${{ matrix.arch }}"
+          echo "Repository: $CHECKOUT_REPOSITORY"
+          echo "Fetch ref: $CHECKOUT_FETCH_REF"
+          echo "Commit: $CHECKOUT_REF"
+          echo "------ uname ------"
+          uname -a
+
+      - name: Checkout
+        if: matrix.arch != 'riscv64'
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.CHECKOUT_REPOSITORY }}
+          ref: ${{ env.CHECKOUT_REF }}
+          submodules: 'false'
+
+      - name: Checkout from local Gitea (riscv64)
+        if: matrix.arch == 'riscv64'
+        run: |
+          git clone --no-checkout https://community-ci.openruyi.cn/RuyiAI-Stack/buddy-mlir .
+          git remote add source https://github.com/$CHECKOUT_REPOSITORY.git
+          git fetch source "$CHECKOUT_FETCH_REF"
+          git checkout "$CHECKOUT_REF"
+
+      - name: Build buddy-mlir
+        uses: ./.github/actions/ci-common
+        with:
+          arch: ${{ matrix.arch }}
+          venv_activate: ${{ matrix.venv_activate }}
+          venv_deactivate: ${{ matrix.venv_deactivate }}
+
+      - name: Build example test targets
+        run: |
+          ${{ matrix.venv_activate }}
+          echo "---- CHECK LOCAL SUBMODULE ----"
+          ls -l llvm || true
+          git submodule status || true
+
+          cmake -S . -B build \
+            -DBUDDY_BERT_EXAMPLES=ON \
+            -DBUDDY_DEEPSEEKR1_EXAMPLES=ON \
+            -DBUDDY_LENET_EXAMPLES=ON \
+            -DBUDDY_MOBILENETV3_EXAMPLES=ON \
+            -DBUDDY_QWEN3_EXAMPLES=ON \
+            -DBUDDY_RESNET_EXAMPLES=ON \
+            -DBUDDY_STABLE_DIFFUSION_EXAMPLES=ON \
+            -DBUDDY_TRANSFORMER_EXAMPLES=ON \
+            -DBUDDY_WHISPER_EXAMPLES=ON \
+            -DBUDDY_ENABLE_PNG=ON
+
+          ninja -C build \
+            buddy-deepseek-r1-cli \
+            buddy-qwen3-0.6b-run \
+            transformer-runner \
+            buddy-bert-run \
+            buddy-lenet-run \
+            buddy-whisper-run \
+            buddy-mobilenetv3-run \
+            buddy-resnet-run \
+            buddy-stable-diffusion-run
+          ${{ matrix.venv_deactivate }}
+
+      - name: Report matrix status
+        if: ${{ always() && env.STATUS_API_PATH != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JOB_STATUS: ${{ job.status }}
+          MATRIX_STATUS_CONTEXT: ${{ format('{0} ({1}-{2})', inputs.status_context || 'test-examples', matrix.os, matrix.arch) }}
+        run: |
+          state='error'
+          description='Example tests did not complete'
+
+          case "$JOB_STATUS" in
+            success)
+              state='success'
+              description='Example tests passed'
+              ;;
+            failure)
+              state='failure'
+              description='Example tests failed'
+              ;;
+            cancelled)
+              description='Example tests were cancelled'
+              ;;
+          esac
+
+          gh api --method POST "$STATUS_API_PATH" \
+            -f state="$state" \
+            -f context="$MATRIX_STATUS_CONTEXT" \
+            -f description="$description" \
+            -f target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 include(ExternalProject)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+include(CTest)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/examples/BuddyBert/CMakeLists.txt
+++ b/examples/BuddyBert/CMakeLists.txt
@@ -87,3 +87,16 @@ target_link_directories(buddy-bert-run PRIVATE ${LLVM_LIBRARY_DIR})
 
 set(BUDDY_BERT_LIBS BERT mlir_c_runner_utils omp)
 target_link_libraries(buddy-bert-run ${BUDDY_BERT_LIBS})
+
+add_test(
+  NAME example.buddy-bert-run
+  COMMAND sh -c "printf '%s\n' 'I am happy today.' | \"$<TARGET_FILE:buddy-bert-run>\""
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+set_tests_properties(
+  example.buddy-bert-run
+  PROPERTIES
+    LABELS "example"
+    PASS_REGULAR_EXPRESSION "The emotion of your sentence is joy."
+    TIMEOUT 900
+)

--- a/examples/BuddyDeepSeekR1/CMakeLists.txt
+++ b/examples/BuddyDeepSeekR1/CMakeLists.txt
@@ -1672,7 +1672,7 @@ target_link_libraries(buddy-deepseek-r1-w8a32-run ${BUDDY_DEEPSEEKR1_W8A32_LIBS}
 target_link_libraries(buddy-deepseek-r1-w8a8-run ${BUDDY_DEEPSEEKR1_W8A8_LIBS})
 target_link_libraries(buddy-deepseek-r1-w4a16-run ${BUDDY_DEEPSEEKR1_W4A16_LIBS})
 target_link_libraries(buddy-deepseek-r1-w8a16-run ${BUDDY_DEEPSEEKR1_W8A16_LIBS})
-target_link_libraries(buddy-deepseek-r1-cli ${BUDDY_DEEPSEEKR1_LIBS} LLVMOption)
+target_link_libraries(buddy-deepseek-r1-cli ${BUDDY_DEEPSEEKR1_LIBS} LLVMOption buddy_runtime_core)
 
 # Create a distributable package
 set(DIST_PACKAGE_NAME "buddy-deepseek-r1")
@@ -1989,6 +1989,19 @@ target_link_libraries(buddy-deepseek-r1-tiered-kv-cache-run ${BUDDY_DEEPSEEKR1_T
 add_custom_target(deepseekr1-tiered-kv-cache
   DEPENDS buddy-deepseek-r1-tiered-kv-cache-run
   COMMENT "Building DeepSeekR1 tiered-kv-cache inference"
+)
+
+add_test(
+  NAME example.buddy-deepseek-r1-cli
+  COMMAND $<TARGET_FILE:buddy-deepseek-r1-cli> --prompt Hi --max-tokens=128
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+set_tests_properties(
+  example.buddy-deepseek-r1-cli
+  PROPERTIES
+    LABELS "example"
+    PASS_REGULAR_EXPRESSION "Total time"
+    TIMEOUT 3600
 )
 
 message(STATUS "DeepSeekR1 Multi-Cache: Building prefill and decode subgraphs for cache sizes: ${KV_CACHE_SIZES}")

--- a/examples/BuddyLeNet/CMakeLists.txt
+++ b/examples/BuddyLeNet/CMakeLists.txt
@@ -75,6 +75,19 @@ target_compile_definitions(buddy-lenet-run PRIVATE
     LENET_EXAMPLE_BUILD_PATH="${LENET_EXAMPLE_BUILD_PATH}"
 )
 
+add_test(
+  NAME example.buddy-lenet-run
+  COMMAND $<TARGET_FILE:buddy-lenet-run>
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+set_tests_properties(
+  example.buddy-lenet-run
+  PROPERTIES
+    LABELS "example"
+    PASS_REGULAR_EXPRESSION "Passed"
+    TIMEOUT 600
+)
+
 set(ONE_SHOT_BUFFERIZE_OPTION "bufferize-function-boundaries=1 function-boundary-type-conversion=identity-layout-map")
 set(LOWER_TO_NVVM_OPTION "cubin-chip=sm_80 cubin-features=+ptx71 cubin-format=fatbin")
 set(CONVERT_MEMCPY_TO_GPU_OPTION "process-args=1")

--- a/examples/BuddyLeNet/buddy-lenet-import.py
+++ b/examples/BuddyLeNet/buddy-lenet-import.py
@@ -18,16 +18,15 @@
 #
 # ===---------------------------------------------------------------------------
 
+import argparse
 import os
 from pathlib import Path
-import argparse
 
 import numpy as np
 import torch
-
 from buddy.compiler.frontend import DynamoCompiler
 from buddy.compiler.graph import GraphDriver
-from buddy.compiler.graph.transform import simply_fuse, apply_classic_fusion
+from buddy.compiler.graph.transform import simply_fuse
 from buddy.compiler.ops import tosa
 from model import LeNet
 
@@ -48,7 +47,13 @@ output_dir.mkdir(parents=True, exist_ok=True)
 # Retrieve the LeNet model path.
 model_path = os.environ.get("LENET_MODEL_PATH")
 if model_path is None:
-    model_path = Path(__file__).resolve().parent / "lenet-model.pth"
+    model_path = (
+        Path(__file__).resolve().parent.parent.parent
+        / "tests"
+        / "Models"
+        / "BuddyLeNet"
+        / "lenet-model.pth"
+    )
 
 model = LeNet()
 model = torch.load(model_path, weights_only=False)

--- a/examples/BuddyLlama/CMakeLists.txt
+++ b/examples/BuddyLlama/CMakeLists.txt
@@ -132,3 +132,16 @@ if(BUDDY_MLIR_USE_MIMALLOC)
 endif()
 
 target_link_libraries(buddy-llama-run ${BUDDY_LLAMA_LIBS})
+
+add_test(
+  NAME example.buddy-llama-run
+  COMMAND sh -c "printf '%s\n' 'Hi' | \"$<TARGET_FILE:buddy-llama-run>\""
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+set_tests_properties(
+  example.buddy-llama-run
+  PROPERTIES
+    LABELS "example;benchmark;manual"
+    PASS_REGULAR_EXPRESSION ".+"
+    TIMEOUT 1800
+)

--- a/examples/BuddyMobileNetV3/CMakeLists.txt
+++ b/examples/BuddyMobileNetV3/CMakeLists.txt
@@ -80,3 +80,16 @@ target_link_directories(buddy-mobilenetv3-run PRIVATE ${LLVM_LIBRARY_DIR})
 
 set(BUDDY_MOBILENETV3_LIBS MOBILENETV3 mlir_c_runner_utils BuddyLibDIP ${PNG_LIBRARIES})
 target_link_libraries(buddy-mobilenetv3-run ${BUDDY_MOBILENETV3_LIBS})
+
+add_test(
+  NAME example.buddy-mobilenetv3-run
+  COMMAND $<TARGET_FILE:buddy-mobilenetv3-run>
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+set_tests_properties(
+  example.buddy-mobilenetv3-run
+  PROPERTIES
+    LABELS "example"
+    PASS_REGULAR_EXPRESSION "Probability: 0.66194"
+    TIMEOUT 1200
+)

--- a/examples/BuddyOneDNN/CMakeLists.txt
+++ b/examples/BuddyOneDNN/CMakeLists.txt
@@ -268,6 +268,19 @@ set_target_properties(buddy-onednn-run PROPERTIES
     BUILD_RPATH "$ORIGIN/../lib:${CMAKE_BINARY_DIR}/lib:${MLIR_RUNNER_UTILS_LIB}:${CMAKE_CURRENT_BINARY_DIR}"
 )
 
+add_test(
+    NAME example.buddy-onednn-run
+    COMMAND $<TARGET_FILE:buddy-onednn-run>
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+set_tests_properties(
+    example.buddy-onednn-run
+    PROPERTIES
+        LABELS "example;benchmark;external"
+        PASS_REGULAR_EXPRESSION "Test PASSED!"
+        TIMEOUT 300
+)
+
 # ============================================================================
 # All Target
 # ============================================================================

--- a/examples/BuddyQwen3/CMakeLists.txt
+++ b/examples/BuddyQwen3/CMakeLists.txt
@@ -272,3 +272,16 @@ if(BUDDY_MLIR_USE_MIMALLOC)
 endif()
 
 target_link_libraries(buddy-qwen3-0.6b-run ${BUDDY_QWEN3_0_6B_LIBS})
+
+add_test(
+  NAME example.buddy-qwen3-0.6b-run
+  COMMAND sh -c "printf '%s\n' 'Hi' | \"$<TARGET_FILE:buddy-qwen3-0.6b-run>\""
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+set_tests_properties(
+  example.buddy-qwen3-0.6b-run
+  PROPERTIES
+    LABELS "example"
+    PASS_REGULAR_EXPRESSION "Hello! How can I assist you today?"
+    TIMEOUT 3600
+)

--- a/examples/BuddyResNet18/CMakeLists.txt
+++ b/examples/BuddyResNet18/CMakeLists.txt
@@ -80,3 +80,16 @@ target_link_directories(buddy-resnet-run PRIVATE ${LLVM_LIBRARY_DIR})
 
 set(BUDDY_RESNET_LIBS RESNET mlir_c_runner_utils BuddyLibDIP ${PNG_LIBRARIES})
 target_link_libraries(buddy-resnet-run ${BUDDY_RESNET_LIBS})
+
+add_test(
+  NAME example.buddy-resnet-run
+  COMMAND $<TARGET_FILE:buddy-resnet-run>
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+set_tests_properties(
+  example.buddy-resnet-run
+  PROPERTIES
+    LABELS "example"
+    PASS_REGULAR_EXPRESSION "Passed"
+    TIMEOUT 1200
+)

--- a/examples/BuddyStableDiffusion/CMakeLists.txt
+++ b/examples/BuddyStableDiffusion/CMakeLists.txt
@@ -314,3 +314,16 @@ if(BUDDY_MLIR_USE_MIMALLOC)
 endif()
 
 target_link_libraries(buddy-stable-diffusion-run ${BUDDY_STABLE_DIFFUSION_LIBS})
+
+add_test(
+  NAME example.buddy-stable-diffusion-run
+  COMMAND sh -c "printf '%s\n' 'Hi' '1' 'Hi' | \"$<TARGET_FILE:buddy-stable-diffusion-run>\""
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+set_tests_properties(
+  example.buddy-stable-diffusion-run
+  PROPERTIES
+    LABELS "example"
+    PASS_REGULAR_EXPRESSION "Image saved successfully to"
+    TIMEOUT 3600
+)

--- a/examples/BuddyTransformer/CMakeLists.txt
+++ b/examples/BuddyTransformer/CMakeLists.txt
@@ -387,6 +387,19 @@ target_link_directories(transformer-runner PRIVATE ${LLVM_LIBRARY_DIR})
 # Link with required libraries for one-step executable
 target_link_libraries(transformer-runner ${BUDDY_TRANSFORMER_LIBS})
 
+add_test(
+  NAME example.transformer-runner
+  COMMAND $<TARGET_FILE:transformer-runner>
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+set_tests_properties(
+  example.transformer-runner
+  PROPERTIES
+    LABELS "example"
+    PASS_REGULAR_EXPRESSION "First few output values: 0.5592 -0.1327 0.9860 -0.4383 -0.0250"
+    TIMEOUT 1200
+)
+
 # One-step compilation targets
 add_custom_target(buddy-transformer-onestep-codegen
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/forward-onestep.o

--- a/examples/BuddyWhisper/CMakeLists.txt
+++ b/examples/BuddyWhisper/CMakeLists.txt
@@ -107,3 +107,16 @@ if(BUDDY_MLIR_USE_MIMALLOC)
 endif()
 
 target_link_libraries(buddy-whisper-run ${BUDDY_WHISPER_LIBS})
+
+add_test(
+  NAME example.buddy-whisper-run
+  COMMAND $<TARGET_FILE:buddy-whisper-run>
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+set_tests_properties(
+  example.buddy-whisper-run
+  PROPERTIES
+    LABELS "example"
+    PASS_REGULAR_EXPRESSION "www"
+    TIMEOUT 1800
+)


### PR DESCRIPTION
## Summary

- Refactored build-mlir into a reusable step. Now `TestBuild.yml` is just a wrapper around `ci-common/action.yml`.
- Added a new CI workflow `test-example.yml` that attempts to compile and run all the examples.
- The tests themselves are built on ctest, where each test case asserts the result of command execution.
- test-example is not triggered automatically because it takes a long time and requires downloading models. However, GitHub does not provide a convenient manual trigger method. So the approach taken here is: allow users with appropriate permissions to trigger the workflow by commenting `/run-example` in a PR. Also, due to GitHub's limitations, this workflow must be merged into main before it can be triggered. Therefore, we must merge first before we can test.
