### PR TITLE
[runtime] Support tiered KV cache DeepSeek R1 builds in buddy-codegen and add the f32 tiered cache spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ If CMake is configured with `-DBUDDY_BUILD_DEEPSEEK_R1_MODEL=ON`, you can build 
 ninja deepseek_r1_model_so deepseek_r1_rax buddy-cli
 ```
 
+To build the DeepSeek R1 f32 tiered KV cache variant for `buddy-cli`, use the
+dedicated spec:
+
+```bash
+python3 tools/buddy-codegen/build_model.py \
+  --spec models/deepseek_r1/specs/f32_tiered_kv_cache.json \
+  --build-dir build
+```
+
 ```bash
 ./build/bin/buddy-cli \
   --model ./build/models/deepseek_r1/deepseek_r1.rax \

--- a/examples/BuddyDeepSeekR1/CMakeLists.txt
+++ b/examples/BuddyDeepSeekR1/CMakeLists.txt
@@ -1982,7 +1982,7 @@ target_link_libraries(buddy-deepseek-r1-tiered-kv-cache-run ${BUDDY_DEEPSEEKR1_T
 
 add_custom_target(deepseekr1-tiered-kv-cache
   DEPENDS buddy-deepseek-r1-tiered-kv-cache-run
-  COMMENT "Building DeepSeekR1 tiered-kv-cache inference"
+  COMMENT "Building DeepSeekR1 tiered-kv-cache inference with cache sizes: ${KV_CACHE_SIZES}"
 )
 
 add_test(
@@ -1997,5 +1997,3 @@ set_tests_properties(
     PASS_REGULAR_EXPRESSION "Total time"
     TIMEOUT 3600
 )
-
-message(STATUS "DeepSeekR1 Multi-Cache: Building prefill and decode subgraphs for cache sizes: ${KV_CACHE_SIZES}")

--- a/midend/lib/Conversion/EliminateMemRefCopy/EliminateMemRefCopy.cpp
+++ b/midend/lib/Conversion/EliminateMemRefCopy/EliminateMemRefCopy.cpp
@@ -42,6 +42,32 @@ using namespace mlir;
 
 namespace {
 
+static bool isFunctionArgument(Value value) {
+  auto arg = dyn_cast<BlockArgument>(value);
+  if (!arg)
+    return false;
+  return isa<func::FuncOp>(arg.getOwner()->getParentOp());
+}
+
+static bool isAliasOfFunctionArgument(Value value) {
+  if (isFunctionArgument(value))
+    return true;
+
+  if (auto castOp = value.getDefiningOp<memref::CastOp>())
+    return isAliasOfFunctionArgument(castOp.getSource());
+
+  if (auto reinterpretOp = value.getDefiningOp<memref::ReinterpretCastOp>())
+    return isAliasOfFunctionArgument(reinterpretOp.getSource());
+
+  if (auto result = dyn_cast<OpResult>(value)) {
+    if (auto metadataOp =
+            dyn_cast<memref::ExtractStridedMetadataOp>(result.getOwner()))
+      return isAliasOfFunctionArgument(metadataOp.getSource());
+  }
+
+  return false;
+}
+
 // Pattern to eliminate memref.copy from function arguments to allocations
 struct EliminateMemRefCopyPattern : public OpRewritePattern<memref::CopyOp> {
   using OpRewritePattern<memref::CopyOp>::OpRewritePattern;
@@ -52,15 +78,8 @@ struct EliminateMemRefCopyPattern : public OpRewritePattern<memref::CopyOp> {
     Value source = copyOp.getSource();
     Value dest = copyOp.getTarget();
 
-    // Check if source is a block argument (function argument)
-    BlockArgument sourceArg = dyn_cast<BlockArgument>(source);
-    if (!sourceArg)
-      return failure();
-
-    // Check if the source is a function argument (not a block argument from a
-    // loop)
-    Block *sourceBlock = sourceArg.getOwner();
-    if (!isa<func::FuncOp>(sourceBlock->getParentOp()))
+    // Check if the source is a function argument or an alias rooted at one.
+    if (!isAliasOfFunctionArgument(source))
       return failure();
 
     // Check if destination is an allocation
@@ -84,10 +103,17 @@ struct EliminateMemRefCopyPattern : public OpRewritePattern<memref::CopyOp> {
 
     // Collect all uses of the allocation
     SmallVector<OpOperand *> uses;
+    SmallVector<memref::DeallocOp> deallocs;
     for (OpOperand &use : allocOp->getUses()) {
       // Skip the copy operation itself
       if (use.getOwner() == copyOp.getOperation())
         continue;
+      // The allocation will be removed, so its dealloc should be removed too.
+      // Retargeting it to a function argument alias is invalid.
+      if (auto deallocOp = dyn_cast<memref::DeallocOp>(use.getOwner())) {
+        deallocs.push_back(deallocOp);
+        continue;
+      }
       uses.push_back(&use);
     }
 
@@ -187,6 +213,9 @@ struct EliminateMemRefCopyPattern : public OpRewritePattern<memref::CopyOp> {
 
     // Erase the copy operation
     rewriter.eraseOp(copyOp);
+
+    for (memref::DeallocOp deallocOp : deallocs)
+      rewriter.eraseOp(deallocOp);
 
     // Erase the allocation if it has no more uses
     if (allocOp->use_empty()) {

--- a/models/deepseek_r1/CMakeLists.txt
+++ b/models/deepseek_r1/CMakeLists.txt
@@ -30,12 +30,55 @@ set(BUDDY_DSR1_LOCAL_MODEL ""
   CACHE PATH "Optional: local HF model directory (weights import; sets DEEPSEEKR1_MODEL_PATH)")
 set(BUDDY_DSR1_COMPILE_JOBS "1"
   CACHE STRING "Parallel MLIR→.o jobs when using compile_pipeline.py")
+set(BUDDY_DSR1_TIERED_KV_CACHE ""
+  CACHE STRING "Auto/ON/OFF: build DeepSeek R1 with tiered KV cache entrypoints")
+set(BUDDY_DSR1_TIERED_CACHE_SIZES ""
+  CACHE STRING "Semicolon-separated tiered KV cache sizes; auto-detected from spec if empty")
 
 # Optional: skip PyTorch import (Mode B) or use pre-built .o (Mode A)
 set(DEEPSEEKR1_BUILD_DIR "" CACHE PATH
   "Mode A: dir containing pre-built forward/subgraph .o files")
 set(DEEPSEEKR1_MLIR_DIR "" CACHE PATH
   "Mode B: dir containing pre-generated forward_prefill.mlir etc.")
+
+if(NOT Python3_EXECUTABLE)
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+endif()
+
+execute_process(
+  COMMAND "${Python3_EXECUTABLE}" -c
+          "import json,sys; s=json.load(open(sys.argv[1])); raw=s.get('tiered_kv_cache', False); enabled=False; sizes=[]\nif isinstance(raw, dict):\n  enabled=bool(raw.get('enabled', True)); sizes=raw.get('cache_sizes', s.get('cache_sizes', []))\nelse:\n  enabled=bool(raw); sizes=s.get('cache_sizes', [])\nif isinstance(sizes, str): sizes=[x.strip() for x in sizes.split(',') if x.strip()]\nif enabled and not sizes: sizes=[32,64,128,256,512,1024]\nprint(('ON' if enabled else 'OFF') + '|' + ','.join(str(x) for x in sizes))"
+          "${BUDDY_DSR1_SPEC}"
+  OUTPUT_VARIABLE _BUDDY_DSR1_TIERED_FROM_SPEC
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE _BUDDY_DSR1_TIERED_PARSE_RESULT)
+
+set(_BUDDY_DSR1_TIERED_ENABLED_FROM_SPEC OFF)
+set(_BUDDY_DSR1_TIERED_SIZES_FROM_SPEC "")
+if(_BUDDY_DSR1_TIERED_PARSE_RESULT EQUAL 0)
+  string(REPLACE "|" ";" _BUDDY_DSR1_TIERED_FIELDS
+         "${_BUDDY_DSR1_TIERED_FROM_SPEC}")
+  list(GET _BUDDY_DSR1_TIERED_FIELDS 0 _BUDDY_DSR1_TIERED_ENABLED_FROM_SPEC)
+  list(LENGTH _BUDDY_DSR1_TIERED_FIELDS _BUDDY_DSR1_TIERED_FIELD_COUNT)
+  if(_BUDDY_DSR1_TIERED_FIELD_COUNT GREATER 1)
+    list(GET _BUDDY_DSR1_TIERED_FIELDS 1 _BUDDY_DSR1_TIERED_SIZES_CSV)
+    string(REPLACE "," ";" _BUDDY_DSR1_TIERED_SIZES_FROM_SPEC
+           "${_BUDDY_DSR1_TIERED_SIZES_CSV}")
+  endif()
+endif()
+
+if(BUDDY_DSR1_TIERED_KV_CACHE STREQUAL "")
+  set(_BUDDY_DSR1_TIERED_ENABLED "${_BUDDY_DSR1_TIERED_ENABLED_FROM_SPEC}")
+else()
+  set(_BUDDY_DSR1_TIERED_ENABLED "${BUDDY_DSR1_TIERED_KV_CACHE}")
+endif()
+
+if(BUDDY_DSR1_TIERED_CACHE_SIZES STREQUAL "")
+  set(_BUDDY_DSR1_TIERED_CACHE_SIZES
+      "${_BUDDY_DSR1_TIERED_SIZES_FROM_SPEC}")
+else()
+  set(_BUDDY_DSR1_TIERED_CACHE_SIZES "${BUDDY_DSR1_TIERED_CACHE_SIZES}")
+endif()
 
 buddy_add_model(
   NAME deepseek_r1
@@ -46,4 +89,6 @@ buddy_add_model(
   BUILD_DIR "${DEEPSEEKR1_BUILD_DIR}"
   MLIR_DIR "${DEEPSEEKR1_MLIR_DIR}"
   COMPILE_JOBS "${BUDDY_DSR1_COMPILE_JOBS}"
+  TIERED_KV_CACHE "${_BUDDY_DSR1_TIERED_ENABLED}"
+  TIERED_CACHE_SIZES "${_BUDDY_DSR1_TIERED_CACHE_SIZES}"
 )

--- a/models/deepseek_r1/specs/f32_tiered_kv_cache.json
+++ b/models/deepseek_r1/specs/f32_tiered_kv_cache.json
@@ -1,0 +1,17 @@
+{
+  "hf_model_path": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+  "model_family": "deepseek_r1",
+  "variant": "f32",
+  "max_token_len": 1024,
+  "num_threads": 48,
+  "tiered_kv_cache": {
+    "enabled": true,
+    "cache_sizes": [32, 64, 128, 256, 512, 1024]
+  },
+  "weights_override": {
+    "total": 1777088064,
+    "linear_elements": 0,
+    "linear_output_channels": 0,
+    "other_elements": 0
+  }
+}

--- a/tests/Conversion/eliminate-memref-copy.mlir
+++ b/tests/Conversion/eliminate-memref-copy.mlir
@@ -37,6 +37,32 @@ module {
     memref.store %sum, %alloc[%c0] : memref<5xf32>
     return %alloc : memref<5xf32>
   }
+
+  // Test a copy whose source is an alias of a function argument. This mirrors
+  // the cache update shape produced after a previous copy is eliminated.
+  func.func @test_alias_chain(%arg0: memref<1x2x1024x128xf32, strided<[?, ?, ?, ?], offset: ?>>) -> memref<1x2x1024x128xf32> {
+    %base, %offset, %sizes:4, %strides:4 = memref.extract_strided_metadata %arg0 : memref<1x2x1024x128xf32, strided<[?, ?, ?, ?], offset: ?>> -> memref<f32>, index, index, index, index, index, index, index, index, index
+    %reinterpret_cast = memref.reinterpret_cast %base to offset: [%offset], sizes: [1, 2, 1024, 128], strides: [%strides#0, %strides#1, %strides#2, 1] : memref<f32> to memref<1x2x1024x128xf32, strided<[?, ?, ?, 1], offset: ?>>
+    %cast = memref.cast %reinterpret_cast : memref<1x2x1024x128xf32, strided<[?, ?, ?, 1], offset: ?>> to memref<1x2x1024x128xf32>
+    %alloc = memref.alloc() : memref<1x2x1024x128xf32>
+    memref.copy %cast, %alloc : memref<1x2x1024x128xf32> to memref<1x2x1024x128xf32>
+    %c0 = arith.constant 0 : index
+    %val = memref.load %alloc[%c0, %c0, %c0, %c0] : memref<1x2x1024x128xf32>
+    memref.store %val, %alloc[%c0, %c0, %c0, %c0] : memref<1x2x1024x128xf32>
+    return %alloc : memref<1x2x1024x128xf32>
+  }
+
+  // Test that the dealloc of an eliminated allocation is removed instead of
+  // being retargeted to a function argument alias.
+  func.func @test_dealloc_removed(%arg0: memref<10xf32, strided<[?], offset: ?>>) {
+    %alloc = memref.alloc() : memref<10xf32>
+    memref.copy %arg0, %alloc : memref<10xf32, strided<[?], offset: ?>> to memref<10xf32>
+    %c0 = arith.constant 0 : index
+    %val = memref.load %alloc[%c0] : memref<10xf32>
+    memref.store %val, %alloc[%c0] : memref<10xf32>
+    memref.dealloc %alloc : memref<10xf32>
+    return
+  }
 }
 
 // CHECK-LABEL: func.func @test_basic
@@ -75,4 +101,26 @@ module {
 // CHECK: memref.load
 // CHECK: arith.addf
 // CHECK: memref.store
+// CHECK: return
+
+// CHECK-LABEL: func.func @test_alias_chain
+// CHECK-NOT: memref.alloc
+// CHECK-NOT: memref.copy
+// CHECK: memref.extract_strided_metadata
+// CHECK: memref.reinterpret_cast
+// CHECK-SAME: strided<[?, ?, ?, 1]
+// CHECK: memref.cast
+// CHECK-SAME: memref<1x2x1024x128xf32>
+// CHECK: memref.load
+// CHECK: memref.store
+// CHECK: return
+
+// CHECK-LABEL: func.func @test_dealloc_removed
+// CHECK-NOT: memref.alloc
+// CHECK-NOT: memref.copy
+// CHECK: memref.extract_strided_metadata
+// CHECK: memref.reinterpret_cast
+// CHECK: memref.load
+// CHECK: memref.store
+// CHECK-NOT: memref.dealloc
 // CHECK: return

--- a/tools/buddy-codegen/cmake/buddy_model.cmake
+++ b/tools/buddy-codegen/cmake/buddy_model.cmake
@@ -72,14 +72,16 @@ endif()
 #   [NUM_THREADS  <N>]                      OpenMP threads (default from spec)
 #   [LLC_ATTRS    <string>]                 LLC target attributes
 #   [COMPILE_JOBS <N>]                      parallel MLIR compilation jobs
+#   [TIERED_KV_CACHE ON|OFF]                build multiple cache-sized entrypoints
+#   [TIERED_CACHE_SIZES <list>]             e.g. "32;64;128;256;512;1024"
 # )
 # ──────────────────────────────────────────────────────────────────────────────
 function(buddy_add_model)
   cmake_parse_arguments(
     MDL                                      # prefix
     ""                                       # flags
-    "NAME;SPEC;RUNNER_SRC;HF_CONFIG;LOCAL_MODEL;BUILD_DIR;MLIR_DIR;NUM_THREADS;LLC_ATTRS;COMPILE_JOBS"
-    ""                                       # multi-value
+    "NAME;SPEC;RUNNER_SRC;HF_CONFIG;LOCAL_MODEL;BUILD_DIR;MLIR_DIR;NUM_THREADS;LLC_ATTRS;COMPILE_JOBS;TIERED_KV_CACHE"
+    "TIERED_CACHE_SIZES"                     # multi-value
     ${ARGN}
   )
 
@@ -110,6 +112,15 @@ function(buddy_add_model)
 
   if(NOT MDL_COMPILE_JOBS)
     set(MDL_COMPILE_JOBS 1)
+  endif()
+
+  if(MDL_TIERED_KV_CACHE)
+    set(MDL_TIERED_KV_CACHE ON)
+  else()
+    set(MDL_TIERED_KV_CACHE OFF)
+  endif()
+  if(MDL_TIERED_KV_CACHE AND NOT MDL_TIERED_CACHE_SIZES)
+    set(MDL_TIERED_CACHE_SIZES 32 64 128 256 512 1024)
   endif()
 
   set(MDL_GEN_MANIFEST_ARGS)
@@ -253,17 +264,42 @@ function(buddy_add_model)
 
   set(MODEL_SO "${BIN}/${MDL_NAME}_model.so")
 
-  set(OBJ_FP "${BIN}/forward_prefill.o")
-  set(OBJ_SP "${BIN}/subgraph_prefill.o")
-  set(OBJ_FD "${BIN}/forward_decode.o")
-  set(OBJ_SD "${BIN}/subgraph_decode.o")
+  set(OBJ_FILES)
+  set(MLIR_COMPILE_DEPS)
+  if(MDL_TIERED_KV_CACHE)
+    foreach(CACHE_SIZE ${MDL_TIERED_CACHE_SIZES})
+      list(APPEND OBJ_FILES
+        "${BIN}/forward_prefill_${CACHE_SIZE}.o"
+        "${BIN}/subgraph_prefill_${CACHE_SIZE}.o"
+        "${BIN}/forward_decode_${CACHE_SIZE}.o"
+        "${BIN}/subgraph_decode_${CACHE_SIZE}.o")
+    endforeach()
+  else()
+    list(APPEND OBJ_FILES
+      "${BIN}/forward_prefill.o"
+      "${BIN}/subgraph_prefill.o"
+      "${BIN}/forward_decode.o"
+      "${BIN}/subgraph_decode.o")
+  endif()
 
   if(MDL_BUILD_DIR)
     # ── Mode A: pre-built .o ───────────────────────────────────────────────
-    set(OBJ_FP "${MDL_BUILD_DIR}/forward_prefill.o")
-    set(OBJ_SP "${MDL_BUILD_DIR}/subgraph_prefill.o")
-    set(OBJ_FD "${MDL_BUILD_DIR}/forward_decode.o")
-    set(OBJ_SD "${MDL_BUILD_DIR}/subgraph_decode.o")
+    set(OBJ_FILES)
+    if(MDL_TIERED_KV_CACHE)
+      foreach(CACHE_SIZE ${MDL_TIERED_CACHE_SIZES})
+        list(APPEND OBJ_FILES
+          "${MDL_BUILD_DIR}/forward_prefill_${CACHE_SIZE}.o"
+          "${MDL_BUILD_DIR}/subgraph_prefill_${CACHE_SIZE}.o"
+          "${MDL_BUILD_DIR}/forward_decode_${CACHE_SIZE}.o"
+          "${MDL_BUILD_DIR}/subgraph_decode_${CACHE_SIZE}.o")
+      endforeach()
+    else()
+      list(APPEND OBJ_FILES
+        "${MDL_BUILD_DIR}/forward_prefill.o"
+        "${MDL_BUILD_DIR}/subgraph_prefill.o"
+        "${MDL_BUILD_DIR}/forward_decode.o"
+        "${MDL_BUILD_DIR}/subgraph_decode.o")
+    endif()
 
   else()
     # Determine MLIR source directory
@@ -314,17 +350,28 @@ function(buddy_add_model)
     endif()
 
     if(MDL_MLIR_DIR)
-      set(MLIR_COMPILE_DEPS
-        "${MLIR_SRC}/forward_prefill.mlir"
-        "${MLIR_SRC}/subgraph0_prefill.mlir"
-        "${MLIR_SRC}/forward_decode.mlir"
-        "${MLIR_SRC}/subgraph0_decode.mlir"
-      )
+      if(MDL_TIERED_KV_CACHE)
+        set(MLIR_COMPILE_DEPS)
+        foreach(CACHE_SIZE ${MDL_TIERED_CACHE_SIZES})
+          list(APPEND MLIR_COMPILE_DEPS
+            "${MLIR_SRC}/forward_prefill_${CACHE_SIZE}.mlir"
+            "${MLIR_SRC}/subgraph0_prefill_${CACHE_SIZE}.mlir"
+            "${MLIR_SRC}/forward_decode_${CACHE_SIZE}.mlir"
+            "${MLIR_SRC}/subgraph0_decode_${CACHE_SIZE}.mlir")
+        endforeach()
+      else()
+        set(MLIR_COMPILE_DEPS
+          "${MLIR_SRC}/forward_prefill.mlir"
+          "${MLIR_SRC}/subgraph0_prefill.mlir"
+          "${MLIR_SRC}/forward_decode.mlir"
+          "${MLIR_SRC}/subgraph0_decode.mlir"
+        )
+      endif()
     endif()
 
     # ── Stage 2: MLIR → .o via compile_pipeline.py ─────────────────────────
     add_custom_command(
-      OUTPUT "${OBJ_FP}" "${OBJ_SP}" "${OBJ_FD}" "${OBJ_SD}"
+      OUTPUT ${OBJ_FILES}
       COMMAND "${Python3_EXECUTABLE}" "${BUDDY_CODEGEN_DIR}/compile_pipeline.py"
               --config "${GEN_CONFIG}"
               --compile-all
@@ -386,11 +433,11 @@ function(buddy_add_model)
               -shared -fPIC
               ${_BUDDY_MODEL_LINK_FLAGS}
               -o "${MODEL_SO}"
-              "${OBJ_FP}" "${OBJ_SP}" "${OBJ_FD}" "${OBJ_SD}"
+              ${OBJ_FILES}
               "-L${LLVM_LIBRARY_DIR}"
               "-Wl,-rpath,${LLVM_LIBRARY_DIR}"
               ${MDL_STAGE3_LIBS}
-    DEPENDS "${OBJ_FP}" "${OBJ_SP}" "${OBJ_FD}" "${OBJ_SD}"
+    DEPENDS ${OBJ_FILES}
     COMMENT "[${MDL_NAME}] Stage 3: linking ${MDL_NAME}_model.so"
     VERBATIM
   )

--- a/tools/buddy-codegen/compile_pipeline.py
+++ b/tools/buddy-codegen/compile_pipeline.py
@@ -71,7 +71,11 @@ LOWER_TO_LLVM = [
 
 
 def build_stages(
-    pipeline_type: str, num_threads: int, llc_attrs: str, variant: str = "f32"
+    pipeline_type: str,
+    num_threads: int,
+    llc_attrs: str,
+    variant: str = "f32",
+    tiered: bool = False,
 ):
     """
     Build the list of (tool_name, [args]) stages for a given pipeline type.
@@ -131,7 +135,10 @@ def build_stages(
             )
             opts.append("-matmul-vectorization-decode=vector-size=32")
         elif variant != "w8a8":
-            opts.append("-matmul-vectorization-decode=vector-size=32")
+            vector_size = 128 if tiered else 32
+            opts.append(
+                f"-matmul-vectorization-decode=vector-size={vector_size}"
+            )
         opts.extend(
             [
                 "-batch-matmul-vectorization-decode=vector-size=128",
@@ -169,6 +176,8 @@ def build_stages(
                 f"-convert-scf-to-openmp=num-threads={num_threads}",
             ]
         )
+        if tiered:
+            opts.append("-cse")
 
     opts.extend(LOWER_TO_LLVM)
     stages.append(("buddy-opt", opts))
@@ -262,6 +271,71 @@ MLIR_FILE_MAP = {
 }
 
 
+def is_tiered_kv_cache(config: dict) -> bool:
+    return bool(config.get("tiered_kv_cache", {}).get("enabled", False))
+
+
+def tiered_cache_sizes(config: dict) -> list[int]:
+    return [
+        int(x) for x in config.get("tiered_kv_cache", {}).get("cache_sizes", [])
+    ]
+
+
+def compile_entries(config: dict) -> list[tuple[str, str, str]]:
+    """Return (pipeline_key, input_mlir_name, output_obj_name) entries."""
+    pipelines = config["compilation"]["pipelines"]
+    if is_tiered_kv_cache(config):
+        entries = []
+        for cache_size in tiered_cache_sizes(config):
+            for key in pipelines:
+                if key == "forward_prefill":
+                    entries.append(
+                        (
+                            key,
+                            f"forward_prefill_{cache_size}.mlir",
+                            f"forward_prefill_{cache_size}.o",
+                        )
+                    )
+                elif key == "subgraph_prefill":
+                    entries.append(
+                        (
+                            key,
+                            f"subgraph0_prefill_{cache_size}.mlir",
+                            f"subgraph_prefill_{cache_size}.o",
+                        )
+                    )
+                elif key == "forward_decode":
+                    entries.append(
+                        (
+                            key,
+                            f"forward_decode_{cache_size}.mlir",
+                            f"forward_decode_{cache_size}.o",
+                        )
+                    )
+                elif key == "subgraph_decode":
+                    entries.append(
+                        (
+                            key,
+                            f"subgraph0_decode_{cache_size}.mlir",
+                            f"subgraph_decode_{cache_size}.o",
+                        )
+                    )
+                else:
+                    raise KeyError(
+                        f"Unknown pipeline key for tiered build: {key}"
+                    )
+        return entries
+
+    variant = config.get("variant", "")
+    suffix = f"-{variant}" if variant not in ("f32", "") else ""
+    entries = []
+    for key in pipelines:
+        base_mlir, base_obj = MLIR_FILE_MAP[key]
+        mlir_name = base_mlir.replace(".mlir", f"{suffix}.mlir")
+        entries.append((key, mlir_name, base_obj))
+    return entries
+
+
 def _compile_one(task: dict) -> str:
     """Compile a single MLIR file. Returns a status message."""
     name = task["name"]
@@ -270,6 +344,7 @@ def _compile_one(task: dict) -> str:
         task["num_threads"],
         task["llc_attrs"],
         task.get("variant", "f32"),
+        task.get("tiered", False),
     )
     run_pipeline(
         stages,
@@ -297,22 +372,15 @@ def compile_all(
 
     os.makedirs(output_dir, exist_ok=True)
 
-    # Build suffix for variant-specific MLIR files (e.g., "-w8a16")
-    suffix = f"-{variant}" if variant not in ("f32", "") else ""
-
     tasks = []
-    for key, pipeline_type in pipelines.items():
-        base_mlir, base_obj = MLIR_FILE_MAP[key]
-        # MLIR inputs may be variant-suffixed (e.g. forward_prefill-w8a16.mlir).
-        # Object files keep stable names (forward_prefill.o): one build dir = one variant.
-        mlir_name = base_mlir.replace(".mlir", f"{suffix}.mlir")
-        obj_name = base_obj
-
+    for key, mlir_name, obj_name in compile_entries(config):
+        pipeline_type = pipelines[key]
         input_path = os.path.join(mlir_dir, mlir_name)
         output_path = os.path.join(output_dir, obj_name)
 
-        if not os.path.exists(input_path):
+        if not os.path.exists(input_path) and not is_tiered_kv_cache(config):
             # Fall back to name without suffix
+            base_mlir, _ = MLIR_FILE_MAP[key]
             input_path = os.path.join(mlir_dir, base_mlir)
 
         tasks.append(
@@ -322,6 +390,7 @@ def compile_all(
                 "num_threads": num_threads,
                 "llc_attrs": llc_attrs,
                 "variant": variant,
+                "tiered": is_tiered_kv_cache(config),
                 "input": input_path,
                 "output": output_path,
                 "buddy_opt": buddy_opt,
@@ -471,9 +540,8 @@ def main():
             so_name = config["compilation"]["so_name"]
 
             obj_files = []
-            for key in config["compilation"]["pipelines"]:
-                _, base_obj = MLIR_FILE_MAP[key]
-                obj_files.append(os.path.join(args.output_dir, base_obj))
+            for _key, _mlir_name, obj_name in compile_entries(config):
+                obj_files.append(os.path.join(args.output_dir, obj_name))
 
             link_shared_lib(
                 obj_files=obj_files,
@@ -488,7 +556,11 @@ def main():
         num_threads = config["compilation"]["num_threads"]
         variant = config.get("variant", "f32")
         stages = build_stages(
-            args.pipeline, num_threads, args.llc_attrs, variant
+            args.pipeline,
+            num_threads,
+            args.llc_attrs,
+            variant,
+            is_tiered_kv_cache(config),
         )
 
         print(

--- a/tools/buddy-codegen/gen_config.py
+++ b/tools/buddy-codegen/gen_config.py
@@ -202,7 +202,7 @@ def count_params(spec: dict) -> dict:
             "    1. Install torch: pip install torch\n"
             "    2. Add weights_override to your spec JSON, e.g.:\n"
             '       "weights_override": {"total": 1777088064}'
-        )
+        ) from None
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -223,23 +223,11 @@ def compute_weights(variant: str, param_counts: dict) -> list[dict]:
 
         if variant in ("f32", "f16", "bf16"):
             num_elements = param_counts["total"]
-        elif variant in ("w8a32", "w8a16"):
-            if etype == "i8":
-                num_elements = param_counts["linear_elements"]
-            else:
-                num_elements = (
-                    param_counts["other_elements"]
-                    + param_counts["linear_output_channels"]
-                )
-        elif variant == "w8a8":
-            if etype == "i8":
-                num_elements = param_counts["linear_elements"]
-            else:
-                num_elements = (
-                    param_counts["other_elements"]
-                    + param_counts["linear_output_channels"]
-                )
-        elif variant == "w4a16":
+        elif (
+            variant in ("w8a32", "w8a16")
+            or variant == "w8a8"
+            or variant == "w4a16"
+        ):
             if etype == "i8":
                 num_elements = param_counts["linear_elements"]
             else:
@@ -263,6 +251,33 @@ def compute_weights(variant: str, param_counts: dict) -> list[dict]:
         )
 
     return weights
+
+
+def derive_tiered_kv_cache(spec: dict) -> dict:
+    """Return tiered KV cache settings from the variant spec."""
+    raw = spec.get("tiered_kv_cache", False)
+    if isinstance(raw, dict):
+        enabled = bool(raw.get("enabled", True))
+        cache_sizes = raw.get("cache_sizes", spec.get("cache_sizes", []))
+    else:
+        enabled = bool(raw)
+        cache_sizes = spec.get("cache_sizes", [])
+
+    if not enabled:
+        return {"enabled": False, "cache_sizes": []}
+
+    if isinstance(cache_sizes, str):
+        cache_sizes = [
+            int(x.strip()) for x in cache_sizes.split(",") if x.strip()
+        ]
+    else:
+        cache_sizes = [int(x) for x in cache_sizes]
+
+    if not cache_sizes:
+        cache_sizes = [32, 64, 128, 256, 512, 1024]
+
+    cache_sizes = sorted(dict.fromkeys(cache_sizes))
+    return {"enabled": True, "cache_sizes": cache_sizes}
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -310,13 +325,33 @@ def gen_config(spec: dict, hf_config_path: str | None = None) -> dict:
     precision = VARIANT_PRECISION.get(variant, VARIANT_PRECISION["f32"])
     param_counts = count_params(spec)
     weights = compute_weights(variant, param_counts)
+    tiered_kv_cache = derive_tiered_kv_cache(spec)
+
+    if tiered_kv_cache["enabled"]:
+        if variant != "f32":
+            raise RuntimeError(
+                "tiered_kv_cache is currently implemented for the f32 "
+                "DeepSeek R1 variant only."
+            )
+        if tiered_kv_cache["cache_sizes"][-1] != shape["max_token_len"]:
+            raise RuntimeError(
+                "The largest tiered KV cache size must equal max_token_len "
+                f"({shape['max_token_len']}); got "
+                f"{tiered_kv_cache['cache_sizes'][-1]}."
+            )
+        # Keep compatibility with the legacy tiered example artifact name.
+        if len(weights) == 1:
+            weights[0]["file"] = spec.get("weights_file", "arg0_mc.data")
 
     kv_type = precision["kv_type"]
+    model_id = f"{model_family}_{variant}"
+    if tiered_kv_cache["enabled"]:
+        model_id = f"{model_id}_tiered_kv_cache"
 
     return {
         "model_family": model_family,
         "variant": variant,
-        "model_id": f"{model_family}_{variant}",
+        "model_id": model_id,
         "hf_model_path": spec["hf_model_path"],
         "architecture": (
             hf["architectures"][0]
@@ -327,11 +362,12 @@ def gen_config(spec: dict, hf_config_path: str | None = None) -> dict:
         "precision": precision,
         "weights": weights,
         "tokens": tokens,
+        "tiered_kv_cache": tiered_kv_cache,
         "cpp_types": {
             "kv": ELEMENT_TYPE_CPP[kv_type],
             "logits": ELEMENT_TYPE_CPP[precision["logits_type"]],
             "kv_memref": f"MemRef<{ELEMENT_TYPE_CPP[kv_type]}, 4>",
-            "logits_memref": f'MemRef<{ELEMENT_TYPE_CPP[precision["logits_type"]]}, 3>',
+            "logits_memref": f"MemRef<{ELEMENT_TYPE_CPP[precision['logits_type']]}, 3>",
         },
         "mlir_types": {
             "kv": ELEMENT_TYPE_MLIR[kv_type],

--- a/tools/buddy-codegen/gen_session.py
+++ b/tools/buddy-codegen/gen_session.py
@@ -105,6 +105,16 @@ def _macro_prefix(config: dict) -> str:
     return f"BUDDY_{short}"
 
 
+def _is_tiered_kv_cache(config: dict) -> bool:
+    return bool(config.get("tiered_kv_cache", {}).get("enabled", False))
+
+
+def _tiered_cache_sizes(config: dict) -> list[int]:
+    return [
+        int(x) for x in config.get("tiered_kv_cache", {}).get("cache_sizes", [])
+    ]
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Header generation
 # ──────────────────────────────────────────────────────────────────────────────
@@ -287,7 +297,512 @@ def gen_header(config: dict) -> str:
 # ──────────────────────────────────────────────────────────────────────────────
 
 
+def gen_impl_tiered(config: dict) -> str:
+    out = StringIO()
+
+    def _p(*a, **kw):
+        print(*a, file=out, **kw)
+
+    p = _p
+
+    mp = _macro_prefix(config)
+    shape = config["shape"]
+    weights = config["weights"]
+    kv_cpp = config["cpp_types"]["kv"]
+    logits_cpp = config["cpp_types"]["logits"]
+    kv_layers = shape["kv_layers"]
+    kv_memref = config["cpp_types"]["kv_memref"]
+    logits_memref = config["cpp_types"]["logits_memref"]
+    cache_sizes = _tiered_cache_sizes(config)
+
+    if kv_cpp != "float" or logits_cpp != "float":
+        raise RuntimeError(
+            "tiered KV cache ModelSession currently supports f32 only"
+        )
+    if not cache_sizes:
+        raise RuntimeError("tiered KV cache ModelSession requires cache_sizes")
+
+    dummy_groups = kv_layers // 2 - 1
+    cache_count = len(cache_sizes)
+    cache_size_list = ", ".join(str(x) for x in cache_sizes)
+    weight_ptr_types = ", ".join(
+        f"MemRef<{w['cpp_type']}, 1> *" for w in weights
+    )
+    weight_addrs_internal = ", ".join(f"{w['tag']}_.get()" for w in weights)
+
+    p(_CPP_FILE_PROLOGUE)
+    p('#include "buddy/runtime/models/ModelSession.h"')
+    p('#include "buddy/runtime/llm/KVCacheManager.h"')
+    p()
+    p("#include <algorithm>")
+    p("#include <array>")
+    p("#include <cstring>")
+    p("#include <dlfcn.h>")
+    p("#include <fstream>")
+    p("#include <stdexcept>")
+    p("#include <string>")
+    p("#include <new> // for std::launder, placement new")
+    p()
+    p("namespace buddy {")
+    p("namespace runtime {")
+    p()
+    p("namespace {")
+    p(f"static constexpr int kTieredCacheCount = {cache_count};")
+    p(
+        "static constexpr std::array<int, kTieredCacheCount> "
+        f"kTieredCacheSizes = {{{cache_size_list}}};"
+    )
+    p()
+    p("int selectPrefillSize(int tokenCount) {")
+    p("  for (int size : kTieredCacheSizes)")
+    p("    if (tokenCount <= size)")
+    p("      return size;")
+    p("  return kTieredCacheSizes.back();")
+    p("}")
+    p()
+    p("int selectDecodeSize(int requiredPosition) {")
+    p("  for (int size : kTieredCacheSizes)")
+    p("    if (requiredPosition < size)")
+    p("      return size;")
+    p("  return kTieredCacheSizes.back();")
+    p("}")
+    p()
+    p("int cacheSizeIndex(int cacheLen) {")
+    p("  for (int i = 0; i < kTieredCacheCount; ++i)")
+    p("    if (kTieredCacheSizes[i] == cacheLen)")
+    p("      return i;")
+    p(
+        '  throw std::runtime_error("[BuddyRuntime] unsupported tiered KV cache size");'
+    )
+    p("}")
+    p("} // namespace")
+    p()
+
+    p("using Dummy1Ref = MemRef<long long, 1>;")
+    p(f"using KV4Ref = {kv_memref};")
+    p(f"using Logits3Ref = {logits_memref};")
+    p()
+    p("struct DecodeKVGroup {")
+    p("  alignas(Dummy1Ref) char dummy_[sizeof(Dummy1Ref)];")
+    p("  alignas(KV4Ref) char kv0_[sizeof(KV4Ref)];")
+    p("  alignas(KV4Ref) char kv1_[sizeof(KV4Ref)];")
+    p("  Dummy1Ref &dummy() {")
+    p("    return *std::launder(reinterpret_cast<Dummy1Ref *>(dummy_));")
+    p("  }")
+    p("  KV4Ref &kv0() {")
+    p("    return *std::launder(reinterpret_cast<KV4Ref *>(kv0_));")
+    p("  }")
+    p("  KV4Ref &kv1() {")
+    p("    return *std::launder(reinterpret_cast<KV4Ref *>(kv1_));")
+    p("  }")
+    p("};")
+    p()
+    p("struct PrefillABI {")
+    p(f"  alignas({kv_memref}) char kv_[sizeof({kv_memref}) *")
+    p(f"                                     {mp}_KV_LAYERS];")
+    p(f"  alignas({logits_memref}) char logits_[sizeof({logits_memref})];")
+    p(f"  {kv_memref} &kv(int i) {{")
+    p(f"    return *std::launder(reinterpret_cast<{kv_memref} *>(")
+    p(f"        kv_ + i * sizeof({kv_memref})));")
+    p("  }")
+    p(f"  {logits_memref} &logits() {{")
+    p(
+        f"    return *std::launder(reinterpret_cast<{logits_memref} *>(logits_));"
+    )
+    p("  }")
+    p("};")
+    p()
+    p("struct DecodeABI {")
+    p("  alignas(Dummy1Ref) char cache_position_out_[sizeof(Dummy1Ref)];")
+    p("  alignas(KV4Ref) char kv0_[sizeof(KV4Ref)];")
+    p("  alignas(KV4Ref) char kv1_[sizeof(KV4Ref)];")
+    p(f"  DecodeKVGroup groups_[{dummy_groups}];")
+    p("  alignas(Logits3Ref) char logits_[sizeof(Logits3Ref)];")
+    p("  Dummy1Ref &cachePositionOut() {")
+    p(
+        "    return *std::launder("
+        "reinterpret_cast<Dummy1Ref *>(cache_position_out_));"
+    )
+    p("  }")
+    p("  Dummy1Ref &dummy(int i) { return groups_[i].dummy(); }")
+    p("  KV4Ref &kv(int i) {")
+    p("    if (i == 0)")
+    p("      return *std::launder(reinterpret_cast<KV4Ref *>(kv0_));")
+    p("    if (i == 1)")
+    p("      return *std::launder(reinterpret_cast<KV4Ref *>(kv1_));")
+    p("    int group = (i - 2) / 2;")
+    p(
+        "    return ((i - 2) % 2 == 0) ? groups_[group].kv0() : groups_[group].kv1();"
+    )
+    p("  }")
+    p("  Logits3Ref &logits() {")
+    p("    return *std::launder(reinterpret_cast<Logits3Ref *>(logits_));")
+    p("  }")
+    p("};")
+    p()
+    p(
+        f"using PrefillFn = void (*)(PrefillABI *, {weight_ptr_types}, Text<size_t, 2> *);"
+    )
+    p("using KV4 = KV4Ref *;")
+    p("using Dummy1 = Dummy1Ref *;")
+    decode_sig_parts = [
+        "DecodeABI *",
+        *[f"MemRef<{w['cpp_type']}, 1> *" for w in weights],
+        "MemRef<long long, 2> *",
+        "MemRef<long long, 1> *",
+        "KV4",
+        "KV4",
+    ]
+    for _i in range(dummy_groups):
+        decode_sig_parts.extend(["Dummy1", "KV4", "KV4"])
+    p("using DecodeFn = void (*)(")
+    line = "    "
+    for idx, part in enumerate(decode_sig_parts):
+        sep = "," if idx < len(decode_sig_parts) - 1 else ");"
+        candidate = line + part + sep + " "
+        if len(candidate) > 78 and line.strip():
+            p(line.rstrip())
+            line = "    " + part + sep + " "
+        else:
+            line = candidate
+    if line.strip():
+        p(line.rstrip())
+    p()
+    p()
+    p("namespace {")
+    p("template <typename SrcABI, typename DstABI>")
+    p("void copyKVCache(SrcABI &src, DstABI &dst, int kvLayers, int headNum,")
+    p("                 int hiddenSize, int srcCacheLen, int dstCacheLen,")
+    p("                 int validTokens) {")
+    p(
+        "  int copyLen = std::min(validTokens, std::min(srcCacheLen, dstCacheLen));"
+    )
+    p("  for (int k = 0; k < kvLayers; ++k) {")
+    p("    for (int h = 0; h < headNum; ++h) {")
+    p("      size_t bytes = (size_t)copyLen * hiddenSize * sizeof(float);")
+    p("      float *srcPtr =")
+    p("          src.kv(k).getData() + (size_t)h * srcCacheLen * hiddenSize;")
+    p("      float *dstPtr =")
+    p("          dst.kv(k).getData() + (size_t)h * dstCacheLen * hiddenSize;")
+    p("      std::memcpy(dstPtr, srcPtr, bytes);")
+    p("    }")
+    p("  }")
+    p("}")
+    p()
+    p("void callDecodeFn(DecodeFn fn, DecodeABI &a,")
+    for idx, w in enumerate(weights):
+        comma = "," if idx < len(weights) - 1 or True else ""
+        p(f"                  MemRef<{w['cpp_type']}, 1> *{w['tag']},")
+    p("                  MemRef<long long, 2> *decodeTokenInput,")
+    p("                  MemRef<long long, 1> *cachePosition) {")
+    call_parts = ["&a"]
+    for w in weights:
+        call_parts.append(w["tag"])
+    call_parts.append("decodeTokenInput")
+    call_parts.append("cachePosition")
+    call_parts.extend(["&a.kv(0)", "&a.kv(1)"])
+    for i in range(dummy_groups):
+        call_parts.extend(
+            [f"&a.dummy({i})", f"&a.kv({2 + i * 2})", f"&a.kv({3 + i * 2})"]
+        )
+    p("  fn(")
+    line = "      "
+    for idx, part in enumerate(call_parts):
+        sep = ", " if idx < len(call_parts) - 1 else ");"
+        candidate = line + part + sep
+        if len(candidate) > 80 and line.strip():
+            p(line.rstrip(", ") + ",")
+            line = "      " + part + sep
+        else:
+            line = candidate
+    if line.strip():
+        p(line)
+    p("}")
+    p("} // namespace")
+    p()
+    p("struct ModelSession::Impl {")
+    p("  std::array<PrefillABI, kTieredCacheCount> prefillAbi;")
+    p("  std::array<DecodeABI, kTieredCacheCount> decodeAbi;")
+    p("  bool abiInitialized = false;")
+    p("  void *soHandle = nullptr;")
+    p("  std::vector<void *> depSoHandles;")
+    p("  std::array<PrefillFn, kTieredCacheCount> prefillFns{};")
+    p("  std::array<DecodeFn, kTieredCacheCount> decodeFns{};")
+    p("  int activeSlot = 0;")
+    p("  bool lastLogitsAreDecode = false;")
+    p()
+    p("  ~Impl() {")
+    p("    if (abiInitialized) {")
+    p("      for (int slot = 0; slot < kTieredCacheCount; ++slot) {")
+    p(f"        for (int i = 0; i < {mp}_KV_LAYERS; ++i)")
+    p("          prefillAbi[slot].kv(i).~KV4Ref();")
+    p("        prefillAbi[slot].logits().~Logits3Ref();")
+    p("        decodeAbi[slot].cachePositionOut().~Dummy1Ref();")
+    p(f"        for (int i = 0; i < {dummy_groups}; ++i)")
+    p("          decodeAbi[slot].dummy(i).~Dummy1Ref();")
+    p(f"        for (int i = 0; i < {mp}_KV_LAYERS; ++i)")
+    p("          decodeAbi[slot].kv(i).~KV4Ref();")
+    p("        decodeAbi[slot].logits().~Logits3Ref();")
+    p("      }")
+    p("    }")
+    p("    if (soHandle) {")
+    p("      dlclose(soHandle);")
+    p("      soHandle = nullptr;")
+    p("    }")
+    p(
+        "    for (auto it = depSoHandles.rbegin(); it != depSoHandles.rend(); ++it)"
+    )
+    p("      if (*it)")
+    p("        dlclose(*it);")
+    p("    depSoHandles.clear();")
+    p("  }")
+    p()
+    p("  void loadSo(const std::string &soPath,")
+    p("              const std::vector<std::string> &dependentSoPaths) {")
+    p("    for (const auto &depPath : dependentSoPaths) {")
+    p(
+        "      void *depHandle = dlopen(depPath.c_str(), RTLD_NOW | RTLD_GLOBAL);"
+    )
+    p("      if (!depHandle)")
+    p(
+        '        throw std::runtime_error("[BuddyRuntime] dependent dlopen failed: " + depPath +'
+    )
+    p('                                 "\\n  " + dlerror());')
+    p("      depSoHandles.push_back(depHandle);")
+    p("    }")
+    p("    soHandle = dlopen(soPath.c_str(), RTLD_NOW | RTLD_LOCAL);")
+    p("    if (!soHandle)")
+    p(
+        '      throw std::runtime_error("[BuddyRuntime] dlopen failed: " + soPath +'
+    )
+    p('                               "\\n  " + dlerror());')
+    p("    for (int i = 0; i < kTieredCacheCount; ++i) {")
+    p("      const std::string suffix = std::to_string(kTieredCacheSizes[i]);")
+    p("      const std::string prefillSym =")
+    p('          "_mlir_ciface_forward_prefill_" + suffix;')
+    p("      const std::string decodeSym =")
+    p('          "_mlir_ciface_forward_decode_" + suffix;')
+    p("      prefillFns[i] =")
+    p(
+        "          reinterpret_cast<PrefillFn>(dlsym(soHandle, prefillSym.c_str()));"
+    )
+    p("      if (!prefillFns[i])")
+    p("        throw std::runtime_error(")
+    p(
+        '            "[BuddyRuntime] symbol not found: " + prefillSym + "\\n  " +'
+    )
+    p("            std::string(dlerror()));")
+    p("      decodeFns[i] =")
+    p(
+        "          reinterpret_cast<DecodeFn>(dlsym(soHandle, decodeSym.c_str()));"
+    )
+    p("      if (!decodeFns[i])")
+    p("        throw std::runtime_error(")
+    p('            "[BuddyRuntime] symbol not found: " + decodeSym + "\\n  " +')
+    p("            std::string(dlerror()));")
+    p("    }")
+    p("  }")
+    p("};")
+    p()
+    p("ModelSession::ModelSession(const Config &cfg) : cfg_(cfg) {")
+    p("  if (cfg_.modelSoPath.empty())")
+    p(
+        '    throw std::runtime_error("[BuddyRuntime] Config.modelSoPath must not be empty.");'
+    )
+    p("  allocateKVCache();")
+    p("  impl_->loadSo(cfg_.modelSoPath, cfg_.dependentSoPaths);")
+    p("}")
+    p()
+    p("ModelSession::~ModelSession() = default;")
+    p()
+    p("std::unique_ptr<ModelSession> ModelSession::create(const Config &cfg) {")
+    p("  return std::unique_ptr<ModelSession>(new ModelSession(cfg));")
+    p("}")
+    p()
+    p("void ModelSession::allocateKVCache() {")
+    p("  impl_ = std::make_unique<Impl>();")
+    p("  intptr_t pshape[1] = {1};")
+    p("  for (int slot = 0; slot < kTieredCacheCount; ++slot) {")
+    p("    int cacheLen = kTieredCacheSizes[slot];")
+    p("    intptr_t kvShape[4] = {1, cfg_.headNum, cacheLen, cfg_.hiddenSize};")
+    p(f"    for (int i = 0; i < {mp}_KV_LAYERS; ++i) {{")
+    p("      new (&impl_->prefillAbi[slot].kv(i)) KV4Ref(kvShape, 0.0f);")
+    p("      new (&impl_->decodeAbi[slot].kv(i)) KV4Ref(kvShape, 0.0f);")
+    p("    }")
+    p("    intptr_t prefillLogitsShape[3] = {1, cacheLen, cfg_.vocabSize};")
+    p("    new (&impl_->prefillAbi[slot].logits())")
+    p("        Logits3Ref(prefillLogitsShape);")
+    p(
+        "    new (&impl_->decodeAbi[slot].cachePositionOut()) Dummy1Ref(pshape, 0LL);"
+    )
+    p(f"    for (int i = 0; i < {dummy_groups}; ++i)")
+    p("      new (&impl_->decodeAbi[slot].dummy(i)) Dummy1Ref(pshape, 0LL);")
+    p("    intptr_t decodeLogitsShape[3] = {1, 1, cfg_.vocabSize};")
+    p(
+        "    new (&impl_->decodeAbi[slot].logits()) Logits3Ref(decodeLogitsShape);"
+    )
+    p("  }")
+    p("  impl_->abiInitialized = true;")
+    p("  intptr_t tshape[2] = {1, 1};")
+    p("  decodeTokenInput_ = std::make_unique<MemRef<long long, 2>>(tshape);")
+    p("  cachePosition_ = std::make_unique<MemRef<long long, 1>>(pshape);")
+    p("}")
+    p()
+    p("void ModelSession::loadWeights(const std::vector<std::string> &paths) {")
+    p(f"  if (paths.size() < {len(weights)}u)")
+    p(
+        f'    throw std::runtime_error("[BuddyRuntime] Expected {len(weights)} weight '
+        f'file(s), got " + std::to_string(paths.size()));'
+    )
+    for idx, w in enumerate(weights):
+        tag = w["tag"]
+        cpp_type = w["cpp_type"]
+        macro_suffix = (
+            "PARAMS_SIZE" if len(weights) == 1 else f"PARAMS_SIZE_{tag.upper()}"
+        )
+        p("  {")
+        p(f"    intptr_t shape[1] = {{{mp}_{macro_suffix}}};")
+        p(f"    {tag}_ = std::make_unique<MemRef<{cpp_type}, 1>>(shape);")
+        p(f"    std::ifstream f(paths[{idx}], std::ios::binary);")
+        p("    if (!f)")
+        p(
+            f'      throw std::runtime_error("[BuddyRuntime] Cannot open weights: " + paths[{idx}]);'
+        )
+        p(f"    f.read(reinterpret_cast<char *>({tag}_->getData()),")
+        p(f"           sizeof({cpp_type}) * {tag}_->getSize());")
+        p("    if (f.fail())")
+        p(
+            f'      throw std::runtime_error("[BuddyRuntime] Read failed: " + paths[{idx}]);'
+        )
+        p("  }")
+    p("}")
+    p()
+    p("void ModelSession::prefill(Text<size_t, 2> &tokens) {")
+    p("  const int tokenCount = (int)tokens.getTokenCnt();")
+    p("  const int cacheLen = selectPrefillSize(tokenCount);")
+    p("  const int slot = cacheSizeIndex(cacheLen);")
+    p("  impl_->activeSlot = slot;")
+    p("  intptr_t *tokenSizes = const_cast<intptr_t *>(tokens.getSizes());")
+    p("  intptr_t *tokenStrides = const_cast<intptr_t *>(tokens.getStrides());")
+    p("  const intptr_t oldLen = tokenSizes[1];")
+    p("  const intptr_t oldStride0 = tokenStrides[0];")
+    p("  const intptr_t oldStride1 = tokenStrides[1];")
+    p("  tokenSizes[1] = cacheLen;")
+    p("  tokenStrides[0] = cacheLen;")
+    p("  tokenStrides[1] = 1;")
+    p(
+        f"  impl_->prefillFns[slot](&impl_->prefillAbi[slot], {weight_addrs_internal}, &tokens);"
+    )
+    p("  tokenSizes[1] = oldLen;")
+    p("  tokenStrides[0] = oldStride0;")
+    p("  tokenStrides[1] = oldStride1;")
+    p("  copyKVCache(impl_->prefillAbi[slot], impl_->decodeAbi[slot],")
+    p("              cfg_.kvLayers, cfg_.headNum, cfg_.hiddenSize,")
+    p("              cacheLen, cacheLen, tokenCount);")
+    p("  impl_->lastLogitsAreDecode = false;")
+    p("  position_ = tokenCount;")
+    p("}")
+    p()
+    p("void ModelSession::decode(int tokenId) {")
+    p("  const int neededCacheLen = selectDecodeSize(position_ + 1);")
+    p("  int neededSlot = cacheSizeIndex(neededCacheLen);")
+    p("  if (neededSlot != impl_->activeSlot) {")
+    p("    int prevCacheLen = kTieredCacheSizes[impl_->activeSlot];")
+    p("    copyKVCache(impl_->decodeAbi[impl_->activeSlot],")
+    p(
+        "                impl_->decodeAbi[neededSlot], cfg_.kvLayers, cfg_.headNum,"
+    )
+    p(
+        "                cfg_.hiddenSize, prevCacheLen, neededCacheLen, position_);"
+    )
+    p("    impl_->activeSlot = neededSlot;")
+    p("  }")
+    p("  decodeTokenInput_->getData()[0] = (long long)tokenId;")
+    p("  cachePosition_->getData()[0] = (long long)position_;")
+    p("  auto &a = impl_->decodeAbi[impl_->activeSlot];")
+    p(f"  for (int i = 0; i < {dummy_groups}; ++i)")
+    p("    a.dummy(i).getData()[0] = (long long)position_;")
+    p(
+        f"  callDecodeFn(impl_->decodeFns[impl_->activeSlot], a, {weight_addrs_internal},"
+    )
+    p("               decodeTokenInput_.get(), cachePosition_.get());")
+    p("  impl_->lastLogitsAreDecode = true;")
+    p("  position_ += 1;")
+    p("}")
+    p()
+    p("void ModelSession::resetPosition() {")
+    p("  position_ = 0;")
+    p("  impl_->activeSlot = 0;")
+    p("  impl_->lastLogitsAreDecode = false;")
+    p("}")
+    p()
+    p(
+        "bool ModelSession::handleKVCacheOverflow(int keepTokenNum, float ropeTheta) {"
+    )
+    p("  if (position_ < cfg_.maxTokenLen)")
+    p("    return false;")
+    p("  const int currentTokens = std::min(position_, cfg_.maxTokenLen);")
+    p("  keepTokenNum = std::clamp(keepTokenNum, 0, currentTokens - 1);")
+    p(
+        "  const int discardLen = std::max(1, (currentTokens - keepTokenNum) / 2);"
+    )
+    p(f"  {kv_cpp} *rawPtrs[{mp}_KV_LAYERS];")
+    p("  auto &a = impl_->decodeAbi[impl_->activeSlot];")
+    p("  for (int i = 0; i < cfg_.kvLayers; ++i)")
+    p("    rawPtrs[i] = a.kv(i).getData();")
+    p("  buddy::kvcache::discardKVCache(rawPtrs, cfg_.kvLayers, cfg_.headNum,")
+    p("                                 cfg_.maxTokenLen, cfg_.hiddenSize,")
+    p(
+        "                                 keepTokenNum, discardLen, currentTokens);"
+    )
+    p("  auto inverseFreqs =")
+    p(
+        "      buddy::kvcache::buildInverseRopeFreqs(ropeTheta, cfg_.hiddenSize);"
+    )
+    p("  buddy::kvcache::adjustKeyCacheRope(")
+    p(
+        "      rawPtrs, cfg_.kvLayers, cfg_.headNum, cfg_.maxTokenLen, cfg_.hiddenSize,"
+    )
+    p("      keepTokenNum, discardLen, currentTokens, inverseFreqs);")
+    p(
+        "  position_ = std::clamp(currentTokens - discardLen, 0, cfg_.maxTokenLen);"
+    )
+    p("  return true;")
+    p("}")
+    p()
+    p("const float *ModelSession::logitsData(int tokenOffset) const {")
+    p("  const int slot = impl_->activeSlot;")
+    p("  if (impl_->lastLogitsAreDecode)")
+    p("    return impl_->decodeAbi[slot].logits().getData();")
+    p("  return impl_->prefillAbi[slot].logits().getData() +")
+    p("         (size_t)tokenOffset * cfg_.vocabSize;")
+    p("}")
+    p()
+    p(
+        "std::string ModelSession::loadedSoPath() const { return cfg_.modelSoPath; }"
+    )
+    p()
+    p("std::unique_ptr<ModelSession>")
+    p("ModelSession::createFromRax(const std::string &raxPath,")
+    p("                            ModelManifest &resolvedManifest) {")
+    p("  resolvedManifest = ModelManifest::loadFromRax(raxPath);")
+    p("  Config cfg;")
+    p("  cfg.modelSoPath = resolvedManifest.soPath;")
+    p("  cfg.dependentSoPaths = resolvedManifest.dependentSoPaths;")
+    p("  return create(cfg);")
+    p("}")
+    p()
+    p("} // namespace runtime")
+    p("} // namespace buddy")
+    p()
+
+    return out.getvalue()
+
+
 def gen_impl(config: dict) -> str:
+    if _is_tiered_kv_cache(config):
+        return gen_impl_tiered(config)
+
     out = StringIO()
 
     def _p(*a, **kw):

--- a/tools/buddy-codegen/import_model.py
+++ b/tools/buddy-codegen/import_model.py
@@ -168,6 +168,157 @@ def compile_graphs(model, config: dict):
     return graphs_prefill, graphs_decode, params
 
 
+def is_tiered_kv_cache(config: dict) -> bool:
+    return bool(config.get("tiered_kv_cache", {}).get("enabled", False))
+
+
+def tiered_cache_sizes(config: dict) -> list[int]:
+    sizes = config.get("tiered_kv_cache", {}).get("cache_sizes", [])
+    return [int(x) for x in sizes]
+
+
+def compile_and_export_tiered_graphs(model, config: dict, output_dir: str):
+    """Generate one prefill/decode pair for every configured KV cache size."""
+    cache_sizes = tiered_cache_sizes(config)
+    if not cache_sizes:
+        raise ValueError("tiered_kv_cache.enabled requires cache_sizes")
+
+    if config["variant"] != "f32":
+        raise ValueError("tiered KV cache import currently supports f32 only")
+
+    pattern_prefill_with_flash = [
+        simply_fuse,
+        apply_classic_fusion,
+        flash_attention_prefill,
+    ]
+    pattern_prefill_no_flash = [
+        simply_fuse,
+        apply_classic_fusion,
+    ]
+    pattern_decode = [simply_fuse, apply_classic_fusion, gqa_attention_fusion]
+
+    params = None
+
+    for prefill_size in cache_sizes:
+        print(
+            f"[import] Tiered prefill graph: seq_len={prefill_size}",
+            file=sys.stderr,
+        )
+        torch._dynamo.reset()
+
+        compiler = DynamoCompiler(
+            primary_registry=tosa.ops_registry,
+            aot_autograd_decomposition=inductor_decomp,
+            func_name=f"forward_prefill_{prefill_size}",
+        )
+
+        with torch.no_grad():
+            input_ids = torch.zeros((1, prefill_size), dtype=torch.int64)
+            graphs = compiler.importer(
+                model,
+                input_ids=input_ids,
+                use_cache=True,
+                cache_implementation="static",
+            )
+            if params is None:
+                params = compiler.imported_params[graphs[0]]
+
+        assert len(graphs) == 1
+        graph = graphs[0]
+        graph.perform([eliminate_transpose, eliminate_matmul_transpose_reshape])
+        if prefill_size >= 64:
+            graph.fuse_ops(pattern_prefill_with_flash)
+        else:
+            graph.fuse_ops(pattern_prefill_no_flash)
+
+        name = f"subgraph0_prefill_{prefill_size}"
+        graph.op_groups[name] = graph.op_groups.pop("subgraph0")
+        graph.group_map_device[name] = DeviceType.CPU
+
+        driver = GraphDriver(graph)
+        driver.subgraphs[0].lower_to_top_level_ir()
+
+        files = {
+            f"subgraph0_prefill_{prefill_size}.mlir": driver.subgraphs[
+                0
+            ]._imported_module,
+            f"forward_prefill_{prefill_size}.mlir": driver.construct_main_graph(
+                True
+            ),
+        }
+        for filename, content in files.items():
+            with open(os.path.join(output_dir, filename), "w") as f:
+                print(content, file=f)
+            print(f"[import] Written: {filename}", file=sys.stderr)
+
+    if params is None:
+        raise RuntimeError("tiered prefill import produced no parameters")
+
+    data_decode = {"input_ids": torch.zeros((1, 1), dtype=torch.int64)}
+    for cache_size in cache_sizes:
+        print(
+            f"[import] Tiered decode graph: cache_len={cache_size}",
+            file=sys.stderr,
+        )
+        torch._dynamo.reset()
+
+        compiler = DynamoCompiler(
+            primary_registry=tosa.ops_registry,
+            aot_autograd_decomposition=inductor_decomp,
+            func_name=f"forward_decode_{cache_size}",
+        )
+
+        with torch.no_grad():
+            past_kv = StaticCache(config=model.config, max_cache_len=cache_size)
+            cache_position = torch.tensor(
+                [min(200 * cache_size // 1024, cache_size - 1)],
+                dtype=torch.int64,
+            )
+
+            model(
+                input_ids=data_decode["input_ids"],
+                past_key_values=past_kv,
+                use_cache=True,
+                cache_implementation="static",
+            )
+
+            graphs = compiler.importer(
+                model,
+                input_ids=data_decode["input_ids"],
+                use_cache=True,
+                cache_position=cache_position,
+                past_key_values=past_kv,
+                cache_implementation="static",
+            )
+
+        assert len(graphs) == 1
+        graph = graphs[0]
+        graph.perform([eliminate_transpose, eliminate_matmul_transpose_reshape])
+        graph.fuse_ops(pattern_decode)
+
+        name = f"subgraph0_decode_{cache_size}"
+        graph.op_groups[name] = graph.op_groups.pop("subgraph0")
+        graph.group_map_device[name] = DeviceType.CPU
+
+        driver = GraphDriver(graph)
+        driver.subgraphs[0].lower_to_top_level_ir()
+
+        files = {
+            f"subgraph0_decode_{cache_size}.mlir": driver.subgraphs[
+                0
+            ]._imported_module,
+            f"forward_decode_{cache_size}.mlir": driver.construct_main_graph(
+                True
+            ),
+        }
+        for filename, content in files.items():
+            with open(os.path.join(output_dir, filename), "w") as f:
+                print(content, file=f)
+            print(f"[import] Written: {filename}", file=sys.stderr)
+
+    return params
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Graph transforms (shared across all variants)
 # ──────────────────────────────────────────────────────────────────────────────
@@ -473,6 +624,20 @@ def import_model(config: dict, output_dir: str):
 
     # 1. Load model
     model = load_model(config)
+
+    if is_tiered_kv_cache(config):
+        if is_quantized:
+            raise ValueError(
+                "tiered KV cache import does not support quantized variants"
+            )
+        original_params = compile_and_export_tiered_graphs(
+            model, config, output_dir
+        )
+        weight_buckets = extract_plain_weights(original_params, config)
+        actual_sizes = export_weights(weight_buckets, config, output_dir)
+        update_config(config, actual_sizes, output_dir)
+        print("[import] Tiered KV cache import complete.", file=sys.stderr)
+        return
 
     # 2. Compile graphs
     graphs_prefill, graphs_decode, original_params = compile_graphs(


### PR DESCRIPTION
Support tiered KV cache DeepSeek R1 builds in buddy-codegen and add the f32 tiered cache spec.

Teach eliminate-memref-copy to eliminate function-argument aliases and add regression coverage for cache copy/dealloc handling.
