### PR TITLE
[examples][frontend] Add BuddyJITTrain: MLP training via Buddy MLIR JIT

### DIFF
--- a/examples/BuddyJITTrain/README.md
+++ b/examples/BuddyJITTrain/README.md
@@ -1,0 +1,138 @@
+# Buddy JIT for PyTorch Training
+
+This example shows how to train a PyTorch model through Buddy MLIR JIT using
+`torch.compile`. Both the forward and backward passes can be compiled to MLIR
+and executed via the Buddy `ExecutionEngine`, while the optimizer step runs in
+PyTorch as usual.
+
+## Prerequisites
+
+To run this example, you should build `buddy-mlir` with MLIR Python Binding.
+
+Firstly, create a python environment (optional) and install the necessary packages.
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install torch
+```
+
+Secondly, build LLVM with MLIR and OpenMP.
+
+```bash
+cd buddy-mlir
+mkdir llvm/build
+cmake -G Ninja ../llvm \
+  -DLLVM_ENABLE_PROJECTS="mlir;clang;openmp" \
+  -DLLVM_TARGETS_TO_BUILD="host;RISCV" \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DOPENMP_ENABLE_LIBOMPTARGET=OFF \
+  -DCMAKE_BUILD_TYPE=RELEASE \
+  -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+  -DPython3_EXECUTABLE=$(which python3)
+ninja check-clang check-mlir omp
+```
+
+Then build buddy-mlir with the Python binding.
+
+```bash
+cd buddy-mlir
+mkdir build
+cd build
+cmake -G Ninja .. \
+    -DMLIR_DIR=$PWD/../llvm/build/lib/cmake/mlir \
+    -DLLVM_DIR=$PWD/../llvm/build/lib/cmake/llvm \
+    -DLLVM_ENABLE_ASSERTIONS=ON \
+    -DCMAKE_BUILD_TYPE=RELEASE \
+    -DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON \
+    -DPython3_EXECUTABLE=$(which python3)
+ninja
+ninja check-buddy
+```
+
+And then set the `PYTHONPATH` to where the packages are built.
+
+```bash
+export PYTHONPATH=/path-to-buddy-mlir/build/python_packages:${PYTHONPATH}
+
+# For example:
+# Navigate to your buddy-mlir/build directory
+cd buddy-mlir/build
+export BUDDY_MLIR_BUILD_DIR=$PWD
+export LLVM_MLIR_BUILD_DIR=$PWD/../llvm/build
+export PYTHONPATH=${BUDDY_MLIR_BUILD_DIR}/python_packages:${PYTHONPATH}
+```
+
+## MLP Training Demo
+
+The example `train_mlp.py` trains a two-layer MLP in three modes: pure PyTorch,
+Buddy MLIR with forward-only compilation, and Buddy MLIR with full forward+backward
+compilation.
+
+First, define a two-layer MLP in `model.py`.
+
+```python
+class MLP(nn.Module):
+    def __init__(self, input_dim: int, hidden_dim: int, output_dim: int):
+        super().__init__()
+        self.fc1 = nn.Linear(input_dim, hidden_dim)
+        self.fc2 = nn.Linear(hidden_dim, output_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(torch.relu(self.fc1(x)))
+```
+
+Second, initialize a `DynamoCompiler` and wrap it with `TorchCompileBackend`.
+Set `compile_backward=True` to also compile the backward graph to MLIR.
+
+```python
+compiler = DynamoCompiler(
+    primary_registry=tosa.ops_registry,
+    aot_autograd_decomposition=inductor_decomp,
+    compile_backward=True,
+)
+model = torch.compile(model, backend=TorchCompileBackend(compiler), dynamic=False)
+```
+
+Lastly, run the standard PyTorch training loop. The compiled graphs execute
+transparently via `ExecutionEngine`; the optimizer step runs in PyTorch as usual.
+
+```python
+optimizer = torch.optim.SGD(model.parameters(), lr=lr)
+criterion = nn.CrossEntropyLoss()
+for epoch in range(epochs):
+    optimizer.zero_grad()
+    loss = criterion(model(x), labels)
+    loss.backward()
+    optimizer.step()
+```
+
+Run the demo:
+
+```bash
+$ python examples/BuddyJITTrain/train_mlp.py
+```
+
+All three modes use the same random seed and produce identical loss values:
+
+```
+=== Pure PyTorch (baseline) ===
+  epoch   1/20  loss=1.3791
+  ...
+  epoch  20/20  loss=1.3848
+  weights changed : True
+
+=== Buddy MLIR JIT – forward only (compile_backward=False) ===
+  epoch   1/20  loss=1.3791
+  ...
+  epoch  20/20  loss=1.3848
+  weights changed : True
+
+=== Buddy MLIR JIT – forward + backward (compile_backward=True) ===
+  epoch   1/20  loss=1.3791
+  ...
+  epoch  20/20  loss=1.3848
+  weights changed : True
+
+All training runs completed.
+```

--- a/examples/BuddyJITTrain/model.py
+++ b/examples/BuddyJITTrain/model.py
@@ -1,0 +1,12 @@
+import torch
+import torch.nn as nn
+
+
+class MLP(nn.Module):
+    def __init__(self, input_dim: int, hidden_dim: int, output_dim: int):
+        super().__init__()
+        self.fc1 = nn.Linear(input_dim, hidden_dim)
+        self.fc2 = nn.Linear(hidden_dim, output_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(torch.relu(self.fc1(x)))

--- a/examples/BuddyJITTrain/train_mlp.py
+++ b/examples/BuddyJITTrain/train_mlp.py
@@ -1,0 +1,107 @@
+"""
+Two-layer MLP training via PyTorch + Buddy MLIR JIT.
+
+Three modes are demonstrated:
+  1. Pure PyTorch (baseline)
+  2. Buddy MLIR forward-only  (compile_backward=False): forward graph compiled
+     to MLIR, backward runs through PyTorch autograd.
+  3. Buddy MLIR forward+backward (compile_backward=True): both graphs compiled
+     to MLIR through Buddy's JIT pipeline.
+"""
+
+import torch
+import torch.nn as nn
+from buddy.compiler.frontend import DynamoCompiler, TorchCompileBackend
+from buddy.compiler.ops import tosa
+from model import MLP
+from torch._inductor.decomposition import decompositions as inductor_decomp
+
+
+def make_buddy_backend(compile_backward: bool) -> TorchCompileBackend:
+    compiler = DynamoCompiler(
+        primary_registry=tosa.ops_registry,
+        aot_autograd_decomposition=inductor_decomp,
+        compile_backward=compile_backward,
+    )
+    return TorchCompileBackend(compiler)
+
+
+def train(
+    label: str,
+    backend=None,
+    input_dim: int = 16,
+    hidden_dim: int = 32,
+    output_dim: int = 4,
+    batch_size: int = 8,
+    epochs: int = 20,
+    lr: float = 0.05,
+    seed: int = 42,
+):
+    torch.manual_seed(seed)
+    model = MLP(input_dim, hidden_dim, output_dim)
+
+    if backend is not None:
+        compiled_model = torch.compile(model, backend=backend, dynamic=False)
+    else:
+        compiled_model = model
+
+    optimizer = torch.optim.SGD(model.parameters(), lr=lr)
+    criterion = nn.CrossEntropyLoss()
+
+    print(f"\n=== {label} ===")
+    w_before = model.fc1.weight.data.clone()
+    initial_loss = None
+
+    for epoch in range(epochs):
+        torch.manual_seed(epoch)
+        x = torch.randn(batch_size, input_dim)
+        labels = torch.randint(0, output_dim, (batch_size,))
+
+        optimizer.zero_grad()
+        outputs = compiled_model(x)
+        loss = criterion(outputs, labels)
+        loss.backward()
+        optimizer.step()
+
+        if epoch == 0:
+            initial_loss = loss.item()
+        if epoch % 5 == 0 or epoch == epochs - 1:
+            print(f"  epoch {epoch + 1:3d}/{epochs}  loss={loss.item():.4f}")
+
+    w_after = model.fc1.weight.data
+    weights_changed = not torch.equal(w_before, w_after)
+    loss_decreased = loss.item() < initial_loss
+
+    print(f"  weights changed : {weights_changed}")
+    print(
+        f"  loss decreased  : {loss_decreased}  "
+        f"({initial_loss:.4f} → {loss.item():.4f})"
+    )
+    return loss.item()
+
+
+def main():
+    # ── 1. Baseline: pure PyTorch ──────────────────────────────────────────
+    train("Pure PyTorch (baseline)", backend=None)
+
+    # ── 2. Buddy MLIR JIT – forward only ──────────────────────────────────
+    # Forward graph is compiled by Buddy MLIR; backward uses PyTorch autograd.
+    fw_backend = make_buddy_backend(compile_backward=False)
+    train(
+        "Buddy MLIR JIT – forward only (compile_backward=False)",
+        backend=fw_backend,
+    )
+
+    # ── 3. Buddy MLIR JIT – forward + backward ────────────────────────────
+    # Both forward and backward graphs are compiled by Buddy MLIR.
+    fwbw_backend = make_buddy_backend(compile_backward=True)
+    train(
+        "Buddy MLIR JIT – forward + backward (compile_backward=True)",
+        backend=fwbw_backend,
+    )
+
+    print("\nAll training runs completed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/lit.cfg.py
+++ b/examples/lit.cfg.py
@@ -32,6 +32,7 @@ config.substitutions.append(("%shlibext", config.llvm_shlib_ext))
 # subdirectories contain auxiliary inputs for various tests in their parent
 # directories.
 config.excludes = [
+    "BuddyJITTrain",
     "BuddyLeNet",
     "BuddyBert",
     "BuddyLlama",

--- a/frontend/Python/frontend.py
+++ b/frontend/Python/frontend.py
@@ -77,6 +77,7 @@ class DynamoCompiler:
         verbose=False,
         enable_external_calls: bool = False,
         capture_scalar_outputs: bool = False,
+        compile_backward: bool = False,
     ) -> None:
         """
         Initializes the Dynamo Compiler.
@@ -92,6 +93,10 @@ class DynamoCompiler:
             enable_external_calls (bool): Enable external function call support (for oneDNN, etc.)
             capture_scalar_outputs (bool): Enable scalar output capture in
                 TorchDynamo to avoid graph breaks from scalar escapes.
+            compile_backward (bool): When True, the backward pass is also
+                compiled through Buddy MLIR (both forward and backward graphs
+                are captured). When False, only the forward graph is compiled
+                and backward runs through PyTorch's eager autograd.
         Attributes:
             _func_name: The function name to be used.
             _aot_autograd_decomposition (Optional[dict], optional):
@@ -114,6 +119,7 @@ class DynamoCompiler:
         self._aot_autograd_decomposition = aot_autograd_decomposition
         self._verbose = verbose
         self._enable_external_calls = enable_external_calls
+        self._compile_backward = compile_backward
         self._imported_graphs = []
         self._ops_registry = {}
         self._imported_params = {}
@@ -879,33 +885,33 @@ class DynamoCompiler:
             return for torchdynamo's call.
         """
 
-        # params = {
-        #     # **dict(gm.named_parameters(remove_duplicate=False)),
-        #     **dict(gm.named_buffers(remove_duplicate=False)),
-        # }
-        # print(len(params))
-        # params_flat, _ = pytree.tree_flatten(params)
-        inputs_pos = []
-        params_pos = []
-        buffers_pos = []
-        for i, node in enumerate(gm.graph.nodes):
-            if i >= len(inputs):
-                break
-            if not str(node).startswith("l_self"):
-                inputs_pos.append(i)
-            elif "buffer" in str(node):
-                buffers_pos.append(i)
-            else:
-                params_pos.append(i)
-
-        params_flat = [inputs[i] for i in params_pos + buffers_pos]
-
         if self._verbose:
             print("Graph in tabular form:")
             gm.graph.print_tabular()
 
         def _compiler(_gm: torch.fx.GraphModule, _inputs: list[torch.Tensor]):
             """Compile a FX graph in Aten/Prims IR to MLIR."""
+            # Classify each placeholder node in THIS specific graph (not the
+            # outer dynamo graph) so that backward graphs — whose nodes carry
+            # names like "primals_1" / "tangents_1" rather than "l_self*" —
+            # are all treated as runtime InputNodes instead of FakeNode params.
+            local_params_pos = []
+            local_buffers_pos = []
+            local_inputs_pos = []
+            for i, node in enumerate(_gm.graph.nodes):
+                if i >= len(_inputs):
+                    break
+                node_str = str(node)
+                if not node_str.startswith("l_self"):
+                    local_inputs_pos.append(i)
+                elif "buffer" in node_str:
+                    local_buffers_pos.append(i)
+                else:
+                    local_params_pos.append(i)
+            local_params_flat = [
+                _inputs[i] for i in local_params_pos + local_buffers_pos
+            ]
+
             graph = Graph(
                 self._ops_registry,
                 self._func_name,
@@ -913,18 +919,24 @@ class DynamoCompiler:
                 self._verbose,
                 self._enable_external_calls,
             )
-            graph._params_ref = params_flat
+            graph._params_ref = local_params_flat
+            # Store positions so exec_buddy_graph can reorder AOT primals to
+            # match the MLIR function signature (params first, then inputs).
+            graph._fw_param_positions = list(local_params_pos) + list(
+                local_buffers_pos
+            )
+            graph._fw_input_positions = list(local_inputs_pos)
             param_nodes = []
             buffers_nodes = []
             input_nodes = []
             other_nodes = []
             all_nodes = list(_gm.graph.nodes)
             for i, node in enumerate(all_nodes):
-                if i in params_pos:
+                if i in local_params_pos:
                     param_nodes.append(node)
-                elif i in buffers_pos:
+                elif i in local_buffers_pos:
                     buffers_nodes.append(node)
-                elif i in inputs_pos:
+                elif i in local_inputs_pos:
                     input_nodes.append(node)
                 else:
                     other_nodes.append(node)
@@ -965,6 +977,15 @@ class DynamoCompiler:
                         buddy_node = self._create_node(
                             gm_node.op, gm_node.name, gm_node.args, node_users
                         )
+                        # Track None positions so exec_buddy_graph can reconstruct
+                        # the full gradient tuple (e.g. dx=None for non-grad inputs).
+                        raw_outputs = gm_node.args[0] if gm_node.args else []
+                        none_pos = [
+                            i for i, a in enumerate(raw_outputs) if a is None
+                        ]
+                        if none_pos:
+                            graph._output_none_positions = none_pos
+                            graph._total_output_count = len(raw_outputs)
 
                     elif gm_node.target is operator.getitem:
                         node_dtype = self._torch_dtype_translate(
@@ -1086,7 +1107,7 @@ class DynamoCompiler:
             graph._enabled_external_groups = enabled_external_groups
             graph.perform(transform_list)
             self._imported_graphs.append(graph)
-            self._imported_params[graph] = params_flat
+            self._imported_params[graph] = local_params_flat
             if return_type == "eager":
                 return _gm.forward
             if return_type == "buddy":
@@ -1103,10 +1124,18 @@ class DynamoCompiler:
                 f"Unsupported return_type={return_type!r}; expected 'eager' or 'buddy'."
             )
 
+        def _noop_bw_compiler(_gm, _inputs):
+            # When compile_backward=False, backward runs through PyTorch eager
+            # without being captured as a Buddy graph.
+            return _gm.forward
+
+        bw_compiler = _compiler if self._compile_backward else _noop_bw_compiler
+
         return aot_module_simplified(
             gm,
             inputs,
             fw_compiler=_compiler,
+            bw_compiler=bw_compiler,
             decompositions=self._aot_autograd_decomposition,
         )
 
@@ -1334,10 +1363,18 @@ class DynamoCompiler:
             def _tensor_to_numpy(tensor: torch.Tensor) -> np.ndarray:
                 if tensor.device.type != "cpu":
                     tensor = tensor.cpu()
-                tensor = tensor.contiguous()
+                tensor = tensor.detach().contiguous()
                 if tensor.dtype == torch.bfloat16:
                     return _bf16_tensor_to_numpy_uint16(tensor)
                 return tensor.numpy()
+
+            # Reorder AOT primals to match MLIR signature (params first, inputs last).
+            p_pos = getattr(graph, "_fw_param_positions", None)
+            i_pos = getattr(graph, "_fw_input_positions", None)
+            if p_pos is not None and i_pos is not None and (p_pos or i_pos):
+                args = tuple(
+                    [args[j] for j in p_pos] + [args[j] for j in i_pos]
+                )
 
             input_arrays = []
             input_descs = []
@@ -1363,9 +1400,31 @@ class DynamoCompiler:
                 if isinstance(out, np.ndarray) and out.dtype == np.uint16:
                     out = _bf16_uint16_numpy_to_f32(out)
                 if isinstance(out, np.ndarray):
+                    # Copy before output_struct (ctypes local) is GC'd.
+                    # Without this, tensors saved for autograd backward
+                    # reference freed memory and segfault.
+                    out = np.array(out, copy=True)
                     output_tensors.append(torch.from_numpy(out))
                 else:
                     output_tensors.append(torch.tensor(out))
+
+            # Reconstruct full output inserting None at positions where the
+            # graph had None (e.g. gradient w.r.t. non-grad inputs).
+            none_positions = getattr(graph, "_output_none_positions", [])
+            if none_positions:
+                total = getattr(
+                    graph, "_total_output_count", len(output_tensors)
+                )
+                none_set = set(none_positions)
+                full = []
+                mlir_idx = 0
+                for i in range(total):
+                    if i in none_set:
+                        full.append(None)
+                    else:
+                        full.append(output_tensors[mlir_idx])
+                        mlir_idx += 1
+                return full
             return output_tensors
 
         return exec_buddy_graph


### PR DESCRIPTION
Implement a PyTorch + Buddy MLIR JIT training path using a two-layer MLP as example. The forward pass (and optionally the backward pass) is compiled to MLIR and executed via the Buddy ExecutionEngine, while the optimizer step runs in PyTorch as usual.

Three modes are demonstrated:
- Pure PyTorch baseline
- Buddy MLIR JIT forward only (compile_backward=False)
- Buddy MLIR JIT forward + backward (compile_backward=True)

All three modes produce numerically identical results.

Frontend changes (frontend/Python/frontend.py):
- Add compile_backward parameter to DynamoCompiler
- Add _noop_bw_compiler so backward runs eagerly when compile_backward=False
- Fix _tensor_to_numpy to call .detach() before .numpy() for param tensors
- Copy exec_buddy_graph outputs to avoid dangling ctypes pointer after GC
- Store _fw_param_positions/_fw_input_positions on graph and reorder AOT primals in exec_buddy_graph to match MLIR function signature (params first)
- Record None gradient positions in backward graph output and reconstruct full gradient tuple in exec_buddy_graph for compile_backward=True