### PR TITLE
[nix] fix out-of-date nix configuration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722813957,
-        "narHash": "sha256-IAoYyYnED7P8zrBFMnmp7ydaJfwTnwcnqxUElC1I26Y=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cb9a96f23c491c081b38eab96d22fa958043c9fa",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {

--- a/midend/python/CMakeLists.txt
+++ b/midend/python/CMakeLists.txt
@@ -119,6 +119,7 @@ link_directories(${LLVM_BINARY_DIR}/tools/mlir/python_packages/mlir_core/mlir/_m
 
 add_mlir_python_modules(BuddyMLIRPythonModules
   ROOT_PREFIX "${BUDDY_BUILD_DIR}/python_packages/buddy_mlir"
+  INSTALL_PREFIX "python_packages/buddy_mlir"
   DECLARED_SOURCES
     BuddyMLIRPythonSources
     MLIRPythonSources

--- a/nix/buddy-llvm.nix
+++ b/nix/buddy-llvm.nix
@@ -11,16 +11,17 @@ let
     ps.pybind11
     ps.pyyaml
     ps.ml-dtypes
+    ps.nanobind
   ]);
 in
 stdenv.mkDerivation rec {
   name = "llvm-for-buddy-mlir";
-  version = "6c59f0e1b0fb56c909ad7c9aad4bde37dc006ae0";
+  version = "01f36b39bd2475a271bbeb95fb9db8ed65e2d065";
   src = fetchFromGitHub {
     owner = "llvm";
     repo = "llvm-project";
     rev = version;
-    hash = "sha256-bMJJ2q1hSh7m0ewclHOmIe7lOHv110rz/P7D3pw8Uiw=";
+    hash = "sha256-JzMItIr8ZGrQ8LcLRrjucIEdTZInR6BTpiwB1SIQFhk=";
   };
 
   requiredSystemFeatures = [ "big-parallel" ];
@@ -36,14 +37,17 @@ stdenv.mkDerivation rec {
 
   cmakeDir = "../llvm";
   cmakeFlags = [
-    "-DLLVM_ENABLE_PROJECTS=mlir"
+    "-DLLVM_ENABLE_PROJECTS=mlir;clang"
     "-DLLVM_TARGETS_TO_BUILD=host;RISCV"
     "-DLLVM_ENABLE_ASSERTIONS=ON"
     "-DCMAKE_BUILD_TYPE=Release"
     # required for MLIR python binding
     "-DMLIR_ENABLE_BINDINGS_PYTHON=ON"
+    "-DPython3_EXECUTABLE=${pythonEnv}/bin/python3"
     # required for not, FileCheck...
     "-DLLVM_INSTALL_UTILS=ON"
+    # Fix Clang 22 C2y extension warnings in benchmark library
+    "-DCMAKE_CXX_FLAGS=-Wno-c2y-extensions"
   ];
 
   outputs = [ "out" "lib" "dev" ];
@@ -55,6 +59,12 @@ stdenv.mkDerivation rec {
     # so it will not be installed for cmake install.
     # We have to do some hack
     cp -v "include/llvm/Config/config.h" "$dev/include/llvm/Config/config.h"
+
+    # copy MLIR Python extension source files from $out to $dev
+    # this is needed because MLIRTargets.cmake references these sources via _IMPORT_PREFIX
+    # which resolves to $dev, but the sources are installed to $out
+    mkdir -p "$dev/src"
+    cp -rv "$out/src/python" "$dev/src/"
 
     # move llvm-config to $dev to resolve a circular dependency
     moveToOutput "bin/llvm-config*" "$dev"

--- a/nix/buddy-mlir.nix
+++ b/nix/buddy-mlir.nix
@@ -8,11 +8,19 @@
 , libpng
 , zlib-ng
 , ccls
+, flatbuffers
+, numactl
+, python3
 }:
 let
+  pythonEnv = python3.withPackages (ps: [
+    ps.numpy
+    ps.pybind11
+    ps.pyyaml
+  ]);
   self = stdenv.mkDerivation {
     pname = "buddy-mlir";
-    version = "unstable-2024-07-18";
+    version = "unstable-2026-05-05";
 
     src = with lib.fileset; toSource {
       root = ./..;
@@ -22,6 +30,8 @@ let
         ./../examples
         ./../frontend
         ./../midend
+        ./../models
+        ./../runtime
         ./../tests
         ./../tools
         ./../thirdparty
@@ -39,14 +49,19 @@ let
 
     buildInputs = [
       buddy-llvm
+      flatbuffers
+      numactl
+      pythonEnv
     ];
 
     cmakeFlags = [
       "-DMLIR_DIR=${buddy-llvm.dev}/lib/cmake/mlir"
       "-DLLVM_DIR=${buddy-llvm.dev}/lib/cmake/llvm"
       "-DLLVM_MAIN_SRC_DIR=${buddy-llvm.src}/llvm"
+      "-DLLVM_ENABLE_ASSERTIONS=ON"
       "-DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON"
       "-DCMAKE_BUILD_TYPE=Release"
+      "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
     ];
 
     passthru = {

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,7 +1,8 @@
 final: prev:
 {
   # Add an alias here can help future migration
-  llvmPkgs = final.llvmPackages_17;
+  # Updated to llvmPackages_22 as llvmPackages_17 has been removed from nixpkgs
+  llvmPkgs = final.llvmPackages_22;
   # Use clang instead of gcc to compile, to avoid gcc13 miscompile issue.
   buddy-llvm = final.callPackage ./buddy-llvm.nix { stdenv = final.llvmPkgs.stdenv; };
   buddy-mlir = final.callPackage ./buddy-mlir.nix { stdenv = final.llvmPkgs.stdenv; };


### PR DESCRIPTION
## Summary

- The Nix configuration hasn’t been updated for a long time; it’s still at the LLVM 17 version. At the same time, the new version introduces new dependencies that need updating; for example, nanobind conflicts with the previous version.
- As the environments required for different backends are often highly complex, I have updated the Nix support to the latest version. This is to make it easier for the buddy-example repository to integrate with different backend environments.
- This process can be verified using these two commands: `nix build .#buddy-llvm` and `nix build .#buddy-mlir`

## Checklist

- [x] The code builds successfully
- [x] Existing tests pass
- [ ] New tests are added where appropriate
- [ ] Code follows the project coding style
- [ ] Documentation is updated if needed
