### PR TITLE
Add VIR new cases support.

### DIFF
--- a/midend/include/Dialect/VIR/VIROps.td
+++ b/midend/include/Dialect/VIR/VIROps.td
@@ -140,7 +140,26 @@ def VIR_FMAOp : VIR_Op<"fma", [AllTypesMatch<["lhs", "rhs", "acc", "result"]>]> 
   let assemblyFormat = "$lhs `,` $rhs `,` $acc attr-dict `:` qualified(type($lhs))";
 }
 
-def VIR_ReduceOp : VIR_Op<"reduce"> {
+def VIR_ReduceOp : VIR_Op<"reduce", [
+    AllTypesMatch<["acc", "result"]>,
+    TypesMatchWith<"accumulator/result type matches input element type",
+                   "input", "acc",
+                   "::llvm::cast<::buddy::vir::DynamicVectorType>($_self)"
+                   ".getElementType()">,
+    PredOpTrait<"reduce kind matches the input element type family", CPred<[{
+      [](::mlir::Operation &op) {
+        auto reduceOp = ::llvm::cast<::buddy::vir::ReduceOp>(&op);
+        ::mlir::Type elementType =
+            reduceOp.getInput().getType().getElementType();
+        ::llvm::StringRef kind = reduceOp.getKind();
+        if (kind == "add" || kind == "maxnum")
+          return ::llvm::isa<::mlir::FloatType>(elementType);
+        if (kind == "maxsi")
+          return ::llvm::isa<::mlir::IntegerType>(elementType);
+        return false;
+      }($_op)
+    }]>>
+  ]> {
   let summary = "Horizontal reduction for dynamic vector IR.";
   let description = [{
     The `reduce` operation reduces a dynamic vector into a scalar using a
@@ -149,13 +168,14 @@ def VIR_ReduceOp : VIR_Op<"reduce"> {
     v1 semantics:
     - `kind = \"add\"`    : floating-point sum reduction
     - `kind = \"maxnum\"` : floating-point maxnum reduction
+    - `kind = \"maxsi\"`  : signed integer max reduction
   }];
   let arguments = (ins
     VIR_DynamicVectorType:$input,
-    AnyFloat:$acc,
+    AnyTypeOf<[AnyInteger, AnyFloat]>:$acc,
     StrAttr:$kind
   );
-  let results = (outs AnyFloat:$result);
+  let results = (outs AnyTypeOf<[AnyInteger, AnyFloat]>:$result);
 
   let assemblyFormat = "$input `,` $acc attr-dict `:` qualified(type($input))"
                        " `,` type($acc) `->` type($result)";

--- a/midend/include/Dialect/VIR/VIROps.td
+++ b/midend/include/Dialect/VIR/VIROps.td
@@ -223,6 +223,32 @@ def VIR_SelectOp : VIR_Op<"select",
                        "`:` qualified(type($condition)) `,` qualified(type($trueValue))";
 }
 
+def VIR_ExtSIOp : VIR_Op<"extsi"> {
+  let summary = "Signed integer extend for dynamic vector IR.";
+  let description = [{
+    The `extsi` operation sign-extends integer element type width elementwise
+    on a dynamic vector.
+  }];
+  let arguments = (ins VIR_DynamicVectorType:$in);
+  let results = (outs VIR_DynamicVectorType:$result);
+  let hasVerifier = 1;
+
+  let assemblyFormat = "$in attr-dict `:` qualified(type($in)) `->` qualified(type($result))";
+}
+
+def VIR_ExtUIOp : VIR_Op<"extui"> {
+  let summary = "Unsigned integer extend for dynamic vector IR.";
+  let description = [{
+    The `extui` operation zero-extends integer element type width elementwise
+    on a dynamic vector.
+  }];
+  let arguments = (ins VIR_DynamicVectorType:$in);
+  let results = (outs VIR_DynamicVectorType:$result);
+  let hasVerifier = 1;
+
+  let assemblyFormat = "$in attr-dict `:` qualified(type($in)) `->` qualified(type($result))";
+}
+
 def VIR_ExtFOp : VIR_Op<"extf"> {
   let summary = "Floating-point extend for dynamic vector IR.";
   let description = [{

--- a/midend/include/Dialect/VIR/VIROps.td
+++ b/midend/include/Dialect/VIR/VIROps.td
@@ -92,6 +92,30 @@ def VIR_StoreOp : VIR_Op<"store"> {
                        "`:` qualified(type($value)) `->` type($base)";
 }
 
+def VIR_ScatterOp : VIR_Op<"scatter"> {
+  let summary = "Scatter operation for dynamic vector IR.";
+  let description = [{
+    The `scatter` operation stores dynamic vector elements into memory using a
+    dynamic vector of offsets along the most-minor dimension. The optional base
+    indices identify the base element for the scatter, and the index vector
+    provides per-lane offsets from that base.
+  }];
+  let arguments = (ins
+    VIR_DynamicVectorType:$value,
+    Arg<AnyMemRef, "the reference to scatter to", [MemWrite]>:$base,
+    VIR_DynamicVectorType:$indexVec,
+    VIR_DynamicVectorType:$mask,
+    Variadic<Index>:$indices
+  );
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = "$value `,` $base `[` $indices `]` `[` $indexVec `]` "
+                       "`,` $mask attr-dict `:` qualified(type($value)) `,` "
+                       "qualified(type($indexVec)) `,` qualified(type($mask)) "
+                       "`->` type($base)";
+}
+
 //===----------------------------------------------------------------------===//
 // Basic Operations
 //===----------------------------------------------------------------------===//

--- a/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
+++ b/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
@@ -309,7 +309,7 @@ static LogicalResult computeShapeAndVL(linalg::LinalgOp linalgOp,
 static buddy::vir::SetVLOp createSetVLRegion(PatternRewriter &rewriter,
                                              Location loc, Value vlVal);
 
-enum class SupportedReduceCombinerKind { AddF, MaxNumF };
+enum class SupportedReduceCombinerKind { AddF, MaxNumF, MaxSI };
 
 static FailureOr<SupportedReduceCombinerKind>
 getSupportedReduceCombinerKind(linalg::ReduceOp reduceOp,
@@ -335,6 +335,8 @@ getSupportedReduceCombinerKind(linalg::ReduceOp reduceOp,
     return SupportedReduceCombinerKind::AddF;
   if (isa<arith::MaxNumFOp>(combiner))
     return SupportedReduceCombinerKind::MaxNumF;
+  if (isa<arith::MaxSIOp>(combiner))
+    return SupportedReduceCombinerKind::MaxSI;
   return failure();
 }
 
@@ -353,16 +355,33 @@ static LogicalResult lowerReduceToScalarLoop(linalg::ReduceOp reduceOp,
   auto outTy = dyn_cast<MemRefType>(init.getType());
   if (!inTy || !outTy)
     return rewriter.notifyMatchFailure(reduceOp, "expected memref operands");
-  if (!inTy.getElementType().isF32() || !outTy.getElementType().isF32())
+  Type inElemTy = inTy.getElementType();
+  Type outElemTy = outTy.getElementType();
+  if (inElemTy != outElemTy)
     return rewriter.notifyMatchFailure(reduceOp,
-                                       "only f32 reduction supported");
+                                       "input/output element types must match");
 
   auto combinerKind = getSupportedReduceCombinerKind(reduceOp, rewriter);
   if (failed(combinerKind))
     return rewriter.notifyMatchFailure(
         reduceOp,
-        "unsupported reduce combiner (expected single-op addf/maxnumf with "
-        "linalg.yield)");
+        "unsupported reduce combiner (expected single-op addf/maxnumf/maxsi "
+        "with linalg.yield)");
+
+  switch (*combinerKind) {
+  case SupportedReduceCombinerKind::AddF:
+  case SupportedReduceCombinerKind::MaxNumF:
+    if (!isa<FloatType>(inElemTy))
+      return rewriter.notifyMatchFailure(
+          reduceOp,
+          "floating-point reduce combiner requires float element type");
+    break;
+  case SupportedReduceCombinerKind::MaxSI:
+    if (!isa<IntegerType>(inElemTy))
+      return rewriter.notifyMatchFailure(
+          reduceOp, "arith.maxsi reduction requires integer element type");
+    break;
+  }
 
   ArrayRef<int64_t> dims = reduceOp.getDimensions();
 
@@ -377,6 +396,8 @@ static LogicalResult lowerReduceToScalarLoop(linalg::ReduceOp reduceOp,
       return "add";
     case SupportedReduceCombinerKind::MaxNumF:
       return "maxnum";
+    case SupportedReduceCombinerKind::MaxSI:
+      return "maxsi";
     }
     llvm_unreachable("unknown reduce combiner");
   };

--- a/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
+++ b/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
@@ -880,6 +880,183 @@ static bool isSupportedGenericBodyOp(Operation &inner) {
              math::ErfOp, math::PowFOp>(inner);
 }
 
+struct StoreOnlyGenericInfo {
+  memref::StoreOp storeOp;
+  Value storedValue;
+  Value storedValueSource;
+  Value scatterIndexSource;
+  Value maskValue;
+  bool isContinuous = false;
+  bool isScatter = false;
+  bool hasMask = false;
+};
+
+static Value stripSupportedIndexCast(Value value) {
+  while (Operation *def = value.getDefiningOp()) {
+    if (auto castOp = dyn_cast<arith::IndexCastOp>(def)) {
+      value = castOp.getIn();
+      continue;
+    }
+    if (auto castOp = dyn_cast<arith::IndexCastUIOp>(def)) {
+      value = castOp.getIn();
+      continue;
+    }
+    break;
+  }
+  return value;
+}
+
+static OpOperand *findOperandForBlockArgument(linalg::GenericOp genericOp,
+                                              Value value) {
+  auto blockArg = dyn_cast<BlockArgument>(value);
+  if (!blockArg || blockArg.getOwner() != genericOp.getBlock())
+    return nullptr;
+  for (OpOperand *opOperand : genericOp.getOpOperandsMatchingBBargs()) {
+    if (genericOp.getMatchingBlockArgument(opOperand) == blockArg)
+      return opOperand;
+  }
+  return nullptr;
+}
+
+static bool isIntegerOrIndexElement(Type type) {
+  return type.isIndex() || isa<IntegerType>(type);
+}
+
+static bool isSupportedStoreOnlyIndexOp(Operation &op) {
+  return isa<linalg::IndexOp, arith::IndexCastOp, arith::IndexCastUIOp>(op);
+}
+
+static FailureOr<StoreOnlyGenericInfo>
+matchVectorizableStoreOnlyGeneric(linalg::GenericOp genericOp) {
+  if (!genericOp.hasPureBufferSemantics())
+    return failure();
+  if (genericOp.getNumDpsInits() != 0)
+    return failure();
+  if (!llvm::all_of(genericOp.getIteratorTypesArray(),
+                    [](utils::IteratorType itTy) {
+                      return linalg::isParallelIterator(itTy);
+                    }))
+    return failure();
+
+  Block &body = genericOp.getRegion().front();
+  auto yield = dyn_cast<linalg::YieldOp>(body.getTerminator());
+  if (!yield || yield.getNumOperands() != 0)
+    return failure();
+
+  memref::StoreOp storeOp;
+  memref::LoadOp oldValueLoadOp;
+  arith::SelectOp maskSelectOp;
+  SmallVector<Operation *> storedValueCastCandidates;
+  for (Operation &inner : body.without_terminator()) {
+    if (auto candidate = dyn_cast<memref::StoreOp>(inner)) {
+      if (storeOp)
+        return failure();
+      storeOp = candidate;
+      continue;
+    }
+    if (auto candidate = dyn_cast<memref::LoadOp>(inner)) {
+      if (oldValueLoadOp)
+        return failure();
+      oldValueLoadOp = candidate;
+      continue;
+    }
+    if (auto candidate = dyn_cast<arith::SelectOp>(inner)) {
+      if (maskSelectOp)
+        return failure();
+      maskSelectOp = candidate;
+      continue;
+    }
+    if (isSupportedStoreOnlyIndexOp(inner))
+      continue;
+    if (isVectorizableFloatCastOp(inner)) {
+      storedValueCastCandidates.push_back(&inner);
+      continue;
+    }
+    return failure();
+  }
+  if (!storeOp)
+    return failure();
+
+  auto storeType = dyn_cast<MemRefType>(storeOp.getMemRef().getType());
+  if (!storeType || storeType.getRank() !=
+                        static_cast<int64_t>(storeOp.getIndices().size()))
+    return failure();
+  if (storeOp.getValueToStore().getType() != storeType.getElementType())
+    return failure();
+
+  StoreOnlyGenericInfo info;
+  info.storeOp = storeOp;
+  info.storedValue = storeOp.getValueToStore();
+  if (auto selectOp = info.storedValue.getDefiningOp<arith::SelectOp>()) {
+    if (selectOp != maskSelectOp || !oldValueLoadOp)
+      return failure();
+    if (selectOp.getFalseValue() != oldValueLoadOp.getResult())
+      return failure();
+    if (oldValueLoadOp.getMemRef() != storeOp.getMemRef())
+      return failure();
+    if (oldValueLoadOp.getIndices().size() != storeOp.getIndices().size())
+      return failure();
+    for (auto [loadIdx, storeIdx] :
+         llvm::zip(oldValueLoadOp.getIndices(), storeOp.getIndices())) {
+      if (loadIdx != storeIdx)
+        return failure();
+    }
+    if (!selectOp.getCondition().getType().isInteger(1))
+      return failure();
+    info.storedValue = selectOp.getTrueValue();
+    info.maskValue = selectOp.getCondition();
+    info.hasMask = true;
+  } else if (maskSelectOp || oldValueLoadOp) {
+    return failure();
+  }
+  info.storedValueSource = info.storedValue;
+  Operation *storedValueDef = info.storedValue.getDefiningOp();
+  if (storedValueDef && isVectorizableFloatCastOp(*storedValueDef) &&
+      storedValueDef->getNumOperands() == 1) {
+    info.storedValueSource = storedValueDef->getOperand(0);
+  }
+  for (Operation *candidate : storedValueCastCandidates) {
+    if (candidate != storedValueDef)
+      return failure();
+  }
+  OpOperand *storedValueOperand =
+      findOperandForBlockArgument(genericOp, info.storedValueSource);
+  if (!storedValueOperand)
+    return failure();
+  if (info.hasMask && !findOperandForBlockArgument(genericOp, info.maskValue))
+    return failure();
+
+  bool continuous = storeOp.getIndices().size() == genericOp.getNumLoops();
+  if (continuous) {
+    for (auto [dim, index] : llvm::enumerate(storeOp.getIndices())) {
+      auto indexOp = index.getDefiningOp<linalg::IndexOp>();
+      if (!indexOp || indexOp.getDim() != dim) {
+        continuous = false;
+        break;
+      }
+    }
+  }
+  if (continuous) {
+    info.isContinuous = true;
+    return info;
+  }
+
+  if (storeOp.getIndices().size() == 1) {
+    Value indexSource = stripSupportedIndexCast(storeOp.getIndices().front());
+    OpOperand *indexOperand =
+        findOperandForBlockArgument(genericOp, indexSource);
+    if (!indexOperand || genericOp.isScalar(indexOperand))
+      return failure();
+    if (!isIntegerOrIndexElement(indexSource.getType()))
+      return failure();
+    info.scatterIndexSource = indexSource;
+    info.isScatter = true;
+    return info;
+  }
+
+  return failure();
+}
+
 static buddy::vir::SetVLOp createSetVLRegion(PatternRewriter &rewriter,
                                              Location loc, Value vlVal) {
   auto setVl = rewriter.create<buddy::vir::SetVLOp>(
@@ -2139,6 +2316,154 @@ static LogicalResult storeYieldValues(linalg::LinalgOp linalgOp,
   return success();
 }
 
+static FailureOr<Value>
+getVectorizedStoreOnlyValue(StoreOnlyGenericInfo info,
+                            PatternRewriter &rewriter,
+                            ArrayRef<int64_t> virShape, IRMapping &valueMap,
+                            DenseMap<Value, Value> &vm) {
+  Location loc = info.storeOp.getLoc();
+  Value mapped;
+  if (auto it = vm.find(info.storedValue); it != vm.end()) {
+    mapped = it->second;
+  } else if (valueMap.contains(info.storedValue)) {
+    mapped = valueMap.lookup(info.storedValue);
+    vm[info.storedValue] = mapped;
+  } else if (Operation *def = info.storedValue.getDefiningOp()) {
+    if (!isVectorizableFloatCastOp(*def) ||
+        !valueMap.contains(def->getOperand(0)))
+      return failure();
+    vm[def->getOperand(0)] = valueMap.lookup(def->getOperand(0));
+    Operation *newOp =
+        createGenericElementwiseVIR(def, rewriter, virShape, vm);
+    if (!newOp || newOp->getNumResults() != 1)
+      return failure();
+    mapped = newOp->getResult(0);
+    vm[info.storedValue] = mapped;
+  }
+
+  if (!mapped)
+    return failure();
+  if (isa<buddy::vir::DynamicVectorType>(mapped.getType()))
+    return mapped;
+
+  auto storeType = cast<MemRefType>(info.storeOp.getMemRef().getType());
+  auto vecTy = buddy::vir::DynamicVectorType::get(virShape,
+                                                  storeType.getElementType());
+  return rewriter.create<buddy::vir::BroadcastOp>(loc, vecTy, mapped)
+      .getResult();
+}
+
+static FailureOr<Value>
+getVectorizedStoreOnlyMask(StoreOnlyGenericInfo info, PatternRewriter &rewriter,
+                           ArrayRef<int64_t> virShape, IRMapping &valueMap,
+                           DenseMap<Value, Value> &vm) {
+  Location loc = info.storeOp.getLoc();
+  auto maskTy = buddy::vir::DynamicVectorType::get(virShape,
+                                                   rewriter.getI1Type());
+  if (!info.hasMask) {
+    Value trueValue = rewriter.create<arith::ConstantIntOp>(loc, 1, 1);
+    return rewriter.create<buddy::vir::BroadcastOp>(loc, maskTy, trueValue)
+        .getResult();
+  }
+
+  Value mapped;
+  if (auto it = vm.find(info.maskValue); it != vm.end()) {
+    mapped = it->second;
+  } else if (valueMap.contains(info.maskValue)) {
+    mapped = valueMap.lookup(info.maskValue);
+    vm[info.maskValue] = mapped;
+  }
+
+  if (!mapped)
+    return failure();
+  if (isa<buddy::vir::DynamicVectorType>(mapped.getType()))
+    return mapped;
+  if (!mapped.getType().isInteger(1))
+    return failure();
+  return rewriter.create<buddy::vir::BroadcastOp>(loc, maskTy, mapped)
+      .getResult();
+}
+
+static LogicalResult
+lowerStoreOnlyGenericToVIR(linalg::GenericOp genericOp,
+                           StoreOnlyGenericInfo info,
+                           PatternRewriter &rewriter) {
+  SmallVector<int64_t> virShape;
+  SmallVector<OpFoldResult> commonShape;
+  Value vlVal;
+  {
+    OpBuilder::InsertionGuard g(rewriter);
+    rewriter.setInsertionPoint(genericOp);
+    if (failed(computeShapeAndVL(genericOp, rewriter, virShape, commonShape,
+                                 vlVal)))
+      return failure();
+  }
+
+  Location loc = genericOp.getLoc();
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(genericOp);
+  createSetVLRegion(rewriter, loc, vlVal);
+
+  DenseMap<Value, Value> transformedMemRefs;
+  IRMapping valueMap;
+  llvm::SetVector<Value> valuesDefinedAbove;
+  mlir::getUsedValuesDefinedAbove(genericOp->getRegion(0), valuesDefinedAbove);
+  valueMap.map(valuesDefinedAbove.getArrayRef(),
+               valuesDefinedAbove.getArrayRef());
+
+  if (failed(transformProjectedPermutationOperands(
+          genericOp, rewriter, commonShape, transformedMemRefs)))
+    return failure();
+  if (failed(mapInputsToVIRVectors(genericOp, rewriter, virShape,
+                                   transformedMemRefs, valueMap)))
+    return failure();
+
+  DenseMap<Value, Value> vm;
+  for (auto it : valueMap.getValueMap())
+    vm[it.first] = it.second;
+
+  FailureOr<Value> mappedStoreValue =
+      getVectorizedStoreOnlyValue(info, rewriter, virShape, valueMap, vm);
+  if (failed(mappedStoreValue))
+    return rewriter.notifyMatchFailure(genericOp,
+                                       "failed to vectorize stored value");
+  FailureOr<Value> mappedMask =
+      getVectorizedStoreOnlyMask(info, rewriter, virShape, valueMap, vm);
+  if (failed(mappedMask))
+    return rewriter.notifyMatchFailure(genericOp, "failed to vectorize mask");
+
+  Value storeBase = info.storeOp.getMemRef();
+  if (valueMap.contains(storeBase))
+    storeBase = valueMap.lookup(storeBase);
+  SmallVector<Value> emptyIdx;
+  if (info.isScatter) {
+    Value indexVec = valueMap.lookup(info.scatterIndexSource);
+    if (!isa<buddy::vir::DynamicVectorType>(indexVec.getType()))
+      return rewriter.notifyMatchFailure(
+          genericOp, "scatter index source must vectorize to VIR vector");
+    rewriter.create<buddy::vir::ScatterOp>(loc, *mappedStoreValue, storeBase,
+                                           indexVec, *mappedMask, emptyIdx);
+  } else if (info.isContinuous) {
+    Value valueToStore = *mappedStoreValue;
+    if (info.hasMask) {
+      auto oldValue = rewriter.create<buddy::vir::LoadOp>(
+          loc, valueToStore.getType(), storeBase, emptyIdx);
+      valueToStore =
+          rewriter
+              .create<buddy::vir::SelectOp>(loc, *mappedMask, valueToStore,
+                                            oldValue.getResult())
+              .getResult();
+    }
+    rewriter.create<buddy::vir::StoreOp>(loc, valueToStore, storeBase, emptyIdx);
+  } else {
+    return failure();
+  }
+
+  rewriter.create<vector::YieldOp>(loc);
+  rewriter.eraseOp(genericOp);
+  return success();
+}
+
 static FailureOr<SmallVector<int64_t>>
 computeTransposedMemRefShape(MemRefType inputType,
                              ArrayRef<int64_t> permutation) {
@@ -2272,6 +2597,13 @@ struct LinalgGenericToVIRPattern : public RewritePattern {
         return rewriter.notifyMatchFailure(
             linalgOp,
             "rank-0 output memref not supported in generic VIR lowering");
+      }
+    }
+    if (auto genericOp = dyn_cast<linalg::GenericOp>(op)) {
+      if (FailureOr<StoreOnlyGenericInfo> storeOnlyInfo =
+              matchVectorizableStoreOnlyGeneric(genericOp);
+          succeeded(storeOnlyInfo)) {
+        return lowerStoreOnlyGenericToVIR(genericOp, *storeOnlyInfo, rewriter);
       }
     }
     bool hasIndexSemantics = false;

--- a/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
+++ b/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
@@ -1067,6 +1067,65 @@ static buddy::vir::SetVLOp createSetVLRegion(PatternRewriter &rewriter,
   return setVl;
 }
 
+static bool isSupportedMatmulElementTypes(Type inputElemTy, Type accElemTy) {
+  if (inputElemTy == accElemTy)
+    return isa<FloatType, IntegerType>(inputElemTy);
+
+  if (auto inputFloat = dyn_cast<FloatType>(inputElemTy)) {
+    auto accFloat = dyn_cast<FloatType>(accElemTy);
+    return accFloat && inputFloat.getWidth() < accFloat.getWidth();
+  }
+
+  if (auto inputInt = dyn_cast<IntegerType>(inputElemTy)) {
+    auto accInt = dyn_cast<IntegerType>(accElemTy);
+    return accInt && inputInt.getWidth() < accInt.getWidth();
+  }
+
+  return false;
+}
+
+static bool isIntegerAccumulator(Type accElemTy) {
+  return isa<IntegerType>(accElemTy);
+}
+
+static Value castVectorToAccumulatorType(
+    OpBuilder &builder, Location loc, Value value,
+    buddy::vir::DynamicVectorType accVecTy, linalg::TypeFn castFn) {
+  auto dynTy = dyn_cast<buddy::vir::DynamicVectorType>(value.getType());
+  if (!dynTy || dynTy.getElementType() == accVecTy.getElementType())
+    return value;
+
+  Type inputElemTy = dynTy.getElementType();
+  Type accElemTy = accVecTy.getElementType();
+  if (isa<FloatType>(inputElemTy) && isa<FloatType>(accElemTy))
+    return builder.create<buddy::vir::ExtFOp>(loc, accVecTy, value)
+        .getResult();
+
+  if (isa<IntegerType>(inputElemTy) && isa<IntegerType>(accElemTy)) {
+    if (castFn == linalg::TypeFn::cast_unsigned)
+      return builder.create<buddy::vir::ExtUIOp>(loc, accVecTy, value)
+          .getResult();
+    return builder.create<buddy::vir::ExtSIOp>(loc, accVecTy, value)
+        .getResult();
+  }
+
+  return Value();
+}
+
+static Value createMatmulAccumulation(
+    OpBuilder &builder, Location loc, Value lhs, Value rhs, Value acc,
+    buddy::vir::DynamicVectorType accVecTy) {
+  Type accElemTy = accVecTy.getElementType();
+  if (isa<FloatType>(accElemTy))
+    return builder.create<buddy::vir::FMAOp>(loc, accVecTy, lhs, rhs, acc)
+        .getResult();
+
+  assert(isIntegerAccumulator(accElemTy) &&
+         "expected integer accumulator for integer matmul");
+  Value product = builder.create<arith::MulIOp>(loc, lhs, rhs).getResult();
+  return builder.create<arith::AddIOp>(loc, product, acc).getResult();
+}
+
 static LogicalResult lowerMatmulToVIR(linalg::MatmulOp matmulOp,
                                       PatternRewriter &rewriter) {
   if (!matmulOp.hasPureBufferSemantics())
@@ -1086,12 +1145,14 @@ static LogicalResult lowerMatmulToVIR(linalg::MatmulOp matmulOp,
   if (aTy.getRank() != 2 || bTy.getRank() != 2 || cTy.getRank() != 2)
     return rewriter.notifyMatchFailure(matmulOp, "expected rank-2 memrefs");
 
-  Type elemTy = aTy.getElementType();
-  if (elemTy != bTy.getElementType() || elemTy != cTy.getElementType())
-    return rewriter.notifyMatchFailure(matmulOp, "element types must match");
-  if (!isa<FloatType>(elemTy))
+  Type inputElemTy = aTy.getElementType();
+  Type accElemTy = cTy.getElementType();
+  if (inputElemTy != bTy.getElementType())
     return rewriter.notifyMatchFailure(matmulOp,
-                                       "only floating-point matmul supported");
+                                       "input element types must match");
+  if (!isSupportedMatmulElementTypes(inputElemTy, accElemTy))
+    return rewriter.notifyMatchFailure(matmulOp,
+                                       "unsupported matmul element types");
 
   // Vectorize along N (the last dimension of B/C).
   Value n = rewriter.create<memref::DimOp>(loc, c, 1);
@@ -1118,8 +1179,11 @@ static LogicalResult lowerMatmulToVIR(linalg::MatmulOp matmulOp,
     kVal = rewriter.create<memref::DimOp>(loc, a, 1);
   }
 
-  auto vecTy =
-      buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
+  auto inputVecTy =
+      buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, inputElemTy);
+  auto accVecTy =
+      buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, accElemTy);
+  linalg::TypeFn castFn = matmulOp.getCast();
 
   auto loopM = rewriter.create<affine::AffineForOp>(
       loc, ValueRange{c0}, rewriter.getDimIdentityMap(), ValueRange{mVal},
@@ -1129,7 +1193,7 @@ static LogicalResult lowerMatmulToVIR(linalg::MatmulOp matmulOp,
         OpBuilder &builder = bld;
         // acc = load(C[i, 0:]) as a vector along N.
         Value acc = builder
-                        .create<buddy::vir::LoadOp>(bodyLoc, vecTy, c,
+                        .create<buddy::vir::LoadOp>(bodyLoc, accVecTy, c,
                                                     ValueRange{i, c0})
                         .getResult();
 
@@ -1144,19 +1208,26 @@ static LogicalResult lowerMatmulToVIR(linalg::MatmulOp matmulOp,
               Value aScalar =
                   builderK.create<memref::LoadOp>(kLoc, a, ValueRange{i, k});
               // aVec = broadcast(aScalar)
-              Value aVec =
-                  builderK.create<buddy::vir::BroadcastOp>(kLoc, vecTy, aScalar)
-                      .getResult();
+              Value aVec = builderK
+                               .create<buddy::vir::BroadcastOp>(kLoc,
+                                                                 inputVecTy,
+                                                                 aScalar)
+                               .getResult();
               // bVec = load(B[k, 0:]) as a vector along N.
               Value bVec = builderK
-                               .create<buddy::vir::LoadOp>(kLoc, vecTy, b,
+                               .create<buddy::vir::LoadOp>(kLoc, inputVecTy, b,
                                                            ValueRange{k, c0})
                                .getResult();
-              // accOut = fma(aVec, bVec, accIn)
-              Value accOut =
-                  builderK
-                      .create<buddy::vir::FMAOp>(kLoc, vecTy, aVec, bVec, accIn)
-                      .getResult();
+              Value aAccVec = castVectorToAccumulatorType(
+                  builderK, kLoc, aVec, accVecTy, castFn);
+              Value bAccVec = castVectorToAccumulatorType(
+                  builderK, kLoc, bVec, accVecTy, castFn);
+              if (!aAccVec || !bAccVec) {
+                matmulOp.emitError("failed to widen matmul inputs");
+                return;
+              }
+              Value accOut = createMatmulAccumulation(
+                  builderK, kLoc, aAccVec, bAccVec, accIn, accVecTy);
               builderK.create<affine::AffineYieldOp>(kLoc, accOut);
             });
         Value finalAcc = loopK.getResult(0);

--- a/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
+++ b/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
@@ -436,6 +436,60 @@ private:
         virSymbolTable[oldResult] = newResult;
     };
 
+    auto remapScatterBaseIndex = [&](Value index) -> FailureOr<Value> {
+      if (virSymbolTable.contains(index))
+        return virSymbolTable.lookup(index);
+
+      if (auto blockArg = dyn_cast<BlockArgument>(index)) {
+        if (blockArg.getOwner() == block)
+          return failure();
+        return index;
+      }
+
+      Operation *defOp = index.getDefiningOp();
+      if (defOp && defOp->getBlock() == block)
+        return failure();
+      return index;
+    };
+
+    auto materializeImplicitMinorBaseIndices =
+        [&](Value base,
+            ValueRange sourceIndices) -> FailureOr<SmallVector<Value>> {
+      SmallVector<Value> destIndices;
+      auto memrefTy = dyn_cast<MemRefType>(base.getType());
+      if (!memrefTy || memrefTy.getRank() == 0)
+        return failure();
+
+      if (!sourceIndices.empty()) {
+        destIndices.reserve(sourceIndices.size());
+        for (Value index : sourceIndices) {
+          FailureOr<Value> mappedIndex = remapScatterBaseIndex(index);
+          if (failed(mappedIndex))
+            return failure();
+          destIndices.push_back(*mappedIndex);
+        }
+        return destIndices;
+      }
+
+      int64_t rank = memrefTy.getRank();
+      destIndices.reserve(rank);
+      for (int64_t i = 0; i < rank - 1; ++i) {
+        if (static_cast<size_t>(i) < leadingIVs.size())
+          destIndices.push_back(leadingIVs[i]);
+        else
+          destIndices.push_back(builder.create<arith::ConstantIndexOp>(loc, 0));
+      }
+      destIndices.push_back(builder.create<arith::ConstantIndexOp>(loc, 0));
+      return destIndices;
+    };
+
+    auto castScalarScatterIndexToIndex = [&](Value idx) -> Value {
+      if (idx.getType().isIndex())
+        return idx;
+      return builder.create<arith::IndexCastOp>(loc, builder.getIndexType(),
+                                                idx);
+    };
+
     for (Operation &innerOp : block->without_terminator()) {
       llvm::TypeSwitch<Operation *>(&innerOp)
           .Case<memref::ExpandShapeOp, memref::SubViewOp, memref::TransposeOp>(
@@ -564,6 +618,49 @@ private:
                                                         destIndices);
               }
             }
+          })
+          .Case<vir::ScatterOp>([&](vir::ScatterOp op) {
+            Value valueToStore = findValue(op.getValue());
+            Value indexVec = findValue(op.getIndexVec());
+            Value mask = findValue(op.getMask());
+            Value base = findValue(op.getBase());
+            if (!valueToStore || !indexVec || !mask || !base) {
+              op.emitError("scatter operands not found in symbol table");
+              return;
+            }
+
+            FailureOr<SmallVector<Value>> baseIndices =
+                materializeImplicitMinorBaseIndices(base, op.getIndices());
+            if (failed(baseIndices)) {
+              op.emitError("failed to materialize base indices for vir.scatter");
+              return;
+            }
+
+            if (isTailLoop) {
+              Value scalarIndex = castScalarScatterIndexToIndex(indexVec);
+              SmallVector<Value> scalarIndices(baseIndices->begin(),
+                                               baseIndices->end());
+              scalarIndices.back() =
+                  builder.create<arith::AddIOp>(loc, scalarIndices.back(),
+                                                scalarIndex);
+              Value oldValue =
+                  builder.create<memref::LoadOp>(loc, base, scalarIndices);
+              Value selected = builder.create<arith::SelectOp>(
+                  loc, mask, valueToStore, oldValue);
+              builder.create<memref::StoreOp>(loc, selected, base,
+                                              scalarIndices);
+              return;
+            }
+
+            auto indexVecTy = dyn_cast<VectorType>(indexVec.getType());
+            auto valueVecTy = dyn_cast<VectorType>(valueToStore.getType());
+            auto maskVecTy = dyn_cast<VectorType>(mask.getType());
+            if (!indexVecTy || !valueVecTy || !maskVecTy) {
+              op.emitError("expected vector operands for non-tail vir.scatter");
+              return;
+            }
+            builder.create<vector::ScatterOp>(loc, base, *baseIndices,
+                                              indexVec, mask, valueToStore);
           })
           .Case<vir::ConstantOp>([&](vir::ConstantOp op) {
             auto constValue = op.getValue();

--- a/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
+++ b/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
@@ -639,9 +639,11 @@ private:
                 out = builder.create<arith::AddFOp>(loc, input, acc);
               } else if (kind == "maxnum") {
                 out = builder.create<arith::MaxNumFOp>(loc, input, acc);
+              } else if (kind == "maxsi") {
+                out = builder.create<arith::MaxSIOp>(loc, input, acc);
               } else {
                 op.emitError(
-                    "unsupported vir.reduce kind (expected add/maxnum)");
+                    "unsupported vir.reduce kind (expected add/maxnum/maxsi)");
                 return;
               }
               virSymbolTable[op.getResult()] = out;
@@ -659,8 +661,11 @@ private:
               combineKind = vector::CombiningKind::ADD;
             } else if (kind == "maxnum") {
               combineKind = vector::CombiningKind::MAXNUMF;
+            } else if (kind == "maxsi") {
+              combineKind = vector::CombiningKind::MAXSI;
             } else {
-              op.emitError("unsupported vir.reduce kind (expected add/maxnum)");
+              op.emitError(
+                  "unsupported vir.reduce kind (expected add/maxnum/maxsi)");
               return;
             }
 

--- a/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
+++ b/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
@@ -788,6 +788,36 @@ private:
               virSymbolTable[op.getResult()] = newOp.getResult();
             }
           })
+          .Case<vir::ExtSIOp>([&](vir::ExtSIOp op) {
+            Value in = findValue(op.getIn());
+            Type outTy = op.getType();
+            if (auto dyn = dyn_cast<vir::DynamicVectorType>(outTy)) {
+              Type elem = dyn.getElementType();
+              if (auto vecTy = dyn_cast<VectorType>(in.getType())) {
+                outTy = VectorType::get(vecTy.getShape(), elem,
+                                        vecTy.getScalableDims());
+              } else {
+                outTy = elem;
+              }
+            }
+            auto newOp = builder.create<arith::ExtSIOp>(loc, outTy, in);
+            virSymbolTable[op.getResult()] = newOp.getResult();
+          })
+          .Case<vir::ExtUIOp>([&](vir::ExtUIOp op) {
+            Value in = findValue(op.getIn());
+            Type outTy = op.getType();
+            if (auto dyn = dyn_cast<vir::DynamicVectorType>(outTy)) {
+              Type elem = dyn.getElementType();
+              if (auto vecTy = dyn_cast<VectorType>(in.getType())) {
+                outTy = VectorType::get(vecTy.getShape(), elem,
+                                        vecTy.getScalableDims());
+              } else {
+                outTy = elem;
+              }
+            }
+            auto newOp = builder.create<arith::ExtUIOp>(loc, outTy, in);
+            virSymbolTable[op.getResult()] = newOp.getResult();
+          })
           .Case<vir::ExtFOp>([&](vir::ExtFOp op) {
             Value in = findValue(op.getIn());
             Type outTy = op.getType();

--- a/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
+++ b/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
@@ -35,10 +35,12 @@
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/Block.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Target/LLVMIR/TypeToLLVM.h"
 #include "llvm/ADT/DenseMap.h"
@@ -345,6 +347,184 @@ private:
   bool verbose;
   bool useCustomVecWid;
 
+  struct CapturedRootAccessSummary {
+    bool hasWrite = false;
+    bool sawOtherRead = false;
+    bool sawOtherWrite = false;
+    bool sawDifferentVectorBase = false;
+    Value vectorBase;
+
+    void recordVectorAccess(Value base, bool isWrite) {
+      if (!vectorBase)
+        vectorBase = base;
+      else if (vectorBase != base)
+        sawDifferentVectorBase = true;
+      if (isWrite)
+        hasWrite = true;
+    }
+
+    void recordOtherAccess(bool isWrite) {
+      if (isWrite) {
+        hasWrite = true;
+        sawOtherWrite = true;
+        return;
+      }
+      sawOtherRead = true;
+    }
+
+    bool isParallelSafe() const {
+      if (!hasWrite)
+        return !sawOtherWrite;
+      return !sawOtherRead && !sawOtherWrite && !sawDifferentVectorBase;
+    }
+  };
+
+  Value getRootMemref(Value value) const {
+    while (Operation *defOp = value.getDefiningOp()) {
+      if (auto transposeOp = dyn_cast<memref::TransposeOp>(defOp)) {
+        value = transposeOp.getIn();
+        continue;
+      }
+      if (auto subViewOp = dyn_cast<memref::SubViewOp>(defOp)) {
+        value = subViewOp.getSource();
+        continue;
+      }
+      if (auto expandShapeOp = dyn_cast<memref::ExpandShapeOp>(defOp)) {
+        value = expandShapeOp.getSrc();
+        continue;
+      }
+      break;
+    }
+    return value;
+  }
+
+  bool isPrivateToSetVLIteration(Value memref, Region &setVLRegion) const {
+    Value root = getRootMemref(memref);
+    if (!isa<BaseMemRefType>(root.getType()))
+      return false;
+
+    Operation *defOp = root.getDefiningOp();
+    if (!defOp || !isa<memref::AllocOp, memref::AllocaOp>(defOp))
+      return false;
+
+    Region *defRegion = defOp->getParentRegion();
+    return defRegion &&
+           (defRegion == &setVLRegion || setVLRegion.isAncestor(defRegion));
+  }
+
+  bool
+  recordCapturedAccess(DenseMap<Value, CapturedRootAccessSummary> &summaries,
+                       Region &setVLRegion, Value base, bool isVectorAccess,
+                       bool isWrite) const {
+    Value root = getRootMemref(base);
+    if (!isa<BaseMemRefType>(root.getType()))
+      return false;
+    if (isPrivateToSetVLIteration(root, setVLRegion))
+      return true;
+
+    auto &summary = summaries[root];
+    if (isVectorAccess) {
+      summary.recordVectorAccess(base, isWrite);
+      return true;
+    }
+
+    summary.recordOtherAccess(isWrite);
+    return true;
+  }
+
+  bool analyzeBlockParallelSafety(
+      Block *block, Region &setVLRegion,
+      DenseMap<Value, CapturedRootAccessSummary> &summaries) const {
+    for (Operation &innerOp : block->without_terminator()) {
+      if (auto forOp = dyn_cast<affine::AffineForOp>(innerOp)) {
+        if (!analyzeBlockParallelSafety(forOp.getBody(), setVLRegion,
+                                        summaries))
+          return false;
+        continue;
+      }
+
+      if (auto loadOp = dyn_cast<vir::LoadOp>(innerOp)) {
+        if (!recordCapturedAccess(summaries, setVLRegion, loadOp.getBase(),
+                                  /*isVectorAccess=*/true,
+                                  /*isWrite=*/false))
+          return false;
+        continue;
+      }
+
+      if (auto storeOp = dyn_cast<vir::StoreOp>(innerOp)) {
+        if (!recordCapturedAccess(summaries, setVLRegion, storeOp.getBase(),
+                                  /*isVectorAccess=*/true,
+                                  /*isWrite=*/true))
+          return false;
+        continue;
+      }
+
+      if (auto scatterOp = dyn_cast<vir::ScatterOp>(innerOp)) {
+        if (!recordCapturedAccess(summaries, setVLRegion, scatterOp.getBase(),
+                                  /*isVectorAccess=*/false,
+                                  /*isWrite=*/true))
+          return false;
+        continue;
+      }
+
+      if (isMemoryEffectFree(&innerOp))
+        continue;
+
+      auto effectOp = dyn_cast<MemoryEffectOpInterface>(&innerOp);
+      if (!effectOp)
+        return false;
+
+      SmallVector<MemoryEffects::EffectInstance, 4> effects;
+      effectOp.getEffects(effects);
+      for (const MemoryEffects::EffectInstance &effect : effects) {
+        Value value = effect.getValue();
+        if (!value)
+          return false;
+
+        auto *effectKind = effect.getEffect();
+        if (isa<MemoryEffects::Allocate, MemoryEffects::Free>(effectKind)) {
+          if (!isPrivateToSetVLIteration(value, setVLRegion))
+            return false;
+          continue;
+        }
+
+        if (isa<MemoryEffects::Read>(effectKind)) {
+          if (!recordCapturedAccess(summaries, setVLRegion, value,
+                                    /*isVectorAccess=*/false,
+                                    /*isWrite=*/false))
+            return false;
+          continue;
+        }
+
+        if (isa<MemoryEffects::Write>(effectKind)) {
+          if (!recordCapturedAccess(summaries, setVLRegion, value,
+                                    /*isVectorAccess=*/false,
+                                    /*isWrite=*/true))
+            return false;
+          continue;
+        }
+
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  bool canParallelizeSetVLRegion(Region &region) const {
+    DenseMap<Value, CapturedRootAccessSummary> summaries;
+    for (Block &block : region) {
+      if (!analyzeBlockParallelSafety(&block, region, summaries))
+        return false;
+    }
+
+    for (const auto &it : summaries) {
+      if (!it.second.isParallelSafe())
+        return false;
+    }
+    return true;
+  }
+
   /// Recursively search for anchor type within a given Region and its nested
   Type findAnchorTypeRecursive(Region &region) const {
     // Check operands and results to find dynamic vector types
@@ -632,7 +812,8 @@ private:
             FailureOr<SmallVector<Value>> baseIndices =
                 materializeImplicitMinorBaseIndices(base, op.getIndices());
             if (failed(baseIndices)) {
-              op.emitError("failed to materialize base indices for vir.scatter");
+              op.emitError(
+                  "failed to materialize base indices for vir.scatter");
               return;
             }
 
@@ -640,9 +821,8 @@ private:
               Value scalarIndex = castScalarScatterIndexToIndex(indexVec);
               SmallVector<Value> scalarIndices(baseIndices->begin(),
                                                baseIndices->end());
-              scalarIndices.back() =
-                  builder.create<arith::AddIOp>(loc, scalarIndices.back(),
-                                                scalarIndex);
+              scalarIndices.back() = builder.create<arith::AddIOp>(
+                  loc, scalarIndices.back(), scalarIndex);
               Value oldValue =
                   builder.create<memref::LoadOp>(loc, base, scalarIndices);
               Value selected = builder.create<arith::SelectOp>(
@@ -659,8 +839,8 @@ private:
               op.emitError("expected vector operands for non-tail vir.scatter");
               return;
             }
-            builder.create<vector::ScatterOp>(loc, base, *baseIndices,
-                                              indexVec, mask, valueToStore);
+            builder.create<vector::ScatterOp>(loc, base, *baseIndices, indexVec,
+                                              mask, valueToStore);
           })
           .Case<vir::ConstantOp>([&](vir::ConstantOp op) {
             auto constValue = op.getValue();
@@ -1422,6 +1602,7 @@ private:
     // !vir.vec<4x?xf32>), we materialize explicit outer loops for those dims
     // and lower the region body per-slice. This matches the current codegen
     // strategy that only vectorizes along the last (dynamic) dimension.
+    bool useParallelMainLoop = canParallelizeSetVLRegion(region);
     SmallVector<int64_t> leadingStaticDims;
     for (Block &blk : region) {
       for (Operation &inner : blk) {
@@ -1489,20 +1670,31 @@ private:
           loc, vlUpboundPat, b.create<arith::ConstantIndexOp>(loc, 1));
       Value zero = b.create<arith::ConstantIndexOp>(loc, 0);
 
-      b.create<affine::AffineForOp>(
-          loc, /*lowerBound=*/ValueRange{zero}, rewriter.getDimIdentityMap(),
-          /*upperBound=*/ValueRange{vlUpbound}, rewriter.getDimIdentityMap(),
-          vectorWid,
-          /*iterArgs=*/ValueRange{},
-          [&](OpBuilder &bb, Location bodyLoc, Value iv, ValueRange) {
-            //===------------------------------------------------------------===//
-            // Step 4: Convert operations inside the dynamic vector region.
-            //===------------------------------------------------------------===//
-            DenseMap<Value, Value> virSymbolTable;
-            lowerBlock(bb, bodyLoc, &region.front(), virSymbolTable, iv,
-                       leadingIVs, targetVectorType, /*isTailLoop=*/false);
-            bb.create<affine::AffineYieldOp>(bodyLoc);
-          });
+      if (useParallelMainLoop) {
+        auto affineParallel = b.create<affine::AffineParallelOp>(
+            loc, TypeRange{}, ArrayRef<arith::AtomicRMWKind>{},
+            ArrayRef<AffineMap>{rewriter.getDimIdentityMap()}, ValueRange{zero},
+            ArrayRef<AffineMap>{rewriter.getDimIdentityMap()},
+            ValueRange{vlUpbound}, ArrayRef<int64_t>{vectorWid});
+        OpBuilder bb = affineParallel.getBodyBuilder();
+        Value iv = affineParallel.getIVs().front();
+
+        DenseMap<Value, Value> virSymbolTable;
+        lowerBlock(bb, loc, &region.front(), virSymbolTable, iv, leadingIVs,
+                   targetVectorType, /*isTailLoop=*/false);
+      } else {
+        b.create<affine::AffineForOp>(
+            loc, /*lowerBound=*/ValueRange{zero}, rewriter.getDimIdentityMap(),
+            /*upperBound=*/ValueRange{vlUpbound}, rewriter.getDimIdentityMap(),
+            vectorWid,
+            /*iterArgs=*/std::nullopt,
+            [&](OpBuilder &bb, Location bodyLoc, Value iv, ValueRange) {
+              DenseMap<Value, Value> virSymbolTable;
+              lowerBlock(bb, bodyLoc, &region.front(), virSymbolTable, iv,
+                         leadingIVs, targetVectorType, /*isTailLoop=*/false);
+              bb.create<affine::AffineYieldOp>(bodyLoc);
+            });
+      }
 
       //===----------------------------------------------------------------===//
       // Step 5: Create a tail loop to process the remaining elements.

--- a/midend/lib/Dialect/VIR/VIROps.cpp
+++ b/midend/lib/Dialect/VIR/VIROps.cpp
@@ -29,3 +29,35 @@
 
 #define GET_OP_CLASSES
 #include "VIR/VIR.cpp.inc"
+
+::mlir::LogicalResult buddy::vir::ScatterOp::verify() {
+  auto valueType = getValue().getType();
+  auto indexVecType = getIndexVec().getType();
+  auto maskType = getMask().getType();
+  ::mlir::Type indexElementType = indexVecType.getElementType();
+
+  if (!::llvm::isa<::mlir::IntegerType, ::mlir::IndexType>(indexElementType))
+    return emitOpError(
+        "scatter index vector element type must be integer or index");
+
+  if (valueType.getShape() != indexVecType.getShape())
+    return emitOpError("scatter value and index vector shapes must match");
+  if (valueType.getShape() != maskType.getShape())
+    return emitOpError("scatter value and mask vector shapes must match");
+
+  if (valueType.getScalingFactor() != indexVecType.getScalingFactor())
+    return emitOpError(
+        "scatter value and index vector scaling factors must match");
+  if (valueType.getScalingFactor() != maskType.getScalingFactor())
+    return emitOpError(
+        "scatter value and mask vector scaling factors must match");
+  if (!maskType.getElementType().isInteger(1))
+    return emitOpError("scatter mask vector element type must be i1");
+
+  auto baseType = ::mlir::cast<::mlir::ShapedType>(getBase().getType());
+  if (valueType.getElementType() != baseType.getElementType())
+    return emitOpError(
+        "scatter value element type must match memref element type");
+
+  return ::mlir::success();
+}

--- a/midend/lib/Dialect/VIR/VIROps.cpp
+++ b/midend/lib/Dialect/VIR/VIROps.cpp
@@ -30,6 +30,30 @@
 #define GET_OP_CLASSES
 #include "VIR/VIR.cpp.inc"
 
+static ::mlir::LogicalResult
+verifyIntegerExtOp(::mlir::Operation *op,
+                   buddy::vir::DynamicVectorType inputType,
+                   buddy::vir::DynamicVectorType resultType) {
+  auto inputInt =
+      ::mlir::dyn_cast<::mlir::IntegerType>(inputType.getElementType());
+  auto resultInt =
+      ::mlir::dyn_cast<::mlir::IntegerType>(resultType.getElementType());
+  if (!inputInt)
+    return op->emitOpError("input element type must be integer");
+  if (!resultInt)
+    return op->emitOpError("result element type must be integer");
+
+  if (inputType.getShape() != resultType.getShape())
+    return op->emitOpError("input and result shapes must match");
+  if (inputType.getScalingFactor() != resultType.getScalingFactor())
+    return op->emitOpError("input and result scaling factors must match");
+  if (resultInt.getWidth() <= inputInt.getWidth())
+    return op->emitOpError(
+        "result integer width must be greater than input integer width");
+
+  return ::mlir::success();
+}
+
 ::mlir::LogicalResult buddy::vir::ScatterOp::verify() {
   auto valueType = getValue().getType();
   auto indexVecType = getIndexVec().getType();
@@ -60,4 +84,14 @@
         "scatter value element type must match memref element type");
 
   return ::mlir::success();
+}
+
+::mlir::LogicalResult buddy::vir::ExtSIOp::verify() {
+  return verifyIntegerExtOp(getOperation(), getIn().getType(),
+                            getResult().getType());
+}
+
+::mlir::LogicalResult buddy::vir::ExtUIOp::verify() {
+  return verifyIntegerExtOp(getOperation(), getIn().getType(),
+                            getResult().getType());
 }

--- a/tests/Conversion/LinalgToVIR/linalg-generic-store-to-vir-to-vector.mlir
+++ b/tests/Conversion/LinalgToVIR/linalg-generic-store-to-vir-to-vector.mlir
@@ -1,0 +1,135 @@
+// RUN: buddy-opt %s -split-input-file -lower-linalg-to-vir -lower-vir-to-vector='vector-width=4' -cse | FileCheck %s
+
+#map1 = affine_map<(d0) -> (d0)>
+
+func.func @store_only_scatter_i32_offsets(%offsets: memref<8xi32>,
+                                          %values: memref<8xf32>,
+                                          %out: memref<?xf32>) {
+  linalg.generic {
+      indexing_maps = [#map1, #map1],
+      iterator_types = ["parallel"]
+    } ins(%offsets, %values : memref<8xi32>, memref<8xf32>) {
+  ^bb0(%idx_i32: i32, %value: f32):
+    %idx = arith.index_cast %idx_i32 : i32 to index
+    memref.store %value, %out[%idx] : memref<?xf32>
+    linalg.yield
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @store_only_scatter_i32_offsets
+// CHECK-NOT: linalg.generic
+// CHECK: vector.scatter
+// CHECK-NOT: linalg.generic
+
+// -----
+
+#map1 = affine_map<(d0) -> (d0)>
+
+func.func @store_only_masked_scatter_i32_offsets(%offsets: memref<8xi32>,
+                                                 %values: memref<8xi32>,
+                                                 %mask: memref<8xi1>,
+                                                 %out: memref<?xi32>) {
+  linalg.generic {
+      indexing_maps = [#map1, #map1, #map1],
+      iterator_types = ["parallel"]
+    } ins(%offsets, %values, %mask : memref<8xi32>, memref<8xi32>, memref<8xi1>) {
+  ^bb0(%idx_i32: i32, %value: i32, %mask_value: i1):
+    %idx = arith.index_cast %idx_i32 : i32 to index
+    %old = memref.load %out[%idx] : memref<?xi32>
+    %selected = arith.select %mask_value, %value, %old : i32
+    memref.store %selected, %out[%idx] : memref<?xi32>
+    linalg.yield
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @store_only_masked_scatter_i32_offsets
+// CHECK-NOT: linalg.generic
+// CHECK: vector.scatter
+// CHECK-SAME: vector<4xi1>
+// CHECK-NOT: linalg.generic
+
+// -----
+
+#map2 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @store_only_transposed_transfer_write(%src: memref<2x4xf32>,
+                                                %out: memref<4x2xf32>) {
+  %out_t = memref.transpose %out (d0, d1) -> (d1, d0)
+      : memref<4x2xf32> to memref<2x4xf32, strided<[1, 2]>>
+  linalg.generic {
+      indexing_maps = [#map2],
+      iterator_types = ["parallel", "parallel"]
+    } ins(%src : memref<2x4xf32>) {
+  ^bb0(%value: f32):
+    %i = linalg.index 0 : index
+    %j = linalg.index 1 : index
+    memref.store %value, %out_t[%i, %j]
+      : memref<2x4xf32, strided<[1, 2]>>
+    linalg.yield
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @store_only_transposed_transfer_write
+// CHECK-NOT: linalg.generic
+// CHECK-NOT: vector.scatter
+// CHECK: memref.transpose
+// CHECK-NOT: linalg.generic
+// CHECK-NOT: vector.scatter
+// CHECK: vector.transfer_write
+// CHECK-NOT: vector.scatter
+// CHECK-NOT: linalg.generic
+
+// -----
+
+#map1 = affine_map<(d0) -> (d0)>
+
+func.func @mixed_store_and_yield_keeps_fallback(%offsets: memref<8xi32>,
+                                                %values: memref<8xf32>,
+                                                %out: memref<8xf32>,
+                                                %side: memref<?xf32>) {
+  linalg.generic {
+      indexing_maps = [#map1, #map1, #map1],
+      iterator_types = ["parallel"]
+    } ins(%offsets, %values : memref<8xi32>, memref<8xf32>)
+      outs(%out : memref<8xf32>) {
+  ^bb0(%idx_i32: i32, %value: f32, %old: f32):
+    %idx = arith.index_cast %idx_i32 : i32 to index
+    memref.store %value, %side[%idx] : memref<?xf32>
+    linalg.yield %value : f32
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @mixed_store_and_yield_keeps_fallback
+// CHECK-NOT: vector.scatter
+// CHECK: memref.store
+// CHECK-NOT: vector.scatter
+
+// -----
+
+#map1 = affine_map<(d0) -> (d0)>
+
+func.func @store_only_sitofp_value_keeps_fallback(%offsets: memref<8xi32>,
+                                                  %values: memref<8xi32>,
+                                                  %out: memref<?xf32>) {
+  linalg.generic {
+      indexing_maps = [#map1, #map1],
+      iterator_types = ["parallel"]
+    } ins(%offsets, %values : memref<8xi32>, memref<8xi32>) {
+  ^bb0(%idx_i32: i32, %value_i32: i32):
+    %idx = arith.index_cast %idx_i32 : i32 to index
+    %value = arith.sitofp %value_i32 : i32 to f32
+    memref.store %value, %out[%idx] : memref<?xf32>
+    linalg.yield
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @store_only_sitofp_value_keeps_fallback
+// CHECK-NOT: vector.scatter
+// CHECK: arith.sitofp
+// CHECK: memref.store
+// CHECK-NOT: vector.scatter

--- a/tests/Conversion/LinalgToVIR/linalg-lowering-to-vir-fallbacks.mlir
+++ b/tests/Conversion/LinalgToVIR/linalg-lowering-to-vir-fallbacks.mlir
@@ -44,6 +44,27 @@ func.func @reduce_maxnumf(%arg0: memref<16xf32>, %arg1: memref<f32>) {
 // CHECK-VEC-REDUCE: arith.maxnumf
 
 // -----
+// CASE: linalg-reduce-to-vir-scalar-maxsi-i32.mlir
+func.func @reduce_maxsi(%arg0: memref<16xi32>, %arg1: memref<i32>) {
+  linalg.reduce ins(%arg0 : memref<16xi32>) outs(%arg1 : memref<i32>) dimensions = [0]
+    (%in: i32, %init: i32) {
+      %max = arith.maxsi %in, %init : i32
+      linalg.yield %max : i32
+    }
+  return
+}
+
+// CHECK-LABEL: func.func @reduce_maxsi
+// CHECK-NOT: linalg.reduce
+// CHECK: vir.set_vl
+// CHECK: vir.load %arg0
+// CHECK: vir.reduce
+// CHECK: memref.store
+// CHECK-VEC-REDUCE-LABEL: func.func @reduce_maxsi
+// CHECK-VEC-REDUCE: vector.reduction <maxsi>
+// CHECK-VEC-REDUCE: arith.maxsi
+
+// -----
 // CASE: linalg-reduce-to-vir-2d-to-1d-addf-f32.mlir
 func.func @reduce_2d_to_1d_addf(%arg0: memref<4x8xf32>, %arg1: memref<4xf32>) {
   linalg.reduce ins(%arg0 : memref<4x8xf32>) outs(%arg1 : memref<4xf32>) dimensions = [1]

--- a/tests/Conversion/LinalgToVIR/linalg-matmul-mixed-precision-to-vir-to-vector.mlir
+++ b/tests/Conversion/LinalgToVIR/linalg-matmul-mixed-precision-to-vir-to-vector.mlir
@@ -1,0 +1,65 @@
+// RUN: buddy-opt %s -split-input-file -lower-linalg-to-vir -lower-vir-to-vector='vector-width=4' -cse | FileCheck %s
+
+func.func @matmul_f16_inputs_f32_output(%A: memref<2x4xf16>,
+                                        %B: memref<4x?xf16>,
+                                        %C: memref<2x?xf32>) {
+  linalg.matmul ins(%A, %B : memref<2x4xf16>, memref<4x?xf16>)
+      outs(%C : memref<2x?xf32>)
+  return
+}
+
+// CHECK-LABEL: func.func @matmul_f16_inputs_f32_output
+// CHECK-NOT: linalg.matmul
+// CHECK: arith.extf {{.*}} : vector<4xf16> to vector<4xf32>
+// CHECK: arith.extf {{.*}} : vector<4xf16> to vector<4xf32>
+// CHECK: vector.fma {{.*}} : vector<4xf32>
+// CHECK: arith.extf {{.*}} : f16 to f32
+// CHECK: arith.extf {{.*}} : f16 to f32
+// CHECK: arith.mulf {{.*}} : f32
+// CHECK: arith.addf {{.*}} : f32
+// CHECK-NOT: linalg.matmul
+
+// -----
+
+func.func @matmul_i8_inputs_i32_output(%A: memref<2x4xi8>,
+                                       %B: memref<4x?xi8>,
+                                       %C: memref<2x?xi32>) {
+  linalg.matmul ins(%A, %B : memref<2x4xi8>, memref<4x?xi8>)
+      outs(%C : memref<2x?xi32>)
+  return
+}
+
+// CHECK-LABEL: func.func @matmul_i8_inputs_i32_output
+// CHECK-NOT: linalg.matmul
+// CHECK: arith.extsi {{.*}} : vector<4xi8> to vector<4xi32>
+// CHECK: arith.extsi {{.*}} : vector<4xi8> to vector<4xi32>
+// CHECK: arith.muli {{.*}} : vector<4xi32>
+// CHECK: arith.addi {{.*}} : vector<4xi32>
+// CHECK: arith.extsi {{.*}} : i8 to i32
+// CHECK: arith.extsi {{.*}} : i8 to i32
+// CHECK: arith.muli {{.*}} : i32
+// CHECK: arith.addi {{.*}} : i32
+// CHECK-NOT: linalg.matmul
+
+// -----
+
+func.func @matmul_u8_inputs_i32_output(%A: memref<2x4xi8>,
+                                       %B: memref<4x?xi8>,
+                                       %C: memref<2x?xi32>) {
+  linalg.matmul {cast = #linalg.type_fn<cast_unsigned>}
+      ins(%A, %B : memref<2x4xi8>, memref<4x?xi8>)
+      outs(%C : memref<2x?xi32>)
+  return
+}
+
+// CHECK-LABEL: func.func @matmul_u8_inputs_i32_output
+// CHECK-NOT: linalg.matmul
+// CHECK: arith.extui {{.*}} : vector<4xi8> to vector<4xi32>
+// CHECK: arith.extui {{.*}} : vector<4xi8> to vector<4xi32>
+// CHECK: arith.muli {{.*}} : vector<4xi32>
+// CHECK: arith.addi {{.*}} : vector<4xi32>
+// CHECK: arith.extui {{.*}} : i8 to i32
+// CHECK: arith.extui {{.*}} : i8 to i32
+// CHECK: arith.muli {{.*}} : i32
+// CHECK: arith.addi {{.*}} : i32
+// CHECK-NOT: linalg.matmul

--- a/tests/Conversion/LinalgToVIR/linalg-matmul-to-vir-to-vector.mlir
+++ b/tests/Conversion/LinalgToVIR/linalg-matmul-to-vir-to-vector.mlir
@@ -1,6 +1,7 @@
 // RUN: buddy-opt %s -lower-linalg-to-vir -lower-vir-to-vector="vector-width=4" -cse --convert-vector-to-scf --lower-affine --expand-strided-metadata --convert-scf-to-cf --convert-cf-to-llvm --convert-vector-to-llvm --finalize-memref-to-llvm --convert-arith-to-llvm --convert-func-to-llvm --reconcile-unrealized-casts | mlir-runner -O0 -e main -entry-point-result=i32 -shared-libs=%mlir_runner_utils_dir/libmlir_runner_utils%shlibext,%mlir_runner_utils_dir/libmlir_c_runner_utils%shlibext | FileCheck %s
 
 func.func private @printMemrefF32(memref<*xf32>) attributes { llvm.emit_c_interface }
+func.func private @printMemrefI32(memref<*xi32>) attributes { llvm.emit_c_interface }
 
 // Test: f32 matmul basic case.
 func.func @case_linalg_matmul_to_vir_to_vector_f32() -> i32 {
@@ -169,10 +170,106 @@ func.func @case_linalg_matmul_to_vir_to_vector_tail_f32() -> i32 {
   return %ret : i32
 }
 
+// Test: f16 input matmul with f32 accumulation/output.
+func.func @case_linalg_matmul_to_vir_to_vector_f16_f32() -> i32 {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %n = arith.constant 5 : index
+
+  %A = memref.alloc() : memref<1x2xf16>
+  %B = memref.alloc(%n) : memref<2x?xf16>
+  %C = memref.alloc(%n) : memref<1x?xf32>
+
+  // A = [1, 2]
+  %a0 = arith.constant 1.0 : f16
+  %a1 = arith.constant 2.0 : f16
+  memref.store %a0, %A[%c0, %c0] : memref<1x2xf16>
+  memref.store %a1, %A[%c0, %c1] : memref<1x2xf16>
+
+  // B[0, j] = j
+  // B[1, j] = 100 + j
+  affine.for %j = 0 to 5 {
+    %jj = arith.index_cast %j : index to i64
+    %b0 = arith.sitofp %jj : i64 to f16
+    %hund = arith.constant 100 : i64
+    %v1 = arith.addi %hund, %jj : i64
+    %b1 = arith.sitofp %v1 : i64 to f16
+    memref.store %b0, %B[%c0, %j] : memref<2x?xf16>
+    memref.store %b1, %B[%c1, %j] : memref<2x?xf16>
+  }
+
+  // Zero-initialize C.
+  affine.for %j = 0 to 5 {
+    %z = arith.constant 0.0 : f32
+    memref.store %z, %C[%c0, %j] : memref<1x?xf32>
+  }
+
+  linalg.matmul ins(%A, %B : memref<1x2xf16>, memref<2x?xf16>)
+      outs(%C : memref<1x?xf32>)
+
+  %printed = memref.cast %C : memref<1x?xf32> to memref<*xf32>
+  call @printMemrefF32(%printed) : (memref<*xf32>) -> ()
+
+  // Expected: C[0,j] = 1*j + 2*(100+j) = 200 + 3*j
+  // CHECK: {{Unranked Memref base@ = 0x[0-9A-Fa-f]{1,} rank = 2 offset = 0 sizes = \[1, 5\] strides = \[5, 1\] data =}}
+  // CHECK{LITERAL}: [[200, 203, 206, 209, 212]]
+
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}
+
+// Test: i8 input matmul with i32 accumulation/output.
+func.func @case_linalg_matmul_to_vir_to_vector_i8_i32() -> i32 {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %n = arith.constant 5 : index
+
+  %A = memref.alloc() : memref<1x2xi8>
+  %B = memref.alloc(%n) : memref<2x?xi8>
+  %C = memref.alloc(%n) : memref<1x?xi32>
+
+  // A = [-2, 3]
+  %a0 = arith.constant -2 : i8
+  %a1 = arith.constant 3 : i8
+  memref.store %a0, %A[%c0, %c0] : memref<1x2xi8>
+  memref.store %a1, %A[%c0, %c1] : memref<1x2xi8>
+
+  // B[0, j] = j
+  // B[1, j] = 10 + j
+  affine.for %j = 0 to 5 {
+    %b0 = arith.index_cast %j : index to i8
+    %ten = arith.constant 10 : i8
+    %b1 = arith.addi %ten, %b0 : i8
+    memref.store %b0, %B[%c0, %j] : memref<2x?xi8>
+    memref.store %b1, %B[%c1, %j] : memref<2x?xi8>
+  }
+
+  // Zero-initialize C.
+  affine.for %j = 0 to 5 {
+    %z = arith.constant 0 : i32
+    memref.store %z, %C[%c0, %j] : memref<1x?xi32>
+  }
+
+  linalg.matmul ins(%A, %B : memref<1x2xi8>, memref<2x?xi8>)
+      outs(%C : memref<1x?xi32>)
+
+  %printed = memref.cast %C : memref<1x?xi32> to memref<*xi32>
+  call @printMemrefI32(%printed) : (memref<*xi32>) -> ()
+
+  // Expected: C[0,j] = -2*j + 3*(10+j) = 30 + j
+  // CHECK: {{Unranked Memref base@ = 0x[0-9A-Fa-f]{1,} rank = 2 offset = 0 sizes = \[1, 5\] strides = \[5, 1\] data =}}
+  // CHECK{LITERAL}: [[30, 31, 32, 33, 34]]
+
+  %ret = arith.constant 0 : i32
+  return %ret : i32
+}
+
 func.func @main() -> i32 {
   %res_case_linalg_matmul_to_vir_to_vector_f32 = call @case_linalg_matmul_to_vir_to_vector_f32() : () -> i32
   %res_case_linalg_matmul_to_vir_to_vector_accumulate_f32 = call @case_linalg_matmul_to_vir_to_vector_accumulate_f32() : () -> i32
   %res_case_linalg_matmul_to_vir_to_vector_tail_f32 = call @case_linalg_matmul_to_vir_to_vector_tail_f32() : () -> i32
+  %res_case_linalg_matmul_to_vir_to_vector_f16_f32 = call @case_linalg_matmul_to_vir_to_vector_f16_f32() : () -> i32
+  %res_case_linalg_matmul_to_vir_to_vector_i8_i32 = call @case_linalg_matmul_to_vir_to_vector_i8_i32() : () -> i32
   %ret = arith.constant 0 : i32
   return %ret : i32
 }

--- a/tests/Conversion/vir-integer-ext-invalid.mlir
+++ b/tests/Conversion/vir-integer-ext-invalid.mlir
@@ -1,0 +1,31 @@
+// RUN: buddy-opt -verify-diagnostics %s
+
+func.func @extsi_rejects_float_input(%input: !vir.vec<?xf32>) {
+  // expected-error@+1 {{input element type must be integer}}
+  %0 = vir.extsi %input : !vir.vec<?xf32> -> !vir.vec<?xi32>
+  return
+}
+
+func.func @extui_rejects_float_result(%input: !vir.vec<?xi8>) {
+  // expected-error@+1 {{result element type must be integer}}
+  %0 = vir.extui %input : !vir.vec<?xi8> -> !vir.vec<?xf32>
+  return
+}
+
+func.func @extsi_rejects_shape_mismatch(%input: !vir.vec<2x?xi8>) {
+  // expected-error@+1 {{input and result shapes must match}}
+  %0 = vir.extsi %input : !vir.vec<2x?xi8> -> !vir.vec<?xi32>
+  return
+}
+
+func.func @extui_rejects_scaling_factor_mismatch(%input: !vir.vec<?xi8, m2>) {
+  // expected-error@+1 {{input and result scaling factors must match}}
+  %0 = vir.extui %input : !vir.vec<?xi8, m2> -> !vir.vec<?xi32>
+  return
+}
+
+func.func @extsi_rejects_non_widening_result(%input: !vir.vec<?xi32>) {
+  // expected-error@+1 {{result integer width must be greater than input integer width}}
+  %0 = vir.extsi %input : !vir.vec<?xi32> -> !vir.vec<?xi32>
+  return
+}

--- a/tests/Conversion/vir-reduce-invalid-kind-type.mlir
+++ b/tests/Conversion/vir-reduce-invalid-kind-type.mlir
@@ -1,0 +1,23 @@
+// RUN: buddy-opt -verify-diagnostics %s
+
+func.func @reduce_add_requires_float(%input: !vir.vec<?xi32>, %acc: i32) -> i32 {
+  // expected-error @+1 {{failed to verify that reduce kind matches the input element type family}}
+  %0 = vir.reduce %input, %acc {kind = "add"} : !vir.vec<?xi32>, i32 -> i32
+  return %0 : i32
+}
+
+// -----
+
+func.func @reduce_maxsi_requires_integer(%input: !vir.vec<?xf32>, %acc: f32) -> f32 {
+  // expected-error @+1 {{failed to verify that reduce kind matches the input element type family}}
+  %0 = vir.reduce %input, %acc {kind = "maxsi"} : !vir.vec<?xf32>, f32 -> f32
+  return %0 : f32
+}
+
+// -----
+
+func.func @reduce_unknown_kind_rejected(%input: !vir.vec<?xf32>, %acc: f32) -> f32 {
+  // expected-error @+1 {{failed to verify that reduce kind matches the input element type family}}
+  %0 = vir.reduce %input, %acc {kind = "mul"} : !vir.vec<?xf32>, f32 -> f32
+  return %0 : f32
+}

--- a/tests/Conversion/vir-scatter-invalid.mlir
+++ b/tests/Conversion/vir-scatter-invalid.mlir
@@ -1,0 +1,49 @@
+// RUN: buddy-opt -verify-diagnostics %s
+
+func.func @scatter_rejects_float_index_vector(
+    %value: !vir.vec<?xf32>, %base: memref<?xf32>,
+    %index: !vir.vec<?xf32>, %mask: !vir.vec<?xi1>) {
+  // expected-error@+1 {{scatter index vector element type must be integer or index}}
+  vir.scatter %value, %base[][%index], %mask : !vir.vec<?xf32>, !vir.vec<?xf32>, !vir.vec<?xi1> -> memref<?xf32>
+  return
+}
+
+func.func @scatter_rejects_shape_mismatch(
+    %value: !vir.vec<2x?xf32>, %base: memref<?xf32>,
+    %index: !vir.vec<?xi32>, %mask: !vir.vec<2x?xi1>) {
+  // expected-error@+1 {{scatter value and index vector shapes must match}}
+  vir.scatter %value, %base[][%index], %mask : !vir.vec<2x?xf32>, !vir.vec<?xi32>, !vir.vec<2x?xi1> -> memref<?xf32>
+  return
+}
+
+func.func @scatter_rejects_scaling_factor_mismatch(
+    %value: !vir.vec<?xf32, m2>, %base: memref<?xf32>,
+    %index: !vir.vec<?xi32, f2>, %mask: !vir.vec<?xi1, m2>) {
+  // expected-error@+1 {{scatter value and index vector scaling factors must match}}
+  vir.scatter %value, %base[][%index], %mask : !vir.vec<?xf32, m2>, !vir.vec<?xi32, f2>, !vir.vec<?xi1, m2> -> memref<?xf32>
+  return
+}
+
+func.func @scatter_rejects_value_memref_element_type_mismatch(
+    %value: !vir.vec<?xf32>, %base: memref<?xi32>,
+    %index: !vir.vec<?xi32>, %mask: !vir.vec<?xi1>) {
+  // expected-error@+1 {{scatter value element type must match memref element type}}
+  vir.scatter %value, %base[][%index], %mask : !vir.vec<?xf32>, !vir.vec<?xi32>, !vir.vec<?xi1> -> memref<?xi32>
+  return
+}
+
+func.func @scatter_rejects_mask_shape_mismatch(
+    %value: !vir.vec<2x?xf32>, %base: memref<?xf32>,
+    %index: !vir.vec<2x?xi32>, %mask: !vir.vec<?xi1>) {
+  // expected-error@+1 {{scatter value and mask vector shapes must match}}
+  vir.scatter %value, %base[][%index], %mask : !vir.vec<2x?xf32>, !vir.vec<2x?xi32>, !vir.vec<?xi1> -> memref<?xf32>
+  return
+}
+
+func.func @scatter_rejects_non_i1_mask(
+    %value: !vir.vec<?xf32>, %base: memref<?xf32>,
+    %index: !vir.vec<?xi32>, %mask: !vir.vec<?xi32>) {
+  // expected-error@+1 {{scatter mask vector element type must be i1}}
+  vir.scatter %value, %base[][%index], %mask : !vir.vec<?xf32>, !vir.vec<?xi32>, !vir.vec<?xi32> -> memref<?xf32>
+  return
+}

--- a/tests/Conversion/vir-scatter-to-vector.mlir
+++ b/tests/Conversion/vir-scatter-to-vector.mlir
@@ -1,0 +1,43 @@
+// RUN: buddy-opt %s -lower-vir-to-vector='vector-width=4' -cse | FileCheck %s
+
+func.func @scatter_implicit_base(%base: memref<16xf32>) {
+  %vl = arith.constant 8 : index
+  %idx = arith.constant 1 : i32
+  vir.set_vl %vl : index {
+    %value = vir.constant { value = 2.000000e+00 : f32 } : !vir.vec<?xf32>
+    %index = vir.broadcast %idx : i32 -> !vir.vec<?xi32>
+    %true = arith.constant true
+    %mask = vir.broadcast %true : i1 -> !vir.vec<?xi1>
+    vir.scatter %value, %base[][%index], %mask : !vir.vec<?xf32>, !vir.vec<?xi32>, !vir.vec<?xi1> -> memref<16xf32>
+    vector.yield
+  }
+  return
+}
+
+func.func @scatter_explicit_base(%base: memref<4x16xf32>) {
+  %vl = arith.constant 8 : index
+  %row = arith.constant 1 : index
+  %col = arith.constant 2 : index
+  %idx = arith.constant 3 : i32
+  vir.set_vl %vl : index {
+    %value = vir.constant { value = 4.000000e+00 : f32 } : !vir.vec<?xf32>
+    %index = vir.broadcast %idx : i32 -> !vir.vec<?xi32>
+    %true = arith.constant true
+    %mask = vir.broadcast %true : i1 -> !vir.vec<?xi1>
+    vir.scatter %value, %base[%row, %col][%index], %mask : !vir.vec<?xf32>, !vir.vec<?xi32>, !vir.vec<?xi1> -> memref<4x16xf32>
+    vector.yield
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @scatter_implicit_base
+// CHECK: vector.scatter
+// CHECK-SAME: memref<16xf32>, vector<4xi32>, vector<4xi1>, vector<4xf32>
+// CHECK: memref.store
+// CHECK-SAME: memref<16xf32>
+
+// CHECK-LABEL: func.func @scatter_explicit_base
+// CHECK: vector.scatter
+// CHECK-SAME: memref<4x16xf32>, vector<4xi32>, vector<4xi1>, vector<4xf32>
+// CHECK: memref.store
+// CHECK-SAME: memref<4x16xf32>

--- a/tests/Conversion/vir-set-vl-affine-parallel.mlir
+++ b/tests/Conversion/vir-set-vl-affine-parallel.mlir
@@ -1,0 +1,19 @@
+// RUN: buddy-opt %s -lower-vir-to-vector='vector-width=4' -cse | FileCheck %s
+
+func.func @vir_set_vl_affine_parallel(%base: memref<128xf32>) {
+  %c128 = arith.constant 128 : index
+  vir.set_vl %c128 : index {
+    %vec = vir.load %base[] : memref<128xf32> -> !vir.vec<?xf32>
+    vir.store %vec, %base[] : !vir.vec<?xf32> -> memref<128xf32>
+    vector.yield
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @vir_set_vl_affine_parallel
+// CHECK: affine.parallel
+// CHECK: vector.load
+// CHECK: vector.store
+// CHECK: affine.for
+// CHECK: memref.load
+// CHECK: memref.store

--- a/tests/Conversion/vir-set-vl-sequential-reduction.mlir
+++ b/tests/Conversion/vir-set-vl-sequential-reduction.mlir
@@ -1,0 +1,21 @@
+// RUN: buddy-opt %s -lower-vir-to-vector='vector-width=4' -cse | FileCheck %s
+
+func.func @vir_set_vl_reduction_is_sequential(%base: memref<128xi32>,
+                                              %acc: memref<i32>) {
+  %c128 = arith.constant 128 : index
+  vir.set_vl %c128 : index {
+    %vec = vir.load %base[] : memref<128xi32> -> !vir.vec<?xi32>
+    %cur = memref.load %acc[] : memref<i32>
+    %next = vir.reduce %vec, %cur {kind = "maxsi"} : !vir.vec<?xi32>, i32 -> i32
+    memref.store %next, %acc[] : memref<i32>
+    vector.yield
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @vir_set_vl_reduction_is_sequential
+// CHECK-NOT: affine.parallel
+// CHECK: affine.for
+// CHECK: vector.load
+// CHECK: vector.reduction <maxsi>
+// CHECK: memref.store


### PR DESCRIPTION
## Summary

- Added support for linalg.reduce containing arith.maxsi.
- Support linalg.generic with only memref.store and lower it to vector.scatter or vector.transfer_write.
- Add support for mixed-precision matrix multiplication by promoting input matrices before computation.


