### PR TITLE
[example] Add Kokoro TTS static inference sample

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(BUDDY_TORQ_EXAMPLES OFF CACHE BOOL
 set(BUDDY_RUNTIME_MATMUL_TORQ OFF CACHE BOOL
     "Build buddy_matmul_torq (runtime buddy_matmul_f32 via TORQ-Tile RVV); requires RISC-V RVV and find_package(TorqTile)")
 set(BUDDY_TRANSFORMER_EXAMPLES OFF CACHE BOOL "Build transformer examples")
+set(BUDDY_TTS_KOKORO_EXAMPLES OFF CACHE BOOL "Build Kokoro TTS example")
 set(BUDDY_ENABLE_OPENCV OFF CACHE BOOL "Enable OpenCV support.")
 
 # DeepSeek R1 (buddy-codegen): heavy codegen, MLIR import, .so / .rax. Off by default

--- a/examples/BuddyTTSKokoro/CMakeLists.txt
+++ b/examples/BuddyTTSKokoro/CMakeLists.txt
@@ -1,0 +1,140 @@
+# Define bufferize options as variables to avoid CMake quote parsing issues.
+set(BUFFERIZE_SIMPLE_OPTS "bufferize-function-boundaries")
+set(TOSA_PIPELINE "builtin.module(func.func(tosa-optional-decompositions,tosa-to-linalg-named),func.func(tosa-to-linalg),func.func(tosa-to-tensor),func.func(tosa-to-arith))")
+
+# Detect RISC-V Vector (RVV) platform.
+if(HAVE_LOCAL_RVV)
+  set(IS_RVV_PLATFORM ON)
+  message(STATUS "RISC-V Vector (RVV) platform detected")
+endif()
+
+# Set platform-specific variables.
+if(IS_RVV_PLATFORM)
+  set(OPENMP_NUM_THREADS "num-threads=32")
+  set(LLC_RISCV_ATTRS "-mattr=+m,+d,+v")
+else()
+  set(OPENMP_NUM_THREADS "num-threads=48")
+  set(LLC_RISCV_ATTRS "")
+endif()
+
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/forward_predictor.mlir
+         ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_predictor.mlir
+         ${CMAKE_CURRENT_BINARY_DIR}/forward_vocoder.mlir
+         ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_vocoder.mlir
+         ${CMAKE_CURRENT_BINARY_DIR}/arg0_predictor.data
+         ${CMAKE_CURRENT_BINARY_DIR}/arg0_vocoder.data
+         ${CMAKE_CURRENT_BINARY_DIR}/input_ids.data
+         ${CMAKE_CURRENT_BINARY_DIR}/ref_s.data
+  COMMAND ${CMAKE_COMMAND} -E env
+          PYTHONPATH=${BUDDY_MLIR_PYTHON_PACKAGES_DIR}:$ENV{PYTHONPATH}
+          ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/import-kokoro.py
+          --output-dir ${CMAKE_CURRENT_BINARY_DIR}
+  COMMENT "Generating Kokoro MLIR and data files..."
+  VERBATIM
+)
+
+add_custom_target(
+  buddy-kokoro-import
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/forward_predictor.mlir
+          ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_predictor.mlir
+          ${CMAKE_CURRENT_BINARY_DIR}/forward_vocoder.mlir
+          ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_vocoder.mlir
+          ${CMAKE_CURRENT_BINARY_DIR}/arg0_predictor.data
+          ${CMAKE_CURRENT_BINARY_DIR}/arg0_vocoder.data
+          ${CMAKE_CURRENT_BINARY_DIR}/input_ids.data
+          ${CMAKE_CURRENT_BINARY_DIR}/ref_s.data
+)
+
+function(add_kokoro_mlir_object target_name mlir_file output_obj)
+  add_custom_command(
+    OUTPUT ${output_obj}
+    COMMAND ${BUDDY_BINARY_DIR}/buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/${mlir_file}
+              -simplify-tosa-reshape |
+            ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+              -pass-pipeline ${TOSA_PIPELINE} |
+            ${BUDDY_BINARY_DIR}/buddy-opt
+              -eliminate-empty-tensors
+              -empty-tensor-to-alloc-tensor
+              -convert-elementwise-to-linalg
+              -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+              -expand-strided-metadata
+              -ownership-based-buffer-deallocation
+              -canonicalize
+              -buffer-deallocation-simplification
+              -bufferization-lower-deallocations
+              -convert-bufferization-to-memref
+              -cse
+              -canonicalize
+              -convert-linalg-to-loops
+              -cse
+              -lower-affine
+              -memref-expand
+              -arith-expand
+              -convert-arith-to-llvm
+              -convert-complex-to-llvm
+              -finalize-memref-to-llvm
+              -convert-scf-to-cf
+              -convert-cf-to-llvm
+              -llvm-request-c-wrappers
+              -convert-arith-to-llvm
+              -convert-math-to-llvm
+              -convert-math-to-libm
+              -convert-func-to-llvm
+              -reconcile-unrealized-casts |
+            ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+            ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+            ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} -filetype=obj -relocation-model=pic -O0
+              -o ${CMAKE_CURRENT_BINARY_DIR}/${output_obj}
+    DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/${mlir_file}
+    COMMENT "Building ${target_name}"
+    VERBATIM
+  )
+endfunction()
+
+add_kokoro_mlir_object(forward_predictor.o forward_predictor.mlir forward_predictor.o)
+add_kokoro_mlir_object(subgraph_predictor.o subgraph0_predictor.mlir subgraph_predictor.o)
+add_kokoro_mlir_object(forward_vocoder.o forward_vocoder.mlir forward_vocoder.o)
+add_kokoro_mlir_object(subgraph_vocoder.o subgraph0_vocoder.mlir subgraph_vocoder.o)
+
+add_library(KOKORO STATIC
+  forward_predictor.o
+  subgraph_predictor.o
+  forward_vocoder.o
+  subgraph_vocoder.o
+)
+
+SET_SOURCE_FILES_PROPERTIES(
+  template.o
+  PROPERTIES
+  EXTERNAL_OBJECT true
+  GENERATED true)
+
+SET_TARGET_PROPERTIES(
+  KOKORO
+  PROPERTIES
+  LINKER_LANGUAGE C)
+
+add_executable(buddy-kokoro-run buddy-kokoro-main.cpp)
+
+set(KOKORO_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
+set(KOKORO_EXAMPLE_BUILD_PATH ${CMAKE_CURRENT_BINARY_DIR})
+
+target_compile_definitions(buddy-kokoro-run PRIVATE
+  KOKORO_EXAMPLE_PATH="${KOKORO_EXAMPLE_PATH}/"
+  KOKORO_EXAMPLE_BUILD_PATH="${KOKORO_EXAMPLE_BUILD_PATH}/"
+)
+
+target_link_directories(buddy-kokoro-run PRIVATE ${LLVM_LIBRARY_DIR})
+
+set(BUDDY_KOKORO_LIBS
+  KOKORO
+  mlir_c_runner_utils
+  omp
+)
+
+if(BUDDY_MLIR_USE_MIMALLOC)
+  list(APPEND BUDDY_KOKORO_LIBS mimalloc)
+endif()
+
+target_link_libraries(buddy-kokoro-run ${BUDDY_KOKORO_LIBS})

--- a/examples/BuddyTTSKokoro/README.md
+++ b/examples/BuddyTTSKokoro/README.md
@@ -1,0 +1,101 @@
+# BuddyTTSKokoro
+
+This example imports and runs a fixed-shape Kokoro-82M TTS pipeline with
+Buddy MLIR.
+
+Kokoro predicts token durations before it builds the frame alignment consumed by
+the vocoder.  That alignment width is data dependent, so this example follows a
+two-stage static pipeline instead of forcing the whole model into one static
+graph:
+
+- `forward_predictor.mlir`, `subgraph0_predictor.mlir`
+  - encode fixed phoneme tokens and reference style
+  - predict token durations
+  - return the intermediate tensors needed by the vocoder
+- `forward_vocoder.mlir`, `subgraph0_vocoder.mlir`
+  - consume a fixed frame-index tensor built by the C++ driver
+  - synthesize the final waveform
+
+The C++ driver computes the duration-to-frame bridge between those two static
+graphs and writes a WAV file.
+
+## Build
+
+The sample follows the same opt-in structure as the other examples.  Enabling
+`BUDDY_TTS_KOKORO_EXAMPLES` imports the MLIR/data files, compiles the generated
+MLIR objects, links the `KOKORO` static library, and builds the native runner:
+
+```bash
+cmake -S . -B build -DBUDDY_TTS_KOKORO_EXAMPLES=ON
+cmake --build build --target buddy-kokoro-run
+```
+
+The generated files are placed in `build/examples/BuddyTTSKokoro/`:
+
+- `forward_predictor.mlir`, `subgraph0_predictor.mlir`
+- `forward_vocoder.mlir`, `subgraph0_vocoder.mlir`
+- `arg0_predictor.data`, `arg0_vocoder.data`
+- `input_ids.data`, `ref_s.data`
+
+The two `arg0_*.data` files contain float model weights packed for the generated
+forward wrappers.  The predictor stage also has an int64 Buddy ABI input for
+deterministic runtime state; the C++ driver recreates that state locally.
+
+## Run
+
+```bash
+./build/bin/buddy-kokoro-run
+```
+
+The default output is:
+
+```text
+build/examples/BuddyTTSKokoro/kokoro_static.wav
+```
+
+The runner accepts explicit input/output paths:
+
+```bash
+./build/bin/buddy-kokoro-run \
+  --params0 build/examples/BuddyTTSKokoro/arg0_predictor.data \
+  --params1 build/examples/BuddyTTSKokoro/arg0_vocoder.data \
+  --tokens build/examples/BuddyTTSKokoro/input_ids.data \
+  --ref-s build/examples/BuddyTTSKokoro/ref_s.data \
+  --output build/examples/BuddyTTSKokoro/kokoro_static.wav
+```
+
+## Input Text
+
+The default fixed-shape sample uses:
+
+- `input_ids` shape `[1, 16]`
+- `ref_s` shape `[1, 256]`
+- speed `1.0`
+- phoneme string `həlˈoʊ wˈɜɹld`
+
+`--phonemes` expects a Kokoro phoneme string, not raw English text.  Passing raw
+English through `--phonemes` treats the characters as already-phonemized input
+and can produce harsh or unnatural audio.
+
+If local G2P assets are installed, the importer can phonemize raw text before
+export:
+
+```bash
+python \
+  examples/BuddyTTSKokoro/import-kokoro.py \
+  --output-dir build/examples/BuddyTTSKokoro \
+  --text "Hello world."
+```
+
+Without those local G2P assets, use `--phonemes` directly:
+
+```bash
+python \
+  examples/BuddyTTSKokoro/import-kokoro.py \
+  --output-dir build/examples/BuddyTTSKokoro \
+  --phonemes "həlˈoʊ wˈɜɹld"
+```
+
+If the input changes enough to alter the predicted alignment length or generated
+audio length, update the static constants in `buddy-kokoro-main.cpp` to match
+the newly generated MLIR/data.

--- a/examples/BuddyTTSKokoro/buddy-kokoro-main.cpp
+++ b/examples/BuddyTTSKokoro/buddy-kokoro-main.cpp
@@ -1,0 +1,290 @@
+//===- buddy-kokoro-main.cpp ----------------------------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include <algorithm>
+#include <buddy/Core/Container.h>
+#include <buddy/DAP/AudioContainer.h>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <sys/time.h>
+#include <utility>
+
+constexpr size_t KokoroSeqLen = 16;
+constexpr size_t KokoroAlignLen = 65;
+constexpr size_t KokoroPredictorParamsSize = 14464562;
+constexpr size_t KokoroVocoderParamsSize = 67345480;
+constexpr size_t KokoroRngStateSize = 1024;
+constexpr size_t KokoroRefStyleSize = 256;
+constexpr size_t KokoroStyleSize = 128;
+constexpr size_t KokoroDurationHiddenWidth = 640;
+constexpr size_t KokoroAudioSamples = 39000;
+constexpr int KokoroSampleRate = 24000;
+
+// The importer splits Kokoro at the data-dependent duration expansion.  The
+// predictor graph produces token-level duration information and intermediate
+// style/hidden tensors.  The C++ bridge turns predicted durations into a fixed
+// frame-index tensor before calling the vocoder graph.
+struct PredictorReturns {
+  MemRef<long long, 1> length;
+  MemRef<bool, 2> textMask;
+  MemRef<float, 2> style;
+  MemRef<float, 3> durationHidden;
+  MemRef<long long, 1> predDur;
+  MemRef<long long, 1> tokenPositions;
+};
+
+extern "C" double _mlir_ciface_rtclock() {
+  struct timeval tp;
+  int stat = gettimeofday(&tp, nullptr);
+  if (stat != 0)
+    fprintf(stderr, "Error returning time from gettimeofday: %d\n", stat);
+  return (tp.tv_sec + tp.tv_usec * 1.0e-6);
+}
+
+extern "C" void _mlir_ciface_forward_predictor(PredictorReturns *result,
+                                               MemRef<float, 1> *params,
+                                               MemRef<long long, 1> *rngState,
+                                               MemRef<long long, 2> *inputIds,
+                                               MemRef<float, 2> *refStyle);
+
+extern "C" void _mlir_ciface_forward_vocoder(
+    MemRef<float, 1> *result, MemRef<float, 1> *params,
+    MemRef<long long, 2> *inputIds, MemRef<long long, 1> *indices,
+    MemRef<float, 3> *durationHidden, MemRef<float, 2> *style,
+    MemRef<bool, 2> *textMask, MemRef<float, 2> *refStyle);
+
+void printLogLabel() { std::cout << "\033[34;1m[Log] \033[0m"; }
+
+void printStageLabel(const std::string &stage) {
+  std::cout << "\033[32;1m[" << stage << "] \033[0m";
+}
+
+void printDone(double seconds) {
+  std::cout << "\033[32;1mdone\033[0m in " << std::fixed << std::setprecision(3)
+            << seconds << "s" << std::endl;
+}
+
+template <typename Func>
+double timeSection(const std::string &stage, Func &&func) {
+  printStageLabel(stage);
+  std::cout << "running..." << std::flush;
+  const auto start = std::chrono::high_resolution_clock::now();
+  func();
+  const auto end = std::chrono::high_resolution_clock::now();
+  const std::chrono::duration<double> elapsed = end - start;
+  std::cout << "\r";
+  printStageLabel(stage);
+  printDone(elapsed.count());
+  return elapsed.count();
+}
+
+template <typename T, size_t N>
+void loadBinary(const std::string &path, MemRef<T, N> &memref) {
+  std::ifstream file(path, std::ios::binary);
+  if (!file.is_open())
+    throw std::runtime_error("failed to open " + path);
+  file.read(reinterpret_cast<char *>(memref.getData()),
+            sizeof(T) * memref.getSize());
+  if (file.gcount() !=
+      static_cast<std::streamsize>(sizeof(T) * memref.getSize()))
+    throw std::runtime_error("short read from " + path);
+}
+
+void saveWav(const std::string &path, MemRef<float, 1> &&audio) {
+  dap::Audio<float, 1> wav(std::move(audio));
+  wav.setBitDepth(16);
+  wav.setChannelsNum(1);
+  wav.setSampleRate(KokoroSampleRate);
+  wav.setSamplesNum(wav.getSize());
+  if (!wav.saveToFile(path, "wav"))
+    throw std::runtime_error("failed to save wav to " + path);
+}
+
+void printAudioStats(MemRef<float, 1> &audio) {
+  double sumSquares = 0.0;
+  float minValue = 0.0f;
+  float maxValue = 0.0f;
+  float peak = 0.0f;
+  if (audio.getSize() > 0) {
+    minValue = audio.getData()[0];
+    maxValue = audio.getData()[0];
+  }
+  for (size_t i = 0; i < audio.getSize(); ++i) {
+    const float sample = audio.getData()[i];
+    minValue = std::min(minValue, sample);
+    maxValue = std::max(maxValue, sample);
+    peak = std::max(peak, std::abs(sample));
+    sumSquares += static_cast<double>(sample) * static_cast<double>(sample);
+  }
+  const double rms =
+      audio.getSize() == 0 ? 0.0 : std::sqrt(sumSquares / audio.getSize());
+  printLogLabel();
+  std::cout << "Audio stats: min=" << minValue << ", max=" << maxValue
+            << ", peak=" << peak << ", rms=" << rms << std::endl;
+}
+
+void fillDefaultRngState(MemRef<long long, 1> &rngState) {
+  // The predictor graph exposes Buddy's int64 parameter pack as an input.  For
+  // this static sample those values are deterministic runtime state rather
+  // than model weights, so the driver recreates them locally.
+  std::fill(rngState.getData(), rngState.getData() + rngState.getSize(), 0LL);
+  for (size_t i = 0; i < 512 && i < rngState.getSize(); ++i)
+    rngState.getData()[i] = static_cast<long long>(i);
+}
+
+size_t buildFrameIndices(PredictorReturns &ret, MemRef<long long, 1> &indices) {
+  // Kokoro normally constructs an alignment matrix whose width depends on the
+  // predicted durations.  The MLIR graphs are fixed-shape, so this bridge
+  // materializes the equivalent frame-index vector and pads/truncates it to the
+  // vocoder shape chosen during import.
+  size_t cursor = 0;
+  for (size_t token = 0; token < KokoroSeqLen && cursor < KokoroAlignLen;
+       ++token) {
+    long long duration = std::max<long long>(1, ret.predDur.getData()[token]);
+    for (long long j = 0; j < duration && cursor < KokoroAlignLen; ++j)
+      indices.getData()[cursor++] = static_cast<long long>(token);
+  }
+  while (cursor < KokoroAlignLen)
+    indices.getData()[cursor++] = static_cast<long long>(KokoroSeqLen - 1);
+  return cursor;
+}
+
+std::string optionValue(int argc, char **argv, const std::string &name,
+                        const std::string &fallback) {
+  for (int i = 1; i + 1 < argc; ++i) {
+    if (argv[i] == name)
+      return argv[i + 1];
+  }
+  return fallback;
+}
+
+int main(int argc, char **argv) {
+  const std::string title =
+      "Kokoro Static TTS Inference Powered by Buddy Compiler";
+  std::cout << "\033[33;1m" << title << "\033[0m" << std::endl;
+
+  const std::string buildDir =
+#ifdef KOKORO_EXAMPLE_BUILD_PATH
+      KOKORO_EXAMPLE_BUILD_PATH;
+#else
+      "./";
+#endif
+
+  const std::string params0Path =
+      optionValue(argc, argv, "--params0", buildDir + "arg0_predictor.data");
+  const std::string params1Path =
+      optionValue(argc, argv, "--params1", buildDir + "arg0_vocoder.data");
+  const std::string inputIdsPath =
+      optionValue(argc, argv, "--tokens", buildDir + "input_ids.data");
+  const std::string refStylePath =
+      optionValue(argc, argv, "--ref-s", buildDir + "ref_s.data");
+  const std::string outputPath =
+      optionValue(argc, argv, "--output", buildDir + "kokoro_static.wav");
+
+  try {
+    printLogLabel();
+    std::cout << "Example data dir: " << std::filesystem::absolute(buildDir)
+              << std::endl;
+    printLogLabel();
+    std::cout << "Predictor params: " << std::filesystem::absolute(params0Path)
+              << std::endl;
+    printLogLabel();
+    std::cout << "Vocoder params: " << std::filesystem::absolute(params1Path)
+              << std::endl;
+    printLogLabel();
+    std::cout << "Token ids: " << std::filesystem::absolute(inputIdsPath)
+              << std::endl;
+    printLogLabel();
+    std::cout << "Reference style: " << std::filesystem::absolute(refStylePath)
+              << std::endl;
+    printLogLabel();
+    std::cout << "Static shapes: seq=" << KokoroSeqLen
+              << ", align=" << KokoroAlignLen
+              << ", audio_samples=" << KokoroAudioSamples
+              << ", sample_rate=" << KokoroSampleRate << std::endl
+              << std::endl;
+
+    MemRef<float, 1> params0({KokoroPredictorParamsSize});
+    MemRef<float, 1> params1({KokoroVocoderParamsSize});
+    MemRef<long long, 1> rngState({KokoroRngStateSize}, 0LL);
+    MemRef<long long, 2> inputIds({1, KokoroSeqLen}, 0LL);
+    MemRef<float, 2> refStyle({1, KokoroRefStyleSize}, 0.0f);
+
+    timeSection("Load data", [&]() {
+      loadBinary(params0Path, params0);
+      loadBinary(params1Path, params1);
+      fillDefaultRngState(rngState);
+      loadBinary(inputIdsPath, inputIds);
+      loadBinary(refStylePath, refStyle);
+    });
+
+    PredictorReturns predictorRet = {
+        MemRef<long long, 1>({1}, 0LL),
+        MemRef<bool, 2>({1, KokoroSeqLen}, false),
+        MemRef<float, 2>({1, KokoroStyleSize}, 0.0f),
+        MemRef<float, 3>({1, KokoroSeqLen, KokoroDurationHiddenWidth}, 0.0f),
+        MemRef<long long, 1>({KokoroSeqLen}, 1LL),
+        MemRef<long long, 1>({KokoroSeqLen}, 0LL)};
+    MemRef<long long, 1> frameIndices({KokoroAlignLen}, 0LL);
+    MemRef<float, 1> audio({KokoroAudioSamples}, 0.0f);
+
+    const auto start = std::chrono::high_resolution_clock::now();
+    timeSection("Predictor", [&]() {
+      _mlir_ciface_forward_predictor(&predictorRet, &params0, &rngState,
+                                     &inputIds, &refStyle);
+    });
+    const size_t frameCount = buildFrameIndices(predictorRet, frameIndices);
+    printLogLabel();
+    std::cout << "Built duration alignment with " << frameCount
+              << " fixed frames" << std::endl;
+    timeSection("Vocoder", [&]() {
+      _mlir_ciface_forward_vocoder(&audio, &params1, &inputIds, &frameIndices,
+                                   &predictorRet.durationHidden,
+                                   &predictorRet.style, &predictorRet.textMask,
+                                   &refStyle);
+    });
+    printAudioStats(audio);
+    const auto end = std::chrono::high_resolution_clock::now();
+
+    timeSection("Save audio", [&]() { saveWav(outputPath, std::move(audio)); });
+
+    auto elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    std::cout << std::endl;
+    printLogLabel();
+    std::cout << "Kokoro static inference finished in "
+              << elapsed.count() / 1000.0 << "s" << std::endl;
+    printLogLabel();
+    std::cout << "Output wav: " << std::filesystem::absolute(outputPath)
+              << std::endl;
+    printLogLabel();
+    std::cout << "First 8 predicted durations:";
+    for (size_t i = 0; i < std::min<size_t>(8, KokoroSeqLen); ++i)
+      std::cout << " " << predictorRet.predDur.getData()[i];
+    std::cout << std::endl;
+  } catch (const std::exception &e) {
+    std::cerr << "\033[31;1m[Error] \033[0m" << e.what() << "\n";
+    return 1;
+  }
+  return 0;
+}

--- a/examples/BuddyTTSKokoro/import-kokoro.py
+++ b/examples/BuddyTTSKokoro/import-kokoro.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+# ===- import-kokoro.py --------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ===---------------------------------------------------------------------------
+#
+# Fixed-shape Kokoro-82M importer.
+#
+# Kokoro is not exported as one monolithic static graph.  The model predicts a
+# token duration vector and then builds an alignment matrix whose frame width is
+# data dependent.  This importer keeps the neural network portions static and
+# leaves that duration-to-frame expansion to the C++ driver:
+#
+#   forward_predictor/subgraph0_predictor:
+#     input ids + reference style -> duration/style/intermediate tensors
+#
+#   forward_vocoder/subgraph0_vocoder:
+#     fixed frame indices + predictor outputs -> waveform
+#
+# The file names and target structure intentionally follow the prefill/decode
+# layout used by LLM examples, with "predictor" and "vocoder" naming the two
+# static stages of the TTS pipeline.
+#
+# ===---------------------------------------------------------------------------
+
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+
+import numpy
+import torch
+import torch._dynamo.config as dynamo_config
+import torch.nn.functional as F
+from buddy.compiler.frontend import DynamoCompiler
+from buddy.compiler.graph import GraphDriver, OutputOp, PlaceholderOp
+from buddy.compiler.graph.transform import (
+    apply_classic_fusion,
+    eliminate_transpose,
+)
+from buddy.compiler.ops import tosa
+from kokoro import KModel, KPipeline
+from kokoro import modules as kokoro_modules
+from kokoro.model import KModelForONNX
+from torch._inductor.decomposition import decompositions as inductor_decomp
+
+
+def _fixed_length_text_encoder_forward(self, x, input_lengths, m):
+    """Fixed-shape TextEncoder path without packed sequence conversion.
+
+    Kokoro's eager implementation uses sequence packing around the LSTM.  That
+    is a good runtime optimization, but it creates shape/data-dependent graph
+    structure during export.  The example uses a fixed token length, so the
+    packed path can be replaced by the equivalent padded LSTM path.
+    """
+    x = self.embedding(x)
+    x = x.transpose(1, 2)
+    m = m.unsqueeze(1)
+    x.masked_fill_(m, 0.0)
+    for c in self.cnn:
+        x = c(x)
+        x.masked_fill_(m, 0.0)
+    x = x.transpose(1, 2)
+    self.lstm.flatten_parameters()
+    x, _ = self.lstm(x)
+    x = x.transpose(-1, -2)
+    x.masked_fill_(m, 0.0)
+    return x
+
+
+def _fixed_length_duration_encoder_forward(self, x, style, text_lengths, m):
+    """Fixed-shape DurationEncoder path without packed sequence conversion.
+
+    This mirrors the TextEncoder adjustment for the duration predictor.  The
+    LSTM still runs on the same fixed-size tensor, but the graph no longer
+    depends on runtime sequence lengths for pack/unpack operations.
+    """
+    masks = m
+    x = x.permute(2, 0, 1)
+    s = style.expand(x.shape[0], x.shape[1], -1)
+    x = torch.cat([x, s], axis=-1)
+    x.masked_fill_(masks.unsqueeze(-1).transpose(0, 1), 0.0)
+    x = x.transpose(0, 1)
+    x = x.transpose(-1, -2)
+    for block in self.lstms:
+        if isinstance(block, kokoro_modules.AdaLayerNorm):
+            x = block(x.transpose(-1, -2), style).transpose(-1, -2)
+            x = torch.cat([x, s.permute(1, 2, 0)], axis=1)
+            x.masked_fill_(masks.unsqueeze(-1).transpose(-1, -2), 0.0)
+        else:
+            x = x.transpose(-1, -2)
+            block.flatten_parameters()
+            x, _ = block(x)
+            x = F.dropout(x, p=self.dropout, training=False)
+            x = x.transpose(-1, -2)
+    return x.transpose(-1, -2)
+
+
+def _split_return_types(return_types: str):
+    return [item.strip() for item in return_types.split(",")]
+
+
+def _keep_only_final_return(module_text: str, func_name: str):
+    """Keep only the final result of a generated subgraph function.
+
+    The vocoder graph contains decoder-side bookkeeping tensors that are only
+    useful to Dynamo's graph-break boundary.  The C++ example needs the final
+    waveform, so the generated graph is projected down to its last return value
+    before the MLIR is compiled.
+    """
+    func_start = module_text.find(f"func.func @{func_name}")
+    if func_start < 0:
+        raise ValueError(f"failed to find function {func_name}")
+
+    signature_match = re.search(
+        r"\) -> \((.*?)\) \{", module_text[func_start:], re.S
+    )
+    if signature_match is None:
+        raise ValueError(f"failed to find return signature for {func_name}")
+    signature_start = func_start + signature_match.start(1)
+    signature_end = func_start + signature_match.end(1)
+    return_types = _split_return_types(signature_match.group(1))
+    last_return_type = return_types[-1]
+    module_text = (
+        module_text[:signature_start]
+        + last_return_type
+        + module_text[signature_end:]
+    )
+
+    return_matches = list(
+        re.finditer(
+            r"\n    return (.*?) : (.*?)\n", module_text[func_start:], re.S
+        )
+    )
+    if not return_matches:
+        raise ValueError(f"failed to find return op for {func_name}")
+    return_match = return_matches[-1]
+    return_start = func_start + return_match.start()
+    return_end = func_start + return_match.end()
+    return_values = [item.strip() for item in return_match.group(1).split(",")]
+    new_return = f"\n    return {return_values[-1]} : {last_return_type}\n"
+    return module_text[:return_start] + new_return + module_text[return_end:]
+
+
+def _keep_only_final_forward_return(
+    module_text: str, func_name: str, callee_name: str
+):
+    """Project the generated forward wrapper to the final subgraph result.
+
+    GraphDriver builds a forward wrapper around the subgraph function.  When
+    the vocoder subgraph is trimmed to return only the waveform, the wrapper's
+    private declaration, call op, and return op must be rewritten consistently.
+    """
+    decl_start = module_text.find(f"func.func private @{callee_name}")
+    if decl_start < 0:
+        raise ValueError(
+            f"failed to find private declaration for {callee_name}"
+        )
+    decl_match = re.search(r"\) -> \((.*?)\)", module_text[decl_start:], re.S)
+    if decl_match is None:
+        raise ValueError(
+            f"failed to find private declaration returns for {callee_name}"
+        )
+    decl_return_types = _split_return_types(decl_match.group(1))
+    last_return_type = decl_return_types[-1]
+    decl_ret_start = decl_start + decl_match.start(1)
+    decl_ret_end = decl_start + decl_match.end(1)
+    module_text = (
+        module_text[:decl_ret_start]
+        + last_return_type
+        + module_text[decl_ret_end:]
+    )
+
+    call_match = re.search(
+        rf"\n    (%[A-Za-z0-9_]+):(\d+) = call @{re.escape(callee_name)}"
+        rf"\((.*?)\) : \((.*?)\) -> \((.*?)\)\n",
+        module_text,
+        re.S,
+    )
+    if call_match is None:
+        raise ValueError(f"failed to find call to {callee_name}")
+    call_result = call_match.group(1)
+    call_args = call_match.group(3)
+    call_arg_types = call_match.group(4)
+    call_start, call_end = call_match.span()
+    new_call = (
+        f"\n    {call_result} = call @{callee_name}({call_args}) : "
+        f"({call_arg_types}) -> {last_return_type}\n"
+    )
+    module_text = module_text[:call_start] + new_call + module_text[call_end:]
+
+    ret_match = re.search(r"\n    return (.*?) : (.*?)\n", module_text, re.S)
+    if ret_match is None:
+        raise ValueError("failed to find forward return op")
+    ret_start, ret_end = ret_match.span()
+    new_return = f"\n    return {call_result} : {last_return_type}\n"
+    module_text = module_text[:ret_start] + new_return + module_text[ret_end:]
+
+    func_match = re.search(
+        rf"func\.func @{re.escape(func_name)}\(.*?\) -> \((.*?)\) \{{",
+        module_text,
+        re.S,
+    )
+    if func_match is None:
+        raise ValueError(f"failed to find {func_name} signature")
+    sig_start, sig_end = func_match.span(1)
+    return module_text[:sig_start] + last_return_type + module_text[sig_end:]
+
+
+def _write_float_param_pack(output_dir: Path, stage_name: str, params):
+    """Write the float parameter pack consumed by a generated forward graph.
+
+    Buddy's packed-parameter ABI creates one memref per dtype.  Kokoro graph 0
+    also has an int64 pack for deterministic runtime state; that pack is filled
+    by the C++ bridge instead of serialized as another model-weight file.
+    """
+    if not params:
+        return
+
+    float_arrays = []
+    for param in params:
+        array = param.detach().cpu().numpy().reshape([-1])
+        if str(array.dtype) == "float32":
+            float_arrays.append(array)
+
+    if float_arrays:
+        path = output_dir / f"arg0_{stage_name}.data"
+        numpy.concatenate(float_arrays).astype(numpy.float32).tofile(path)
+
+
+def _load_model(model_path: Path):
+    if model_path.is_dir():
+        config_path = model_path / "config.json"
+        model_file = model_path / "kokoro-v1_0.pth"
+        with config_path.open("r", encoding="utf-8") as f:
+            config_dict = json.load(f)
+        config_dict.setdefault("plbert", {})
+        config_dict["plbert"]["_attn_implementation"] = "eager"
+        return KModel(config=config_dict, model=str(model_file)).eval()
+    return KModel(repo_id=str(model_path)).eval()
+
+
+def _default_input_ids(model, phonemes: str, seq_len: int):
+    """Create a fixed-size non-empty token sample for the C++ example.
+
+    Kokoro's token ABI wraps phoneme IDs with leading/trailing 0 tokens.  A
+    zero-filled input is syntactically valid for static import, but it
+    represents empty content and produces an almost silent waveform.  The
+    default phoneme sample is therefore encoded here instead of in the C++
+    runtime.
+    """
+    token_ids = [
+        model.vocab.get(phoneme)
+        for phoneme in phonemes
+        if model.vocab.get(phoneme) is not None
+    ]
+    if not token_ids:
+        raise ValueError(
+            "failed to convert phonemes to Kokoro token ids; pass a phoneme "
+            "string such as 'həlˈoʊ wˈɜɹld', not plain text"
+        )
+    token_ids = [0, *token_ids[: max(0, seq_len - 2)], 0]
+    token_ids.extend([0] * (seq_len - len(token_ids)))
+    return numpy.asarray(token_ids[:seq_len], dtype=numpy.int64).reshape(
+        1, seq_len
+    )
+
+
+def _phonemize_text(text: str, lang_code: str) -> str:
+    """Convert raw text to Kokoro phonemes when local G2P is available."""
+    try:
+        pipeline = KPipeline(lang_code=lang_code, model=False)
+        results = list(pipeline(text, split_pattern=None))
+    except Exception as exc:
+        raise RuntimeError(
+            "failed to phonemize --text with Kokoro's local G2P pipeline. "
+            "Use --phonemes with an already phonemized Kokoro string, or "
+            "install the missing G2P assets such as the spaCy English model."
+        ) from exc
+    phonemes = "".join(result.phonemes for result in results if result.phonemes)
+    if not phonemes:
+        raise ValueError(f"failed to phonemize text: {text!r}")
+    return phonemes
+
+
+def _write_default_inputs(
+    output_dir: Path, model_path: Path, model, phonemes: str, seq_len: int
+):
+    input_ids = _default_input_ids(model, phonemes, seq_len)
+    input_ids.tofile(output_dir / "input_ids.data")
+
+    ref_s = numpy.zeros((1, 256), dtype=numpy.float32)
+    voice_path = model_path / "voices" / "af_heart.pt"
+    if voice_path.exists():
+        voice_pack = torch.load(voice_path, map_location="cpu")
+        if isinstance(voice_pack, torch.Tensor) and voice_pack.numel() >= 256:
+            index = min(seq_len, int(voice_pack.shape[0]) - 1)
+            ref_s = (
+                voice_pack[index]
+                .reshape(1, 256)
+                .detach()
+                .cpu()
+                .numpy()
+                .astype(numpy.float32)
+            )
+    ref_s.tofile(output_dir / "ref_s.data")
+    return input_ids, ref_s
+
+
+def _write_graph_artifacts(
+    graph,
+    stage_name: str,
+    output_dir: Path,
+    compiler,
+    *,
+    keep_only_final_return: bool = False,
+):
+    """Lower one Dynamo graph and save its forward/subgraph MLIR files."""
+    func_name = f"forward_{stage_name}"
+    subgraph_name = f"subgraph0_{stage_name}"
+    graph._func_name = func_name
+    graph.perform([eliminate_transpose])
+    graph.fuse_ops([apply_classic_fusion])
+    _set_single_subgraph_from_body(graph, subgraph_name)
+
+    driver = GraphDriver(graph)
+    for subgraph in driver.subgraphs:
+        subgraph.lower_to_top_level_ir()
+
+    final_subgraph_name = driver.topological_sort_subgraph()[-1]
+    subgraph_files = []
+    for subgraph_name, subgraph in driver._subgraphs.items():
+        subgraph_path = output_dir / f"{subgraph_name}.mlir"
+        subgraph_module = str(subgraph._imported_module)
+        if keep_only_final_return and subgraph_name == final_subgraph_name:
+            subgraph_module = _keep_only_final_return(
+                subgraph_module, subgraph_name
+            )
+        with subgraph_path.open("w", encoding="utf-8") as f:
+            print(subgraph_module, file=f)
+        subgraph_files.append(subgraph_path.name)
+
+    forward_path = output_dir / f"{func_name}.mlir"
+    forward_module = str(driver.construct_main_graph(True))
+    if keep_only_final_return:
+        forward_module = _keep_only_final_forward_return(
+            forward_module, func_name, final_subgraph_name
+        )
+    with forward_path.open("w", encoding="utf-8") as f:
+        print(forward_module, file=f)
+
+    params = compiler.imported_params[graph]
+    _write_float_param_pack(output_dir, stage_name, params)
+    print(f"Saved {stage_name} MLIR to {', '.join(subgraph_files)}")
+
+
+def _remove_stale_outputs(output_dir: Path):
+    patterns = [
+        "arg0_predictor.data",
+        "arg0_vocoder.data",
+        "input_ids.data",
+        "ref_s.data",
+        "forward*.mlir",
+        "subgraph*.mlir",
+    ]
+    for pattern in patterns:
+        for path in output_dir.glob(pattern):
+            if path.is_file():
+                path.unlink()
+
+
+def _graph_body_ops(graph):
+    return [
+        op for op in graph.body if not isinstance(op, (PlaceholderOp, OutputOp))
+    ]
+
+
+def _set_single_subgraph_from_body(graph, name: str):
+    graph.op_groups = {name: _graph_body_ops(graph)}
+    graph.group_map_device = {name: graph.device}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Import fixed-shape Kokoro-82M static pipeline graphs."
+    )
+    parser.add_argument(
+        "--model-path",
+        type=Path,
+        default=Path(os.environ.get("KOKORO_MODEL_PATH", "hexgrad/Kokoro-82M")),
+        help="Local Kokoro-82M directory or HuggingFace repo id.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("./"),
+        help="Directory to save MLIR, parameter data, and generated config.",
+    )
+    parser.add_argument(
+        "--seq-len",
+        type=int,
+        default=int(os.environ.get("KOKORO_STATIC_SEQ_LEN", "16")),
+        help="Fixed phoneme token length.",
+    )
+    parser.add_argument(
+        "--speed",
+        type=float,
+        default=1.0,
+        help="Fixed Kokoro speed scalar used during graph import.",
+    )
+    parser.add_argument(
+        "--phonemes",
+        type=str,
+        default="həlˈoʊ wˈɜɹld",
+        help=(
+            "Fixed Kokoro phoneme string used to generate input_ids.data. "
+            "This is already phonemized text, not raw English."
+        ),
+    )
+    parser.add_argument(
+        "--text",
+        type=str,
+        default=None,
+        help=(
+            "Raw text to phonemize with Kokoro's local G2P before generating "
+            "input_ids.data. Requires local G2P assets."
+        ),
+    )
+    parser.add_argument(
+        "--lang-code",
+        type=str,
+        default="a",
+        help="Kokoro language code used with --text; 'a' is American English.",
+    )
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    _remove_stale_outputs(args.output_dir)
+    dynamo_config.allow_rnn = True
+    torch.backends.mkldnn.enabled = False
+    kokoro_modules.TextEncoder.forward = _fixed_length_text_encoder_forward
+    kokoro_modules.DurationEncoder.forward = (
+        _fixed_length_duration_encoder_forward
+    )
+
+    base_model = _load_model(args.model_path)
+    try:
+        phonemes = (
+            _phonemize_text(args.text, args.lang_code)
+            if args.text is not None
+            else args.phonemes
+        )
+    except Exception as exc:
+        raise SystemExit(f"error: {exc}") from None
+    print(f"Using phonemes: {phonemes}")
+    input_ids_data, ref_s_data = _write_default_inputs(
+        args.output_dir,
+        args.model_path,
+        base_model,
+        phonemes,
+        args.seq_len,
+    )
+    model = KModelForONNX(base_model).eval()
+    for param in model.parameters():
+        param.requires_grad_(False)
+
+    compiler = DynamoCompiler(
+        primary_registry=tosa.ops_registry,
+        aot_autograd_decomposition=inductor_decomp,
+        capture_scalar_outputs=True,
+    )
+
+    input_ids = torch.from_numpy(input_ids_data.copy())
+    ref_s = torch.from_numpy(ref_s_data.copy())
+
+    with torch.no_grad():
+        graphs = compiler.importer(
+            model,
+            input_ids=input_ids,
+            ref_s=ref_s,
+            speed=args.speed,
+        )
+
+    if len(graphs) != 2:
+        raise RuntimeError(
+            "The fixed-shape Kokoro example expects exactly 2 Dynamo graphs "
+            f"(one graph break), but imported {len(graphs)} graph(s). "
+            "Check the fixed-length TextEncoder/DurationEncoder patches and "
+            "TorchDynamo graph-break logs."
+        )
+
+    graph_stages = ["predictor", "vocoder"]
+    for index, graph in enumerate(graphs):
+        _write_graph_artifacts(
+            graph,
+            graph_stages[index],
+            args.output_dir,
+            compiler,
+            keep_only_final_return=(index == 1),
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -52,6 +52,10 @@ if (BUDDY_YOLO26_EXAMPLES)
   add_subdirectory(BuddyYOLO26)
 endif()
 
+if (BUDDY_TTS_KOKORO_EXAMPLES)
+  add_subdirectory(BuddyTTSKokoro)
+endif()
+
 if (BUDDY_STABLE_DIFFUSION_EXAMPLES)
   add_subdirectory(BuddyStableDiffusion)
 endif()

--- a/examples/lit.cfg.py
+++ b/examples/lit.cfg.py
@@ -41,6 +41,7 @@ config.excludes = [
     "BuddyStableDiffusion",
     "BuddyDeepSeekR1",
     "BuddyQwen3",
+    "BuddyTTSKokoro",
     "BuddyTensorParallel",
     "BuddyTransformer",
     "BuddyYOLO26",

--- a/frontend/Python/frontend.py
+++ b/frontend/Python/frontend.py
@@ -28,6 +28,7 @@ import ctypes.util
 import operator
 import os
 import platform
+import re
 from typing import Any
 
 import numpy as np
@@ -131,6 +132,7 @@ class DynamoCompiler:
             "unsqueeze.default": UnsqueezeOp,
             "view.default": ViewOp,
             "view.dtype": ViewDtypeOp,
+            "_unsafe_view.default": ViewOp,
             "ones.default": OnesOp,
             "full.default": FullOp,
             "embedding.default": EmbeddingOp,
@@ -366,6 +368,7 @@ class DynamoCompiler:
             "isinf.default": IsInfOp,
             "isnan.default": IsNanOp,
             "floor_divide.default": FloorDivideOp,
+            "floordiv": FloorDivideOp,
             "fmod.Tensor": FmodOp,
             "fmod.Scalar": FmodOp,
             "remainder.Tensor": RemainderOp,
@@ -721,6 +724,8 @@ class DynamoCompiler:
         if isinstance(value, torch.Tensor):
             node_dtype = self._torch_dtype_translate(str(value.dtype))
             return value.shape, node_dtype
+        if isinstance(value, (list, tuple)) and len(value) == 1:
+            return self._infer_meta_from_value(value[0])
         if isinstance(value, np.generic):
             value = value.item()
         if isinstance(value, (torch.SymInt, int)):
@@ -730,6 +735,203 @@ class DynamoCompiler:
         if isinstance(value, (torch.SymBool, bool)):
             return [], TensorDType.Bool
         return None
+
+    @staticmethod
+    def _parse_numeric_literal_from_stack_trace(stack_trace):
+        """
+        Extract a numeric literal that is visible in the traced Python source.
+
+        AOTAutograd may lift source-level constants such as `torch.tensor(2)`
+        or `some_tensor[...] = 0` into `_tensor_constant` nodes.  If the source
+        line carries an explicit numeric literal, preserve that value instead
+        of trusting a symbolic FakeTensor scalar.  Return None when the stack
+        trace does not contain a literal this importer can prove.
+
+        This is intentionally source-pattern based: it only accepts literals
+        that are written directly in the Python line recorded by FX.  Values
+        computed from inputs, tensor sizes, or module state must not be guessed
+        here because that would hide a real dynamic dependency.
+        """
+        if not stack_trace:
+            return None
+
+        number = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)"
+        tensor_match = re.search(
+            rf"torch\.tensor\(\s*({number})(?![\w.])",
+            stack_trace,
+        )
+        if tensor_match:
+            literal = tensor_match.group(1)
+            return float(literal) if "." in literal else int(literal)
+
+        stack_lines = [
+            line.strip() for line in stack_trace.splitlines() if line.strip()
+        ]
+        if not stack_lines:
+            return None
+
+        assignment_match = re.search(
+            rf"=\s*({number})\s*$",
+            stack_lines[-1],
+        )
+        if assignment_match:
+            literal = assignment_match.group(1)
+            return float(literal) if "." in literal else int(literal)
+
+        return None
+
+    @staticmethod
+    def _parse_numeric_range_from_stack_trace(stack_trace, shape):
+        """
+        Recover a small integer range constant from a lifted tensor constant.
+
+        Some model code builds tensor constants from Python `range(...)`.  During
+        tracing, individual elements may appear as symbolic scalar values even
+        though the tensor length is fixed.  This helper only handles the explicit
+        `range(1, self.<field> + 2)` pattern and uses the traced tensor shape to
+        materialize `[1, 2, ..., N]`.  Return None for anything less explicit so
+        later lowering can reject unresolved symbolic elements.
+
+        The helper does not read `self.<field>` from the original module.  The
+        traced shape is the authority for N, and the source pattern is only a
+        proof that the tensor contents are the simple integer sequence
+        `[1, 2, ..., N]`.
+        """
+        if not stack_trace or not shape:
+            return None
+
+        range_match = re.search(
+            r"range\(\s*1\s*,\s*self\.\w+\s*\+\s*2\s*\)", stack_trace
+        )
+        if range_match is None:
+            return None
+
+        try:
+            length = int(shape[-1])
+        except Exception:
+            return None
+
+        values = list(range(1, length + 1))
+        for dim in reversed(list(shape)[:-1]):
+            try:
+                dim = int(dim)
+            except Exception:
+                return None
+            if dim != 1:
+                return None
+            values = [values]
+        return values
+
+    @staticmethod
+    def _try_resolve_symbolic_scalar(value):
+        """
+        Resolve a PyTorch SymInt/SymFloat scalar when PyTorch has a static hint.
+
+        Returns a Python int/float if PyTorch can provide a hint, otherwise
+        None.  Callers decide whether unresolved symbolic values are legal.
+
+        This method is the only place where symbolic scalar metadata is
+        converted to a Python value.  If PyTorch has not attached a concrete
+        hint, the importer treats the value as genuinely dynamic.
+        """
+        try:
+            from torch.fx.experimental import symbolic_shapes as _sym
+
+            if "Float" in str(type(value)):
+                hint = getattr(value.node, "hint", None)
+                if hint is not None:
+                    return float(hint)
+                return float(_sym.size_hint(value))
+
+            try:
+                return int(_sym.hint_int(value))
+            except Exception:
+                hint = getattr(value.node, "hint", None)
+                if hint is not None:
+                    return int(hint)
+                raise
+        except Exception:
+            return None
+
+    def _resolve_tensor_constant_value(self, gm_node):
+        """
+        Resolve the Python value carried by an FX `_tensor_constant` node.
+
+        Resolution order:
+        1. explicit numeric literal in the traced source line;
+        2. scalar tensor value, including SymInt/SymFloat with static hints;
+        3. explicit Python range tensor rebuilt from source + traced shape;
+        4. concrete non-scalar tensor/list value.
+
+        The method deliberately does not invent fallback values.  If a symbolic
+        scalar cannot be proven static, it raises so the unsupported dynamic
+        value remains visible to the caller.
+
+        `_tensor_constant` is a special FX `get_attr` produced for constants
+        lifted out of Python code.  Buddy's tensor constant lowering expects the
+        literal value in the node arguments, so this method centralizes the
+        small set of legal ways to recover that value.
+        """
+        val = gm_node.meta.get("val")
+        stack_trace = gm_node.meta.get("stack_trace") or ""
+
+        # Some libraries write constants as torch.tensor(...) or assignment
+        # literals inside forward.  AOTAutograd can lift those into
+        # _tensor_constant nodes whose runtime value is symbolic, even though
+        # the source literal is static.  Prefer that explicit source literal.
+        value = self._parse_numeric_literal_from_stack_trace(stack_trace)
+        if value is not None:
+            return value
+
+        if isinstance(val, torch.Tensor):
+            if val.numel() == 1:
+                value = val.item()
+                if hasattr(value, "node") and hasattr(value.node, "expr"):
+                    resolved = self._try_resolve_symbolic_scalar(value)
+                    if resolved is None:
+                        raise RuntimeError(
+                            f"Symbolic _tensor_constant '{gm_node.name}' cannot be "
+                            f"resolved statically (value={value})."
+                        )
+                    return resolved
+                return value
+
+            # Recover explicit Python range constants when the traced shape
+            # fixes their size; otherwise keep the real tensor/list value and
+            # let lowering reject unresolved symbolic elements.
+            value = self._parse_numeric_range_from_stack_trace(
+                stack_trace, list(val.shape)
+            )
+            if value is not None:
+                return value
+            return val.detach().cpu().tolist()
+
+        if isinstance(val, (int, float)):
+            return val
+
+        raise NotImplementedError("Unsupported _tensor_constant format")
+
+    def _resolve_tensor_constant_meta(self, gm_node):
+        """
+        Return Buddy tensor metadata for an FX `_tensor_constant` node.
+
+        Prefer the actual tensor value metadata when present; otherwise use FX
+        `tensor_meta`.  Missing metadata is an importer error because lowering
+        needs a ranked tensor type for constants.
+        """
+        val = gm_node.meta.get("val")
+        if isinstance(val, torch.Tensor):
+            return list(val.shape), self._torch_dtype_translate(str(val.dtype))
+
+        tensor_meta = gm_node.meta.get("tensor_meta")
+        if tensor_meta is None:
+            raise RuntimeError(
+                f"Missing tensor metadata for _tensor_constant '{gm_node.name}'"
+            )
+        return (
+            list(tensor_meta.shape),
+            self._torch_dtype_translate(str(tensor_meta.dtype)),
+        )
 
     def _resolve_call_function_node_name(self, target):
         """Map Python call_function targets to Buddy op names."""
@@ -949,15 +1151,18 @@ class DynamoCompiler:
                         ):
                             continue
                     if gm_node.op == "placeholder":
-                        node_dtype = self._torch_dtype_translate(
-                            str(gm_node.meta["tensor_meta"].dtype)
+                        tensor_meta = gm_node.meta.get("tensor_meta")
+                        shape, node_dtype = self._resolve_single_output_meta(
+                            gm_node,
+                            tensor_meta,
+                            schema=None,
                         )
                         buddy_node = self._create_node(
                             gm_node.op,
                             gm_node.name,
                             gm_node.args,
                             node_users,
-                            gm_node.meta["tensor_meta"].shape,
+                            shape,
                             node_dtype,
                         )
 
@@ -980,36 +1185,15 @@ class DynamoCompiler:
                         )
                     elif gm_node.op == "get_attr":
                         if "_tensor_constant" in gm_node.name:
-                            import re
-
-                            stack_trace = gm_node.meta.get("stack_trace") or ""
-                            match = re.search(
-                                r"torch\.tensor\(([-+]?\d+(\.\d+)?), dtype=[a-zA-Z]+\)",
-                                stack_trace,
-                            )
-                            value = None
-                            if match:
-                                value = float(match.group(1))
-                            if value is None:
-                                val = gm_node.meta.get("val")
-                                if isinstance(val, torch.Tensor):
-                                    if val.numel() != 1:
-                                        raise NotImplementedError(
-                                            "_tensor_constant only supports scalar tensors"
-                                        )
-                                    value = val.item()
-                                elif isinstance(val, (int, float)):
-                                    value = val
-                            if value is None:
-                                raise NotImplementedError(
-                                    "Unsupported _tensor_constant format"
-                                )
-
+                            # AOTAutograd exposes lifted Python constants as
+                            # get_attr nodes named `_tensor_constantN`.  They
+                            # are not parameters or buffers, so convert them to
+                            # Buddy TensorConstantOp nodes and insert the
+                            # resolved literal as an explicit argument.
+                            value = self._resolve_tensor_constant_value(gm_node)
                             gm_node.insert_arg(len(gm_node.args), value)
-                            val = gm_node.meta.get("val")
-                            node_shape = val.shape
-                            node_dtype = self._torch_dtype_translate(
-                                str(val.dtype)
+                            node_shape, node_dtype = (
+                                self._resolve_tensor_constant_meta(gm_node)
                             )
                             buddy_node = self._create_node(
                                 "_tensor_constant",

--- a/frontend/Python/graph/graph.py
+++ b/frontend/Python/graph/graph.py
@@ -811,7 +811,11 @@ class GraphImporter:
                 for node in self._body:
                     if node in extern_func:
                         continue
-                    old_ops = [op for op in func_op.body.blocks[0].operations]
+                    old_ops = (
+                        [op for op in func_op.body.blocks[0].operations]
+                        if self._verbose
+                        else None
+                    )
                     if isinstance(node, OutputOp):
                         output_node_args = node.args
                         returns = [
@@ -829,8 +833,10 @@ class GraphImporter:
                         )
                     else:
                         self._import_op(node)
-                    new_ops = [op for op in func_op.body.blocks[0].operations]
                     if self._verbose:
+                        new_ops = [
+                            op for op in func_op.body.blocks[0].operations
+                        ]
                         print("=" * 20 + "Graph Node" + "=" * 20)
                         print("Node: " + node.name)
                         print("Type: " + str(node._op_type))

--- a/frontend/Python/graph/graph_driver.py
+++ b/frontend/Python/graph/graph_driver.py
@@ -20,11 +20,12 @@
 #
 # ===---------------------------------------------------------------------------
 
-from buddy_mlir import ir
-from collections import deque, defaultdict
+from collections import deque
 
-from .graph import Graph, GraphImporter, TensorMeta, NodeType
-from .operation import FuncOp, CallOp, PlaceholderOp, OutputOp, GetItemOp
+from buddy_mlir import ir
+
+from .graph import Graph, GraphImporter, NodeType, TensorMeta
+from .operation import CallOp, FuncOp, GetItemOp, OutputOp, PlaceholderOp
 
 
 class GraphDriver:
@@ -68,6 +69,44 @@ class GraphDriver:
     @property
     def subgraphs(self):
         return list(self._subgraphs.values())
+
+    @staticmethod
+    def _normalize_subgraph_input_meta(node):
+        """Return TensorMeta for one tensor crossing a subgraph boundary.
+
+        CallOp metadata stores all returned shapes/dtypes as lists.  When a
+        boundary input is a GetItemOp, use the getitem index to recover the
+        concrete tensor metadata.  If multi-result metadata reaches this point
+        without an index, fail explicitly instead of silently selecting the
+        first result.
+        """
+        node_shape = node.tensor_meta["shape"]
+        node_dtype = node.tensor_meta["dtype"]
+
+        if node_shape and isinstance(node_shape[0], (list, tuple)):
+            result_index = None
+            if isinstance(node, GetItemOp) and len(node.args) > 1:
+                result_index = int(node.args[1])
+            elif len(node_shape) == 1:
+                result_index = 0
+
+            if result_index is None:
+                raise ValueError(
+                    "subgraph input has multi-result tensor metadata but no "
+                    "GetItemOp index"
+                )
+            node_shape = node_shape[result_index]
+            if isinstance(node_dtype, (list, tuple)):
+                node_dtype = node_dtype[result_index]
+        elif isinstance(node_dtype, (list, tuple)):
+            if len(node_dtype) != 1:
+                raise ValueError(
+                    "subgraph input has multi-result dtype metadata but "
+                    "single-result shape metadata"
+                )
+            node_dtype = node_dtype[0]
+
+        return TensorMeta(list(node_shape), node_dtype)
 
     def build_subgraph_by_group(self):
         """
@@ -133,9 +172,7 @@ class GraphDriver:
             # Construct input placeholder nodes
             for inp in subgraphs_inputs[subgraph_name]:
                 node = self._graph.node_table[inp]
-                node_shape = node.tensor_meta["shape"]
-                node_dtype = node.tensor_meta["dtype"]
-                input_tensor_meta = TensorMeta(node_shape, node_dtype)
+                input_tensor_meta = self._normalize_subgraph_input_meta(node)
                 subgraph_input.append(input_tensor_meta)
                 placeholder_node = PlaceholderOp()
                 placeholder_node.name = inp
@@ -173,9 +210,7 @@ class GraphDriver:
         - list: A list of subgraph names in topological order if the graph is acyclic; otherwise, None.
         """
         # Calculate in degree of each subgraph
-        in_degree = {
-            subgraph_name: 0 for subgraph_name in list(self._subgraphs.keys())
-        }
+        in_degree = dict.fromkeys(list(self._subgraphs.keys()), 0)
         for src, dests in self._subgraph_dependencies.items():
             for dest in dests:
                 in_degree[dest] += 1
@@ -248,7 +283,7 @@ class GraphDriver:
         # Adding CallOp to invoke the single subgraph
         for i, subgraph_name in enumerate(topo_order):
             call_node = CallOp()
-            call_node.name = "call{}".format(i)
+            call_node.name = f"call{i}"
             call_node.call_func_name = subgraph_name
             call_node.tensor_meta = {"shape": [], "dtype": []}
             for inp in self._subgraphs_inputs[subgraph_name]:
@@ -277,7 +312,7 @@ class GraphDriver:
             getitem_node = GetItemOp()
             getitem_node.add_argument(call_node.name)
             getitem_node.add_argument(i)
-            getitem_node.name = "getitem{}".format(i)
+            getitem_node.name = f"getitem{i}"
             output_node.add_argument(getitem_node.name)
             main_graph.add_node(getitem_node)
         # Marking the final output of the main graph

--- a/frontend/Python/graph/operation.py
+++ b/frontend/Python/graph/operation.py
@@ -159,6 +159,16 @@ class Op:
 
     @tensor_meta.setter
     def tensor_meta(self, new_tensor_meta):
+        # GraphDriver passes TensorMeta objects when synthesizing placeholder
+        # nodes for partitioned graphs.  Store metadata in the dict layout used
+        # by existing Op users.
+        if hasattr(new_tensor_meta, "shape") and hasattr(
+            new_tensor_meta, "dtype"
+        ):
+            new_tensor_meta = {
+                "shape": new_tensor_meta.shape,
+                "dtype": new_tensor_meta.dtype,
+            }
         self._tensor_meta.update(new_tensor_meta)
 
 

--- a/frontend/Python/ops/linalg.py
+++ b/frontend/Python/ops/linalg.py
@@ -23,6 +23,7 @@ import copy
 
 import buddy_mlir.ir as ir
 import numpy
+import torch
 from buddy_mlir.dialects import (
     arith,
     bufferization,
@@ -2572,7 +2573,18 @@ def where_op(
     input3 = symbol_table.get((str(node.args[2]), 0))
     if input1 is None or input2 is None or input3 is None:
         return
-    output_shape = list(node.tensor_meta["shape"])
+    # FX metadata may carry SymInt-like dimensions here.  Keep already-lowered
+    # MLIR values, convert concrete dimensions to int, and mark anything still
+    # unresolved as dynamic so ranked tensor construction remains explicit.
+    output_shape = []
+    for dim in list(node.tensor_meta["shape"]):
+        if isinstance(dim, ir.Value):
+            output_shape.append(dim)
+        else:
+            try:
+                output_shape.append(int(dim))
+            except Exception:
+                output_shape.append(ir.ShapedType.get_dynamic_size())
     dtype = node.tensor_meta["dtype"]
     mlir_dtype = mlir_element_type_get(dtype)
     tensor_type = ir.RankedTensorType.get(output_shape, mlir_dtype)
@@ -4775,26 +4787,110 @@ def tensor_constant_op(
     symbol_table: dict[tuple[str, int], ir.Operation],
 ):
     """
-    Converts a Buddy Constant0Op operation to an MLIR arith.ConstantOp.
+    Convert a Buddy TensorConstantOp to an MLIR arith.ConstantOp.
 
-    This operation creates a constant tensor filled with zeros. It constructs a ranked tensor
-    of the specified shape and data type, generates a zero-valued element attribute, and
-    initializes the entire tensor with this value using a splat attribute.
+    The frontend inserts the literal Python value as node.args[0] for lifted
+    FX `_tensor_constant` nodes. Scalar values lower to splat attributes;
+    list/array values lower to dense attributes with the exact traced shape.
+    Symbolic elements must resolve to concrete Python values before this point.
+    This lowering deliberately raises on unresolved SymInt/SymFloat instead of
+    inventing a default value, because changing a constant silently would alter
+    model semantics.
 
     Parameters:
-        node (Constant0Op): The Buddy Constant0Op node containing the tensor shape and data type metadata.
+        node (TensorConstantOp): The Buddy node containing tensor metadata and
+            a concrete constant value in node.args[0].
         symbol_table (dict): A dictionary mapping tensor names to their corresponding MLIR operations.
 
     Returns:
-        op: An MLIR arith.ConstantOp representing a tensor filled with zeros.
+        op: An MLIR arith.ConstantOp representing the constant tensor.
     """
     dtype = node.tensor_meta["dtype"]
     mlir_dtype = mlir_element_type_get(dtype)
     output_shape = list(node.tensor_meta["shape"])
     tensor_type = ir.RankedTensorType.get(output_shape, mlir_dtype)
     value = node.args[0]
-    element = mlir_element_attr_get(dtype, value)
-    attr = ir.DenseElementsAttr.get_splat(tensor_type, element)
+
+    dtype_str = str(dtype).lower()
+    if "." in dtype_str:
+        dtype_str = dtype_str.split(".")[-1]
+
+    _DTYPE_MAP = {
+        "float32": numpy.float32,
+        "float64": numpy.float64,
+        "float16": numpy.float16,
+        "bfloat16": numpy.float32,
+        "complex64": numpy.complex64,
+        "complex128": numpy.complex128,
+        "int8": numpy.int8,
+        "int16": numpy.int16,
+        "int32": numpy.int32,
+        "int64": numpy.int64,
+        "uint8": numpy.uint8,
+        "bool": numpy.bool_,
+    }
+    np_dtype = _DTYPE_MAP.get(dtype_str, numpy.float32)
+
+    def _resolve_symints(v):
+        """Recursively convert resolvable symbolic scalar elements."""
+        if isinstance(v, (list, tuple)):
+            return [_resolve_symints(x) for x in v]
+        if isinstance(v, torch.SymFloat):
+            try:
+                return float(v)
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Unresolved SymFloat in linalg.tensor_constant_op: {v}"
+                ) from exc
+        if isinstance(v, torch.SymInt):
+            try:
+                return int(v)
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Unresolved SymInt in linalg.tensor_constant_op: {v}"
+                ) from exc
+        return v
+
+    value = _resolve_symints(value)
+
+    if dtype in (TensorDType.Complex64, TensorDType.Complex128):
+        # Complex splats require a dense array path because the generic scalar
+        # attribute helper only covers real numeric attributes.
+        np_dtype = (
+            numpy.complex64
+            if dtype == TensorDType.Complex64
+            else numpy.complex128
+        )
+        np_array = numpy.full(
+            tuple(output_shape),
+            complex(value),
+            dtype=np_dtype,
+        )
+        attr = ir.DenseElementsAttr.get(np_array, type=tensor_type)
+    elif isinstance(value, (int, float)):
+        element = mlir_element_attr_get(dtype, value)
+        attr = ir.DenseElementsAttr.get_splat(tensor_type, element)
+    else:
+        # Non-scalar constants must match the traced tensor type exactly. A
+        # reshape is allowed only when it preserves the explicit element list.
+        np_array = numpy.array(value, dtype=np_dtype)
+        expected_shape = tuple(output_shape)
+        if np_array.shape != expected_shape:
+            try:
+                np_array = np_array.reshape(expected_shape)
+            except ValueError as exc:
+                raise RuntimeError(
+                    f"Cannot reshape tensor constant with shape {np_array.shape} to expected "
+                    f"shape {expected_shape} in linalg.tensor_constant_op."
+                ) from exc
+        np_array = numpy.ascontiguousarray(np_array, dtype=np_dtype)
+
+        if dtype_str == "bfloat16":
+            raw = numpy.ascontiguousarray(np_array.astype(numpy.float32))
+            attr = ir.DenseElementsAttr.get(raw.tobytes(), type=tensor_type)
+        else:
+            attr = ir.DenseElementsAttr.get(np_array, type=tensor_type)
+
     op = arith.ConstantOp(tensor_type, attr)
     return op
 

--- a/frontend/Python/ops/tosa.py
+++ b/frontend/Python/ops/tosa.py
@@ -390,7 +390,7 @@ def _is_complex_scalar(value) -> bool:
 
 
 def _complex_scalar_to_tensor(
-    scalar: complex, complex_type: ir.Type, shape: List[int]
+    scalar: complex, complex_type: ir.Type, shape: list[int]
 ):
     """Create a splat tensor for a scalar complex value."""
     scalar = complex(scalar)
@@ -438,6 +438,214 @@ def _promote_real_tensor_to_complex(value: ir.Value, complex_type: ir.Type):
     cval = complex_dialect.CreateOp(complex_type, block.arguments[0], zero)
     block.append(cval)
     block.append(linalg.YieldOp([cval.result]))
+    return op.result
+
+
+def _is_complex_element_type(element_type: ir.Type) -> bool:
+    """Return whether an MLIR tensor element type is complex."""
+    return ir.ComplexType.isinstance(element_type)
+
+
+def _transpose_with_linalg(
+    input_tensor: ir.Value, perm: Sequence[int], output_shape: Sequence[int]
+) -> ir.Value:
+    """Transpose a tensor through linalg.generic for element types TOSA lacks.
+
+    TOSA transpose is not accepted for complex tensors in the current lowering
+    pipeline.  The linalg form uses output indices to extract the corresponding
+    input element, preserving the same permutation semantics while keeping the
+    operation legal for complex element types.
+    """
+    input_type = ir.RankedTensorType(input_tensor.type)
+    element_type = input_type.element_type
+    output_shape = [int(dim) for dim in output_shape]
+    result_type = ir.RankedTensorType.get(output_shape, element_type)
+    output = tensor.EmptyOp(output_shape, element_type)
+    rank = len(output_shape)
+    identity = ir.AffineMap.get_permutation(list(range(rank)))
+    op = linalg.GenericOp(
+        [result_type],
+        [],
+        [output],
+        ir.ArrayAttr.get([ir.AffineMapAttr.get(identity)]),
+        ir.ArrayAttr.get(
+            [ir.Attribute.parse("#linalg.iterator_type<parallel>")] * rank
+        ),
+    )
+    block = ir.Block.create_at_start(op.region, [element_type])
+
+    out_indices = []
+    for dim in range(rank):
+        idx = linalg.IndexOp(ir._i64Attr(dim, None))
+        block.append(idx)
+        out_indices.append(idx.result)
+
+    in_indices = [None] * rank
+    for out_dim, in_dim in enumerate(perm):
+        in_indices[int(in_dim)] = out_indices[out_dim]
+
+    value = tensor.ExtractOp(input_tensor, in_indices)
+    block.append(value)
+    block.append(linalg.YieldOp([value.result]))
+    return op.result
+
+
+def _transpose_or_linalg(
+    input_tensor: ir.Value, perm: Sequence[int], output_shape: Sequence[int]
+) -> ir.Value:
+    """Dispatch transpose lowering by element type.
+
+    Real tensors keep the existing TOSA lowering.  Complex tensors are routed
+    to linalg because the subsequent TOSA-to-linalg path does not handle
+    complex transpose directly.
+    """
+    element_type = ir.RankedTensorType(input_tensor.type).element_type
+    if _is_complex_element_type(element_type):
+        return _transpose_with_linalg(input_tensor, perm, output_shape)
+
+    result_type = ir.RankedTensorType.get(list(output_shape), element_type)
+    return tosa.TransposeOp(
+        result_type, input_tensor, _create_permutation_attr(perm)
+    ).result
+
+
+def _complex_binary_linalg(
+    lhs: ir.Value,
+    rhs: ir.Value,
+    output_shape: Sequence[int],
+    output_element_type: ir.Type,
+    op_name: str,
+) -> ir.Value:
+    """Lower elementwise complex add/sub/mul with scalar linalg arithmetic."""
+    output_shape = [int(dim) for dim in output_shape]
+    result_type = ir.RankedTensorType.get(output_shape, output_element_type)
+    output = tensor.EmptyOp(output_shape, output_element_type)
+    rank = len(output_shape)
+    identity = ir.AffineMap.get_permutation(list(range(rank)))
+    op = linalg.GenericOp(
+        [result_type],
+        [lhs, rhs],
+        [output],
+        ir.ArrayAttr.get(
+            [
+                ir.AffineMapAttr.get(identity),
+                ir.AffineMapAttr.get(identity),
+                ir.AffineMapAttr.get(identity),
+            ]
+        ),
+        ir.ArrayAttr.get(
+            [ir.Attribute.parse("#linalg.iterator_type<parallel>")] * rank
+        ),
+    )
+    block = ir.Block.create_at_start(
+        op.region,
+        [output_element_type, output_element_type, output_element_type],
+    )
+
+    lhs_re = complex_dialect.ReOp(block.arguments[0])
+    lhs_im = complex_dialect.ImOp(block.arguments[0])
+    rhs_re = complex_dialect.ReOp(block.arguments[1])
+    rhs_im = complex_dialect.ImOp(block.arguments[1])
+    block.append(lhs_re)
+    block.append(lhs_im)
+    block.append(rhs_re)
+    block.append(rhs_im)
+
+    if op_name == "mul":
+        ac = arith.MulFOp(lhs_re.result, rhs_re.result)
+        bd = arith.MulFOp(lhs_im.result, rhs_im.result)
+        ad = arith.MulFOp(lhs_re.result, rhs_im.result)
+        bc = arith.MulFOp(lhs_im.result, rhs_re.result)
+        real = arith.SubFOp(ac.result, bd.result)
+        imag = arith.AddFOp(ad.result, bc.result)
+        for scalar_op in (ac, bd, ad, bc, real, imag):
+            block.append(scalar_op)
+    elif op_name == "add":
+        real = arith.AddFOp(lhs_re.result, rhs_re.result)
+        imag = arith.AddFOp(lhs_im.result, rhs_im.result)
+        block.append(real)
+        block.append(imag)
+    elif op_name == "sub":
+        real = arith.SubFOp(lhs_re.result, rhs_re.result)
+        imag = arith.SubFOp(lhs_im.result, rhs_im.result)
+        block.append(real)
+        block.append(imag)
+    else:
+        raise NotImplementedError(f"Unsupported complex binary op: {op_name}")
+
+    value = complex_dialect.CreateOp(
+        output_element_type, real.result, imag.result
+    )
+    block.append(value)
+    block.append(linalg.YieldOp([value.result]))
+    return op.result
+
+
+def _to_complex_operand(
+    operand,
+    complex_type: ir.Type,
+    fallback_shape: Sequence[int],
+) -> ir.Value:
+    """Convert scalar or real tensor operands to complex tensor operands."""
+    fallback_shape = [int(dim) for dim in fallback_shape]
+    if isinstance(operand, ir.Value):
+        elem_ty = ir.RankedTensorType(operand.type).element_type
+        if ir.ComplexType.isinstance(elem_ty):
+            return operand
+        return _promote_real_tensor_to_complex(operand, complex_type)
+    if isinstance(operand, (int, float)) or _is_complex_scalar(operand):
+        return _complex_scalar_to_tensor(operand, complex_type, fallback_shape)
+    raise ValueError(f"Unsupported complex operand type: {type(operand)}")
+
+
+def _complex_exp_linalg(
+    input_tensor: ir.Value, output_shape: Sequence[int]
+) -> ir.Value:
+    """Lower complex exp with Euler's formula in a linalg.generic region."""
+    input_type = ir.RankedTensorType(input_tensor.type)
+    complex_type = input_type.element_type
+    output_shape = [int(dim) for dim in output_shape]
+    result_type = ir.RankedTensorType.get(output_shape, complex_type)
+    output = tensor.EmptyOp(output_shape, complex_type)
+    rank = len(output_shape)
+    identity = ir.AffineMap.get_permutation(list(range(rank)))
+    op = linalg.GenericOp(
+        [result_type],
+        [input_tensor],
+        [output],
+        ir.ArrayAttr.get(
+            [
+                ir.AffineMapAttr.get(identity),
+                ir.AffineMapAttr.get(identity),
+            ]
+        ),
+        ir.ArrayAttr.get(
+            [ir.Attribute.parse("#linalg.iterator_type<parallel>")] * rank
+        ),
+    )
+    block = ir.Block.create_at_start(op.region, [complex_type, complex_type])
+    real = complex_dialect.ReOp(block.arguments[0])
+    imag = complex_dialect.ImOp(block.arguments[0])
+    exp_real = math.ExpOp(real.result)
+    cos_imag = math.CosOp(imag.result)
+    sin_imag = math.SinOp(imag.result)
+    result_real = arith.MulFOp(exp_real.result, cos_imag.result)
+    result_imag = arith.MulFOp(exp_real.result, sin_imag.result)
+    result = complex_dialect.CreateOp(
+        complex_type, result_real.result, result_imag.result
+    )
+    for scalar_op in (
+        real,
+        imag,
+        exp_real,
+        cos_imag,
+        sin_imag,
+        result_real,
+        result_imag,
+        result,
+    ):
+        block.append(scalar_op)
+    block.append(linalg.YieldOp([result.result]))
     return op.result
 
 
@@ -804,6 +1012,25 @@ def add_op(node: AddOp, symbol_table):
     input2 = symbol_table.get((str(node.args[1]), 0), node.args[1])
     dtype = node.tensor_meta["dtype"]
     mlir_dtype = mlir_element_type_get(dtype)
+    if ir.ComplexType.isinstance(mlir_dtype):
+        output_shape = list(node.tensor_meta["shape"])
+        shape1 = (
+            list(ir.RankedTensorType(input1.type).shape)
+            if isinstance(input1, ir.Value)
+            else None
+        )
+        shape2 = (
+            list(ir.RankedTensorType(input2.type).shape)
+            if isinstance(input2, ir.Value)
+            else None
+        )
+        ref_shape = shape1 or shape2 or output_shape
+        input1 = _to_complex_operand(input1, mlir_dtype, shape2 or ref_shape)
+        input2 = _to_complex_operand(input2, mlir_dtype, shape1 or ref_shape)
+        return _complex_binary_linalg(
+            input1, input2, output_shape, mlir_dtype, "add"
+        )
+
     if isinstance(node.args[0], str) and isinstance(node.args[1], str):
         input1_dtype = ir.RankedTensorType(input1.type).element_type
         input2_dtype = ir.RankedTensorType(input2.type).element_type
@@ -835,6 +1062,25 @@ def sub_op(node: SubOp, symbol_table):
     input2 = symbol_table.get((str(node.args[1]), 0), node.args[1])
     dtype = node.tensor_meta["dtype"]
     mlir_dtype = mlir_element_type_get(dtype)
+    if ir.ComplexType.isinstance(mlir_dtype):
+        output_shape = list(node.tensor_meta["shape"])
+        shape1 = (
+            list(ir.RankedTensorType(input1.type).shape)
+            if isinstance(input1, ir.Value)
+            else None
+        )
+        shape2 = (
+            list(ir.RankedTensorType(input2.type).shape)
+            if isinstance(input2, ir.Value)
+            else None
+        )
+        ref_shape = shape1 or shape2 or output_shape
+        input1 = _to_complex_operand(input1, mlir_dtype, shape2 or ref_shape)
+        input2 = _to_complex_operand(input2, mlir_dtype, shape1 or ref_shape)
+        return _complex_binary_linalg(
+            input1, input2, output_shape, mlir_dtype, "sub"
+        )
+
     if isinstance(node.args[0], str) and isinstance(node.args[1], str):
         input1_dtype = ir.RankedTensorType(input1.type).element_type
         input2_dtype = ir.RankedTensorType(input2.type).element_type
@@ -885,25 +1131,16 @@ def mul_op(node: MulOp, symbol_table):
             if isinstance(input2_raw, ir.Value)
             else None
         )
-        ref_shape = shape1 or shape2 or [1]
-
-        def _to_complex_operand(opnd, fallback_shape):
-            if isinstance(opnd, ir.Value):
-                elem_ty = ir.RankedTensorType(opnd.type).element_type
-                if ir.ComplexType.isinstance(elem_ty):
-                    return opnd
-                return _promote_real_tensor_to_complex(opnd, mlir_dtype)
-            if isinstance(opnd, (int, float)) or _is_complex_scalar(opnd):
-                return _complex_scalar_to_tensor(
-                    opnd, mlir_dtype, fallback_shape
-                )
-            raise ValueError(
-                f"Unsupported mul operand type in complex path: {type(opnd)}"
-            )
-
-        input1 = _to_complex_operand(input1_raw, shape2 or ref_shape)
-        input2 = _to_complex_operand(input2_raw, shape1 or ref_shape)
-        return _gen_arith_binary_op(input1, input2, _inner_op)
+        ref_shape = shape1 or shape2 or output_shape
+        input1 = _to_complex_operand(
+            input1_raw, mlir_dtype, shape2 or ref_shape
+        )
+        input2 = _to_complex_operand(
+            input2_raw, mlir_dtype, shape1 or ref_shape
+        )
+        return _complex_binary_linalg(
+            input1, input2, output_shape, mlir_dtype, "mul"
+        )
 
     if isinstance(node.args[0], str):
         input1 = symbol_table.get((str(node.args[0]), 0), node.args[0])
@@ -1011,6 +1248,9 @@ def exp_op(node: ExpOp, symbol_table):
     input1 = symbol_table.get((str(node.args[0]), 0))
     sizes = ir.RankedTensorType(input1.type).shape
     result_element_type = ir.RankedTensorType(input1.type).element_type
+    if _is_complex_element_type(result_element_type):
+        return _complex_exp_linalg(input1, sizes)
+
     expResultTensorType = ir.RankedTensorType.get(sizes, result_element_type)
     op = tosa.ExpOp(expResultTensorType, input1)
     return op
@@ -1024,6 +1264,44 @@ def abs_op(node: AbsOp, symbol_table):
     input1 = symbol_table.get((str(node.args[0]), 0))
     sizes = ir.RankedTensorType(input1.type).shape
     result_element_type = ir.RankedTensorType(input1.type).element_type
+    if _is_complex_element_type(result_element_type):
+        complex_element_type = ir.ComplexType(result_element_type).element_type
+        real_result_type = ir.RankedTensorType.get(sizes, complex_element_type)
+        output = tensor.EmptyOp(sizes, complex_element_type)
+        identity = ir.AffineMap.get_permutation(list(range(len(sizes))))
+        op = linalg.GenericOp(
+            [real_result_type],
+            [input1],
+            [output],
+            ir.ArrayAttr.get(
+                [
+                    ir.AffineMapAttr.get(identity),
+                    ir.AffineMapAttr.get(identity),
+                ]
+            ),
+            ir.ArrayAttr.get(
+                [ir.Attribute.parse("#linalg.iterator_type<parallel>")]
+                * len(sizes)
+            ),
+        )
+        block = ir.Block.create_at_start(
+            op.region, [result_element_type, complex_element_type]
+        )
+        real = complex_dialect.ReOp(block.arguments[0])
+        imag = complex_dialect.ImOp(block.arguments[0])
+        real_sq = arith.MulFOp(real.result, real.result)
+        imag_sq = arith.MulFOp(imag.result, imag.result)
+        sum_sq = arith.AddFOp(real_sq.result, imag_sq.result)
+        magnitude = math.SqrtOp(sum_sq.result)
+        block.append(real)
+        block.append(imag)
+        block.append(real_sq)
+        block.append(imag_sq)
+        block.append(sum_sq)
+        block.append(magnitude)
+        block.append(linalg.YieldOp([magnitude.result]))
+        return op
+
     abs_result_tensor_type = ir.RankedTensorType.get(sizes, result_element_type)
     op = tosa.AbsOp(abs_result_tensor_type, input1)
     return op
@@ -1259,6 +1537,15 @@ def rsqrt_op(node: RsqrtOp, symbol_table):
     input1 = symbol_table.get((str(node.args[0]), 0))
     sizes = ir.RankedTensorType(input1.type).shape
     result_element_type = ir.RankedTensorType(input1.type).element_type
+    if not (
+        ir.FloatType.isinstance(result_element_type)
+        or ir.BF16Type.isinstance(result_element_type)
+    ):
+        result_element_type = ir.F32Type.get()
+        input1 = tosa.CastOp(
+            ir.RankedTensorType.get(sizes, result_element_type), input1
+        ).result
+
     rsqrt_result_tensor_type = ir.RankedTensorType.get(
         sizes, result_element_type
     )
@@ -2597,7 +2884,8 @@ def reshape_op(node: ReshapeOp, symbol_table):
     """
     input1 = symbol_table.get((str(node.args[0]), 0))
     new_shape = []
-    if node._newshape is None:
+    explicit_newshape = getattr(node, "_newshape", None)
+    if explicit_newshape is None:
         shape_arg = node.args[1]
 
         if isinstance(shape_arg, (list, tuple)):
@@ -2608,7 +2896,7 @@ def reshape_op(node: ReshapeOp, symbol_table):
             except TypeError:
                 new_shape = [shape_arg]
     else:
-        new_shape = list(node._newshape)
+        new_shape = list(explicit_newshape)
 
     resolved_shape = _resolve_static_shape(new_shape, symbol_table)
     if resolved_shape is None:
@@ -3206,18 +3494,13 @@ def permute_op(node: PermuteOp, symbol_table):
     """
     input_tensor = symbol_table.get((str(node.args[0]), 0))
     perm = node.args[1]
-    perms_attr = _create_permutation_attr(perm)
     result_element_type = ir.RankedTensorType(input_tensor.type).element_type
     init_shape = ir.RankedTensorType(input_tensor.type).shape
     new_shape = []
     for perm_item in perm:
         new_shape.append(init_shape[perm_item])
 
-    permute_result_type = ir.RankedTensorType.get(
-        new_shape, result_element_type
-    )
-    permute_op = tosa.TransposeOp(permute_result_type, input_tensor, perms_attr)
-    return permute_op
+    return _transpose_or_linalg(input_tensor, perm, new_shape)
 
 
 def embedding_op(node: EmbeddingOp, symbol_table):
@@ -3448,14 +3731,7 @@ def transpose_op(node: TransposeOp, symbol_table):
     perm_list[dim1] = perm_list[dim2]
     perm_list[dim2] = temp
     output_shape = list(node.tensor_meta["shape"])
-    perms_attr = _create_permutation_attr(perm_list)
-    result_element_type = ir.RankedTensorType(input1.type).element_type
-    permute_result_type = ir.RankedTensorType.get(
-        output_shape, result_element_type
-    )
-    op = tosa.TransposeOp(permute_result_type, input1, perms_attr)
-
-    return op
+    return _transpose_or_linalg(input1, perm_list, output_shape)
 
 
 def maxpool2d_op(node: MaxPool2dOp, symbol_table):
@@ -3545,6 +3821,187 @@ def maxpool2d_op(node: MaxPool2dOp, symbol_table):
         )
         op = tosa.TransposeOp(permute_result_type, op.result, perms_attr)
     return op
+
+
+def _is_depthwise_conv_transpose1d_ncw(
+    input_shape: Sequence[int],
+    weight_shape: Sequence[int],
+    out_shape: Sequence[int],
+    groups: int,
+) -> bool:
+    """Return true for NCW depthwise ConvTranspose1d.
+
+    PyTorch stores ConvTranspose1d weights as
+    [in_channels, out_channels / groups, kernel_width].  The depthwise case
+    has one input channel and one output channel per group, so it can be
+    lowered without splitting the graph into one transpose_conv2d per channel.
+    """
+    if len(input_shape) != 3 or len(weight_shape) != 3 or len(out_shape) != 3:
+        return False
+
+    input_c = int(input_shape[1])
+    output_c = int(out_shape[1])
+    weight_input_c = int(weight_shape[0])
+    weight_output_per_group = int(weight_shape[1])
+    groups = int(groups)
+    if groups <= 0:
+        return False
+
+    input_per_group = weight_input_c // groups
+    return (
+        weight_input_c % groups == 0
+        and input_per_group == 1
+        and weight_output_per_group == 1
+        and groups == input_c
+        and output_c == input_c
+    )
+
+
+def _depthwise_conv_transpose1d_ncw_op(
+    input_val: ir.Value,
+    weight_val: ir.Value,
+    bias_tensor: ir.Value,
+    input_shape: Sequence[int],
+    weight_shape: Sequence[int],
+    out_shape: Sequence[int],
+    groups: int,
+    stride: Sequence[int],
+    input_padding: Sequence[int],
+    result_element_type: ir.Type,
+):
+    """Lower NCW depthwise ConvTranspose1d to explicit SCF loops.
+
+    This is a narrow mapping for the common depthwise upsample form:
+    groups == in_channels == out_channels and weight shape [C, 1, K].
+    The generic grouped path is still used for other grouped transposed
+    convolutions.  Keeping this case separate avoids emitting hundreds or
+    thousands of independent TOSA transpose_conv2d ops for channel-wise
+    upsample layers.
+
+    For each output position ow, the source input index is:
+        iw = (ow + padding - kw) / stride
+    The term contributes only when the division is exact and iw is in range.
+    output_padding is represented by the already-computed output shape; it
+    does not change this reverse index mapping.
+    """
+    input_n, input_c, input_w = [int(dim) for dim in input_shape]
+    weight_c, weight_multiplier, kernel_w = [int(dim) for dim in weight_shape]
+    output_n, output_c, output_w = [int(dim) for dim in out_shape]
+    groups = int(groups)
+    if (
+        weight_multiplier != 1
+        or groups != input_c
+        or weight_c != input_c
+        or output_c != input_c
+        or output_n != input_n
+    ):
+        raise NotImplementedError(
+            "depthwise ConvTranspose1d lowering only supports "
+            "groups == in_channels == out_channels"
+        )
+
+    index_type = ir.IndexType.get()
+    c0 = arith.ConstantOp(index_type, 0)
+    c1 = arith.ConstantOp(index_type, 1)
+    n_bound = arith.ConstantOp(index_type, output_n)
+    c_bound = arith.ConstantOp(index_type, output_c)
+    out_w_bound = arith.ConstantOp(index_type, output_w)
+    k_bound = arith.ConstantOp(index_type, kernel_w)
+    in_w_bound = arith.ConstantOp(index_type, input_w)
+    stride_const = arith.ConstantOp(index_type, int(stride[0]))
+    pad_const = arith.ConstantOp(index_type, int(input_padding[0]))
+
+    output_memref = memref.AllocOp(
+        ir.MemRefType.get(out_shape, result_element_type), [], []
+    )
+    input_memref = bufferization.ToBufferOp(
+        ir.MemRefType.get(input_shape, result_element_type), input_val
+    ).result
+    weight_memref = bufferization.ToBufferOp(
+        ir.MemRefType.get(list(weight_shape), result_element_type), weight_val
+    ).result
+    bias_memref = bufferization.ToBufferOp(
+        ir.MemRefType.get([output_c], result_element_type), bias_tensor
+    ).result
+
+    n_loop = scf.ForOp(c0.result, n_bound.result, c1.result)
+    with ir.InsertionPoint(n_loop.body):
+        n_idx = n_loop.induction_variable
+        c_loop = scf.ForOp(c0.result, c_bound.result, c1.result)
+        with ir.InsertionPoint(c_loop.body):
+            c_idx = c_loop.induction_variable
+            ow_loop = scf.ForOp(c0.result, out_w_bound.result, c1.result)
+            with ir.InsertionPoint(ow_loop.body):
+                ow_idx = ow_loop.induction_variable
+                bias_val = memref.LoadOp(bias_memref, [c_idx]).result
+
+                kw_loop = scf.ForOp(
+                    c0.result,
+                    k_bound.result,
+                    c1.result,
+                    iter_args=[bias_val],
+                )
+                with ir.InsertionPoint(kw_loop.body):
+                    kw_idx = kw_loop.induction_variable
+                    acc = kw_loop.inner_iter_args[0]
+
+                    shifted = arith.AddIOp(ow_idx, pad_const.result).result
+                    shifted = arith.SubIOp(shifted, kw_idx).result
+                    rem = arith.RemSIOp(shifted, stride_const.result).result
+                    divisible = arith.CmpIOp(
+                        arith.CmpIPredicate.eq,
+                        rem,
+                        c0.result,
+                    ).result
+                    iw_idx = arith.DivSIOp(shifted, stride_const.result).result
+                    iw_ge_0 = arith.CmpIOp(
+                        arith.CmpIPredicate.sge,
+                        iw_idx,
+                        c0.result,
+                    ).result
+                    iw_lt_w = arith.CmpIOp(
+                        arith.CmpIPredicate.slt,
+                        iw_idx,
+                        in_w_bound.result,
+                    ).result
+                    in_bounds = arith.AndIOp(
+                        divisible,
+                        arith.AndIOp(iw_ge_0, iw_lt_w).result,
+                    ).result
+
+                    if_op = scf.IfOp(
+                        in_bounds,
+                        [result_element_type],
+                        hasElse=True,
+                    )
+                    with ir.InsertionPoint(if_op.then_block):
+                        input_elem = memref.LoadOp(
+                            input_memref, [n_idx, c_idx, iw_idx]
+                        ).result
+                        weight_elem = memref.LoadOp(
+                            weight_memref, [c_idx, c0.result, kw_idx]
+                        ).result
+                        product = arith.MulFOp(input_elem, weight_elem).result
+                        updated = arith.AddFOp(acc, product).result
+                        scf.YieldOp([updated])
+                    with ir.InsertionPoint(if_op.else_block):
+                        scf.YieldOp([acc])
+
+                    scf.YieldOp([if_op.result])
+
+                memref.StoreOp(
+                    kw_loop.result,
+                    output_memref.result,
+                    [n_idx, c_idx, ow_idx],
+                )
+                scf.YieldOp([])
+            scf.YieldOp([])
+        scf.YieldOp([])
+
+    output_tensor_type = ir.RankedTensorType.get(out_shape, result_element_type)
+    return bufferization.ToTensorOp(
+        output_tensor_type, output_memref.result, restrict=True
+    )
 
 
 # TODO: Rename convolution2d_op -> convolution_op
@@ -3805,7 +4262,7 @@ def convolution2d_op(node: Conv2dOp, symbol_table):
     # Convolution 1D
     elif len(weight_shape) == 3:
         # Prepare input with padding.
-        if input_padding[0] != 0:
+        if input_padding[0] != 0 and not is_kernel_transposed:
             input_shape = list(ir.RankedTensorType(input_val.type).shape)
             padded_type = ir.RankedTensorType.get(
                 [
@@ -3924,7 +4381,151 @@ def convolution2d_op(node: Conv2dOp, symbol_table):
                         sanitized.append(ir.ShapedType.get_dynamic_size())
             return sanitized
 
-        if groups == 1:
+        if is_kernel_transposed:
+            if sum(dilation) > len(dilation):
+                raise NotImplementedError(
+                    "ConvTranspose1d with dilation is not supported"
+                )
+
+            # Handle depthwise ConvTranspose1d before the generic grouped
+            # fallback.  The fallback slices each group and emits one
+            # transpose_conv2d per channel, which is correct but produces very
+            # large IR for channel-wise upsample layers.  This narrow mapping
+            # keeps other grouped transposed convolutions on the existing path.
+            if _is_depthwise_conv_transpose1d_ncw(
+                input_shape, weight_shape, out_shape, groups
+            ):
+                return _depthwise_conv_transpose1d_ncw_op(
+                    input_val,
+                    weight_val,
+                    bias_tensor,
+                    input_shape,
+                    weight_shape,
+                    out_shape,
+                    groups,
+                    stride,
+                    input_padding,
+                    result_element_type,
+                )
+
+            group_outputs = []
+            cin_per_group = int(weight_shape[0]) // groups
+            cout_per_group = int(weight_shape[1])
+            for g in range(groups):
+                g_in_start = g * cin_per_group
+                g_out_start = g * cout_per_group
+                sliced_input = _slice_1d(
+                    input_val, 1, g_in_start, cin_per_group
+                )
+                sliced_weight = _slice_1d(
+                    weight_val, 0, g_in_start, cin_per_group
+                )
+                sliced_bias = _slice_1d(
+                    bias_tensor, 0, g_out_start, cout_per_group
+                )
+
+                input_3d_shape = [
+                    input_shape[0],
+                    input_shape[2],
+                    cin_per_group,
+                ]
+                input_3d = tosa.TransposeOp(
+                    ir.RankedTensorType.get(
+                        input_3d_shape, result_element_type
+                    ),
+                    sliced_input,
+                    _create_permutation_attr([0, 2, 1]),
+                ).result
+                input_4d_shape = [
+                    input_shape[0],
+                    input_shape[2],
+                    1,
+                    cin_per_group,
+                ]
+                input_4d = tosa.ReshapeOp(
+                    input_3d, _create_shape_operand(input_4d_shape)
+                ).result
+
+                weight_3d_shape = [
+                    cout_per_group,
+                    int(weight_shape[2]),
+                    cin_per_group,
+                ]
+                weight_3d = tosa.TransposeOp(
+                    ir.RankedTensorType.get(
+                        weight_3d_shape, result_element_type
+                    ),
+                    sliced_weight,
+                    _create_permutation_attr([1, 2, 0]),
+                ).result
+                weight_4d_shape = [
+                    cout_per_group,
+                    int(weight_shape[2]),
+                    1,
+                    cin_per_group,
+                ]
+                weight_4d = tosa.ReshapeOp(
+                    weight_3d, _create_shape_operand(weight_4d_shape)
+                ).result
+
+                output_4d_shape = [
+                    out_shape[0],
+                    out_shape[2],
+                    1,
+                    cout_per_group,
+                ]
+                output_4d_type = ir.RankedTensorType.get(
+                    output_4d_shape, result_element_type
+                )
+                input_zp = _create_zero_point_tensor(input_4d)
+                weight_zp = _create_zero_point_tensor(weight_4d)
+                out_padding_4d = [
+                    -int(input_padding[0]),
+                    int(out_padding[0]) - int(input_padding[0]),
+                    0,
+                    0,
+                ]
+                transpose_conv = tosa.TransposeConv2DOp(
+                    output_4d_type,
+                    input_4d,
+                    weight_4d,
+                    sliced_bias,
+                    input_zp,
+                    weight_zp,
+                    ir._denseI64ArrayAttr(out_padding_4d, None),
+                    ir._denseI64ArrayAttr([int(stride[0]), 1], None),
+                    acc_type,
+                ).result
+                output_3d_shape = [
+                    out_shape[0],
+                    out_shape[2],
+                    cout_per_group,
+                ]
+                output_nwc = tosa.ReshapeOp(
+                    transpose_conv, _create_shape_operand(output_3d_shape)
+                ).result
+                group_outputs.append(
+                    tosa.TransposeOp(
+                        ir.RankedTensorType.get(
+                            [
+                                out_shape[0],
+                                cout_per_group,
+                                out_shape[2],
+                            ],
+                            result_element_type,
+                        ),
+                        output_nwc,
+                        _create_permutation_attr([0, 2, 1]),
+                    ).result
+                )
+
+            op = (
+                group_outputs[0]
+                if len(group_outputs) == 1
+                else tosa.ConcatOp(group_outputs, 1)
+            )
+
+        elif groups == 1:
             output_conv = tensor.EmptyOp(
                 _sanitize_shape_for_empty(out_shape), result_element_type
             )

--- a/frontend/Python/ops/tosa.py
+++ b/frontend/Python/ops/tosa.py
@@ -382,23 +382,155 @@ def _scalar_to_tensor(
     return tosa.ConstOp(attr).results[0]
 
 
+def _is_complex_scalar(value) -> bool:
+    """Return True for Python or NumPy scalar complex values."""
+    return isinstance(value, complex) or isinstance(
+        value, numpy.complexfloating
+    )
+
+
+def _complex_scalar_to_tensor(
+    scalar: complex, complex_type: ir.Type, shape: List[int]
+):
+    """Create a splat tensor for a scalar complex value."""
+    scalar = complex(scalar)
+    complex_elem = ir.ComplexType(complex_type).element_type
+    real = arith.ConstantOp(
+        complex_elem, ir.FloatAttr.get(complex_elem, float(scalar.real))
+    ).result
+    imag = arith.ConstantOp(
+        complex_elem, ir.FloatAttr.get(complex_elem, float(scalar.imag))
+    ).result
+    cval = complex_dialect.CreateOp(complex_type, real, imag).result
+    return tensor.SplatOp(
+        ir.RankedTensorType.get(list(shape), complex_type), cval, []
+    ).result
+
+
+def _promote_real_tensor_to_complex(value: ir.Value, complex_type: ir.Type):
+    """Promote a real tensor to a complex tensor with zero imaginary part."""
+    value_ty = ir.RankedTensorType(value.type)
+    complex_elem = ir.ComplexType(complex_type).element_type
+    shape = list(value_ty.shape)
+    if str(value_ty.element_type) != str(complex_elem):
+        cast_ty = ir.RankedTensorType.get(shape, complex_elem)
+        value = tosa.CastOp(cast_ty, value).result
+    zero = arith.ConstantOp(
+        complex_elem, ir.FloatAttr.get(complex_elem, 0.0)
+    ).result
+    output = tensor.EmptyOp(shape, complex_type)
+    generic_map = ir.AffineMap.get_permutation([i for i in range(len(shape))])
+    op = linalg.GenericOp(
+        [ir.RankedTensorType.get(shape, complex_type)],
+        [value],
+        [output],
+        ir.ArrayAttr.get(
+            [
+                ir.AffineMapAttr.get(generic_map),
+                ir.AffineMapAttr.get(generic_map),
+            ]
+        ),
+        ir.ArrayAttr.get(
+            [ir.Attribute.parse("#linalg.iterator_type<parallel>")] * len(shape)
+        ),
+    )
+    block = ir.Block.create_at_start(op.region, [complex_elem, complex_type])
+    cval = complex_dialect.CreateOp(complex_type, block.arguments[0], zero)
+    block.append(cval)
+    block.append(linalg.YieldOp([cval.result]))
+    return op.result
+
+
+def _resolve_dense_scalar_op_result(value):
+    """Read a scalar integer from a constant-like MLIR op result if present."""
+    owner = getattr(value, "owner", None)
+    opview = getattr(owner, "opview", None) if owner is not None else None
+    attrs = getattr(opview, "attributes", None) if opview is not None else None
+    if attrs is None:
+        return None
+    for attr_name in ("values", "value"):
+        try:
+            dense_attr = attrs[attr_name]
+            if len(dense_attr) > 0:
+                return int(dense_attr[0])
+        except Exception:
+            pass
+    return None
+
+
+def _resolve_static_shape_dim(dim, symbol_table):
+    """Resolve one shape dimension when it is represented by a static scalar."""
+    if isinstance(dim, (int, numpy.integer)):
+        return int(dim)
+
+    resolved = symbol_table.get((str(dim), 0), dim)
+    if isinstance(resolved, (int, numpy.integer)):
+        return int(resolved)
+    if isinstance(resolved, ir.OpResult):
+        const_value = _resolve_dense_scalar_op_result(resolved)
+        if const_value is not None:
+            return const_value
+    return int(resolved)
+
+
+def _resolve_static_shape(shape_values, symbol_table):
+    """Resolve a shape list; return None when any dimension is still dynamic."""
+    try:
+        return [
+            _resolve_static_shape_dim(dim, symbol_table)
+            for dim in list(shape_values)
+        ]
+    except Exception:
+        return None
+
+
 def _normalize_binary_operator_args(arg1, arg2):
     """Normalize the types of binary operator arguments."""
     if isinstance(arg1, ir.Value) and (
-        isinstance(arg2, float) or isinstance(arg2, int)
+        isinstance(arg2, float)
+        or isinstance(arg2, int)
+        or _is_complex_scalar(arg2)
     ):
+        elem_ty = ir.RankedTensorType(arg1.type).element_type
+        if _is_complex_scalar(arg2):
+            arg2 = complex(arg2)
+            if ir.ComplexType.isinstance(elem_ty):
+                arg2 = _complex_scalar_to_tensor(
+                    arg2, elem_ty, ir.RankedTensorType(arg1.type).shape
+                )
+                return arg1, arg2
+            if abs(arg2.imag) > 0:
+                raise ValueError(
+                    f"Cannot apply complex scalar {arg2} to non-complex tensor type {elem_ty}"
+                )
+            arg2 = float(arg2.real)
         arg2 = _scalar_to_tensor(
             arg2,
-            ir.RankedTensorType(arg1.type).element_type,
+            elem_ty,
             ir.RankedTensorType(arg1.type).shape,
         )
         return arg1, arg2
     elif isinstance(arg2, ir.Value) and (
-        isinstance(arg1, float) or isinstance(arg1, int)
+        isinstance(arg1, float)
+        or isinstance(arg1, int)
+        or _is_complex_scalar(arg1)
     ):
+        elem_ty = ir.RankedTensorType(arg2.type).element_type
+        if _is_complex_scalar(arg1):
+            arg1 = complex(arg1)
+            if ir.ComplexType.isinstance(elem_ty):
+                arg1 = _complex_scalar_to_tensor(
+                    arg1, elem_ty, ir.RankedTensorType(arg2.type).shape
+                )
+                return arg1, arg2
+            if abs(arg1.imag) > 0:
+                raise ValueError(
+                    f"Cannot apply complex scalar {arg1} to non-complex tensor type {elem_ty}"
+                )
+            arg1 = float(arg1.real)
         arg1 = _scalar_to_tensor(
             arg1,
-            ir.RankedTensorType(arg2.type).element_type,
+            elem_ty,
             ir.RankedTensorType(arg2.type).shape,
         )
         return arg1, arg2
@@ -738,6 +870,40 @@ def mul_op(node: MulOp, symbol_table):
     output_shape = list(node.tensor_meta["shape"])
     dtype = node.tensor_meta["dtype"]
     mlir_dtype = mlir_element_type_get(dtype)
+
+    if isinstance(mlir_dtype, ir.ComplexType):
+        input1_raw = symbol_table.get((str(node.args[0]), 0), node.args[0])
+        input2_raw = symbol_table.get((str(node.args[1]), 0), node.args[1])
+
+        shape1 = (
+            list(ir.RankedTensorType(input1_raw.type).shape)
+            if isinstance(input1_raw, ir.Value)
+            else None
+        )
+        shape2 = (
+            list(ir.RankedTensorType(input2_raw.type).shape)
+            if isinstance(input2_raw, ir.Value)
+            else None
+        )
+        ref_shape = shape1 or shape2 or [1]
+
+        def _to_complex_operand(opnd, fallback_shape):
+            if isinstance(opnd, ir.Value):
+                elem_ty = ir.RankedTensorType(opnd.type).element_type
+                if ir.ComplexType.isinstance(elem_ty):
+                    return opnd
+                return _promote_real_tensor_to_complex(opnd, mlir_dtype)
+            if isinstance(opnd, (int, float)) or _is_complex_scalar(opnd):
+                return _complex_scalar_to_tensor(
+                    opnd, mlir_dtype, fallback_shape
+                )
+            raise ValueError(
+                f"Unsupported mul operand type in complex path: {type(opnd)}"
+            )
+
+        input1 = _to_complex_operand(input1_raw, shape2 or ref_shape)
+        input2 = _to_complex_operand(input2_raw, shape1 or ref_shape)
+        return _gen_arith_binary_op(input1, input2, _inner_op)
 
     if isinstance(node.args[0], str):
         input1 = symbol_table.get((str(node.args[0]), 0), node.args[0])
@@ -2444,6 +2610,15 @@ def reshape_op(node: ReshapeOp, symbol_table):
     else:
         new_shape = list(node._newshape)
 
+    resolved_shape = _resolve_static_shape(new_shape, symbol_table)
+    if resolved_shape is None:
+        # Some captured reshape shapes are represented as scalar MLIR values
+        # even when the result type is already static.  Use tensor_meta only as
+        # a static shape source; dynamic dimensions will still fail below.
+        new_shape = [int(dim) for dim in list(node.tensor_meta["shape"])]
+    else:
+        new_shape = resolved_shape
+
     now_shape = ir.RankedTensorType(input1.type).shape
     total_size = 1
     for dim_siz in now_shape:
@@ -3132,10 +3307,7 @@ def expand_op(node: ExpandOp, symbol_table) -> ir.Operation:
         to_expand_tensor.type
     ).element_type
 
-    if result_element_type in (
-        ir.IntegerType.get_signless(1),
-        ir.IntegerType.get_signless(64),
-    ):
+    if ir.IntegerType.isinstance(result_element_type):
         element = ir.IntegerAttr.get(result_element_type, 0)
     elif (
         result_element_type == ir.F32Type.get()
@@ -3660,59 +3832,147 @@ def convolution2d_op(node: Conv2dOp, symbol_table):
             pad_zp = tosa.ConstOp(
                 ir.DenseElementsAttr.get_splat(ty, ir.FloatAttr.get_f32(0.0))
             ).result
-            input_val = tosa.PadOp(padded_type, input_val, pad_constant, pad_zp)
+            input_val = tosa.PadOp(
+                padded_type, input_val, pad_constant, pad_zp
+            ).result
+
         output_type = ir.RankedTensorType.get(out_shape, result_element_type)
-        output_conv = tensor.EmptyOp(list(out_shape), result_element_type)
-        assert groups == 1, "only support one group"
-        # Con1D Operation Without Bias
-        conv_op = linalg.conv_1d_ncw_fcw(
-            input_val,
-            weight_val,
-            outs=[output_conv],
-            strides=stride_attr,
-            dilations=dilation_attr,
-        )
-        output = tensor.EmptyOp(list(out_shape), result_element_type)
-        generic_map = ir.AffineMap.get_permutation(
-            [i for i in range(len(list(out_shape)))]
-        )
-        loop_type = [
-            ir.Attribute.parse("#linalg.iterator_type<parallel>")
-        ] * len(list(out_shape))
-        loop_type[1] = ir.Attribute.parse("#linalg.iterator_type<reduction>")
-        # Add Bias To Conv2d.
-        op = linalg.GenericOp(
-            [output_type],
-            [conv_op, bias_tensor],
-            [output],
-            ir.ArrayAttr.get(
+
+        cin_per_group = int(weight_shape[1])
+        cout_per_group = int(out_channels) // groups
+
+        def _slice_1d(tensor, dim, start, size):
+            """Slice an NCW/FCW/bias tensor while preserving other dimensions."""
+            inp_shape = list(ir.RankedTensorType(tensor.type).shape)
+            new_shape = inp_shape[:dim] + [size] + inp_shape[dim + 1 :]
+            start_list = [0] * len(inp_shape)
+            start_list[dim] = int(start)
+            size_list = list(inp_shape)
+            size_list[dim] = size
+            start_operand = _create_shape_operand(start_list)
+            size_operand = _create_shape_operand(size_list)
+            return tosa.SliceOp(
+                ir.RankedTensorType.get(new_shape, result_element_type),
+                tensor,
+                start_operand,
+                size_operand,
+            ).result
+
+        def _add_bias(conv_result, bias_slice):
+            """Broadcast channel bias over NCW Conv1D output."""
+            out_shape_list = list(ir.RankedTensorType(conv_result.type).shape)
+
+            output = tensor.EmptyOp(out_shape_list, result_element_type)
+            generic_map = ir.AffineMap.get_permutation(
+                [i for i in range(len(out_shape_list))]
+            )
+            loop_type = [
+                ir.Attribute.parse("#linalg.iterator_type<parallel>")
+            ] * len(out_shape_list)
+            loop_type[1] = ir.Attribute.parse(
+                "#linalg.iterator_type<reduction>"
+            )
+
+            op = linalg.GenericOp(
+                [ir.RankedTensorType.get(out_shape_list, result_element_type)],
+                [conv_result, bias_slice],
+                [output],
+                ir.ArrayAttr.get(
+                    [
+                        ir.AffineMapAttr.get(
+                            generic_map.get_submap(
+                                [i for i in range(len(out_shape_list))]
+                            )
+                        ),
+                        ir.AffineMapAttr.get(generic_map.get_submap([1])),
+                        ir.AffineMapAttr.get(
+                            generic_map.get_submap(
+                                [i for i in range(len(out_shape_list))]
+                            )
+                        ),
+                    ]
+                ),
+                ir.ArrayAttr.get(loop_type),
+            )
+            block = ir.Block.create_at_start(
+                op.region,
                 [
-                    ir.AffineMapAttr.get(
-                        generic_map.get_submap(
-                            [i for i in range(len(list(out_shape)))]
+                    result_element_type,
+                    ir.RankedTensorType(bias_slice.type).element_type,
+                    result_element_type,
+                ],
+            )
+            add_op = arith.AddFOp(block.arguments[1], block.arguments[0])
+            block.append(add_op)
+            block.append(linalg.YieldOp([add_op.result]))
+            return op.result
+
+        def _sanitize_shape_for_empty(shape_vals):
+            sanitized = []
+            for dim in list(shape_vals):
+                if isinstance(dim, ir.Value):
+                    sanitized.append(dim)
+                else:
+                    try:
+                        dim_i = int(dim)
+                        sanitized.append(
+                            dim_i
+                            if dim_i >= 0
+                            else ir.ShapedType.get_dynamic_size()
                         )
-                    ),
-                    ir.AffineMapAttr.get(generic_map.get_submap([1])),
-                    ir.AffineMapAttr.get(
-                        generic_map.get_submap(
-                            [i for i in range(len(list(out_shape)))]
-                        )
-                    ),
-                ]
-            ),
-            ir.ArrayAttr.get(loop_type),
-        )
-        block = ir.Block.create_at_start(
-            op.region,
-            [
-                result_element_type,
-                ir.RankedTensorType(bias_tensor.type).element_type,
-                result_element_type,
-            ],
-        )
-        add_op = arith.AddFOp(block.arguments[1], block.arguments[0])
-        block.append(add_op)
-        block.append(linalg.YieldOp([add_op.result]))
+                    except Exception:
+                        sanitized.append(ir.ShapedType.get_dynamic_size())
+            return sanitized
+
+        if groups == 1:
+            output_conv = tensor.EmptyOp(
+                _sanitize_shape_for_empty(out_shape), result_element_type
+            )
+            conv_op = linalg.conv_1d_ncw_fcw(
+                input_val,
+                weight_val,
+                outs=[output_conv],
+                strides=stride_attr,
+                dilations=dilation_attr,
+            )
+            op = _add_bias(conv_op, bias_tensor)
+
+        else:
+            # linalg.conv_1d_ncw_fcw has no groups attribute.  Lower grouped
+            # Conv1D as independent single-group convolutions and concatenate
+            # their channel slices, matching PyTorch's grouped conv semantics.
+            group_outputs = []
+            for g in range(groups):
+                g_in_start = g * cin_per_group
+                g_out_start = g * cout_per_group
+
+                sliced_input = _slice_1d(
+                    input_val, 1, g_in_start, cin_per_group
+                )
+                sliced_weight = _slice_1d(
+                    weight_val, 0, g_out_start, cout_per_group
+                )
+                sliced_weight = _slice_1d(sliced_weight, 1, 0, cin_per_group)
+                sliced_bias = _slice_1d(
+                    bias_tensor, 0, g_out_start, cout_per_group
+                )
+
+                group_out_shape = list(out_shape)
+                group_out_shape[1] = cout_per_group
+                group_output_conv = tensor.EmptyOp(
+                    _sanitize_shape_for_empty(group_out_shape),
+                    result_element_type,
+                )
+                conv_op = linalg.conv_1d_ncw_fcw(
+                    sliced_input,
+                    sliced_weight,
+                    outs=[group_output_conv],
+                    strides=stride_attr,
+                    dilations=dilation_attr,
+                )
+                group_outputs.append(_add_bias(conv_op, sliced_bias))
+
+            op = tosa.ConcatOp(group_outputs, 1)
 
     return op
 
@@ -3750,7 +4010,21 @@ def iota_op(node: IotaOp, symbol_table):
     count = node.args[0]
     step = node.kwargs["step"]
     if not isinstance(count, int):
-        count = int(count)
+        resolved_count = symbol_table.get((str(count), 0), count)
+        if isinstance(resolved_count, ir.OpResult):
+            const_count = _resolve_dense_scalar_op_result(resolved_count)
+            if const_count is not None:
+                resolved_count = const_count
+            if isinstance(resolved_count, ir.OpResult):
+                # Iota materializes a dense constant here.  If the count comes
+                # from a scalar shape computation but the output vector length
+                # is already static, the output type is the reliable source.
+                if len(output_shape) == 1:
+                    try:
+                        resolved_count = int(output_shape[0])
+                    except Exception:
+                        pass
+        count = int(resolved_count)
     return _build_range_tensor(output_shape, dtype, start, step)
 
 


### PR DESCRIPTION
## Summary

This PR adds an opt-in fixed-shape Kokoro TTS example and the frontend lowering support required to import and compile it.

Kokoro cannot be exported as one single fully static graph in the same way as a simple feed-forward model, because it predicts token durations first and then builds an alignment whose frame length depends on those predicted durations. To keep the compiled MLIR static, this example splits the model into two fixed-shape stages:

- `predictor`: token/style inputs -> duration and intermediate tensors
- `vocoder`: fixed frame indices + predictor outputs -> waveform

The C++ runner performs the small data-dependent duration-to-frame bridge between the two static graphs.

## What Changed

### Kokoro example

Added `examples/BuddyTTSKokoro`.

The example includes:

- `import-kokoro.py` to import Kokoro-82M into fixed-shape MLIR stages
- `buddy-kokoro-main.cpp` to run the generated predictor/vocoder graphs end to end
- `CMakeLists.txt` to generate MLIR/data files, compile MLIR objects, link the `KOKORO` static library, and build `buddy-kokoro-run`
- `README.md` with build, run, and input phoneme guidance

The example is controlled only by:

```bash
cmake -S . -B build -DBUDDY_TTS_KOKORO_EXAMPLES=ON
cmake --build build --target buddy-kokoro-run
```

This keeps it consistent with the existing example structure.

### Fixed-shape Kokoro import

Kokoro's original `TextEncoder` and `DurationEncoder` use packed LSTM sequence paths. Those paths introduce shape/data-dependent graph behavior during export. For this fixed-shape example, the importer patches them to use padded fixed-length LSTM execution instead.

This avoids graph breaks around packed sequence conversion while preserving the static token length used by the sample.

### Runtime duration bridge

Kokoro predicts token durations before vocoder execution. The duration expansion is data dependent, so forcing it into static MLIR would make the graph shape unstable.

Instead, the importer emits two static stages, and the C++ runner:

- runs the predictor graph
- reads predicted durations
- builds a fixed-size frame-index tensor
- runs the vocoder graph
- writes `kokoro_static.wav`

This keeps the neural network portions static while isolating the dynamic control/data expansion in runtime glue.

### Frontend graph metadata handling

When partitioned graphs communicate through multi-result `CallOp`s, shape/dtype metadata may be stored as lists. Previously, synthesized subgraph placeholders expected one concrete tensor metadata object.

This caused issues when a subgraph input came from a multi-result boundary value.

This PR adds explicit normalization for subgraph input metadata:

- if the value is selected by `GetItemOp`, use its result index
- if there is only one result, use that result
- otherwise fail explicitly instead of silently selecting the first result

This avoids generating placeholders with incorrect shape/dtype metadata.

### TensorMeta assignment

`GraphDriver` synthesizes placeholder nodes using `TensorMeta`, while most existing `Op` users store metadata as dictionaries.

The `Op.tensor_meta` setter now accepts TensorMeta-like objects and converts them into the existing dict layout:

```python
{"shape": ..., "dtype": ...}
```

This keeps downstream users compatible without changing the public metadata representation.

### Complex tensor lowering

Kokoro's vocoder path introduces complex-valued tensor operations. Some TOSA operations used by the existing lowering path do not handle complex element types cleanly.

This PR adds linalg-based helpers for complex tensors, including:

- complex transpose through `linalg.generic`
- complex add/sub/mul
- complex exp
- complex abs

Real tensor paths continue to use the existing TOSA lowering. Complex tensors are routed through linalg where needed.

### Depthwise ConvTranspose1d lowering

The vocoder contains NCW depthwise `ConvTranspose1d` layers. The generic grouped transposed convolution lowering can split the operation per channel and emit many `tosa.transpose_conv2d` operations.

That made the generated IR extremely large and slowed down compilation significantly.

This PR adds a narrow dedicated lowering for the depthwise case:

```text
groups == in_channels == out_channels
weight shape == [C, 1, K]
layout == NCW
```

The lowering emits explicit SCF loops for this depthwise transposed convolution case. Other grouped transposed convolutions still use the existing generic path.

This reduces graph size for the vocoder path and avoids the per-channel transpose-conv explosion.

### Non-verbose graph import cleanup

`GraphImporter` previously captured old/new MLIR operation snapshots even when verbose logging was disabled.

This PR only builds those snapshots in verbose mode, avoiding unnecessary work during normal imports.

## Checklist

- [x] The code builds successfully
- [ ] Existing tests pass
- [ ] New tests are added where appropriate
- [x] Code follows the project coding style
- [x] Documentation is updated if needed
