### PR TITLE
[ci] riscv64: GITHUB_ENV does not work in currently shell block

### DIFF
--- a/.github/actions/ci-common/action.yml
+++ b/.github/actions/ci-common/action.yml
@@ -81,10 +81,13 @@ runs:
       id: prepare-llvm-build
       shell: bash
       run: |
+        LLVM_SRC="${{ steps.setup-llvm.outputs.llvm_src }}"
+        LLVM_BUILD_DIR="${{ env.LLVM_BUILD_ROOT }}/${{ steps.setup-llvm.outputs.cache_hash }}"
+
         echo "LLVM_SRC=${{ steps.setup-llvm.outputs.llvm_src }}" >> $GITHUB_ENV
         echo "LLVM_BUILD_DIR=${{ env.LLVM_BUILD_ROOT }}/${{ steps.setup-llvm.outputs.cache_hash }}" >> $GITHUB_ENV
         if [ -f "${LLVM_BUILD_DIR}/build/CMakeCache.txt" ] &&
-          grep -q "${{ steps.setup-llvm.outputs.llvm_src }}" "${LLVM_BUILD_DIR}/build/CMakeCache.txt"; then
+          grep -q "${LLVM_SRC}" "${LLVM_BUILD_DIR}/build/CMakeCache.txt"; then
           echo "need-rebuild=false" >> "$GITHUB_OUTPUT"
         else
           echo "need-rebuild=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/TestBuild.yml
+++ b/.github/workflows/TestBuild.yml
@@ -49,18 +49,10 @@ jobs:
           uname -a
 
       - name: Checkout
-        if: matrix.arch != 'riscv64'
         uses: actions/checkout@v6
         with:
           submodules: 'false'
-      - name: Checkout from local Gitea (riscv64)
-        if: matrix.arch == 'riscv64'
-        run: |
-          git clone --no-checkout https://community-ci.openruyi.cn/RuyiAI-Stack/buddy-mlir
-          cd buddy-mlir
-          git remote add github https://github.com/buddy-compiler/buddy-mlir.git
-          git fetch github ${{ github.sha }}
-          git checkout ${{ github.sha }}
+          fetch-depth: 300
 
       - name: Build buddy-mlir
         uses: ./.github/actions/ci-common


### PR DESCRIPTION
Otherwise each cCI job will request to build LLVM modules.
