### PR TITLE
[ci] Release buddy-cli

### DIFF
--- a/.github/workflows/TestBuild.yml
+++ b/.github/workflows/TestBuild.yml
@@ -56,7 +56,8 @@ jobs:
       - name: Checkout from local Gitea (riscv64)
         if: matrix.arch == 'riscv64'
         run: |
-          git clone --no-checkout https://community-ci.openruyi.cn/RuyiAI-Stack/buddy-mlir .
+          git clone --no-checkout https://community-ci.openruyi.cn/RuyiAI-Stack/buddy-mlir
+          cd buddy-mlir
           git remote add github https://github.com/buddy-compiler/buddy-mlir.git
           git fetch github ${{ github.sha }}
           git checkout ${{ github.sha }}
@@ -69,15 +70,15 @@ jobs:
           venv_deactivate: ${{ matrix.venv_deactivate }}
 
       - name: Run check-buddy
-        if: matrix.arch == 'x64'
+        if: matrix.arch != 'arm64'
         run: |
           ${{ matrix.venv_activate }}
           ninja -C build check-buddy
           ${{ matrix.venv_deactivate }}
 
       - name: Run check-buddy
-        if: matrix.arch != 'x64'
+        if: matrix.arch == 'arm64'
         run: |
           ${{ matrix.venv_activate }}
-          ninja -C build check-buddy | true
+          ninja -C build check-buddy || true
           ${{ matrix.venv_deactivate }}

--- a/.github/workflows/build-manylinux.yml
+++ b/.github/workflows/build-manylinux.yml
@@ -19,7 +19,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: release/v${{ inputs.version }}
-          name: Buddy Compiler ${{ inputs.version }}
+          name: BUDDY MLIR ${{ inputs.version }}
           draft: true
           overwrite_files: true
         env:
@@ -96,12 +96,10 @@ jobs:
           ./scripts/release_wheel_manylinux.sh "${{ steps.vars.outputs.py_tag }}" ${{ inputs.version }} "${{ matrix.target_arch }}"
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: release/v${{ inputs.version }}
-          draft: true
-          overwrite_files: true
-          files: |
-            ${{ steps.vars.outputs.host_build_dir }}/${{ matrix.target_arch }}/buddy/${{ steps.vars.outputs.py_tag }}/${{ steps.vars.outputs.buddy_hash }}/target/buddy-${{ inputs.version }}-${{ steps.vars.outputs.py_tag }}-manylinux*
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "release/v${{ inputs.version }}" \
+            ${{ steps.vars.outputs.host_build_dir }}/${{ matrix.target_arch }}/buddy/${{ steps.vars.outputs.py_tag }}/${{ steps.vars.outputs.buddy_hash }}/target/buddy-${{ inputs.version }}-${{ steps.vars.outputs.py_tag }}-manylinux* \
+            --clobber

--- a/.github/workflows/build-manylinux.yml
+++ b/.github/workflows/build-manylinux.yml
@@ -103,3 +103,15 @@ jobs:
           gh release upload "release/v${{ inputs.version }}" \
             ${{ steps.vars.outputs.host_build_dir }}/${{ matrix.target_arch }}/buddy/${{ steps.vars.outputs.py_tag }}/${{ steps.vars.outputs.buddy_hash }}/target/buddy-${{ inputs.version }}-${{ steps.vars.outputs.py_tag }}-manylinux* \
             --clobber
+
+      - name: Upload buddy-cli
+        if: ${{ (matrix.target_arch == 'x86_64' && matrix.python == '3.10') || (matrix.target_arch == 'riscv64' && matrix.python == '3.12') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BUDDY_BUILD_DIR=${{ steps.vars.outputs.host_build_dir }}/${{ matrix.target_arch }}/buddy/${{ steps.vars.outputs.py_tag }}/${{ steps.vars.outputs.buddy_hash }}
+          cp -a "${BUDDY_BUILD_DIR}/dist/bin/buddy-cli" "${BUDDY_BUILD_DIR}/target/buddy-cli-${{ inputs.version }}.${{ matrix.target_arch }}"
+          gh release upload "release/v${{ inputs.version }}" \
+            "${BUDDY_BUILD_DIR}/target/buddy-cli-${{ inputs.version }}.${{ matrix.target_arch }}" \
+            --clobber

--- a/midend/lib/CMakeLists.txt
+++ b/midend/lib/CMakeLists.txt
@@ -67,23 +67,49 @@ target_compile_definitions(static_mlir_async_runtime
   MLIR_ASYNCRUNTIME_DEFINE_FUNCTIONS
   )
 
+# Build static library for MLIR float16 utils runtime.
+add_mlir_library(StaticMLIRFloat16Utils
+  STATIC
+  ${MLIR_MAIN_SRC_DIR}/lib/ExecutionEngine/Float16bits.cpp
+
+  EXCLUDE_FROM_LIBMLIR
+)
+set_property(TARGET StaticMLIRFloat16Utils PROPERTY CXX_STANDARD 17)
+
+# Build static library for MLIR sparse tensor runtime.
+add_mlir_library(StaticMLIRSparseTensorRuntime
+  STATIC
+  ${MLIR_MAIN_SRC_DIR}/lib/ExecutionEngine/SparseTensor/File.cpp
+  ${MLIR_MAIN_SRC_DIR}/lib/ExecutionEngine/SparseTensor/MapRef.cpp
+  ${MLIR_MAIN_SRC_DIR}/lib/ExecutionEngine/SparseTensor/Storage.cpp
+
+  EXCLUDE_FROM_LIBMLIR
+
+  LINK_LIBS PUBLIC
+  MLIRSparseTensorEnums
+  StaticMLIRFloat16Utils
+)
+set_property(TARGET StaticMLIRSparseTensorRuntime PROPERTY CXX_STANDARD 17)
+
 # Build static library for MLIR C runner utils runtime.
 add_mlir_library(StaticMLIRCRunnerUtils
+  STATIC
   ${MLIR_MAIN_SRC_DIR}/lib/ExecutionEngine/CRunnerUtils.cpp
   ${MLIR_MAIN_SRC_DIR}/lib/ExecutionEngine/SparseTensorRuntime.cpp
 
   EXCLUDE_FROM_LIBMLIR
 
   LINK_LIBS PUBLIC
-  mlir_float16_utils
+  StaticMLIRFloat16Utils
   MLIRSparseTensorEnums
-  MLIRSparseTensorRuntime
+  StaticMLIRSparseTensorRuntime
   )
 set_property(TARGET StaticMLIRCRunnerUtils PROPERTY CXX_STANDARD 17)
 target_compile_definitions(StaticMLIRCRunnerUtils PRIVATE StaticMLIRCRunnerUtils_EXPORTS)
 
 # Build static library for MLIR runner utils runtime.
 add_mlir_library(StaticMLIRRunnerUtils
+  STATIC
   ${MLIR_MAIN_SRC_DIR}/lib/ExecutionEngine/RunnerUtils.cpp
 
   EXCLUDE_FROM_LIBMLIR

--- a/midend/python/CMakeLists.txt
+++ b/midend/python/CMakeLists.txt
@@ -104,8 +104,6 @@ declare_mlir_python_extension(BuddyMLIRPythonSources.Extension
 ################################################################################
 
 add_mlir_python_common_capi_library(BuddyMLIRPythonCAPI
-  INSTALL_COMPONENT BuddyMLIRPythonModules
-  INSTALL_DESTINATION python_packages/buddy_mlir/_mlir_libs
   OUTPUT_DIRECTORY "${BUDDY_BUILD_DIR}/python_packages/buddy_mlir/_mlir_libs"
   RELATIVE_INSTALL_ROOT "../../.."
   DECLARED_SOURCES
@@ -121,7 +119,6 @@ link_directories(${LLVM_BINARY_DIR}/tools/mlir/python_packages/mlir_core/mlir/_m
 
 add_mlir_python_modules(BuddyMLIRPythonModules
   ROOT_PREFIX "${BUDDY_BUILD_DIR}/python_packages/buddy_mlir"
-  INSTALL_PREFIX "python_packages/buddy_mlir"
   DECLARED_SOURCES
     BuddyMLIRPythonSources
     MLIRPythonSources

--- a/scripts/install_buddy_cli.sh
+++ b/scripts/install_buddy_cli.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO="${BUDDY_CLI_REPO:-buddy-compiler/buddy-mlir}"
+INSTALL_DIR="${BUDDY_CLI_INSTALL_DIR:-$HOME/.local/bin}"
+REQUESTED_VERSION="${1:-latest}"
+
+case "$(uname -s)" in
+  Linux)
+    ;;
+  *)
+    echo "Only Linux is supported by this installer." >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  x86_64|amd64)
+    TARGET_ARCH="x86_64"
+    ;;
+  riscv64)
+    TARGET_ARCH="riscv64"
+    ;;
+  *)
+    echo "Unsupported architecture: $(uname -m)" >&2
+    echo "Supported: x86_64, riscv64" >&2
+    exit 1
+    ;;
+esac
+
+resolve_tag() {
+  if [ "${REQUESTED_VERSION}" = "latest" ]; then
+    curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+      | sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' \
+      | head -n 1
+    return
+  fi
+
+  case "${REQUESTED_VERSION}" in
+    release/*)
+      printf '%s\n' "${REQUESTED_VERSION}"
+      ;;
+    v*)
+      printf 'release/%s\n' "${REQUESTED_VERSION}"
+      ;;
+    *)
+      printf 'release/v%s\n' "${REQUESTED_VERSION}"
+      ;;
+  esac
+}
+
+TAG="$(resolve_tag)"
+if [ -z "${TAG}" ]; then
+  echo "Failed to resolve release tag for ${REQUESTED_VERSION}." >&2
+  exit 1
+fi
+
+VERSION="${TAG#release/v}"
+ASSET_NAME="buddy-cli-${VERSION}.${TARGET_ARCH}"
+ASSET_URL="https://github.com/${REPO}/releases/download/${TAG}/${ASSET_NAME}"
+
+mkdir -p "${INSTALL_DIR}"
+
+echo "Downloading ${ASSET_NAME} from ${TAG}..."
+curl -fL "${ASSET_URL}" -o "${INSTALL_DIR}/buddy-cli"
+chmod 0755 "${INSTALL_DIR}/buddy-cli"
+
+echo "Installed buddy-cli to ${INSTALL_DIR}/buddy-cli"
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*)
+    ;;
+  *)
+    echo "Add ${INSTALL_DIR} to PATH to use buddy-cli directly."
+    ;;
+esac

--- a/tools/buddy-cli/CMakeLists.txt
+++ b/tools/buddy-cli/CMakeLists.txt
@@ -16,7 +16,7 @@ else()
   )
 endif()
 target_link_libraries(buddy-cli PRIVATE
-  mlir_c_runner_utils
+  StaticMLIRCRunnerUtils
   LLVMSupport
 )
 target_link_directories(buddy-cli PRIVATE ${LLVM_LIBRARY_DIR})


### PR DESCRIPTION
## Summary

- Upload buddy-cli to github release
- Add script to install buddy-cli with oneline curl
- Remove buddy_mlir from cmake install, buddy_mlir should only exists in python whl, and be managed by setup.py
