### PR TITLE
[example ]Use fused pass for distributed DeepSeek inference

### DIFF
--- a/examples/BuddyTensorParallel/CMakeLists.txt
+++ b/examples/BuddyTensorParallel/CMakeLists.txt
@@ -491,7 +491,7 @@ set(SUBGRAPH_DECODE_PASSES
   -optimize-allocation-liveness
   -assume-tight-memref-layout
   -staticize-memref-layout
-  -matmul-vectorization-decode=vector-size=32
+  -matmul-transpose-b-vectorization-decode
   -batch-matmul-vectorization-decode=vector-size=128
   -batchmatmul-transpose-b-vectorization=vector-size=16
   -convert-linalg-to-affine-loops
@@ -530,7 +530,7 @@ set(SUBGRAPH_DECODE_PASSES_RVV_K64
   -optimize-allocation-liveness
   -assume-tight-memref-layout
   -staticize-memref-layout
-  "-matmul-parallel-vectorization-tiling=vector-size=64 k-block-size=64"
+  -matmul-transpose-b-vectorization-decode
   -batch-matmul-vectorization-decode=vector-size=128
   -batchmatmul-transpose-b-vectorization=vector-size=16
   -convert-linalg-to-affine-loops
@@ -569,7 +569,7 @@ set(SUBGRAPH_DECODE_PASSES_RVV_K16
   -optimize-allocation-liveness
   -assume-tight-memref-layout
   -staticize-memref-layout
-  "-matmul-parallel-vectorization-tiling=vector-size=64 k-block-size=16"
+  -matmul-transpose-b-vectorization-decode
   -batch-matmul-vectorization-decode=vector-size=128
   -batchmatmul-transpose-b-vectorization=vector-size=16
   -convert-linalg-to-affine-loops

--- a/examples/BuddyTensorParallel/import-deepseek-r1.py
+++ b/examples/BuddyTensorParallel/import-deepseek-r1.py
@@ -29,7 +29,6 @@ from buddy.compiler.graph.operation import *
 from buddy.compiler.graph.transform import (
     apply_classic_fusion,
     eliminate_matmul_transpose_reshape,
-    eliminate_transpose,
     flash_attention_prefill,
     gqa_attention_fusion,
     simply_fuse,
@@ -136,15 +135,10 @@ graph_decode = graphs_decode[0]
 
 params = dynamo_compiler_prefill.imported_params[graph_prefill]
 # Enable verbose mode for debugging eliminate_matmul_transpose_reshape
-graphs_prefill[0].perform(
-    [eliminate_transpose, eliminate_matmul_transpose_reshape]
-)
-graphs_decode[0].perform(
-    [eliminate_transpose, eliminate_matmul_transpose_reshape]
-)
+graphs_prefill[0].perform([eliminate_matmul_transpose_reshape])
+graphs_decode[0].perform([eliminate_matmul_transpose_reshape])
 pattern_list_prefill = [
     simply_fuse,
-    apply_classic_fusion,
     flash_attention_prefill,
 ]
 pattern_list_decode = [
@@ -170,21 +164,22 @@ graph_decode.group_map_device["subgraph0_decode"] = DeviceType.CPU
 DECODE_STRATEGY = SplitStrategy(
     name="decode",
     parallel_num=2,
-    ops_count=[6, 44, 2, 6, 11, 2],
+    ops_count=[6, 47, 2, 6, 11, 2],
     # ops_count=[6, 14, 28, 2, 6, 11, 2],
     stage_boundary_op=PowOp,
     stage_boundary_op_num=57,
     paral_input_positions={
         0: [-1, -1, -1, -1],
-        169: [-1, 1, -1],
+        169: [-1, 0, -1],
         "default": [
             [-1, -1],
-            [1, 0, 1, 0, 1, 0, 0, -1, 1, 1, -1, -1, -1, -1],
+            # [1, 0, 1, 0, 1, 0, 0, -1, 1, 1, -1, -1, -1, -1],
+            [0, 0, 0, 0, 0, 0, 1, -1, 1, 1, -1, -1, -1, -1],
             # [1,0,1,0,1,0,-1,],
             # [0,-1,1,1,-1,-1,-1,1,1,2],
             [-1, -1],
             [-1, -1],
-            [1, 1, 0, -1],
+            [0, 0, 1, -1],
             [-1, -1],
         ],
     },
@@ -193,7 +188,7 @@ DECODE_STRATEGY = SplitStrategy(
 PREFILL_STRATEGY = SplitStrategy(
     name="prefill",
     parallel_num=2,
-    ops_count=[6, 50, 2, 6, 11, 2],
+    ops_count=[6, 54, 2, 6, 14, 2],
     # ops_count=[6, 15, 36, 2, 6, 11, 2],
     stage_boundary_op=PowOp,
     stage_boundary_op_num=57,
@@ -202,17 +197,19 @@ PREFILL_STRATEGY = SplitStrategy(
         169: [-1, -1, -1],
         "default": [
             [-1, 1],
-            [1, 0, 1, 0, 1, 0, 0, -1, -1, -1, -1],
+            # [1, 0, 1, 0, 1, 0, 0, -1, -1, -1, -1],
+            [0, 0, 0, 0, 0, 0, 1, -1, -1, -1, -1],
             # [1,0,1,0,1,0,-1],
             # [0,-1,-1,-1,1,1,1],
             [1, 0],
             [-1, 1],
-            [1, 1, 0, -1],
+            [0, 0, 1, -1],
             [1, 0],
         ],
     },
 )
 
+# driver_prefill = PartitionedGraphDriver(graphs_prefill[0])
 driver_prefill = PartitionedGraphDriver(graphs_prefill[0], PREFILL_STRATEGY)
 for i in range(len(driver_prefill.subgraphs)):
     driver_prefill.subgraphs[i].lower_to_top_level_ir()

--- a/frontend/Python/graph/partitioned_graph_driver.py
+++ b/frontend/Python/graph/partitioned_graph_driver.py
@@ -48,6 +48,7 @@ from .operation import (
     PlaceholderOp,
     ReshapeOp,
     SubOp,
+    TransposeMatmulFusedOp,
     ViewOp,
 )
 from .type import DeviceType
@@ -279,6 +280,47 @@ class PartitionedGraphDriver:
                         new_shape = list(input1_shape)
                         new_shape[-1] = input2_shape[-1]
                         self._add_paral_op_shape(node.name, new_shape)
+
+                # 3. TransposeMatmulFusedOp
+                elif isinstance(node, TransposeMatmulFusedOp):
+                    # args: input, weight
+                    #
+                    # Semantics:
+                    #   input  shape: [..., M, K]
+                    #   weight shape: [N, K]
+                    #   output shape: [..., M, N]
+                    #
+                    # This corresponds to:
+                    #   linalg.matmul_transpose_b(input, weight)
+                    #
+                    # Different from MatmulOp:
+                    #   MatmulOp uses weight [K, N], output N = weight_shape[-1]
+                    #   TransposeMatmulFusedOp uses weight [N, K], output N = weight_shape[-2]
+
+                    if (node.args[0] in self._paral_op_shape) or (
+                        node.args[1] in self._paral_op_shape
+                    ):
+                        input1_shape = self._get_shape_from_cache_or_node(
+                            node.args[0]
+                        )
+                        input2_shape = self._get_shape_from_cache_or_node(
+                            node.args[1]
+                        )
+
+                        if input1_shape and input2_shape:
+                            # Need at least [..., M, K] and [N, K].
+                            if (
+                                len(input1_shape) >= 2
+                                and len(input2_shape) >= 2
+                            ):
+                                new_shape = list(input1_shape)
+
+                                # input2 is original non-transposed weight:
+                                #   [N, K]
+                                # so output last dim is N.
+                                new_shape[-1] = input2_shape[-2]
+
+                                self._add_paral_op_shape(node.name, new_shape)
 
                 # 3. AddMMOp
                 elif isinstance(node, AddMMOp):

--- a/frontend/Python/ops/linalg.py
+++ b/frontend/Python/ops/linalg.py
@@ -1346,7 +1346,19 @@ def matmul_transpose_b_op(
 
     if input1 is None or input2 is None:
         return
-    output_shape = list(node.tensor_meta["shape"])
+
+    input1_shape = ir.RankedTensorType(input1.type).shape
+    input2_shape = ir.RankedTensorType(input2.type).shape
+
+    if input1_shape[1] != input2_shape[1]:
+        raise ValueError(
+            f"Invalid matmul_transpose_b shape for node {node.name}: "
+            f"input1_shape={list(input1_shape)}, "
+            f"input2_shape={list(input2_shape)}"
+        )
+
+    output_shape = [input1_shape[0], input2_shape[0]]
+
     dtype = node.tensor_meta["dtype"]
     mlir_dtype = mlir_element_type_get(dtype)
     tensor_type = ir.RankedTensorType.get(output_shape, mlir_dtype)


### PR DESCRIPTION
## Summary

- This PR updates the distributed DeepSeek inference path to use the fused `matmul_transpose_b` lowering and optimization flow.


## Changes

- Applies the fused AddMM + Transpose path during graph transformation.
- Uses the fused transpose-B matmul pass in the RVV lowering pipeline.
- Updates the split strategy and linalg op support needed by the fused path.

## Dependency

This PR depends on #786 and #785, which adds and registers `-matmul-transpose-b-vectorization-decode`.
Please merge #786  and #785 before this PR.

## Testing

- Verified distributed DeepSeek-R1-Distill-Qwen-1.5B inference on the RVV platform.
- Decode performance reaches about `0.9 s/token` with the fused pass pipeline.
