### PR TITLE
examples: add Gemma4 fp16 end-to-end inference pipeline

### DIFF
--- a/examples/BuddyGemma4/CMakeLists.txt
+++ b/examples/BuddyGemma4/CMakeLists.txt
@@ -18,6 +18,7 @@ if(IS_RVV_PLATFORM)
 else()
   set(OPENMP_NUM_THREADS "num-threads=48")
   set(LLC_RISCV_ATTRS "")
+  set(LLC_X86_ATTRS "-mcpu=native")
 endif()
 
 # Skip import commands on RVV platform
@@ -32,7 +33,27 @@ if(NOT IS_RVV_PLATFORM)
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/import-gemma4.py
             --output-dir ${CMAKE_CURRENT_BINARY_DIR}
             --precision f32
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/patch_decode_mlir.py
+            ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode_e2b.mlir
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/import-gemma4.py
+            ${CMAKE_CURRENT_SOURCE_DIR}/patch_decode_mlir.py
     COMMENT "Generating Gemma4-E2B MLIR and data files..."
+  )
+
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/forward_prefill_e2b-f16.mlir
+           ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_prefill_e2b-f16.mlir
+           ${CMAKE_CURRENT_BINARY_DIR}/forward_decode_e2b-f16.mlir
+           ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode_e2b-f16.mlir
+           ${CMAKE_CURRENT_BINARY_DIR}/arg0_e2b-f16.data
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/import-gemma4.py
+            --output-dir ${CMAKE_CURRENT_BINARY_DIR}
+            --precision f16
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/patch_decode_mlir.py
+            ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode_e2b-f16.mlir
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/import-gemma4.py
+            ${CMAKE_CURRENT_SOURCE_DIR}/patch_decode_mlir.py
+    COMMENT "Generating Gemma4-E2B F16 MLIR and data files..."
   )
 endif()
 
@@ -77,7 +98,7 @@ add_custom_command(
             -reconcile-unrealized-casts |
         ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
         ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
-        ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} -filetype=obj -relocation-model=pic -O3
+        ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} ${LLC_X86_ATTRS} -filetype=obj -relocation-model=pic -O3
           -o ${CMAKE_CURRENT_BINARY_DIR}/forward_prefill_e2b.o
   DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/forward_prefill_e2b.mlir
   COMMENT "Building forward_prefill_e2b.o"
@@ -110,7 +131,7 @@ add_custom_command(
             -affine-parallelize
             -convert-vector-to-scf
             -lower-affine
-            -convert-scf-to-openmp=num-threads=48
+            -convert-scf-to-openmp=${OPENMP_NUM_THREADS}
             -cse
             -memref-expand
             -arith-expand
@@ -128,7 +149,7 @@ add_custom_command(
             -reconcile-unrealized-casts |
           ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
           ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
-          ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} -filetype=obj -relocation-model=pic -O3
+          ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} ${LLC_X86_ATTRS} -filetype=obj -relocation-model=pic -O3
             -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph_prefill_e2b.o
     DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_prefill_e2b.mlir
     COMMENT "Building subgraph_prefill_e2b.o"
@@ -175,7 +196,7 @@ add_custom_command(
             -reconcile-unrealized-casts |
         ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
         ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
-        ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} -filetype=obj -relocation-model=pic -O3
+        ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} ${LLC_X86_ATTRS} -filetype=obj -relocation-model=pic -O3
           -o ${CMAKE_CURRENT_BINARY_DIR}/forward_decode_e2b.o
   DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/forward_decode_e2b.mlir
   COMMENT "Building forward_decode_e2b.o"
@@ -229,12 +250,209 @@ add_custom_command(
             -reconcile-unrealized-casts |
           ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
           ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
-          ${LLVM_TOOLS_BINARY_DIR}/llc -filetype=obj -relocation-model=pic -O3
+          ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} ${LLC_X86_ATTRS} -filetype=obj -relocation-model=pic -O3
             -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph_decode_e2b.o
     DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode_e2b.mlir
     COMMENT "Building subgraph_decode_e2b.o"
     VERBATIM)
 
+
+add_custom_command(
+  OUTPUT forward_prefill_e2b-f16.o
+  COMMAND ${BUDDY_BINARY_DIR}/buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/forward_prefill_e2b-f16.mlir
+            -simplify-tosa-reshape |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+            -pass-pipeline ${TOSA_PIPELINE} |
+          ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -canonicalize
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -cse
+            -canonicalize
+            -optimize-allocation-liveness
+            -matmul-vectorization-blis
+            -batchmatmul-optimize
+            -convert-linalg-to-affine-loops
+            -affine-parallelize
+            -convert-vector-to-scf
+            -lower-affine
+            -convert-scf-to-openmp=${OPENMP_NUM_THREADS}
+            -memref-expand
+            -arith-expand
+            -convert-vector-to-llvm
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -llvm-request-c-wrappers
+            -convert-openmp-to-llvm
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+        ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+        ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+        ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} ${LLC_X86_ATTRS} -filetype=obj -relocation-model=pic -O3
+          -o ${CMAKE_CURRENT_BINARY_DIR}/forward_prefill_e2b-f16.o
+  DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/forward_prefill_e2b-f16.mlir
+  COMMENT "Building forward_prefill_e2b-f16.o"
+  VERBATIM)
+
+add_custom_command(
+    OUTPUT subgraph_prefill_e2b-f16.o
+    COMMAND ${BUDDY_BINARY_DIR}/buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_prefill_e2b-f16.mlir
+              -simplify-tosa-reshape |
+            ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+              -pass-pipeline ${TOSA_PIPELINE} |
+            ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -convert-elementwise-to-linalg
+            -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -canonicalize
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -cse
+            -canonicalize
+            -optimize-allocation-liveness
+            -matmul-vectorization-blis
+            -batchmatmul-optimize
+            -batchmatmul-transpose-b-vectorization
+            -convert-linalg-to-affine-loops
+            -affine-parallelize
+            -convert-vector-to-scf
+            -lower-affine
+            -convert-scf-to-openmp=${OPENMP_NUM_THREADS}
+            -cse
+            -memref-expand
+            -arith-expand
+            -convert-vector-to-llvm
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -llvm-request-c-wrappers
+            -convert-openmp-to-llvm
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+          ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+          ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} ${LLC_X86_ATTRS} -filetype=obj -relocation-model=pic -O3
+            -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph_prefill_e2b-f16.o
+    DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_prefill_e2b-f16.mlir
+    COMMENT "Building subgraph_prefill_e2b-f16.o"
+    VERBATIM)
+
+add_custom_command(
+  OUTPUT forward_decode_e2b-f16.o
+  COMMAND ${BUDDY_BINARY_DIR}/buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/forward_decode_e2b-f16.mlir
+            -simplify-tosa-reshape |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+            -pass-pipeline ${TOSA_PIPELINE} |
+          ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -canonicalize
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -cse
+            -canonicalize
+            -optimize-allocation-liveness
+            -matmul-vectorization-blis
+            -batchmatmul-optimize
+            -convert-linalg-to-affine-loops
+            -affine-parallelize
+            -convert-vector-to-scf
+            -lower-affine
+            -convert-scf-to-openmp=${OPENMP_NUM_THREADS}
+            -memref-expand
+            -arith-expand
+            -convert-vector-to-llvm
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -llvm-request-c-wrappers
+            -convert-openmp-to-llvm
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+        ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+        ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+        ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} ${LLC_X86_ATTRS} -filetype=obj -relocation-model=pic -O3
+          -o ${CMAKE_CURRENT_BINARY_DIR}/forward_decode_e2b-f16.o
+  DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/forward_decode_e2b-f16.mlir
+  COMMENT "Building forward_decode_e2b-f16.o"
+  VERBATIM)
+
+add_custom_command(
+    OUTPUT subgraph_decode_e2b-f16.o
+    COMMAND ${BUDDY_BINARY_DIR}/buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode_e2b-f16.mlir
+              -simplify-tosa-reshape
+              -simplify-tosa-matmul-scalar |
+            ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+              -pass-pipeline ${TOSA_PIPELINE} |
+            ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -convert-elementwise-to-linalg
+            -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -canonicalize
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -cse
+            -canonicalize
+            -optimize-allocation-liveness
+            -eliminate-memref-copy
+            -assume-tight-memref-layout
+            -staticize-memref-layout
+            -matmul-vectorization-decode=vector-size=32
+            -batch-matmul-vectorization-decode=vector-size=128
+            -batchmatmul-transpose-b-vectorization=vector-size=16
+            -convert-linalg-to-affine-loops
+            -convert-vector-to-scf
+            -lower-affine
+            -convert-scf-to-openmp=${OPENMP_NUM_THREADS}
+            -cse
+            -memref-expand
+            -arith-expand
+            -convert-vector-to-llvm
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -llvm-request-c-wrappers
+            -convert-openmp-to-llvm
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+          ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+          ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} ${LLC_X86_ATTRS} -filetype=obj -relocation-model=pic -O3
+            -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph_decode_e2b-f16.o
+    DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode_e2b-f16.mlir
+    COMMENT "Building subgraph_decode_e2b-f16.o"
+    VERBATIM)
 
 add_library(GEMMA4_E2B STATIC forward_prefill_e2b.o subgraph_prefill_e2b.o forward_decode_e2b.o subgraph_decode_e2b.o)
 
@@ -249,8 +467,18 @@ SET_TARGET_PROPERTIES(
   PROPERTIES
   LINKER_LANGUAGE C)
 
+add_library(GEMMA4_E2B_F16 STATIC
+  forward_prefill_e2b-f16.o subgraph_prefill_e2b-f16.o
+  forward_decode_e2b-f16.o subgraph_decode_e2b-f16.o)
+
+SET_TARGET_PROPERTIES(
+  GEMMA4_E2B_F16
+  PROPERTIES
+  LINKER_LANGUAGE C)
+
 
 add_executable(buddy-gemma4-e2b-run buddy-gemma4-e2b-main.cpp)
+add_executable(buddy-gemma4-e2b-f16-run buddy-gemma4-e2b-f16-main.cpp)
 
 set(GEMMA4_E2B_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 set(GEMMA4_E2B_EXAMPLE_BUILD_PATH ${CMAKE_CURRENT_BINARY_DIR})
@@ -260,8 +488,13 @@ target_compile_definitions(buddy-gemma4-e2b-run PRIVATE
   GEMMA4_E2B_EXAMPLE_BUILD_PATH="${GEMMA4_E2B_EXAMPLE_BUILD_PATH}/"
 )
 
+target_compile_definitions(buddy-gemma4-e2b-f16-run PRIVATE
+  GEMMA4_E2B_EXAMPLE_PATH="${GEMMA4_E2B_EXAMPLE_PATH}/"
+  GEMMA4_E2B_EXAMPLE_BUILD_PATH="${GEMMA4_E2B_EXAMPLE_BUILD_PATH}/"
+)
 
 target_link_directories(buddy-gemma4-e2b-run PRIVATE ${LLVM_LIBRARY_DIR})
+target_link_directories(buddy-gemma4-e2b-f16-run PRIVATE ${LLVM_LIBRARY_DIR})
 
 set(BUDDY_GEMMA4_E2B_LIBS
   GEMMA4_E2B
@@ -269,11 +502,19 @@ set(BUDDY_GEMMA4_E2B_LIBS
   omp
 )
 
+set(BUDDY_GEMMA4_E2B_F16_LIBS
+  GEMMA4_E2B_F16
+  mlir_c_runner_utils
+  omp
+)
+
 if(BUDDY_MLIR_USE_MIMALLOC)
   list(APPEND BUDDY_GEMMA4_E2B_LIBS mimalloc)
+  list(APPEND BUDDY_GEMMA4_E2B_F16_LIBS mimalloc)
 endif()
 
 target_link_libraries(buddy-gemma4-e2b-run ${BUDDY_GEMMA4_E2B_LIBS})
+target_link_libraries(buddy-gemma4-e2b-f16-run ${BUDDY_GEMMA4_E2B_F16_LIBS})
 
 # Create a distributable package
 set(DIST_PACKAGE_NAME "buddy-gemma4-e2b")

--- a/examples/BuddyGemma4/buddy-gemma4-e2b-f16-main.cpp
+++ b/examples/BuddyGemma4/buddy-gemma4-e2b-f16-main.cpp
@@ -1,0 +1,633 @@
+//===- buddy-gemma4-e2b-f16-main.cpp
+//---------------------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+#include <algorithm>
+#include <buddy/Core/Container.h>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+// ===== Operator Timing Infrastructure =====
+
+struct TimingRecord {
+  std::string op_name;
+  std::vector<double> times_ms;
+
+  void add_time(double time_sec) { times_ms.push_back(time_sec * 1000.0); }
+
+  double get_total() const {
+    return std::accumulate(times_ms.begin(), times_ms.end(), 0.0);
+  }
+};
+
+static std::map<std::string, TimingRecord> g_timing_data;
+
+extern "C" {
+double rtclock() {
+  auto now = std::chrono::high_resolution_clock::now();
+  return std::chrono::duration<double>(now.time_since_epoch()).count();
+}
+
+void record_timing(const char *op_name, double duration_sec) {
+  std::string name(op_name);
+  g_timing_data[name].op_name = name;
+  g_timing_data[name].add_time(duration_sec);
+}
+
+void _mlir_ciface_record_timing(void *op_name_ptr, double duration_sec) {
+  const char *op_name = reinterpret_cast<const char *>(op_name_ptr);
+  record_timing(op_name, duration_sec);
+}
+}
+
+void print_timing_report() {
+  std::cout << "\n";
+  std::cout << "========================================\n";
+  std::cout << "     Operator Timing Report\n";
+  std::cout << "========================================\n";
+  std::cout << std::fixed << std::setprecision(4);
+
+  double total_time = 0.0;
+  for (const auto &[name, record] : g_timing_data)
+    total_time += record.get_total();
+
+  std::cout << std::left << std::setw(30) << "Operator" << std::right
+            << std::setw(16) << "Total (ms)" << std::setw(12) << "% Total"
+            << "\n";
+  std::cout << "----------------------------------------"
+            << "------------------------------\n";
+
+  for (const auto &[name, record] : g_timing_data) {
+    double total = record.get_total();
+    double percentage = (total_time > 0) ? (total / total_time * 100.0) : 0.0;
+    std::cout << std::left << std::setw(30) << name << std::right
+              << std::setw(16) << total << std::setw(11) << percentage << "%\n";
+  }
+
+  std::cout << "----------------------------------------"
+            << "------------------------------\n";
+  std::cout << std::left << std::setw(30) << "TOTAL" << std::right
+            << std::setw(16) << total_time << std::setw(11) << "100.0%\n";
+  std::cout << "========================================\n\n";
+}
+
+void clear_timing_data() { g_timing_data.clear(); }
+
+// ===== End of Timing Infrastructure =====
+
+#include <buddy/LLM/TextContainer.h>
+#include <cstddef>
+#include <filesystem>
+#include <sys/time.h>
+
+using namespace buddy;
+
+double total_time = 0;
+constexpr size_t ParamsSize = 4628569765;
+constexpr size_t MaxVocabSize = 262144;
+constexpr size_t MaxTokenLength = 512;
+constexpr size_t SlidingCacheLen = 512;
+constexpr size_t SlidingHeadDim = 256;
+constexpr size_t FullCacheLen = 512;
+constexpr size_t FullHeadDim = 512;
+constexpr size_t KVHeadNum = 1;
+
+extern "C" double _mlir_ciface_rtclock() {
+#ifndef _WIN32
+  struct timeval tp;
+  int stat = gettimeofday(&tp, nullptr);
+  if (stat != 0)
+    fprintf(stderr, "Error returning time from gettimeofday: %d\n", stat);
+  return (tp.tv_sec + tp.tv_usec * 1.0e-6);
+#else
+  fprintf(stderr, "Timing utility not implemented on Windows\n");
+  return 0.0;
+#endif
+}
+
+struct MemRefContainer {
+  // Group 0 (sliding layers 0-3 + full layer 0)
+  MemRef<uint16_t, 4> sk0k, sk0v;
+  MemRef<long long, 1> cl0;
+  MemRef<uint16_t, 4> sk1k, sk1v;
+  MemRef<long long, 1> cl1;
+  MemRef<uint16_t, 4> sk2k, sk2v;
+  MemRef<long long, 1> cl2;
+  MemRef<uint16_t, 4> sk3k, sk3v;
+  MemRef<long long, 1> cl3;
+  MemRef<long long, 1> fcl0;
+  MemRef<uint16_t, 4> fk0k, fk0v;
+  // Group 1 (sliding layers 4-7 + full layer 1)
+  MemRef<uint16_t, 4> sk4k, sk4v;
+  MemRef<long long, 1> cl4;
+  MemRef<uint16_t, 4> sk5k, sk5v;
+  MemRef<long long, 1> cl5;
+  MemRef<uint16_t, 4> sk6k, sk6v;
+  MemRef<long long, 1> cl6;
+  MemRef<uint16_t, 4> sk7k, sk7v;
+  MemRef<long long, 1> cl7;
+  MemRef<long long, 1> fcl1;
+  MemRef<uint16_t, 4> fk1k, fk1v;
+  // Group 2 (sliding layers 8-11 + full layer 2)
+  MemRef<uint16_t, 4> sk8k, sk8v;
+  MemRef<long long, 1> cl8;
+  MemRef<uint16_t, 4> sk9k, sk9v;
+  MemRef<long long, 1> cl9;
+  MemRef<uint16_t, 4> sk10k, sk10v;
+  MemRef<long long, 1> cl10;
+  MemRef<uint16_t, 4> sk11k, sk11v;
+  MemRef<long long, 1> cl11;
+  MemRef<long long, 1> fcl2;
+  MemRef<uint16_t, 4> fk2k, fk2v;
+  // Logits
+  MemRef<uint16_t, 3> logits;
+};
+
+extern "C" void _mlir_ciface_forward_prefill(
+    MemRefContainer *result, MemRef<uint16_t, 1> *params,
+    Text<size_t, 2> *input_ids, MemRef<long long, 1> *cl0,
+    MemRef<uint16_t, 4> *sk0k, MemRef<uint16_t, 4> *sk0v,
+    MemRef<long long, 1> *cl1, MemRef<uint16_t, 4> *sk1k,
+    MemRef<uint16_t, 4> *sk1v, MemRef<long long, 1> *cl2,
+    MemRef<uint16_t, 4> *sk2k, MemRef<uint16_t, 4> *sk2v,
+    MemRef<long long, 1> *cl3, MemRef<uint16_t, 4> *sk3k,
+    MemRef<uint16_t, 4> *sk3v, MemRef<long long, 1> *fcl0,
+    MemRef<uint16_t, 4> *fk0k, MemRef<uint16_t, 4> *fk0v,
+    MemRef<long long, 1> *cl4, MemRef<uint16_t, 4> *sk4k,
+    MemRef<uint16_t, 4> *sk4v, MemRef<long long, 1> *cl5,
+    MemRef<uint16_t, 4> *sk5k, MemRef<uint16_t, 4> *sk5v,
+    MemRef<long long, 1> *cl6, MemRef<uint16_t, 4> *sk6k,
+    MemRef<uint16_t, 4> *sk6v, MemRef<long long, 1> *cl7,
+    MemRef<uint16_t, 4> *sk7k, MemRef<uint16_t, 4> *sk7v,
+    MemRef<long long, 1> *fcl1, MemRef<uint16_t, 4> *fk1k,
+    MemRef<uint16_t, 4> *fk1v, MemRef<long long, 1> *cl8,
+    MemRef<uint16_t, 4> *sk8k, MemRef<uint16_t, 4> *sk8v,
+    MemRef<long long, 1> *cl9, MemRef<uint16_t, 4> *sk9k,
+    MemRef<uint16_t, 4> *sk9v, MemRef<long long, 1> *cl10,
+    MemRef<uint16_t, 4> *sk10k, MemRef<uint16_t, 4> *sk10v,
+    MemRef<long long, 1> *cl11, MemRef<uint16_t, 4> *sk11k,
+    MemRef<uint16_t, 4> *sk11v, MemRef<long long, 1> *fcl2,
+    MemRef<uint16_t, 4> *fk2k, MemRef<uint16_t, 4> *fk2v);
+
+extern "C" void _mlir_ciface_forward_decode(
+    MemRefContainer *result, MemRef<uint16_t, 1> *params,
+    MemRef<long long, 2> *input_ids, MemRef<long long, 1> *cache_position,
+    MemRef<uint16_t, 4> *sk0k, MemRef<uint16_t, 4> *sk0v,
+    MemRef<long long, 1> *cl0, MemRef<uint16_t, 4> *sk1k,
+    MemRef<uint16_t, 4> *sk1v, MemRef<long long, 1> *cl1,
+    MemRef<uint16_t, 4> *sk2k, MemRef<uint16_t, 4> *sk2v,
+    MemRef<long long, 1> *cl2, MemRef<uint16_t, 4> *sk3k,
+    MemRef<uint16_t, 4> *sk3v, MemRef<long long, 1> *cl3,
+    MemRef<uint16_t, 4> *fk0k, MemRef<uint16_t, 4> *fk0v,
+    MemRef<long long, 1> *fcl0, MemRef<uint16_t, 4> *sk4k,
+    MemRef<uint16_t, 4> *sk4v, MemRef<long long, 1> *cl4,
+    MemRef<uint16_t, 4> *sk5k, MemRef<uint16_t, 4> *sk5v,
+    MemRef<long long, 1> *cl5, MemRef<uint16_t, 4> *sk6k,
+    MemRef<uint16_t, 4> *sk6v, MemRef<long long, 1> *cl6,
+    MemRef<uint16_t, 4> *sk7k, MemRef<uint16_t, 4> *sk7v,
+    MemRef<long long, 1> *cl7, MemRef<uint16_t, 4> *fk1k,
+    MemRef<uint16_t, 4> *fk1v, MemRef<long long, 1> *fcl1,
+    MemRef<uint16_t, 4> *sk8k, MemRef<uint16_t, 4> *sk8v,
+    MemRef<long long, 1> *cl8, MemRef<uint16_t, 4> *sk9k,
+    MemRef<uint16_t, 4> *sk9v, MemRef<long long, 1> *cl9,
+    MemRef<uint16_t, 4> *sk10k, MemRef<uint16_t, 4> *sk10v,
+    MemRef<long long, 1> *cl10, MemRef<uint16_t, 4> *sk11k,
+    MemRef<uint16_t, 4> *sk11v, MemRef<long long, 1> *cl11,
+    MemRef<uint16_t, 4> *fk2k, MemRef<uint16_t, 4> *fk2v);
+
+// -----------------------------------------------------------------------------
+// Helper Functions
+// -----------------------------------------------------------------------------
+
+void getUserInput(std::string &inputStr) {
+  std::cout << "\nPlease send a message:" << std::endl;
+  std::cout << ">>> ";
+  getline(std::cin, inputStr);
+  std::cout << std::endl;
+}
+
+void printLogLabel() { std::cout << "\033[34;1m[Log] \033[0m"; }
+
+void printIterInfo(size_t iterIdx, std::string str, double time) {
+  total_time += time;
+  std::cout << "\033[32;1m[Iteration " << iterIdx << "] \033[0m";
+  std::cout << "Token: " << str << " | "
+            << "Time: " << time << "s" << std::endl;
+}
+
+void tokenizeInput(const std::string &vocabFile,
+                   Text<size_t, 2> &inputContainer) {
+  printLogLabel();
+  std::cout << "Vocab file: " << std::filesystem::canonical(vocabFile)
+            << std::endl;
+  const auto start = std::chrono::high_resolution_clock::now();
+  inputContainer.tokenizeGemma4(vocabFile, MaxTokenLength);
+  const auto end = std::chrono::high_resolution_clock::now();
+  const std::chrono::duration<double, std::milli> elapsed = end - start;
+  printLogLabel();
+  std::cout << "Tokenize time: " << elapsed.count() << "ms" << std::endl;
+}
+
+void loadParameters(const std::string &paramFilePath,
+                    MemRef<uint16_t, 1> &params) {
+  const auto loadStart = std::chrono::high_resolution_clock::now();
+  std::ifstream paramFile(paramFilePath, std::ios::in | std::ios::binary);
+  if (!paramFile.is_open()) {
+    throw std::runtime_error("[Error] Failed to open params file!");
+  }
+  printLogLabel();
+  std::cout << "Loading params..." << std::endl;
+  printLogLabel();
+  std::cout << "Params file: " << std::filesystem::canonical(paramFilePath)
+            << std::endl;
+  paramFile.read(reinterpret_cast<char *>(params.getData()),
+                 sizeof(uint16_t) * params.getSize());
+  if (paramFile.fail()) {
+    throw std::runtime_error("Error occurred while reading params file!");
+  }
+  paramFile.close();
+  const auto loadEnd = std::chrono::high_resolution_clock::now();
+  const std::chrono::duration<double, std::milli> loadTime =
+      loadEnd - loadStart;
+  printLogLabel();
+  std::cout << "Params load time: " << (double)(loadTime.count()) / 1000
+            << "s\n"
+            << std::endl;
+}
+
+// IEEE 754 half precision -> single precision decode for argmax
+float decode_f16(uint16_t h) {
+  uint16_t h_exp = (h & 0x7C00) >> 10;
+  uint16_t h_sig = h & 0x03FF;
+  uint16_t h_sign = h >> 15;
+  if (h_exp == 0) {
+    float f = std::ldexp((float)h_sig, -24);
+    return h_sign ? -f : f;
+  } else if (h_exp == 0x1F) {
+    return h_sig ? std::numeric_limits<float>::quiet_NaN()
+                 : (h_sign ? -INFINITY : INFINITY);
+  } else {
+    float f = std::ldexp((float)(h_sig | 0x0400), h_exp - 25);
+    return h_sign ? -f : f;
+  }
+}
+
+int findMaxIndex(const uint16_t *start, size_t length) {
+  int maxIdx = 0;
+  float maxVal = decode_f16(start[0]);
+  for (size_t i = 1; i < length; ++i) {
+    float val = decode_f16(start[i]);
+    if (val > maxVal) {
+      maxVal = val;
+      maxIdx = (int)i;
+    }
+  }
+  return maxIdx;
+}
+
+void copyKVFromPrefill(MemRefContainer &prefill, MemRefContainer &decode,
+                       int cachePos) {
+  auto copyOne = [&](MemRef<uint16_t, 4> &dst, MemRef<uint16_t, 4> &src) {
+    int headDim = dst.getSizes()[3];
+    int copyLen = std::min(cachePos, (int)dst.getSizes()[2]);
+    for (int h = 0; h < (int)KVHeadNum; h++) {
+      std::memcpy(dst.getData() + h * dst.getSizes()[2] * headDim,
+                  src.getData() + h * src.getSizes()[2] * headDim,
+                  sizeof(uint16_t) * copyLen * headDim);
+    }
+  };
+  // Sliding KV
+  copyOne(decode.sk0k, prefill.sk0k);
+  copyOne(decode.sk0v, prefill.sk0v);
+  copyOne(decode.sk1k, prefill.sk1k);
+  copyOne(decode.sk1v, prefill.sk1v);
+  copyOne(decode.sk2k, prefill.sk2k);
+  copyOne(decode.sk2v, prefill.sk2v);
+  copyOne(decode.sk3k, prefill.sk3k);
+  copyOne(decode.sk3v, prefill.sk3v);
+  copyOne(decode.sk4k, prefill.sk4k);
+  copyOne(decode.sk4v, prefill.sk4v);
+  copyOne(decode.sk5k, prefill.sk5k);
+  copyOne(decode.sk5v, prefill.sk5v);
+  copyOne(decode.sk6k, prefill.sk6k);
+  copyOne(decode.sk6v, prefill.sk6v);
+  copyOne(decode.sk7k, prefill.sk7k);
+  copyOne(decode.sk7v, prefill.sk7v);
+  copyOne(decode.sk8k, prefill.sk8k);
+  copyOne(decode.sk8v, prefill.sk8v);
+  copyOne(decode.sk9k, prefill.sk9k);
+  copyOne(decode.sk9v, prefill.sk9v);
+  copyOne(decode.sk10k, prefill.sk10k);
+  copyOne(decode.sk10v, prefill.sk10v);
+  copyOne(decode.sk11k, prefill.sk11k);
+  copyOne(decode.sk11v, prefill.sk11v);
+  // Full KV
+  copyOne(decode.fk0k, prefill.fk0k);
+  copyOne(decode.fk0v, prefill.fk0v);
+  copyOne(decode.fk1k, prefill.fk1k);
+  copyOne(decode.fk1v, prefill.fk1v);
+  copyOne(decode.fk2k, prefill.fk2k);
+  copyOne(decode.fk2v, prefill.fk2v);
+  // Cumlens
+  decode.cl0.getData()[0] = cachePos;
+  decode.cl1.getData()[0] = cachePos;
+  decode.cl2.getData()[0] = cachePos;
+  decode.cl3.getData()[0] = cachePos;
+  decode.cl4.getData()[0] = cachePos;
+  decode.cl5.getData()[0] = cachePos;
+  decode.cl6.getData()[0] = cachePos;
+  decode.cl7.getData()[0] = cachePos;
+  decode.cl8.getData()[0] = cachePos;
+  decode.cl9.getData()[0] = cachePos;
+  decode.cl10.getData()[0] = cachePos;
+  decode.cl11.getData()[0] = cachePos;
+  decode.fcl0.getData()[0] = cachePos;
+  decode.fcl1.getData()[0] = cachePos;
+  decode.fcl2.getData()[0] = cachePos;
+}
+
+#define SLIDING_KV {1, KVHeadNum, SlidingCacheLen, SlidingHeadDim}
+#define FULL_KV {1, KVHeadNum, FullCacheLen, FullHeadDim}
+
+// -----------------------------------------------------------------------------
+// Gemma4-E2B F16 Inference Main Entry
+// -----------------------------------------------------------------------------
+
+int main() {
+  const std::string title =
+      "Gemma4-E2B F16 Inference Powered by Buddy Compiler";
+  std::cout << "\033[33;1m" << title << "\033[0m" << std::endl;
+
+  std::string exampleDir = GEMMA4_E2B_EXAMPLE_PATH;
+  std::string buildDir = GEMMA4_E2B_EXAMPLE_BUILD_PATH;
+  const std::string vocabDir = buildDir + "vocab.txt";
+  const std::string paramsDir = buildDir + "arg0_e2b-f16.data";
+
+  std::string inputStr;
+  getUserInput(inputStr);
+
+  Text<size_t, 2> outputContainer;
+  Text<size_t, 2> inputContainerPrefill(inputStr);
+  MemRef<long long, 2> inputContainerDecode({1, 1}, 0LL);
+  MemRef<uint16_t, 1> ParamsContainer({ParamsSize});
+  MemRef<long long, 1> cachePosition({1}, 0LL);
+
+  MemRef<uint16_t, 3> logitsPrefill({1, MaxTokenLength, MaxVocabSize});
+
+  // KV cache buffers for prefill input (zero-initialized)
+  MemRef<uint16_t, 4> sk0k(SLIDING_KV, (uint16_t)0),
+      sk0v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk1k(SLIDING_KV, (uint16_t)0),
+      sk1v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk2k(SLIDING_KV, (uint16_t)0),
+      sk2v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk3k(SLIDING_KV, (uint16_t)0),
+      sk3v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk4k(SLIDING_KV, (uint16_t)0),
+      sk4v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk5k(SLIDING_KV, (uint16_t)0),
+      sk5v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk6k(SLIDING_KV, (uint16_t)0),
+      sk6v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk7k(SLIDING_KV, (uint16_t)0),
+      sk7v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk8k(SLIDING_KV, (uint16_t)0),
+      sk8v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk9k(SLIDING_KV, (uint16_t)0),
+      sk9v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk10k(SLIDING_KV, (uint16_t)0),
+      sk10v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk11k(SLIDING_KV, (uint16_t)0),
+      sk11v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> fk0k(FULL_KV, (uint16_t)0), fk0v(FULL_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> fk1k(FULL_KV, (uint16_t)0), fk1v(FULL_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> fk2k(FULL_KV, (uint16_t)0), fk2v(FULL_KV, (uint16_t)0);
+  MemRef<long long, 1> cl0({1}, 0LL), cl1({1}, 0LL), cl2({1}, 0LL),
+      cl3({1}, 0LL), cl4({1}, 0LL), cl5({1}, 0LL), cl6({1}, 0LL), cl7({1}, 0LL),
+      cl8({1}, 0LL), cl9({1}, 0LL), cl10({1}, 0LL), cl11({1}, 0LL),
+      fcl0({1}, 0LL), fcl1({1}, 0LL), fcl2({1}, 0LL);
+
+  MemRefContainer prefillResultContainer = {{SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {{1}, 0LL},
+                                            {FULL_KV, (uint16_t)0},
+                                            {FULL_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {{1}, 0LL},
+                                            {FULL_KV, (uint16_t)0},
+                                            {FULL_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {{1}, 0LL},
+                                            {FULL_KV, (uint16_t)0},
+                                            {FULL_KV, (uint16_t)0},
+                                            logitsPrefill};
+
+  tokenizeInput(vocabDir, inputContainerPrefill);
+  outputContainer.loadVocab(vocabDir);
+  loadParameters(paramsDir, ParamsContainer);
+
+  // ---- Prefill ----
+  double prefillTokensPerSec = 0.0;
+  const auto inferenceStart = std::chrono::high_resolution_clock::now();
+  _mlir_ciface_forward_prefill(
+      &prefillResultContainer, &ParamsContainer, &inputContainerPrefill, &cl0,
+      &sk0k, &sk0v, &cl1, &sk1k, &sk1v, &cl2, &sk2k, &sk2v, &cl3, &sk3k, &sk3v,
+      &fcl0, &fk0k, &fk0v, &cl4, &sk4k, &sk4v, &cl5, &sk5k, &sk5v, &cl6, &sk6k,
+      &sk6v, &cl7, &sk7k, &sk7v, &fcl1, &fk1k, &fk1v, &cl8, &sk8k, &sk8v, &cl9,
+      &sk9k, &sk9v, &cl10, &sk10k, &sk10v, &cl11, &sk11k, &sk11v, &fcl2, &fk2k,
+      &fk2v);
+  const auto inferenceEnd = std::chrono::high_resolution_clock::now();
+  const std::chrono::duration<double, std::milli> inferenceTime =
+      inferenceEnd - inferenceStart;
+
+  int tokenIndex = inputContainerPrefill.getTokenCnt() - 1;
+  const uint16_t *startPtr =
+      prefillResultContainer.logits.getData() + tokenIndex * MaxVocabSize;
+  int maxIndex = findMaxIndex(startPtr, MaxVocabSize);
+
+  std::string tok = inputContainerPrefill.getStr(maxIndex);
+  printIterInfo(0, tok, inferenceTime.count() / 1000);
+
+  const double prefillSeconds = inferenceTime.count() / 1000.0;
+  if (prefillSeconds > 0.0)
+    prefillTokensPerSec = static_cast<double>(MaxTokenLength) / prefillSeconds;
+  inputContainerDecode.getData()[0] = (long long)maxIndex;
+  outputContainer.appendTokenIdx(maxIndex);
+
+  // ---- Copy KV from prefill to decode ----
+  MemRef<uint16_t, 3> logitsDecode({1, 1, MaxVocabSize});
+  MemRefContainer decodeResultContainer = {{SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {{1}, 0LL},
+                                           {FULL_KV, (uint16_t)0},
+                                           {FULL_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {{1}, 0LL},
+                                           {FULL_KV, (uint16_t)0},
+                                           {FULL_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {{1}, 0LL},
+                                           {FULL_KV, (uint16_t)0},
+                                           {FULL_KV, (uint16_t)0},
+                                           logitsDecode};
+  MemRefContainer *ptrDecodeResultContainer = &decodeResultContainer;
+
+  copyKVFromPrefill(prefillResultContainer, decodeResultContainer,
+                    inputContainerPrefill.getTokenCnt() + 1);
+
+  // ---- Decode loop ----
+  cachePosition.getData()[0] = inputContainerPrefill.getTokenCnt() + 1;
+  int generateLen = MaxTokenLength - inputContainerPrefill.getTokenCnt();
+  double decodeTimeAccumMs = 0.0;
+  size_t decodeTokens = 0;
+
+  for (int i = 1; i <= generateLen; i++) {
+    const auto decStart = std::chrono::high_resolution_clock::now();
+    _mlir_ciface_forward_decode(
+        ptrDecodeResultContainer, &ParamsContainer, &inputContainerDecode,
+        &cachePosition, &ptrDecodeResultContainer->sk0k,
+        &ptrDecodeResultContainer->sk0v, &ptrDecodeResultContainer->cl0,
+        &ptrDecodeResultContainer->sk1k, &ptrDecodeResultContainer->sk1v,
+        &ptrDecodeResultContainer->cl1, &ptrDecodeResultContainer->sk2k,
+        &ptrDecodeResultContainer->sk2v, &ptrDecodeResultContainer->cl2,
+        &ptrDecodeResultContainer->sk3k, &ptrDecodeResultContainer->sk3v,
+        &ptrDecodeResultContainer->cl3, &ptrDecodeResultContainer->fk0k,
+        &ptrDecodeResultContainer->fk0v, &ptrDecodeResultContainer->fcl0,
+        &ptrDecodeResultContainer->sk4k, &ptrDecodeResultContainer->sk4v,
+        &ptrDecodeResultContainer->cl4, &ptrDecodeResultContainer->sk5k,
+        &ptrDecodeResultContainer->sk5v, &ptrDecodeResultContainer->cl5,
+        &ptrDecodeResultContainer->sk6k, &ptrDecodeResultContainer->sk6v,
+        &ptrDecodeResultContainer->cl6, &ptrDecodeResultContainer->sk7k,
+        &ptrDecodeResultContainer->sk7v, &ptrDecodeResultContainer->cl7,
+        &ptrDecodeResultContainer->fk1k, &ptrDecodeResultContainer->fk1v,
+        &ptrDecodeResultContainer->fcl1, &ptrDecodeResultContainer->sk8k,
+        &ptrDecodeResultContainer->sk8v, &ptrDecodeResultContainer->cl8,
+        &ptrDecodeResultContainer->sk9k, &ptrDecodeResultContainer->sk9v,
+        &ptrDecodeResultContainer->cl9, &ptrDecodeResultContainer->sk10k,
+        &ptrDecodeResultContainer->sk10v, &ptrDecodeResultContainer->cl10,
+        &ptrDecodeResultContainer->sk11k, &ptrDecodeResultContainer->sk11v,
+        &ptrDecodeResultContainer->cl11, &ptrDecodeResultContainer->fk2k,
+        &ptrDecodeResultContainer->fk2v);
+    const auto decEnd = std::chrono::high_resolution_clock::now();
+    const std::chrono::duration<double, std::milli> decTime = decEnd - decStart;
+    decodeTimeAccumMs += decTime.count();
+    decodeTokens += 1;
+
+    const uint16_t *logitStart = ptrDecodeResultContainer->logits.getData();
+    maxIndex = findMaxIndex(logitStart, MaxVocabSize);
+    tok = inputContainerPrefill.getStr(maxIndex);
+    printIterInfo(i, tok, decTime.count() / 1000);
+
+    print_timing_report();
+    clear_timing_data();
+
+    if (maxIndex == 1 || maxIndex == 106) {
+      break;
+    }
+    inputContainerDecode.getData()[0] = maxIndex;
+    outputContainer.appendTokenIdx(maxIndex);
+    cachePosition.getData()[0] += 1;
+  }
+
+  const double decodeSeconds = decodeTimeAccumMs / 1000.0;
+  const double decodeTokensPerSec =
+      decodeSeconds > 0.0 ? static_cast<double>(decodeTokens) / decodeSeconds
+                          : 0.0;
+
+  std::cout << "\n\033[33;1m[Total time]\033[0m " << total_time << std::endl;
+  std::cout << "\033[33;1m[Prefilling]\033[0m " << prefillTokensPerSec
+            << " tokens/s" << std::endl;
+  std::cout << "\033[33;1m[Decoding]\033[0m " << decodeTokensPerSec
+            << " tokens/s" << std::endl;
+  std::cout << "\033[33;1m[Input]\033[0m " << inputStr << std::endl;
+  std::cout << "\033[33;1m[Output]\033[0m " << outputContainer.revertGemma4()
+            << std::endl;
+
+  return 0;
+}

--- a/examples/BuddyGemma4/import-gemma4.py
+++ b/examples/BuddyGemma4/import-gemma4.py
@@ -59,8 +59,11 @@ parser.add_argument(
     "--precision",
     type=str,
     default="f32",
-    choices=["f32"],
-    help="Precision mode for generated MLIR and input data.",
+    choices=["f32", "f16"],
+    help=(
+        "Precision mode for generated MLIR and input data. "
+        "Choose from 'f32' or 'f16'."
+    ),
 )
 args = parser.parse_args()
 
@@ -75,7 +78,9 @@ MaxTokenLength = 512
 
 # Load the full multimodal model and extract language model weights.
 print("Loading full model from:", model_path)
-full_model = AutoModelForCausalLM.from_pretrained(model_path, dtype=torch.float32, low_cpu_mem_usage=True)
+full_model = AutoModelForCausalLM.from_pretrained(
+    model_path, dtype=torch.float32, low_cpu_mem_usage=True
+)
 full_sd = full_model.state_dict()
 
 causal_sd = {}
@@ -85,7 +90,10 @@ for k, v in full_sd.items():
     elif k.startswith("lm_head."):
         causal_sd[k] = v
 
-if "lm_head.weight" not in causal_sd and "model.embed_tokens.weight" in causal_sd:
+if (
+    "lm_head.weight" not in causal_sd
+    and "model.embed_tokens.weight" in causal_sd
+):
     causal_sd["lm_head.weight"] = causal_sd["model.embed_tokens.weight"]
 
 full_config = AutoConfig.from_pretrained(model_path)
@@ -93,12 +101,62 @@ tc = full_config.text_config
 model = Gemma4ForCausalLM(tc)
 model.load_state_dict(causal_sd, strict=True)
 model.eval()
+if args.precision == "f16":
+    model = model.half()
 model.config.use_cache = False
 del full_model, full_sd, causal_sd
 
+# Patch f32 upcasts to keep computation in f16.
+# Gemma4RMSNorm and Gemma4TextRotaryEmbedding both explicitly cast to float32
+# for numerical stability, producing a graph dominated by f32 ops even when the
+# model weights are f16. Patching them here forces all computation to stay in
+# the input dtype so that the traced graph is genuinely f16.
+if args.precision == "f16":
+    from transformers.models.gemma4.modeling_gemma4 import (
+        Gemma4RMSNorm,
+        Gemma4TextRotaryEmbedding,
+    )
+
+    def _rms_norm_forward_f16(
+        self, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        # mean() promotes f16→f32 on CPU, so hidden_states * f32_norm_factor
+        # would produce a mixed-type tosa.mul that fails MLIR validation.
+        # Explicitly upcast, compute, downcast to keep types consistent.
+        input_dtype = hidden_states.dtype
+        hidden_f32 = hidden_states.float()
+        mean_sq = hidden_f32.pow(2).mean(-1, keepdim=True) + self.eps
+        normed_output = (hidden_f32 * torch.pow(mean_sq, -0.5)).to(input_dtype)
+        if self.with_scale:
+            normed_output = normed_output * self.weight.to(input_dtype)
+        return normed_output
+
+    @torch.no_grad()
+    def _rope_forward_f16(self, x, position_ids, layer_type=None):
+        inv_freq = getattr(self, f"{layer_type}_inv_freq")
+        attention_scaling = getattr(self, f"{layer_type}_attention_scaling")
+        dtype = x.dtype
+        inv_freq_expanded = (
+            inv_freq[None, :, None]
+            .to(dtype)
+            .expand(position_ids.shape[0], -1, 1)
+            .to(x.device)
+        )
+        position_ids_expanded = position_ids[:, None, :].to(dtype)
+        freqs = (inv_freq_expanded @ position_ids_expanded).transpose(1, 2)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        cos = emb.cos() * attention_scaling
+        sin = emb.sin() * attention_scaling
+        return cos, sin
+
+    Gemma4RMSNorm.forward = _rms_norm_forward_f16
+    Gemma4TextRotaryEmbedding.forward = _rope_forward_f16
+
 # Pre-initialize StaticCache to avoid Dynamo graph breaks.
 print("Pre-initializing StaticCache for prefill...")
-cache_prefill = StaticCache(config=tc, max_cache_len=MaxTokenLength, batch_size=1)
+cache_prefill = StaticCache(
+    config=tc, max_cache_len=MaxTokenLength, batch_size=1
+)
 with torch.no_grad():
     model(
         input_ids=torch.zeros((1, 1), dtype=torch.int64),
@@ -136,7 +194,9 @@ with torch.no_grad():
     )
 
     print("Pre-initializing StaticCache for decode...")
-    cache_decode = StaticCache(config=tc, max_cache_len=MaxTokenLength, batch_size=1)
+    cache_decode = StaticCache(
+        config=tc, max_cache_len=MaxTokenLength, batch_size=1
+    )
     model(
         input_ids=torch.zeros((1, 1), dtype=torch.int64),
         past_key_values=cache_decode,
@@ -164,15 +224,23 @@ with torch.no_grad():
         past_key_values=cache_decode,
     )
 
-assert len(graphs_prefill) == 1, f"Expected 1 prefill graph, got {len(graphs_prefill)}"
-assert len(graphs_decode) == 1, f"Expected 1 decode graph, got {len(graphs_decode)}"
+assert len(graphs_prefill) == 1, (
+    f"Expected 1 prefill graph, got {len(graphs_prefill)}"
+)
+assert len(graphs_decode) == 1, (
+    f"Expected 1 decode graph, got {len(graphs_decode)}"
+)
 graph_prefill = graphs_prefill[0]
 graph_decode = graphs_decode[0]
 
 params = dynamo_compiler_prefill.imported_params[graph_prefill]
 
-graphs_prefill[0].perform([eliminate_transpose, eliminate_matmul_transpose_reshape])
-graphs_decode[0].perform([eliminate_transpose, eliminate_matmul_transpose_reshape])
+graphs_prefill[0].perform(
+    [eliminate_transpose, eliminate_matmul_transpose_reshape]
+)
+graphs_decode[0].perform(
+    [eliminate_transpose, eliminate_matmul_transpose_reshape]
+)
 pattern_list_prefill = [
     simply_fuse,
     apply_classic_fusion,
@@ -188,10 +256,14 @@ pattern_list_decode = [
 graphs_prefill[0].fuse_ops(pattern_list_prefill)
 graphs_decode[0].fuse_ops(pattern_list_decode)
 
-graph_prefill.op_groups["subgraph0_prefill"] = graph_prefill.op_groups.pop("subgraph0")
+graph_prefill.op_groups["subgraph0_prefill"] = graph_prefill.op_groups.pop(
+    "subgraph0"
+)
 graph_prefill.group_map_device["subgraph0_prefill"] = DeviceType.CPU
 
-graph_decode.op_groups["subgraph0_decode"] = graph_decode.op_groups.pop("subgraph0")
+graph_decode.op_groups["subgraph0_decode"] = graph_decode.op_groups.pop(
+    "subgraph0"
+)
 graph_decode.group_map_device["subgraph0_decode"] = DeviceType.CPU
 
 driver_prefill = GraphDriver(graphs_prefill[0])
@@ -200,16 +272,28 @@ driver_prefill.subgraphs[0].lower_to_top_level_ir()
 driver_decode = GraphDriver(graphs_decode[0])
 driver_decode.subgraphs[0].lower_to_top_level_ir()
 
-with open(os.path.join(output_dir, "subgraph0_prefill_e2b.mlir"), "w") as module_file:
-    print(driver_prefill.subgraphs[0]._imported_module, file=module_file)
-with open(os.path.join(output_dir, "forward_prefill_e2b.mlir"), "w") as module_file:
-    print(driver_prefill.construct_main_graph(True), file=module_file)
-all_param = numpy.concatenate([param.detach().numpy().reshape([-1]) for param in params])
-all_param.tofile(os.path.join(output_dir, "arg0_e2b.data"))
+suffix = "-f16" if args.precision == "f16" else ""
 
-with open(os.path.join(output_dir, "subgraph0_decode_e2b.mlir"), "w") as module_file:
+with open(
+    os.path.join(output_dir, f"subgraph0_prefill_e2b{suffix}.mlir"), "w"
+) as module_file:
+    print(driver_prefill.subgraphs[0]._imported_module, file=module_file)
+with open(
+    os.path.join(output_dir, f"forward_prefill_e2b{suffix}.mlir"), "w"
+) as module_file:
+    print(driver_prefill.construct_main_graph(True), file=module_file)
+all_param = numpy.concatenate(
+    [param.detach().numpy().reshape([-1]) for param in params]
+)
+all_param.tofile(os.path.join(output_dir, f"arg0_e2b{suffix}.data"))
+
+with open(
+    os.path.join(output_dir, f"subgraph0_decode_e2b{suffix}.mlir"), "w"
+) as module_file:
     print(driver_decode.subgraphs[0]._imported_module, file=module_file)
-with open(os.path.join(output_dir, "forward_decode_e2b.mlir"), "w") as module_file:
+with open(
+    os.path.join(output_dir, f"forward_decode_e2b{suffix}.mlir"), "w"
+) as module_file:
     print(driver_decode.construct_main_graph(True), file=module_file)
 
 # Export vocabulary file for the C++ tokenizer.
@@ -228,7 +312,7 @@ print("All files saved to:", output_dir)
 # torch._dynamo bakes cumulative_length as a compile-time constant, but it must
 # be dynamic for correct attention masking across different cache positions.
 patch_script = os.path.join(os.path.dirname(__file__), "patch_decode_mlir.py")
-decode_mlir = os.path.join(output_dir, "subgraph0_decode_e2b.mlir")
+decode_mlir = os.path.join(output_dir, f"subgraph0_decode_e2b{suffix}.mlir")
 if os.path.exists(patch_script) and os.path.exists(decode_mlir):
     print("Patching constant-folded cumulative_length in decode subgraph...")
     subprocess.run(["python3", patch_script, decode_mlir], check=True)

--- a/examples/BuddyGemma4/patch_decode_mlir.py
+++ b/examples/BuddyGemma4/patch_decode_mlir.py
@@ -22,68 +22,112 @@ Only the first attention block still bakes constants; later layers already use
 const on the previous line (not an existing %argN).
 """
 
+import argparse
+import os
 import re
 import sys
 
-CUMLEN_ARG = "%arg16"
 
-mlir_path = (
-    sys.argv[1]
-    if len(sys.argv) > 1
-    else (
-        "/home/zhuxinye/buddy-mlir/build/examples/BuddyGemma4/"
-        "subgraph0_decode_e2b.mlir"
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Patch Gemma4 decode MLIR to use runtime cumulative length."
     )
-)
+    parser.add_argument("mlir_path", type=str, help="Path to decode MLIR file.")
+    parser.add_argument(
+        "--cumlen-arg",
+        type=str,
+        default="%arg16",
+        help="SSA value to use for runtime cumulative length.",
+    )
+    parser.add_argument(
+        "--strict-no-change",
+        action="store_true",
+        help="Return non-zero when no modifications were applied.",
+    )
+    return parser.parse_args()
+
+
+args = parse_args()
+CUMLEN_ARG = args.cumlen_arg
+mlir_path = args.mlir_path
+
+if not os.path.exists(mlir_path):
+    print(f"ERROR: file does not exist: {mlir_path}")
+    sys.exit(2)
 
 with open(mlir_path) as f:
     content = f.read()
 
 lines = content.split("\n")
 
-# Regex: tosa.add %generated..., %op : (tensor<1xi64>, tensor<1xi64>) [-> ...]
-RE_ADD_GEN = re.compile(
-    r"(%\w+) = tosa\.add (%generated(?:_\d+)?), (%\w+) : "
-    r"\(tensor<1xi64>, tensor<1xi64>\)(?: -> tensor<1xi64>)?"
-)
+# --- Pass 1: collect all SSA values that are tensor.generate results ---
+# Handles both:
+#   %generated = tensor.generate  { ... }         (unquoted, named)
+#   %N = "tensor.generate"() ({ ... })            (quoted, numeric SSA)
+RE_GEN_UNQUOTED = re.compile(r"(%\w+) = tensor\.generate\b")
+RE_GEN_QUOTED = re.compile(r'(%\w+) = "tensor\.generate"\(\)')
+generate_vars: set[str] = set()
+for line in lines:
+    s = line.strip()
+    for pat in (RE_GEN_UNQUOTED, RE_GEN_QUOTED):
+        m = pat.match(s)
+        if m:
+            generate_vars.add(m.group(1))
+
 # Previous line: const 1 for cumlen offset (kv_length = 1 at trace)
 RE_CONST_ONE = re.compile(
-    r'(%\w+) = "tosa\.const"\(\) <\{values = dense<1> : tensor<1xi64>\}>'
+    r'(%\w+) = (?:"tosa\.const"\(\)|tosa\.const) '
+    r"<\{values = dense<1> : tensor<1xi64>\}>"
+)
+
+# tosa.add with unquoted syntax:  %R = tosa.add %A, %B : (...)
+RE_ADD_UNQUOTED = re.compile(
+    r"(%\w+) = tosa\.add (%\w+), (%\w+) : "
+    r"\(tensor<1xi64>, tensor<1xi64>\)(?: -> tensor<1xi64>)?"
+)
+# tosa.add with quoted syntax:  %R = "tosa.add"(%A, %B) : (...)
+RE_ADD_QUOTED = re.compile(
+    r'(%\w+) = "tosa\.add"\((%\w+), (%\w+)\) : '
+    r"\(tensor<1xi64>, tensor<1xi64>\)(?: -> tensor<1xi64>)?"
 )
 
 patch_count = 0
 i = 0
 while i < len(lines):
-    # --- New IR: tensor.generate + const1 + tosa.add ---
-    m_add = RE_ADD_GEN.match(lines[i].strip())
-    if m_add and i > 0:
-        _result, gen, op2 = m_add.groups()
-        m_const = RE_CONST_ONE.match(lines[i - 1].strip())
-        if m_const and m_const.group(1) == op2:
-            old_line = lines[i]
-            new_line = old_line.replace(
-                f"tosa.add {gen}, {op2}",
-                f"tosa.add {CUMLEN_ARG}, {op2}",
-            )
-            lines[i] = new_line
-            patch_count += 1
-            print(f"  Line {i + 1}: {old_line.strip()} -> {new_line.strip()}")
-            i += 1
-            continue
+    s = line_strip = lines[i].strip()
 
-    # --- Legacy: const0 + const1 + add (dense<0> / dense<1> on 1xi64) ---
+    # --- Pattern A: tensor.generate + const1 + tosa.add (any syntax) ---
+    for re_add in (RE_ADD_UNQUOTED, RE_ADD_QUOTED):
+        m_add = re_add.match(line_strip)
+        if m_add and i > 0:
+            _result, lhs, rhs = m_add.groups()
+            m_const = RE_CONST_ONE.match(lines[i - 1].strip())
+            if m_const and m_const.group(1) == rhs and lhs in generate_vars:
+                old_line = lines[i]
+                # Replace first occurrence of the lhs variable in the add
+                new_line = old_line.replace(lhs, CUMLEN_ARG, 1)
+                lines[i] = new_line
+                patch_count += 1
+                print(
+                    f"  Line {i + 1}: {old_line.strip()} -> {new_line.strip()}"
+                )
+                break
+
+    # --- Pattern B: const0 + const1 + unquoted add (legacy f32 style) ---
     if i + 2 < len(lines):
         l0 = lines[i].strip()
         l1 = lines[i + 1].strip()
         l2 = lines[i + 2].strip()
 
         m0 = re.match(
-            r'(%\w+) = "tosa\.const"\(\) <\{values = dense<0> : '
+            r'(%\w+) = (?:"tosa\.const"\(\)|tosa\.const) '
+            r"<\{values = dense<0> : "
             r"tensor<1xi64>\}>",
             l0,
         )
         m1 = re.match(
-            r'(%\w+) = "tosa\.const"\(\) <\{values = dense<1> : '
+            r'(%\w+) = (?:"tosa\.const"\(\)|tosa\.const) '
+            r"<\{values = dense<1> : "
             r"tensor<1xi64>\}>",
             l1,
         )
@@ -110,8 +154,17 @@ while i < len(lines):
     i += 1
 
 if patch_count == 0:
-    print("WARNING: No patches applied!")
-    sys.exit(1)
+    # Already-patched files are expected on incremental rebuilds.
+    already_patched = CUMLEN_ARG in content
+    if already_patched and not args.strict_no_change:
+        print("No patch needed (file appears already patched).")
+        sys.exit(0)
+    else:
+        print("WARNING: No patches applied!")
+        if args.strict_no_change:
+            sys.exit(1)
+        print("Continuing without changes.")
+        sys.exit(0)
 
 print(f"\nApplied {patch_count} patches")
 


### PR DESCRIPTION
## Summary
This PR adds end-to-end FP16 inference support for examples/BuddyGemma4 (Gemma-4-E2B text path), including import, lowering, build targets, and runtime entrypoint.
<img width="497" height="136" alt="image" src="https://github.com/user-attachments/assets/3cc56a12-bd70-4272-b1cf-5ec3bc2d4cba" />

