### PR TITLE
[Example] Add DeepSeekR1 GPU E2E inference pipeline

### DIFF
--- a/examples/BuddyDeepSeekR1-GPU/CMakeLists.txt
+++ b/examples/BuddyDeepSeekR1-GPU/CMakeLists.txt
@@ -1,0 +1,265 @@
+set(BUFFERIZE_SIMPLE_OPTS "bufferize-function-boundaries")
+set(TOSA_PIPELINE "builtin.module(func.func(tosa-to-linalg-named),func.func(tosa-to-linalg),func.func(tosa-to-tensor),func.func(tosa-to-arith))")
+
+set(CUDA_SM "sm_80" CACHE STRING "CUDA SM target (e.g. sm_80, sm_86, sm_89)")
+set(CUDA_FEATURES "+ptx71" CACHE STRING "CUDA PTX features (e.g. +ptx71)")
+set(NVVM_PIPELINE_OPTS "cubin-chip=${CUDA_SM} cubin-features=${CUDA_FEATURES} cubin-format=fatbin")
+
+# ---------------------------------------------------------------------------
+# Import: generate MLIR files and parameters using the DeepSeekR1 import script
+# ---------------------------------------------------------------------------
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/forward_prefill.mlir
+         ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_prefill.mlir
+         ${CMAKE_CURRENT_BINARY_DIR}/forward_decode.mlir
+         ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode.mlir
+         ${CMAKE_CURRENT_BINARY_DIR}/arg0.data
+  COMMAND ${Python3_EXECUTABLE}
+          ${CMAKE_CURRENT_SOURCE_DIR}/import-deepseek-r1-gpu.py
+          --output-dir ${CMAKE_CURRENT_BINARY_DIR}
+  COMMENT "Generating DeepSeekR1 MLIR and parameter files for GPU..."
+)
+
+# ---------------------------------------------------------------------------
+# Forward prefill: standard LLVM pipeline (no OpenMP, no CPU vectorization)
+# The forward orchestrates calls to the GPU subgraph; unified memory makes all
+# allocations accessible from both CPU and GPU without explicit transfers.
+# ---------------------------------------------------------------------------
+add_custom_command(
+  OUTPUT forward_prefill.o
+  COMMAND ${BUDDY_BINARY_DIR}/buddy-opt
+            ${CMAKE_CURRENT_BINARY_DIR}/forward_prefill.mlir
+            -simplify-tosa-reshape |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+            -pass-pipeline ${TOSA_PIPELINE} |
+          ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -canonicalize
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -cse
+            -canonicalize
+            -optimize-allocation-liveness
+            -convert-linalg-to-affine-loops
+            -convert-vector-to-scf
+            -lower-affine
+            -memref-expand
+            -arith-expand
+            -convert-vector-to-llvm
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -llvm-request-c-wrappers
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+          ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+          ${LLVM_TOOLS_BINARY_DIR}/llc -filetype=obj -relocation-model=pic -O3
+            -o ${CMAKE_CURRENT_BINARY_DIR}/forward_prefill.o
+  DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/forward_prefill.mlir
+  COMMENT "Building forward_prefill.o (GPU)"
+  VERBATIM)
+
+# ---------------------------------------------------------------------------
+# Subgraph prefill: GPU pipeline
+# linalg → parallel-loops → gpu-map → gpu-kernel-outlining → NVVM
+# ---------------------------------------------------------------------------
+add_custom_command(
+  OUTPUT subgraph_prefill.o
+  COMMAND ${BUDDY_BINARY_DIR}/buddy-opt
+            ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_prefill.mlir
+            -simplify-tosa-reshape |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+            -pass-pipeline ${TOSA_PIPELINE} |
+          ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -convert-elementwise-to-linalg
+            -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -canonicalize
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -cse
+            -canonicalize
+            -optimize-allocation-liveness
+            -convert-strided-copy-to-parallel
+            -matmul-gpu-tiling
+            -convert-linalg-to-parallel-loops
+            -canonicalize
+            -nest-parallel-loops-for-gpu
+            -gpu-map-parallel-loops
+            -convert-parallel-loops-to-gpu
+            -legalize-shmem-outlining
+            -gpu-kernel-outlining
+            -buffer-hoisting
+            -canonicalize
+            -cse |
+          ${BUDDY_BINARY_DIR}/buddy-opt
+            -convert-memcpy-to-gpu=process-args=0
+            -gpu-async-region
+            -canonicalize |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+            -llvm-request-c-wrappers
+            -gpu-lower-to-nvvm-pipeline=${NVVM_PIPELINE_OPTS} |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+          ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+          ${LLVM_TOOLS_BINARY_DIR}/llc -filetype=obj -relocation-model=pic -O3
+            -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph_prefill.o
+  DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_prefill.mlir
+  COMMENT "Building subgraph_prefill.o (GPU)"
+  VERBATIM)
+
+# ---------------------------------------------------------------------------
+# Forward decode: same pipeline as forward prefill
+# ---------------------------------------------------------------------------
+add_custom_command(
+  OUTPUT forward_decode.o
+  COMMAND ${BUDDY_BINARY_DIR}/buddy-opt
+            ${CMAKE_CURRENT_BINARY_DIR}/forward_decode.mlir
+            -simplify-tosa-reshape |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+            -pass-pipeline ${TOSA_PIPELINE} |
+          ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -canonicalize
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -cse
+            -canonicalize
+            -optimize-allocation-liveness
+            -convert-memcpy-to-gpu=process-args=0
+            -convert-linalg-to-affine-loops
+            -convert-vector-to-scf
+            -lower-affine
+            -memref-expand
+            -arith-expand
+            -convert-vector-to-llvm
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+            -llvm-request-c-wrappers
+            -gpu-to-llvm |
+          ${BUDDY_BINARY_DIR}/buddy-opt
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+          ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+          ${LLVM_TOOLS_BINARY_DIR}/llc -filetype=obj -relocation-model=pic -O3
+            -o ${CMAKE_CURRENT_BINARY_DIR}/forward_decode.o
+  DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/forward_decode.mlir
+  COMMENT "Building forward_decode.o (GPU)"
+  VERBATIM)
+
+# ---------------------------------------------------------------------------
+# Subgraph decode: GPU pipeline (with matmul-scalar simplification for decode)
+# ---------------------------------------------------------------------------
+add_custom_command(
+  OUTPUT subgraph_decode.o
+  COMMAND ${BUDDY_BINARY_DIR}/buddy-opt
+            ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode.mlir
+            -simplify-tosa-reshape
+            -simplify-tosa-matmul-scalar |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+            -pass-pipeline ${TOSA_PIPELINE} |
+          ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -convert-elementwise-to-linalg
+            -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -canonicalize
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -cse
+            -canonicalize
+            -optimize-allocation-liveness
+            -convert-strided-copy-to-parallel
+            -matmul-gpu-tiling
+            -convert-linalg-to-parallel-loops
+            -canonicalize
+            -nest-parallel-loops-for-gpu
+            -gpu-map-parallel-loops
+            -convert-parallel-loops-to-gpu
+            -legalize-shmem-outlining
+            -gpu-kernel-outlining
+            -buffer-hoisting
+            -canonicalize
+            -cse |
+          ${BUDDY_BINARY_DIR}/buddy-opt
+            -convert-memcpy-to-gpu=process-args=0
+            -gpu-async-region
+            -canonicalize |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+            -llvm-request-c-wrappers
+            -gpu-lower-to-nvvm-pipeline=${NVVM_PIPELINE_OPTS} |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+          ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+          ${LLVM_TOOLS_BINARY_DIR}/llc -filetype=obj -relocation-model=pic -O3
+            -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph_decode.o
+  DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode.mlir
+  COMMENT "Building subgraph_decode.o (GPU)"
+  VERBATIM)
+
+# ---------------------------------------------------------------------------
+# Static library
+# ---------------------------------------------------------------------------
+add_library(DEEPSEEKR1_GPU STATIC
+  forward_prefill.o
+  subgraph_prefill.o
+  forward_decode.o
+  subgraph_decode.o)
+
+SET_SOURCE_FILES_PROPERTIES(
+  forward_prefill.o subgraph_prefill.o forward_decode.o subgraph_decode.o
+  PROPERTIES EXTERNAL_OBJECT true GENERATED true)
+
+SET_TARGET_PROPERTIES(DEEPSEEKR1_GPU PROPERTIES LINKER_LANGUAGE C)
+
+# ---------------------------------------------------------------------------
+# Executable
+# ---------------------------------------------------------------------------
+add_executable(buddy-deepseek-r1-gpu-run buddy-deepseek-r1-gpu-main.cpp)
+
+# DEEPSEEKR1_GPU_EXAMPLE_PATH points to the CPU source directory (contains vocab.txt).
+# DEEPSEEKR1_GPU_EXAMPLE_BUILD_PATH points to this GPU build directory (contains arg0.data).
+set(DEEPSEEKR1_GPU_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../BuddyDeepSeekR1/)
+set(DEEPSEEKR1_GPU_EXAMPLE_BUILD_PATH ${CMAKE_CURRENT_BINARY_DIR})
+
+target_compile_definitions(buddy-deepseek-r1-gpu-run PRIVATE
+  DEEPSEEKR1_GPU_EXAMPLE_PATH="${DEEPSEEKR1_GPU_EXAMPLE_PATH}"
+  DEEPSEEKR1_GPU_EXAMPLE_BUILD_PATH="${DEEPSEEKR1_GPU_EXAMPLE_BUILD_PATH}/"
+)
+
+target_include_directories(buddy-deepseek-r1-gpu-run PRIVATE /usr/local/cuda/include)
+
+target_link_directories(buddy-deepseek-r1-gpu-run PRIVATE ${LLVM_LIBRARY_DIR} /usr/local/cuda/lib64)
+
+set(BUDDY_DEEPSEEKR1_GPU_LIBS
+  DEEPSEEKR1_GPU
+  mlir_cuda_runtime
+  mlir_c_runner_utils
+  mlir_runner_utils
+  cudart
+)
+
+target_link_libraries(buddy-deepseek-r1-gpu-run ${BUDDY_DEEPSEEKR1_GPU_LIBS})

--- a/examples/BuddyDeepSeekR1-GPU/README.md
+++ b/examples/BuddyDeepSeekR1-GPU/README.md
@@ -1,0 +1,121 @@
+# Buddy Compiler DeepSeekR1 GPU Example
+
+## Introduction
+
+This example runs DeepSeekR1-Distill-Qwen-1.5B inference on NVIDIA GPUs using Buddy Compiler. The model is compiled through MLIR's GPU pipeline (parallel-loops -> NVVM) with CUDA managed memory for seamless CPU/GPU data sharing.
+
+## Prerequisites
+
+- NVIDIA GPU with compute capability >= 8.0 (A100, A800, H100, etc.)
+- CUDA toolkit installed (nvcc, libcuda, libcudart)
+- Python environment with PyTorch and Transformers
+
+```bash
+conda activate <your-env>
+pip install -r requirements.txt
+```
+
+## Build
+
+### 1. Build LLVM/MLIR with CUDA support
+
+```bash
+cd buddy-mlir/llvm/build
+cmake -G Ninja ../llvm \
+    -DLLVM_ENABLE_PROJECTS="mlir;clang" \
+    -DLLVM_TARGETS_TO_BUILD="host;NVPTX" \
+    -DMLIR_ENABLE_CUDA_RUNNER=ON \
+    -DCMAKE_BUILD_TYPE=RELEASE \
+    -DLLVM_ENABLE_ASSERTIONS=ON
+ninja check-mlir
+```
+
+### 2. Build Buddy Compiler
+
+```bash
+cd buddy-mlir/build
+cmake -G Ninja .. \
+    -DMLIR_DIR=$PWD/../llvm/build/lib/cmake/mlir \
+    -DLLVM_DIR=$PWD/../llvm/build/lib/cmake/llvm \
+    -DLLVM_ENABLE_ASSERTIONS=ON \
+    -DCMAKE_BUILD_TYPE=RELEASE \
+    -DBUDDY_ENABLE_OPENCV=OFF
+ninja buddy-opt
+```
+
+### 3. Set environment variables
+
+```bash
+export BUDDY_MLIR_BUILD_DIR=$PWD
+export LLVM_MLIR_BUILD_DIR=$PWD/../llvm/build
+export PYTHONPATH=${BUDDY_MLIR_BUILD_DIR}/python_packages:${PYTHONPATH}
+export DEEPSEEKR1_MODEL_PATH=/path/to/DeepSeek-R1-Distill-Qwen-1.5B
+```
+
+### 4. Build and run
+
+```bash
+# Target a specific GPU architecture (default: sm_80 for A100)
+cmake -DCUDA_SM=sm_80 ..
+ninja buddy-deepseek-r1-gpu-run
+```
+
+The build will:
+1. Run the import script to generate MLIR files and parameter data from the HuggingFace model
+2. Compile `forward_prefill.mlir` and `forward_decode.mlir` (CPU orchestration with GPU memory management)
+3. Compile `subgraph0_prefill.mlir` and `subgraph0_decode.mlir` (GPU compute kernels via NVVM pipeline)
+4. Link everything into `buddy-deepseek-r1-gpu-run`
+
+### 5. Run inference
+
+```bash
+cd buddy-mlir/build
+
+# Select GPU device
+export CUDA_VISIBLE_DEVICES=0
+
+# Run with library path
+LD_LIBRARY_PATH=/path/to/conda/env/lib:$LD_LIBRARY_PATH \
+    ./bin/buddy-deepseek-r1-gpu-run
+```
+
+The program will prompt for input text. Example:
+
+```
+DeepSeekR1 GPU Inference Powered by Buddy Compiler
+
+Please send a message:
+>>> Hello
+
+[Iteration 0] Token: Alright | Time: 235.38s
+[Iteration 1] Token: , | Time: 1.49s
+[Iteration 2] Token: the | Time: 1.45s
+...
+```
+
+## Architecture
+
+```
+main.cpp
+  |
+  |-- forward_prefill (CPU, standard LLVM pipeline + GPU memory mgmt)
+  |     |-- subgraph0_prefill (GPU, NVVM pipeline)
+  |
+  |-- forward_decode (CPU, standard LLVM pipeline + GPU memory mgmt)
+        |-- subgraph0_decode (GPU, NVVM pipeline)
+```
+
+- **Forward functions**: Orchestrate the inference loop on CPU. Slice model parameters, manage KV caches, call GPU subgraphs. Compiled with `convert-memcpy-to-gpu` pass + `gpu-to-llvm` lowering to allocate buffers as CUDA managed memory.
+- **Subgraph functions**: Run the actual compute on GPU. Linalg ops are lowered to parallel loops, mapped to GPU blocks, outlined as CUDA kernels, and compiled to CUBIN via the NVVM pipeline.
+- **CUDA managed memory**: All GPU allocations use `cuMemAllocManaged`, making buffers accessible from both CPU and GPU without explicit transfers. This simplifies KV cache passing between prefill and decode phases.
+
+## Performance
+
+Measured on NVIDIA A100 80GB PCIe:
+
+| Phase | Performance |
+|-------|-------------|
+| Prefill (1024 tokens) | ~235s |
+| Decode | ~1.4s/token |
+
+Note: Current performance is unoptimized (1 thread per GPU block, no tiling, no shared memory). Significant speedups are possible with kernel optimization.

--- a/examples/BuddyDeepSeekR1-GPU/buddy-deepseek-r1-gpu-main.cpp
+++ b/examples/BuddyDeepSeekR1-GPU/buddy-deepseek-r1-gpu-main.cpp
@@ -1,0 +1,727 @@
+//===- buddy-deepseek-r1-gpu-main.cpp -------------------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+//
+// DeepSeekR1 GPU inference entry point.
+//
+// The subgraph MLIR files are compiled with the NVVM (GPU) pipeline so that
+// linalg ops are lowered to CUDA kernels via the parallel-loops → GPU path.
+// The forward wrappers are compiled with the standard LLVM lowering pipeline.
+//
+// At runtime the MLIR CUDA runtime (mlir_cuda_runtime) manages GPU memory via
+// cudaMallocManaged (unified memory), so outputs returned by the GPU subgraph
+// are CPU-accessible without an explicit device-to-host copy.
+//
+// std::_Exit(0) is used at the end to skip MLIR CUDA runtime atexit handlers
+// that attempt to unload modules after the CUDA context is already destroyed.
+//
+//===----------------------------------------------------------------------===//
+
+#include <array>
+#include <buddy/Core/Container.h>
+#include <buddy/LLM/TextContainer.h>
+#include <chrono>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <cuda_runtime.h>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sys/time.h>
+
+using namespace buddy;
+
+extern "C" void *mgpuMemAlloc(uint64_t sizeBytes, void *stream,
+                              bool isHostShared);
+
+// MemRef backed by cudaMallocManaged (unified memory).
+// GPU kernels can access this directly without explicit H2D copies.
+// Sets `allocated = nullptr` so the base ~MemRef() does not call free().
+class CudaManagedMemRef1D : public MemRef<float, 1> {
+  float *cuda_ptr_ = nullptr;
+
+public:
+  explicit CudaManagedMemRef1D(size_t count) {
+    cudaError_t err = cudaMallocManaged(&cuda_ptr_, sizeof(float) * count);
+    if (err != cudaSuccess)
+      throw std::runtime_error(std::string("cudaMallocManaged failed: ") +
+                               cudaGetErrorString(err));
+    this->aligned = cuda_ptr_;
+    this->allocated = this->aligned; // must match aligned for MLIR descriptor
+    this->sizes[0] = static_cast<intptr_t>(count);
+    this->strides[0] = 1;
+    this->offset = 0;
+  }
+  ~CudaManagedMemRef1D() {
+    if (cuda_ptr_)
+      cudaFree(cuda_ptr_);
+  }
+};
+
+// Generic N-dimensional managed-memory wrapper.
+// Accepts the same initializer_list<intptr_t> shape + init-value interface as
+// MemRef constructors so existing call sites can be changed with minimal churn.
+template <typename T, size_t N> class CudaManagedMemRef : public MemRef<T, N> {
+  T *cuda_ptr_ = nullptr;
+
+public:
+  explicit CudaManagedMemRef(std::initializer_list<intptr_t> shape,
+                             T initVal = T{}) {
+    size_t count = 1;
+    size_t i = 0;
+    for (auto s : shape) {
+      this->sizes[i++] = s;
+      count *= static_cast<size_t>(s);
+    }
+    cudaError_t err = cudaMallocManaged(&cuda_ptr_, sizeof(T) * count);
+    if (err != cudaSuccess)
+      throw std::runtime_error(std::string("cudaMallocManaged failed: ") +
+                               cudaGetErrorString(err));
+    std::fill(cuda_ptr_, cuda_ptr_ + count, initVal);
+    this->aligned = cuda_ptr_;
+    this->allocated = this->aligned; // must match aligned for MLIR descriptor
+    this->offset = 0;
+    this->strides[N - 1] = 1;
+    for (int j = static_cast<int>(N) - 2; j >= 0; --j)
+      this->strides[j] = this->strides[j + 1] * this->sizes[j + 1];
+  }
+  ~CudaManagedMemRef() {
+    if (cuda_ptr_)
+      cudaFree(cuda_ptr_);
+  }
+};
+
+double total_time = 0;
+constexpr size_t ParamsSize = 1777088064;
+constexpr size_t MaxVocabSize = 151936;
+constexpr size_t MaxTokenLength = 1024;
+
+constexpr size_t NUM_LAYERS = 56;
+constexpr size_t HiddenSize = 128;
+constexpr size_t HeadNum = 2;
+
+extern "C" double _mlir_ciface_rtclock() {
+#ifndef _WIN32
+  struct timeval tp;
+  int stat = gettimeofday(&tp, nullptr);
+  if (stat != 0)
+    fprintf(stderr, "Error returning time from gettimeofday: %d\n", stat);
+  return (tp.tv_sec + tp.tv_usec * 1.0e-6);
+#else
+  fprintf(stderr, "Timing utility not implemented on Windows\n");
+  return 0.0;
+#endif // _WIN32
+}
+
+struct MemRefContainer {
+
+  MemRef<float, 4> kv0;
+  MemRef<float, 4> kv1;
+  MemRef<float, 4> kv2;
+  MemRef<float, 4> kv3;
+  MemRef<float, 4> kv4;
+  MemRef<float, 4> kv5;
+  MemRef<float, 4> kv6;
+  MemRef<float, 4> kv7;
+  MemRef<float, 4> kv8;
+  MemRef<float, 4> kv9;
+  MemRef<float, 4> kv10;
+  MemRef<float, 4> kv11;
+  MemRef<float, 4> kv12;
+  MemRef<float, 4> kv13;
+  MemRef<float, 4> kv14;
+  MemRef<float, 4> kv15;
+  MemRef<float, 4> kv16;
+  MemRef<float, 4> kv17;
+  MemRef<float, 4> kv18;
+  MemRef<float, 4> kv19;
+  MemRef<float, 4> kv20;
+  MemRef<float, 4> kv21;
+  MemRef<float, 4> kv22;
+  MemRef<float, 4> kv23;
+  MemRef<float, 4> kv24;
+  MemRef<float, 4> kv25;
+  MemRef<float, 4> kv26;
+  MemRef<float, 4> kv27;
+  MemRef<float, 4> kv28;
+  MemRef<float, 4> kv29;
+  MemRef<float, 4> kv30;
+  MemRef<float, 4> kv31;
+  MemRef<float, 4> kv32;
+  MemRef<float, 4> kv33;
+  MemRef<float, 4> kv34;
+  MemRef<float, 4> kv35;
+  MemRef<float, 4> kv36;
+  MemRef<float, 4> kv37;
+  MemRef<float, 4> kv38;
+  MemRef<float, 4> kv39;
+  MemRef<float, 4> kv40;
+  MemRef<float, 4> kv41;
+  MemRef<float, 4> kv42;
+  MemRef<float, 4> kv43;
+  MemRef<float, 4> kv44;
+  MemRef<float, 4> kv45;
+  MemRef<float, 4> kv46;
+  MemRef<float, 4> kv47;
+  MemRef<float, 4> kv48;
+  MemRef<float, 4> kv49;
+  MemRef<float, 4> kv50;
+  MemRef<float, 4> kv51;
+  MemRef<float, 4> kv52;
+  MemRef<float, 4> kv53;
+  MemRef<float, 4> kv54;
+  MemRef<float, 4> kv55;
+
+  MemRef<float, 3> logits;
+
+  std::array<MemRef<float, 4> *, 56> kv_ptrs;
+
+  MemRefContainer(
+      MemRef<float, 4> k0, MemRef<float, 4> k1, MemRef<float, 4> k2,
+      MemRef<float, 4> k3, MemRef<float, 4> k4, MemRef<float, 4> k5,
+      MemRef<float, 4> k6, MemRef<float, 4> k7, MemRef<float, 4> k8,
+      MemRef<float, 4> k9, MemRef<float, 4> k10, MemRef<float, 4> k11,
+      MemRef<float, 4> k12, MemRef<float, 4> k13, MemRef<float, 4> k14,
+      MemRef<float, 4> k15, MemRef<float, 4> k16, MemRef<float, 4> k17,
+      MemRef<float, 4> k18, MemRef<float, 4> k19, MemRef<float, 4> k20,
+      MemRef<float, 4> k21, MemRef<float, 4> k22, MemRef<float, 4> k23,
+      MemRef<float, 4> k24, MemRef<float, 4> k25, MemRef<float, 4> k26,
+      MemRef<float, 4> k27, MemRef<float, 4> k28, MemRef<float, 4> k29,
+      MemRef<float, 4> k30, MemRef<float, 4> k31, MemRef<float, 4> k32,
+      MemRef<float, 4> k33, MemRef<float, 4> k34, MemRef<float, 4> k35,
+      MemRef<float, 4> k36, MemRef<float, 4> k37, MemRef<float, 4> k38,
+      MemRef<float, 4> k39, MemRef<float, 4> k40, MemRef<float, 4> k41,
+      MemRef<float, 4> k42, MemRef<float, 4> k43, MemRef<float, 4> k44,
+      MemRef<float, 4> k45, MemRef<float, 4> k46, MemRef<float, 4> k47,
+      MemRef<float, 4> k48, MemRef<float, 4> k49, MemRef<float, 4> k50,
+      MemRef<float, 4> k51, MemRef<float, 4> k52, MemRef<float, 4> k53,
+      MemRef<float, 4> k54, MemRef<float, 4> k55, MemRef<float, 3> l)
+      : kv0(k0), kv1(k1), kv2(k2), kv3(k3), kv4(k4), kv5(k5), kv6(k6), kv7(k7),
+        kv8(k8), kv9(k9), kv10(k10), kv11(k11), kv12(k12), kv13(k13), kv14(k14),
+        kv15(k15), kv16(k16), kv17(k17), kv18(k18), kv19(k19), kv20(k20),
+        kv21(k21), kv22(k22), kv23(k23), kv24(k24), kv25(k25), kv26(k26),
+        kv27(k27), kv28(k28), kv29(k29), kv30(k30), kv31(k31), kv32(k32),
+        kv33(k33), kv34(k34), kv35(k35), kv36(k36), kv37(k37), kv38(k38),
+        kv39(k39), kv40(k40), kv41(k41), kv42(k42), kv43(k43), kv44(k44),
+        kv45(k45), kv46(k46), kv47(k47), kv48(k48), kv49(k49), kv50(k50),
+        kv51(k51), kv52(k52), kv53(k53), kv54(k54), kv55(k55), logits(l),
+        kv_ptrs{&kv0,  &kv1,  &kv2,  &kv3,  &kv4,  &kv5,  &kv6,  &kv7,
+
+                &kv8,  &kv9,  &kv10, &kv11, &kv12, &kv13, &kv14, &kv15,
+
+                &kv16, &kv17, &kv18, &kv19, &kv20, &kv21, &kv22, &kv23,
+
+                &kv24, &kv25, &kv26, &kv27, &kv28, &kv29, &kv30, &kv31,
+
+                &kv32, &kv33, &kv34, &kv35, &kv36, &kv37, &kv38, &kv39,
+
+                &kv40, &kv41, &kv42, &kv43, &kv44, &kv45, &kv46, &kv47,
+
+                &kv48, &kv49, &kv50, &kv51, &kv52, &kv53, &kv54, &kv55} {}
+};
+
+// Decode returns 85 values: [cache_pos, kv_a, kv_b] × 28 layers + logits.
+// Laid out as raw bytes to match the MLIR sret struct exactly without needing
+// MemRef default constructors (which are protected).
+struct DecodeResultContainer {
+  // MemRef<long long, 1>: 2 ptrs + offset + 1 size + 1 stride = 5 × i64 = 40
+  // bytes MemRef<float, 4>:     2 ptrs + offset + 4 sizes + 4 strides = 11 ×
+  // i64 = 88 bytes MemRef<float, 3>:     2 ptrs + offset + 3 sizes + 3 strides
+  // = 9 × i64 = 72 bytes Per layer: 40 + 88 + 88 = 216 bytes. 28 layers = 6048.
+  // + 72 logits = 6120.
+  static constexpr size_t kMemRef1xi64Size = 40;
+  static constexpr size_t kMemRef4xf32Size = 88;
+  static constexpr size_t kMemRef3xf32Size = 72;
+  static constexpr size_t kLayerSize = kMemRef1xi64Size + 2 * kMemRef4xf32Size;
+  static constexpr size_t kNumLayerGroups = NUM_LAYERS / 2; // 28
+  static constexpr size_t kTotalSize =
+      kNumLayerGroups * kLayerSize + kMemRef3xf32Size;
+
+  alignas(16) char data[kTotalSize];
+
+  MemRef<float, 4> &kv(int i) {
+    int group = i / 2;
+    int which = i % 2;
+    size_t off =
+        group * kLayerSize + kMemRef1xi64Size + which * kMemRef4xf32Size;
+    return *reinterpret_cast<MemRef<float, 4> *>(data + off);
+  }
+
+  MemRef<float, 3> &logits() {
+    size_t off = kNumLayerGroups * kLayerSize;
+    return *reinterpret_cast<MemRef<float, 3> *>(data + off);
+  }
+};
+
+extern "C" void _mlir_ciface_forward_prefill(MemRefContainer *result,
+                                             MemRef<float, 1> *arg0,
+                                             MemRef<long long, 2> *arg1);
+
+// forward_decode takes 87 args: params, tokens, cache_pos, then [kv_a, kv_b,
+// cache_idx] × 28.
+extern "C" void _mlir_ciface_forward_decode(
+    DecodeResultContainer *result, MemRef<float, 1> *params,
+    MemRef<long long, 2> *tokens, MemRef<long long, 1> *cachePos,
+    // 28 groups of: kv_a, kv_b, cache_idx
+    MemRef<float, 4> *kv0, MemRef<float, 4> *kv1, MemRef<long long, 1> *idx0,
+    MemRef<float, 4> *kv2, MemRef<float, 4> *kv3, MemRef<long long, 1> *idx1,
+    MemRef<float, 4> *kv4, MemRef<float, 4> *kv5, MemRef<long long, 1> *idx2,
+    MemRef<float, 4> *kv6, MemRef<float, 4> *kv7, MemRef<long long, 1> *idx3,
+    MemRef<float, 4> *kv8, MemRef<float, 4> *kv9, MemRef<long long, 1> *idx4,
+    MemRef<float, 4> *kv10, MemRef<float, 4> *kv11, MemRef<long long, 1> *idx5,
+    MemRef<float, 4> *kv12, MemRef<float, 4> *kv13, MemRef<long long, 1> *idx6,
+    MemRef<float, 4> *kv14, MemRef<float, 4> *kv15, MemRef<long long, 1> *idx7,
+    MemRef<float, 4> *kv16, MemRef<float, 4> *kv17, MemRef<long long, 1> *idx8,
+    MemRef<float, 4> *kv18, MemRef<float, 4> *kv19, MemRef<long long, 1> *idx9,
+    MemRef<float, 4> *kv20, MemRef<float, 4> *kv21, MemRef<long long, 1> *idx10,
+    MemRef<float, 4> *kv22, MemRef<float, 4> *kv23, MemRef<long long, 1> *idx11,
+    MemRef<float, 4> *kv24, MemRef<float, 4> *kv25, MemRef<long long, 1> *idx12,
+    MemRef<float, 4> *kv26, MemRef<float, 4> *kv27, MemRef<long long, 1> *idx13,
+    MemRef<float, 4> *kv28, MemRef<float, 4> *kv29, MemRef<long long, 1> *idx14,
+    MemRef<float, 4> *kv30, MemRef<float, 4> *kv31, MemRef<long long, 1> *idx15,
+    MemRef<float, 4> *kv32, MemRef<float, 4> *kv33, MemRef<long long, 1> *idx16,
+    MemRef<float, 4> *kv34, MemRef<float, 4> *kv35, MemRef<long long, 1> *idx17,
+    MemRef<float, 4> *kv36, MemRef<float, 4> *kv37, MemRef<long long, 1> *idx18,
+    MemRef<float, 4> *kv38, MemRef<float, 4> *kv39, MemRef<long long, 1> *idx19,
+    MemRef<float, 4> *kv40, MemRef<float, 4> *kv41, MemRef<long long, 1> *idx20,
+    MemRef<float, 4> *kv42, MemRef<float, 4> *kv43, MemRef<long long, 1> *idx21,
+    MemRef<float, 4> *kv44, MemRef<float, 4> *kv45, MemRef<long long, 1> *idx22,
+    MemRef<float, 4> *kv46, MemRef<float, 4> *kv47, MemRef<long long, 1> *idx23,
+    MemRef<float, 4> *kv48, MemRef<float, 4> *kv49, MemRef<long long, 1> *idx24,
+    MemRef<float, 4> *kv50, MemRef<float, 4> *kv51, MemRef<long long, 1> *idx25,
+    MemRef<float, 4> *kv52, MemRef<float, 4> *kv53, MemRef<long long, 1> *idx26,
+    MemRef<float, 4> *kv54, MemRef<float, 4> *kv55,
+    MemRef<long long, 1> *idx27);
+
+// -----------------------------------------------------------------------------
+// Helper Functions
+// -----------------------------------------------------------------------------
+
+/// Capture input message.
+void getUserInput(std::string &inputStr) {
+  std::cout << "\nPlease send a message:" << std::endl;
+  std::cout << ">>> ";
+  getline(std::cin, inputStr);
+  std::cout << std::endl;
+}
+
+/// Print [Log] label in bold blue format.
+void printLogLabel() { std::cout << "\033[34;1m[Log] \033[0m"; }
+
+/// Print information for each iteration.
+void printIterInfo(size_t iterIdx, std::string str, double time) {
+  total_time += time;
+  std::cout << "\033[32;1m[Iteration " << iterIdx << "] \033[0m";
+  std::cout << "Token: " << str << " | "
+            << "Time: " << time << "s" << std::endl;
+}
+
+/// Tokenize input data in the container.
+void tokenizeInput(const std::string &vocabFile,
+                   Text<size_t, 2> &inputContainer) {
+  printLogLabel();
+  std::cout << "Vocab file: " << std::filesystem::canonical(vocabFile)
+            << std::endl;
+  const auto buddyTokenizeStart = std::chrono::high_resolution_clock::now();
+  inputContainer.tokenizeDeepSeekR1(vocabFile, MaxTokenLength);
+  const auto buddyTokenizeEnd = std::chrono::high_resolution_clock::now();
+  const std::chrono::duration<double, std::milli> buddyTokenizeTime =
+      buddyTokenizeEnd - buddyTokenizeStart;
+  printLogLabel();
+  std::cout << "Tokenize time: " << buddyTokenizeTime.count() << "ms"
+            << std::endl;
+}
+
+/// Load parameters into data container.
+void loadParameters(const std::string &paramFilePath,
+                    MemRef<float, 1> &params) {
+  const auto loadStart = std::chrono::high_resolution_clock::now();
+  std::ifstream paramFile(paramFilePath, std::ios::in | std::ios::binary);
+  if (!paramFile.is_open()) {
+    throw std::runtime_error("[Error] Failed to open params file!");
+  }
+  printLogLabel();
+  std::cout << "Loading params..." << std::endl;
+  printLogLabel();
+  std::cout << "Params file: " << std::filesystem::canonical(paramFilePath)
+            << std::endl;
+  paramFile.read(reinterpret_cast<char *>(params.getData()),
+                 sizeof(float) * (params.getSize()));
+  if (paramFile.fail()) {
+    throw std::runtime_error("Error occurred while reading params file!");
+  }
+  paramFile.close();
+  const auto loadEnd = std::chrono::high_resolution_clock::now();
+  const std::chrono::duration<double, std::milli> loadTime =
+      loadEnd - loadStart;
+  printLogLabel();
+  std::cout << "Params load time: " << (double)(loadTime.count()) / 1000
+            << "s\n"
+            << std::endl;
+}
+
+/// Find the index of the max value.
+int findMaxIndex(const float *start, const float *end) {
+  return std::distance(start, std::max_element(start, end));
+}
+
+void copy_kv_by_cache_position_block(const MemRefContainer &prefill,
+                                     MemRefContainer &decode,
+                                     int cache_position) {
+  constexpr int num_kv = 56;
+  int copy_len = std::min(cache_position, (int)MaxTokenLength);
+
+  for (int k = 0; k < num_kv; ++k) {
+    auto &src = *prefill.kv_ptrs[k];
+    auto &dst = *decode.kv_ptrs[k];
+
+    for (int h = 0; h < (int)HeadNum; ++h) {
+      size_t bytes_to_copy =
+          static_cast<size_t>(copy_len) * HiddenSize * sizeof(float);
+
+      float *src_ptr = src.getData() + h * MaxTokenLength * HiddenSize;
+      float *dst_ptr = dst.getData() + h * MaxTokenLength * HiddenSize;
+
+      std::memcpy(dst_ptr, src_ptr, bytes_to_copy);
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// DeepSeekR1 GPU Inference Main Entry
+// -----------------------------------------------------------------------------
+
+int main() {
+  /// Print the title of this example.
+  const std::string title =
+      "DeepSeekR1 GPU Inference Powered by Buddy Compiler";
+  std::cout << "\033[33;1m" << title << "\033[0m" << std::endl;
+
+  /// Define directories of vocabulary and parameter files.
+  /// DEEPSEEKR1_GPU_EXAMPLE_PATH points to the CPU source directory
+  /// (vocab.txt). DEEPSEEKR1_GPU_EXAMPLE_BUILD_PATH points to the GPU build
+  /// directory (arg0.data).
+  std::string deepSeekR1Dir = DEEPSEEKR1_GPU_EXAMPLE_PATH;
+  std::string deepSeekR1BuildDir = DEEPSEEKR1_GPU_EXAMPLE_BUILD_PATH;
+  const std::string vocabDir = deepSeekR1Dir + "vocab.txt";
+  const std::string paramsDir = deepSeekR1BuildDir + "arg0.data";
+
+  /// Get user message.
+  std::string inputStr;
+  getUserInput(inputStr);
+
+  /// Initialize data containers
+  Text<size_t, 2> outputContainer;
+  Text<size_t, 2> inputContainerPrefill(inputStr);
+  CudaManagedMemRef<long long, 2> prefillTokensGPU({1, MaxTokenLength}, 0LL);
+  CudaManagedMemRef<long long, 2> inputContainerDecode({1, 1}, 0LL);
+  CudaManagedMemRef1D ParamsContainer(ParamsSize);
+  CudaManagedMemRef<long long, 1> cachePosition({1}, 0LL);
+
+  MemRef<float, 3> logits_prefill({1, MaxTokenLength, MaxVocabSize});
+
+  CudaManagedMemRef<float, 4> kv0({1, HeadNum, MaxTokenLength, HiddenSize},
+                                  0.0f);
+  CudaManagedMemRef<float, 4> kv1({1, HeadNum, MaxTokenLength, HiddenSize},
+                                  0.0f);
+  CudaManagedMemRef<float, 4> kv2({1, HeadNum, MaxTokenLength, HiddenSize},
+                                  0.0f);
+  CudaManagedMemRef<float, 4> kv3({1, HeadNum, MaxTokenLength, HiddenSize},
+                                  0.0f);
+  CudaManagedMemRef<float, 4> kv4({1, HeadNum, MaxTokenLength, HiddenSize},
+                                  0.0f);
+  CudaManagedMemRef<float, 4> kv5({1, HeadNum, MaxTokenLength, HiddenSize},
+                                  0.0f);
+  CudaManagedMemRef<float, 4> kv6({1, HeadNum, MaxTokenLength, HiddenSize},
+                                  0.0f);
+  CudaManagedMemRef<float, 4> kv7({1, HeadNum, MaxTokenLength, HiddenSize},
+                                  0.0f);
+
+  CudaManagedMemRef<float, 4> kv8({1, HeadNum, MaxTokenLength, HiddenSize},
+                                  0.0f);
+  CudaManagedMemRef<float, 4> kv9({1, HeadNum, MaxTokenLength, HiddenSize},
+                                  0.0f);
+  CudaManagedMemRef<float, 4> kv10({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv11({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv12({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv13({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv14({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv15({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+
+  CudaManagedMemRef<float, 4> kv16({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv17({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv18({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv19({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv20({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv21({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv22({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv23({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+
+  CudaManagedMemRef<float, 4> kv24({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv25({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv26({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv27({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv28({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv29({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv30({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv31({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+
+  CudaManagedMemRef<float, 4> kv32({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv33({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv34({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv35({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv36({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv37({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv38({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv39({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+
+  CudaManagedMemRef<float, 4> kv40({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv41({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv42({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv43({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv44({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv45({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv46({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv47({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+
+  CudaManagedMemRef<float, 4> kv48({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv49({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv50({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv51({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv52({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv53({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv54({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+  CudaManagedMemRef<float, 4> kv55({1, HeadNum, MaxTokenLength, HiddenSize},
+                                   0.0f);
+
+  MemRefContainer prefillResultContainer(
+      kv0, kv1, kv2, kv3, kv4, kv5, kv6, kv7, kv8, kv9, kv10, kv11, kv12, kv13,
+      kv14, kv15, kv16, kv17, kv18, kv19, kv20, kv21, kv22, kv23, kv24, kv25,
+      kv26, kv27, kv28, kv29, kv30, kv31, kv32, kv33, kv34, kv35, kv36, kv37,
+      kv38, kv39, kv40, kv41, kv42, kv43, kv44, kv45, kv46, kv47, kv48, kv49,
+      kv50, kv51, kv52, kv53, kv54, kv55, logits_prefill);
+  MemRefContainer *ptrPrefillResultContainer = &prefillResultContainer;
+
+  /// Fill data into containers
+  tokenizeInput(vocabDir, inputContainerPrefill);
+  outputContainer.loadVocab(vocabDir);
+  loadParameters(paramsDir, ParamsContainer);
+
+  // Copy prefill token IDs into GPU-accessible managed memory.
+  // Text<size_t,2> uses regular malloc (CPU-only); GPU kernels cannot access
+  // it directly. prefillTokensGPU uses cudaMallocManaged so the same virtual
+  // address is valid on both CPU and GPU.
+  {
+    size_t tokenCnt = static_cast<size_t>(inputContainerPrefill.getTokenCnt());
+    for (size_t i = 0; i < tokenCnt; ++i)
+      prefillTokensGPU.getData()[i] =
+          static_cast<long long>(inputContainerPrefill.getData()[i]);
+  }
+
+  /// Run DeepSeekR1 GPU Inference
+  double prefillTokensPerSec = 0.0;
+  const auto inferenceStart = std::chrono::high_resolution_clock::now();
+  _mlir_ciface_forward_prefill(ptrPrefillResultContainer, &ParamsContainer,
+                               &prefillTokensGPU);
+  cudaDeviceSynchronize();
+  const auto inferenceEnd = std::chrono::high_resolution_clock::now();
+  const std::chrono::duration<double, std::milli> inferenceTime =
+      inferenceEnd - inferenceStart;
+
+  int tokenIndex = inputContainerPrefill.getTokenCnt() - 1;
+  const float *startPtr =
+      ptrPrefillResultContainer->logits.getData() + tokenIndex * MaxVocabSize;
+  const float *endPtr = startPtr + MaxVocabSize;
+  int maxIndex = findMaxIndex(startPtr, endPtr);
+  std::string tok = inputContainerPrefill.getStr(maxIndex);
+  printIterInfo(0, tok, inferenceTime.count() / 1000);
+  const double prefillSeconds = inferenceTime.count() / 1000.0;
+  if (prefillSeconds > 0.0) {
+    prefillTokensPerSec = static_cast<double>(MaxTokenLength) / prefillSeconds;
+  }
+  inputContainerDecode.getData()[0] = (long long)maxIndex;
+  outputContainer.appendTokenIdx(maxIndex);
+
+  DecodeResultContainer decodeResult;
+  DecodeResultContainer *ptrDecodeResult = &decodeResult;
+
+  // Allocate decode KV caches via the MLIR CUDA runtime (same allocator as
+  // GPU subgraphs) and copy prefill results into them.
+  {
+    const size_t kvElems = 1 * HeadNum * MaxTokenLength * HiddenSize;
+    const size_t kvBytes = kvElems * sizeof(float);
+    const intptr_t kvSizes[4] = {1, (intptr_t)HeadNum, (intptr_t)MaxTokenLength,
+                                 (intptr_t)HiddenSize};
+    const intptr_t kvStrides[4] = {
+        (intptr_t)(HeadNum * MaxTokenLength * HiddenSize),
+        (intptr_t)(MaxTokenLength * HiddenSize), (intptr_t)HiddenSize, 1};
+    int copy_len =
+        std::min((int)inputContainerPrefill.getTokenCnt(), (int)MaxTokenLength);
+    for (int k = 0; k < (int)NUM_LAYERS; ++k) {
+      float *buf = (float *)mgpuMemAlloc(kvBytes, /*stream=*/nullptr,
+                                         /*isHostShared=*/false);
+      std::memset(buf, 0, kvBytes);
+      // Write the MemRef descriptor directly (fields are protected).
+      // Layout: allocated(8), aligned(8), offset(8), sizes[4](32),
+      // strides[4](32)
+      char *desc = reinterpret_cast<char *>(&ptrDecodeResult->kv(k));
+      intptr_t zero = 0;
+      std::memcpy(desc + 0, &buf, 8);        // allocated
+      std::memcpy(desc + 8, &buf, 8);        // aligned
+      std::memcpy(desc + 16, &zero, 8);      // offset
+      std::memcpy(desc + 24, kvSizes, 32);   // sizes[4]
+      std::memcpy(desc + 56, kvStrides, 32); // strides[4]
+      // Copy prefill KV data.
+      auto &src = *prefillResultContainer.kv_ptrs[k];
+      cudaDeviceSynchronize();
+      for (int h = 0; h < (int)HeadNum; ++h) {
+        size_t bytes =
+            static_cast<size_t>(copy_len) * HiddenSize * sizeof(float);
+        float *sp = src.getData() + h * MaxTokenLength * HiddenSize;
+        float *dp = buf + h * MaxTokenLength * HiddenSize;
+        std::memcpy(dp, sp, bytes);
+      }
+    }
+  }
+
+  cachePosition.getData()[0] = inputContainerPrefill.getTokenCnt();
+  int generateLen = MaxTokenLength - inputContainerPrefill.getTokenCnt();
+  double decodeTimeAccumMs = 0.0;
+  size_t decodeTokens = 0;
+  for (int i = 1; i <= generateLen; i++) {
+    const auto inferenceStart = std::chrono::high_resolution_clock::now();
+    _mlir_ciface_forward_decode(
+        ptrDecodeResult, &ParamsContainer, &inputContainerDecode,
+        &cachePosition, &ptrDecodeResult->kv(0), &ptrDecodeResult->kv(1),
+        &cachePosition, &ptrDecodeResult->kv(2), &ptrDecodeResult->kv(3),
+        &cachePosition, &ptrDecodeResult->kv(4), &ptrDecodeResult->kv(5),
+        &cachePosition, &ptrDecodeResult->kv(6), &ptrDecodeResult->kv(7),
+        &cachePosition, &ptrDecodeResult->kv(8), &ptrDecodeResult->kv(9),
+        &cachePosition, &ptrDecodeResult->kv(10), &ptrDecodeResult->kv(11),
+        &cachePosition, &ptrDecodeResult->kv(12), &ptrDecodeResult->kv(13),
+        &cachePosition, &ptrDecodeResult->kv(14), &ptrDecodeResult->kv(15),
+        &cachePosition, &ptrDecodeResult->kv(16), &ptrDecodeResult->kv(17),
+        &cachePosition, &ptrDecodeResult->kv(18), &ptrDecodeResult->kv(19),
+        &cachePosition, &ptrDecodeResult->kv(20), &ptrDecodeResult->kv(21),
+        &cachePosition, &ptrDecodeResult->kv(22), &ptrDecodeResult->kv(23),
+        &cachePosition, &ptrDecodeResult->kv(24), &ptrDecodeResult->kv(25),
+        &cachePosition, &ptrDecodeResult->kv(26), &ptrDecodeResult->kv(27),
+        &cachePosition, &ptrDecodeResult->kv(28), &ptrDecodeResult->kv(29),
+        &cachePosition, &ptrDecodeResult->kv(30), &ptrDecodeResult->kv(31),
+        &cachePosition, &ptrDecodeResult->kv(32), &ptrDecodeResult->kv(33),
+        &cachePosition, &ptrDecodeResult->kv(34), &ptrDecodeResult->kv(35),
+        &cachePosition, &ptrDecodeResult->kv(36), &ptrDecodeResult->kv(37),
+        &cachePosition, &ptrDecodeResult->kv(38), &ptrDecodeResult->kv(39),
+        &cachePosition, &ptrDecodeResult->kv(40), &ptrDecodeResult->kv(41),
+        &cachePosition, &ptrDecodeResult->kv(42), &ptrDecodeResult->kv(43),
+        &cachePosition, &ptrDecodeResult->kv(44), &ptrDecodeResult->kv(45),
+        &cachePosition, &ptrDecodeResult->kv(46), &ptrDecodeResult->kv(47),
+        &cachePosition, &ptrDecodeResult->kv(48), &ptrDecodeResult->kv(49),
+        &cachePosition, &ptrDecodeResult->kv(50), &ptrDecodeResult->kv(51),
+        &cachePosition, &ptrDecodeResult->kv(52), &ptrDecodeResult->kv(53),
+        &cachePosition, &ptrDecodeResult->kv(54), &ptrDecodeResult->kv(55),
+        &cachePosition);
+    cudaDeviceSynchronize();
+
+    const auto inferenceEnd = std::chrono::high_resolution_clock::now();
+    const std::chrono::duration<double, std::milli> inferenceTime =
+        inferenceEnd - inferenceStart;
+    decodeTimeAccumMs += inferenceTime.count();
+    decodeTokens += 1;
+
+    // Determine the generated token.
+    const float *startPtr = ptrDecodeResult->logits().getData();
+    const float *endPtr = startPtr + MaxVocabSize;
+    maxIndex = findMaxIndex(startPtr, endPtr);
+    std::string tok = inputContainerPrefill.getStr(maxIndex);
+    // Print the generated token and inference time.
+    printIterInfo(i, tok, inferenceTime.count() / 1000);
+
+    // Stop if a <|end▁of▁sentence|> token is generated.
+    if (maxIndex == 151643) {
+      break;
+    }
+    // Append the generated token into the input and output container.
+    inputContainerDecode.getData()[0] = maxIndex;
+    outputContainer.appendTokenIdx(maxIndex);
+    cachePosition.getData()[0] += 1;
+  }
+
+  const double decodeSeconds = decodeTimeAccumMs / 1000.0;
+  const double decodeTokensPerSec =
+      decodeSeconds > 0.0 ? static_cast<double>(decodeTokens) / decodeSeconds
+                          : 0.0;
+
+  /// Print the final result
+  std::cout << "\n\033[33;1m[Total time]\033[0m " << total_time << std::endl;
+  std::cout << "\033[33;1m[Prefilling]\033[0m " << prefillTokensPerSec
+            << " tokens/s" << std::endl;
+  std::cout << "\033[33;1m[Decoding]\033[0m " << decodeTokensPerSec
+            << " tokens/s" << std::endl;
+  std::cout << "\033[33;1m[Input]\033[0m " << inputStr << std::endl;
+  std::cout << "\033[33;1m[Output]\033[0m "
+            << outputContainer.revertDeepSeekR1() << std::endl;
+
+  std::cout.flush();
+  // Use _Exit to skip MLIR CUDA runtime atexit handlers which attempt to call
+  // cuModuleUnload after the CUDA context has already been destroyed.
+  std::_Exit(0);
+}

--- a/examples/BuddyDeepSeekR1-GPU/import-deepseek-r1-gpu.py
+++ b/examples/BuddyDeepSeekR1-GPU/import-deepseek-r1-gpu.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# ===- import-deepseek-r1-gpu.py -----------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ===---------------------------------------------------------------------------
+#
+# This is the GPU AOT importer for the DeepSeekR1 model.
+# The subgraph is assigned DeviceType.GPU so that the GraphDriver emits MLIR
+# suitable for the GPU lowering pipeline (parallel-loops → NVVM).
+#
+# ===---------------------------------------------------------------------------
+
+import argparse
+import os
+
+import numpy
+import torch
+from buddy.compiler.frontend import DynamoCompiler
+from buddy.compiler.graph import GraphDriver
+from buddy.compiler.graph.operation import (  # noqa: F403
+    eliminate_matmul_transpose_reshape,
+    eliminate_transpose,
+)
+from buddy.compiler.graph.transform import (
+    simply_fuse,
+)
+from buddy.compiler.graph.type import DeviceType
+from buddy.compiler.ops import tosa
+from torch._inductor.decomposition import decompositions as inductor_decomp
+from transformers import (
+    AutoModelForCausalLM,
+    StaticCache,
+)
+
+parser = argparse.ArgumentParser(
+    description="DeepSeekR1 GPU Model AOT Importer"
+)
+parser.add_argument(
+    "--output-dir",
+    type=str,
+    default="./",
+    help="Directory to save output files.",
+)
+args = parser.parse_args()
+
+output_dir = args.output_dir
+os.makedirs(output_dir, exist_ok=True)
+
+model_path = os.environ.get("DEEPSEEKR1_MODEL_PATH")
+if model_path is None:
+    model_path = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+
+model = AutoModelForCausalLM.from_pretrained(model_path).eval().float()
+model.config.use_cache = False
+
+dynamo_compiler_prefill = DynamoCompiler(
+    primary_registry=tosa.ops_registry,
+    aot_autograd_decomposition=inductor_decomp,
+    func_name="forward_prefill",
+)
+
+dynamo_compiler_decode = DynamoCompiler(
+    primary_registry=tosa.ops_registry,
+    aot_autograd_decomposition=inductor_decomp,
+    func_name="forward_decode",
+)
+
+with torch.no_grad():
+    past_key_values_prefill = StaticCache(
+        config=model.config, max_cache_len=1024
+    )
+    past_key_values_decode = StaticCache(
+        config=model.config, max_cache_len=1024
+    )
+
+    data_prefill = {
+        "input_ids": torch.zeros((1, 1024), dtype=torch.int64),
+    }
+    data_decode = {
+        "input_ids": torch.zeros((1, 1), dtype=torch.int64),
+    }
+
+    cache_position = torch.tensor([200], dtype=torch.int64)
+
+    graphs_prefill = dynamo_compiler_prefill.importer(
+        model,
+        input_ids=data_prefill["input_ids"],
+        use_cache=True,
+        cache_implementation="static",
+    )
+    model(
+        input_ids=data_decode["input_ids"],
+        past_key_values=past_key_values_decode,
+        use_cache=True,
+        cache_implementation="static",
+    )
+    graphs_decode = dynamo_compiler_decode.importer(
+        model,
+        input_ids=data_decode["input_ids"],
+        use_cache=True,
+        cache_position=cache_position,
+        past_key_values=past_key_values_decode,
+        cache_implementation="static",
+    )
+
+assert len(graphs_prefill) == 1
+assert len(graphs_decode) == 1
+graph_prefill = graphs_prefill[0]
+graph_decode = graphs_decode[0]
+
+params = dynamo_compiler_prefill.imported_params[graph_prefill]
+
+graphs_prefill[0].perform(
+    [eliminate_transpose, eliminate_matmul_transpose_reshape]
+)
+graphs_decode[0].perform(
+    [eliminate_transpose, eliminate_matmul_transpose_reshape]
+)
+
+pattern_list_prefill = [
+    simply_fuse,
+]
+pattern_list_decode = [
+    simply_fuse,
+]
+
+graphs_prefill[0].fuse_ops(pattern_list_prefill)
+graphs_decode[0].fuse_ops(pattern_list_decode)
+
+graph_prefill.op_groups["subgraph0_prefill"] = graph_prefill.op_groups.pop(
+    "subgraph0"
+)
+graph_prefill.group_map_device["subgraph0_prefill"] = DeviceType.GPU
+
+graph_decode.op_groups["subgraph0_decode"] = graph_decode.op_groups.pop(
+    "subgraph0"
+)
+graph_decode.group_map_device["subgraph0_decode"] = DeviceType.GPU
+
+driver_prefill = GraphDriver(graphs_prefill[0])
+driver_prefill.subgraphs[0].lower_to_top_level_ir()
+
+driver_decode = GraphDriver(graphs_decode[0])
+driver_decode.subgraphs[0].lower_to_top_level_ir()
+
+with open(
+    os.path.join(output_dir, "subgraph0_prefill.mlir"), "w"
+) as module_file:
+    print(driver_prefill.subgraphs[0]._imported_module, file=module_file)
+with open(os.path.join(output_dir, "forward_prefill.mlir"), "w") as module_file:
+    print(driver_prefill.construct_main_graph(True), file=module_file)
+
+with open(
+    os.path.join(output_dir, "subgraph0_decode.mlir"), "w"
+) as module_file:
+    print(driver_decode.subgraphs[0]._imported_module, file=module_file)
+with open(os.path.join(output_dir, "forward_decode.mlir"), "w") as module_file:
+    print(driver_decode.construct_main_graph(True), file=module_file)
+
+all_param = numpy.concatenate(
+    [param.detach().numpy().reshape([-1]) for param in params]
+)
+all_param.tofile(os.path.join(output_dir, "arg0.data"))

--- a/examples/BuddyGemma4/CMakeLists.txt
+++ b/examples/BuddyGemma4/CMakeLists.txt
@@ -18,6 +18,7 @@ if(IS_RVV_PLATFORM)
 else()
   set(OPENMP_NUM_THREADS "num-threads=48")
   set(LLC_RISCV_ATTRS "")
+  set(LLC_X86_ATTRS "-mcpu=native")
 endif()
 
 # Skip import commands on RVV platform
@@ -32,7 +33,27 @@ if(NOT IS_RVV_PLATFORM)
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/import-gemma4.py
             --output-dir ${CMAKE_CURRENT_BINARY_DIR}
             --precision f32
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/patch_decode_mlir.py
+            ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode_e2b.mlir
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/import-gemma4.py
+            ${CMAKE_CURRENT_SOURCE_DIR}/patch_decode_mlir.py
     COMMENT "Generating Gemma4-E2B MLIR and data files..."
+  )
+
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/forward_prefill_e2b-f16.mlir
+           ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_prefill_e2b-f16.mlir
+           ${CMAKE_CURRENT_BINARY_DIR}/forward_decode_e2b-f16.mlir
+           ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode_e2b-f16.mlir
+           ${CMAKE_CURRENT_BINARY_DIR}/arg0_e2b-f16.data
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/import-gemma4.py
+            --output-dir ${CMAKE_CURRENT_BINARY_DIR}
+            --precision f16
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/patch_decode_mlir.py
+            ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode_e2b-f16.mlir
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/import-gemma4.py
+            ${CMAKE_CURRENT_SOURCE_DIR}/patch_decode_mlir.py
+    COMMENT "Generating Gemma4-E2B F16 MLIR and data files..."
   )
 endif()
 
@@ -77,7 +98,7 @@ add_custom_command(
             -reconcile-unrealized-casts |
         ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
         ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
-        ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} -filetype=obj -relocation-model=pic -O3
+        ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} ${LLC_X86_ATTRS} -filetype=obj -relocation-model=pic -O3
           -o ${CMAKE_CURRENT_BINARY_DIR}/forward_prefill_e2b.o
   DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/forward_prefill_e2b.mlir
   COMMENT "Building forward_prefill_e2b.o"
@@ -110,7 +131,7 @@ add_custom_command(
             -affine-parallelize
             -convert-vector-to-scf
             -lower-affine
-            -convert-scf-to-openmp=num-threads=48
+            -convert-scf-to-openmp=${OPENMP_NUM_THREADS}
             -cse
             -memref-expand
             -arith-expand
@@ -128,7 +149,7 @@ add_custom_command(
             -reconcile-unrealized-casts |
           ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
           ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
-          ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} -filetype=obj -relocation-model=pic -O3
+          ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} ${LLC_X86_ATTRS} -filetype=obj -relocation-model=pic -O3
             -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph_prefill_e2b.o
     DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_prefill_e2b.mlir
     COMMENT "Building subgraph_prefill_e2b.o"
@@ -175,7 +196,7 @@ add_custom_command(
             -reconcile-unrealized-casts |
         ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
         ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
-        ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} -filetype=obj -relocation-model=pic -O3
+        ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} ${LLC_X86_ATTRS} -filetype=obj -relocation-model=pic -O3
           -o ${CMAKE_CURRENT_BINARY_DIR}/forward_decode_e2b.o
   DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/forward_decode_e2b.mlir
   COMMENT "Building forward_decode_e2b.o"
@@ -229,12 +250,209 @@ add_custom_command(
             -reconcile-unrealized-casts |
           ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
           ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
-          ${LLVM_TOOLS_BINARY_DIR}/llc -filetype=obj -relocation-model=pic -O3
+          ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} ${LLC_X86_ATTRS} -filetype=obj -relocation-model=pic -O3
             -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph_decode_e2b.o
     DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode_e2b.mlir
     COMMENT "Building subgraph_decode_e2b.o"
     VERBATIM)
 
+
+add_custom_command(
+  OUTPUT forward_prefill_e2b-f16.o
+  COMMAND ${BUDDY_BINARY_DIR}/buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/forward_prefill_e2b-f16.mlir
+            -simplify-tosa-reshape |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+            -pass-pipeline ${TOSA_PIPELINE} |
+          ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -canonicalize
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -cse
+            -canonicalize
+            -optimize-allocation-liveness
+            -matmul-vectorization-blis
+            -batchmatmul-optimize
+            -convert-linalg-to-affine-loops
+            -affine-parallelize
+            -convert-vector-to-scf
+            -lower-affine
+            -convert-scf-to-openmp=${OPENMP_NUM_THREADS}
+            -memref-expand
+            -arith-expand
+            -convert-vector-to-llvm
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -llvm-request-c-wrappers
+            -convert-openmp-to-llvm
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+        ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+        ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+        ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} ${LLC_X86_ATTRS} -filetype=obj -relocation-model=pic -O3
+          -o ${CMAKE_CURRENT_BINARY_DIR}/forward_prefill_e2b-f16.o
+  DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/forward_prefill_e2b-f16.mlir
+  COMMENT "Building forward_prefill_e2b-f16.o"
+  VERBATIM)
+
+add_custom_command(
+    OUTPUT subgraph_prefill_e2b-f16.o
+    COMMAND ${BUDDY_BINARY_DIR}/buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_prefill_e2b-f16.mlir
+              -simplify-tosa-reshape |
+            ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+              -pass-pipeline ${TOSA_PIPELINE} |
+            ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -convert-elementwise-to-linalg
+            -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -canonicalize
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -cse
+            -canonicalize
+            -optimize-allocation-liveness
+            -matmul-vectorization-blis
+            -batchmatmul-optimize
+            -batchmatmul-transpose-b-vectorization
+            -convert-linalg-to-affine-loops
+            -affine-parallelize
+            -convert-vector-to-scf
+            -lower-affine
+            -convert-scf-to-openmp=${OPENMP_NUM_THREADS}
+            -cse
+            -memref-expand
+            -arith-expand
+            -convert-vector-to-llvm
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -llvm-request-c-wrappers
+            -convert-openmp-to-llvm
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+          ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+          ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} ${LLC_X86_ATTRS} -filetype=obj -relocation-model=pic -O3
+            -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph_prefill_e2b-f16.o
+    DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_prefill_e2b-f16.mlir
+    COMMENT "Building subgraph_prefill_e2b-f16.o"
+    VERBATIM)
+
+add_custom_command(
+  OUTPUT forward_decode_e2b-f16.o
+  COMMAND ${BUDDY_BINARY_DIR}/buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/forward_decode_e2b-f16.mlir
+            -simplify-tosa-reshape |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+            -pass-pipeline ${TOSA_PIPELINE} |
+          ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -canonicalize
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -cse
+            -canonicalize
+            -optimize-allocation-liveness
+            -matmul-vectorization-blis
+            -batchmatmul-optimize
+            -convert-linalg-to-affine-loops
+            -affine-parallelize
+            -convert-vector-to-scf
+            -lower-affine
+            -convert-scf-to-openmp=${OPENMP_NUM_THREADS}
+            -memref-expand
+            -arith-expand
+            -convert-vector-to-llvm
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -llvm-request-c-wrappers
+            -convert-openmp-to-llvm
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+        ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+        ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+        ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} ${LLC_X86_ATTRS} -filetype=obj -relocation-model=pic -O3
+          -o ${CMAKE_CURRENT_BINARY_DIR}/forward_decode_e2b-f16.o
+  DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/forward_decode_e2b-f16.mlir
+  COMMENT "Building forward_decode_e2b-f16.o"
+  VERBATIM)
+
+add_custom_command(
+    OUTPUT subgraph_decode_e2b-f16.o
+    COMMAND ${BUDDY_BINARY_DIR}/buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode_e2b-f16.mlir
+              -simplify-tosa-reshape
+              -simplify-tosa-matmul-scalar |
+            ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+              -pass-pipeline ${TOSA_PIPELINE} |
+            ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -convert-elementwise-to-linalg
+            -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -canonicalize
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -cse
+            -canonicalize
+            -optimize-allocation-liveness
+            -eliminate-memref-copy
+            -assume-tight-memref-layout
+            -staticize-memref-layout
+            -matmul-vectorization-decode=vector-size=32
+            -batch-matmul-vectorization-decode=vector-size=128
+            -batchmatmul-transpose-b-vectorization=vector-size=16
+            -convert-linalg-to-affine-loops
+            -convert-vector-to-scf
+            -lower-affine
+            -convert-scf-to-openmp=${OPENMP_NUM_THREADS}
+            -cse
+            -memref-expand
+            -arith-expand
+            -convert-vector-to-llvm
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -llvm-request-c-wrappers
+            -convert-openmp-to-llvm
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+          ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+          ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} ${LLC_X86_ATTRS} -filetype=obj -relocation-model=pic -O3
+            -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph_decode_e2b-f16.o
+    DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode_e2b-f16.mlir
+    COMMENT "Building subgraph_decode_e2b-f16.o"
+    VERBATIM)
 
 add_library(GEMMA4_E2B STATIC forward_prefill_e2b.o subgraph_prefill_e2b.o forward_decode_e2b.o subgraph_decode_e2b.o)
 
@@ -249,8 +467,18 @@ SET_TARGET_PROPERTIES(
   PROPERTIES
   LINKER_LANGUAGE C)
 
+add_library(GEMMA4_E2B_F16 STATIC
+  forward_prefill_e2b-f16.o subgraph_prefill_e2b-f16.o
+  forward_decode_e2b-f16.o subgraph_decode_e2b-f16.o)
+
+SET_TARGET_PROPERTIES(
+  GEMMA4_E2B_F16
+  PROPERTIES
+  LINKER_LANGUAGE C)
+
 
 add_executable(buddy-gemma4-e2b-run buddy-gemma4-e2b-main.cpp)
+add_executable(buddy-gemma4-e2b-f16-run buddy-gemma4-e2b-f16-main.cpp)
 
 set(GEMMA4_E2B_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 set(GEMMA4_E2B_EXAMPLE_BUILD_PATH ${CMAKE_CURRENT_BINARY_DIR})
@@ -260,8 +488,13 @@ target_compile_definitions(buddy-gemma4-e2b-run PRIVATE
   GEMMA4_E2B_EXAMPLE_BUILD_PATH="${GEMMA4_E2B_EXAMPLE_BUILD_PATH}/"
 )
 
+target_compile_definitions(buddy-gemma4-e2b-f16-run PRIVATE
+  GEMMA4_E2B_EXAMPLE_PATH="${GEMMA4_E2B_EXAMPLE_PATH}/"
+  GEMMA4_E2B_EXAMPLE_BUILD_PATH="${GEMMA4_E2B_EXAMPLE_BUILD_PATH}/"
+)
 
 target_link_directories(buddy-gemma4-e2b-run PRIVATE ${LLVM_LIBRARY_DIR})
+target_link_directories(buddy-gemma4-e2b-f16-run PRIVATE ${LLVM_LIBRARY_DIR})
 
 set(BUDDY_GEMMA4_E2B_LIBS
   GEMMA4_E2B
@@ -269,11 +502,19 @@ set(BUDDY_GEMMA4_E2B_LIBS
   omp
 )
 
+set(BUDDY_GEMMA4_E2B_F16_LIBS
+  GEMMA4_E2B_F16
+  mlir_c_runner_utils
+  omp
+)
+
 if(BUDDY_MLIR_USE_MIMALLOC)
   list(APPEND BUDDY_GEMMA4_E2B_LIBS mimalloc)
+  list(APPEND BUDDY_GEMMA4_E2B_F16_LIBS mimalloc)
 endif()
 
 target_link_libraries(buddy-gemma4-e2b-run ${BUDDY_GEMMA4_E2B_LIBS})
+target_link_libraries(buddy-gemma4-e2b-f16-run ${BUDDY_GEMMA4_E2B_F16_LIBS})
 
 # Create a distributable package
 set(DIST_PACKAGE_NAME "buddy-gemma4-e2b")

--- a/examples/BuddyGemma4/buddy-gemma4-e2b-f16-main.cpp
+++ b/examples/BuddyGemma4/buddy-gemma4-e2b-f16-main.cpp
@@ -1,0 +1,633 @@
+//===- buddy-gemma4-e2b-f16-main.cpp
+//---------------------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+#include <algorithm>
+#include <buddy/Core/Container.h>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+// ===== Operator Timing Infrastructure =====
+
+struct TimingRecord {
+  std::string op_name;
+  std::vector<double> times_ms;
+
+  void add_time(double time_sec) { times_ms.push_back(time_sec * 1000.0); }
+
+  double get_total() const {
+    return std::accumulate(times_ms.begin(), times_ms.end(), 0.0);
+  }
+};
+
+static std::map<std::string, TimingRecord> g_timing_data;
+
+extern "C" {
+double rtclock() {
+  auto now = std::chrono::high_resolution_clock::now();
+  return std::chrono::duration<double>(now.time_since_epoch()).count();
+}
+
+void record_timing(const char *op_name, double duration_sec) {
+  std::string name(op_name);
+  g_timing_data[name].op_name = name;
+  g_timing_data[name].add_time(duration_sec);
+}
+
+void _mlir_ciface_record_timing(void *op_name_ptr, double duration_sec) {
+  const char *op_name = reinterpret_cast<const char *>(op_name_ptr);
+  record_timing(op_name, duration_sec);
+}
+}
+
+void print_timing_report() {
+  std::cout << "\n";
+  std::cout << "========================================\n";
+  std::cout << "     Operator Timing Report\n";
+  std::cout << "========================================\n";
+  std::cout << std::fixed << std::setprecision(4);
+
+  double total_time = 0.0;
+  for (const auto &[name, record] : g_timing_data)
+    total_time += record.get_total();
+
+  std::cout << std::left << std::setw(30) << "Operator" << std::right
+            << std::setw(16) << "Total (ms)" << std::setw(12) << "% Total"
+            << "\n";
+  std::cout << "----------------------------------------"
+            << "------------------------------\n";
+
+  for (const auto &[name, record] : g_timing_data) {
+    double total = record.get_total();
+    double percentage = (total_time > 0) ? (total / total_time * 100.0) : 0.0;
+    std::cout << std::left << std::setw(30) << name << std::right
+              << std::setw(16) << total << std::setw(11) << percentage << "%\n";
+  }
+
+  std::cout << "----------------------------------------"
+            << "------------------------------\n";
+  std::cout << std::left << std::setw(30) << "TOTAL" << std::right
+            << std::setw(16) << total_time << std::setw(11) << "100.0%\n";
+  std::cout << "========================================\n\n";
+}
+
+void clear_timing_data() { g_timing_data.clear(); }
+
+// ===== End of Timing Infrastructure =====
+
+#include <buddy/LLM/TextContainer.h>
+#include <cstddef>
+#include <filesystem>
+#include <sys/time.h>
+
+using namespace buddy;
+
+double total_time = 0;
+constexpr size_t ParamsSize = 4628569765;
+constexpr size_t MaxVocabSize = 262144;
+constexpr size_t MaxTokenLength = 512;
+constexpr size_t SlidingCacheLen = 512;
+constexpr size_t SlidingHeadDim = 256;
+constexpr size_t FullCacheLen = 512;
+constexpr size_t FullHeadDim = 512;
+constexpr size_t KVHeadNum = 1;
+
+extern "C" double _mlir_ciface_rtclock() {
+#ifndef _WIN32
+  struct timeval tp;
+  int stat = gettimeofday(&tp, nullptr);
+  if (stat != 0)
+    fprintf(stderr, "Error returning time from gettimeofday: %d\n", stat);
+  return (tp.tv_sec + tp.tv_usec * 1.0e-6);
+#else
+  fprintf(stderr, "Timing utility not implemented on Windows\n");
+  return 0.0;
+#endif
+}
+
+struct MemRefContainer {
+  // Group 0 (sliding layers 0-3 + full layer 0)
+  MemRef<uint16_t, 4> sk0k, sk0v;
+  MemRef<long long, 1> cl0;
+  MemRef<uint16_t, 4> sk1k, sk1v;
+  MemRef<long long, 1> cl1;
+  MemRef<uint16_t, 4> sk2k, sk2v;
+  MemRef<long long, 1> cl2;
+  MemRef<uint16_t, 4> sk3k, sk3v;
+  MemRef<long long, 1> cl3;
+  MemRef<long long, 1> fcl0;
+  MemRef<uint16_t, 4> fk0k, fk0v;
+  // Group 1 (sliding layers 4-7 + full layer 1)
+  MemRef<uint16_t, 4> sk4k, sk4v;
+  MemRef<long long, 1> cl4;
+  MemRef<uint16_t, 4> sk5k, sk5v;
+  MemRef<long long, 1> cl5;
+  MemRef<uint16_t, 4> sk6k, sk6v;
+  MemRef<long long, 1> cl6;
+  MemRef<uint16_t, 4> sk7k, sk7v;
+  MemRef<long long, 1> cl7;
+  MemRef<long long, 1> fcl1;
+  MemRef<uint16_t, 4> fk1k, fk1v;
+  // Group 2 (sliding layers 8-11 + full layer 2)
+  MemRef<uint16_t, 4> sk8k, sk8v;
+  MemRef<long long, 1> cl8;
+  MemRef<uint16_t, 4> sk9k, sk9v;
+  MemRef<long long, 1> cl9;
+  MemRef<uint16_t, 4> sk10k, sk10v;
+  MemRef<long long, 1> cl10;
+  MemRef<uint16_t, 4> sk11k, sk11v;
+  MemRef<long long, 1> cl11;
+  MemRef<long long, 1> fcl2;
+  MemRef<uint16_t, 4> fk2k, fk2v;
+  // Logits
+  MemRef<uint16_t, 3> logits;
+};
+
+extern "C" void _mlir_ciface_forward_prefill(
+    MemRefContainer *result, MemRef<uint16_t, 1> *params,
+    Text<size_t, 2> *input_ids, MemRef<long long, 1> *cl0,
+    MemRef<uint16_t, 4> *sk0k, MemRef<uint16_t, 4> *sk0v,
+    MemRef<long long, 1> *cl1, MemRef<uint16_t, 4> *sk1k,
+    MemRef<uint16_t, 4> *sk1v, MemRef<long long, 1> *cl2,
+    MemRef<uint16_t, 4> *sk2k, MemRef<uint16_t, 4> *sk2v,
+    MemRef<long long, 1> *cl3, MemRef<uint16_t, 4> *sk3k,
+    MemRef<uint16_t, 4> *sk3v, MemRef<long long, 1> *fcl0,
+    MemRef<uint16_t, 4> *fk0k, MemRef<uint16_t, 4> *fk0v,
+    MemRef<long long, 1> *cl4, MemRef<uint16_t, 4> *sk4k,
+    MemRef<uint16_t, 4> *sk4v, MemRef<long long, 1> *cl5,
+    MemRef<uint16_t, 4> *sk5k, MemRef<uint16_t, 4> *sk5v,
+    MemRef<long long, 1> *cl6, MemRef<uint16_t, 4> *sk6k,
+    MemRef<uint16_t, 4> *sk6v, MemRef<long long, 1> *cl7,
+    MemRef<uint16_t, 4> *sk7k, MemRef<uint16_t, 4> *sk7v,
+    MemRef<long long, 1> *fcl1, MemRef<uint16_t, 4> *fk1k,
+    MemRef<uint16_t, 4> *fk1v, MemRef<long long, 1> *cl8,
+    MemRef<uint16_t, 4> *sk8k, MemRef<uint16_t, 4> *sk8v,
+    MemRef<long long, 1> *cl9, MemRef<uint16_t, 4> *sk9k,
+    MemRef<uint16_t, 4> *sk9v, MemRef<long long, 1> *cl10,
+    MemRef<uint16_t, 4> *sk10k, MemRef<uint16_t, 4> *sk10v,
+    MemRef<long long, 1> *cl11, MemRef<uint16_t, 4> *sk11k,
+    MemRef<uint16_t, 4> *sk11v, MemRef<long long, 1> *fcl2,
+    MemRef<uint16_t, 4> *fk2k, MemRef<uint16_t, 4> *fk2v);
+
+extern "C" void _mlir_ciface_forward_decode(
+    MemRefContainer *result, MemRef<uint16_t, 1> *params,
+    MemRef<long long, 2> *input_ids, MemRef<long long, 1> *cache_position,
+    MemRef<uint16_t, 4> *sk0k, MemRef<uint16_t, 4> *sk0v,
+    MemRef<long long, 1> *cl0, MemRef<uint16_t, 4> *sk1k,
+    MemRef<uint16_t, 4> *sk1v, MemRef<long long, 1> *cl1,
+    MemRef<uint16_t, 4> *sk2k, MemRef<uint16_t, 4> *sk2v,
+    MemRef<long long, 1> *cl2, MemRef<uint16_t, 4> *sk3k,
+    MemRef<uint16_t, 4> *sk3v, MemRef<long long, 1> *cl3,
+    MemRef<uint16_t, 4> *fk0k, MemRef<uint16_t, 4> *fk0v,
+    MemRef<long long, 1> *fcl0, MemRef<uint16_t, 4> *sk4k,
+    MemRef<uint16_t, 4> *sk4v, MemRef<long long, 1> *cl4,
+    MemRef<uint16_t, 4> *sk5k, MemRef<uint16_t, 4> *sk5v,
+    MemRef<long long, 1> *cl5, MemRef<uint16_t, 4> *sk6k,
+    MemRef<uint16_t, 4> *sk6v, MemRef<long long, 1> *cl6,
+    MemRef<uint16_t, 4> *sk7k, MemRef<uint16_t, 4> *sk7v,
+    MemRef<long long, 1> *cl7, MemRef<uint16_t, 4> *fk1k,
+    MemRef<uint16_t, 4> *fk1v, MemRef<long long, 1> *fcl1,
+    MemRef<uint16_t, 4> *sk8k, MemRef<uint16_t, 4> *sk8v,
+    MemRef<long long, 1> *cl8, MemRef<uint16_t, 4> *sk9k,
+    MemRef<uint16_t, 4> *sk9v, MemRef<long long, 1> *cl9,
+    MemRef<uint16_t, 4> *sk10k, MemRef<uint16_t, 4> *sk10v,
+    MemRef<long long, 1> *cl10, MemRef<uint16_t, 4> *sk11k,
+    MemRef<uint16_t, 4> *sk11v, MemRef<long long, 1> *cl11,
+    MemRef<uint16_t, 4> *fk2k, MemRef<uint16_t, 4> *fk2v);
+
+// -----------------------------------------------------------------------------
+// Helper Functions
+// -----------------------------------------------------------------------------
+
+void getUserInput(std::string &inputStr) {
+  std::cout << "\nPlease send a message:" << std::endl;
+  std::cout << ">>> ";
+  getline(std::cin, inputStr);
+  std::cout << std::endl;
+}
+
+void printLogLabel() { std::cout << "\033[34;1m[Log] \033[0m"; }
+
+void printIterInfo(size_t iterIdx, std::string str, double time) {
+  total_time += time;
+  std::cout << "\033[32;1m[Iteration " << iterIdx << "] \033[0m";
+  std::cout << "Token: " << str << " | "
+            << "Time: " << time << "s" << std::endl;
+}
+
+void tokenizeInput(const std::string &vocabFile,
+                   Text<size_t, 2> &inputContainer) {
+  printLogLabel();
+  std::cout << "Vocab file: " << std::filesystem::canonical(vocabFile)
+            << std::endl;
+  const auto start = std::chrono::high_resolution_clock::now();
+  inputContainer.tokenizeGemma4(vocabFile, MaxTokenLength);
+  const auto end = std::chrono::high_resolution_clock::now();
+  const std::chrono::duration<double, std::milli> elapsed = end - start;
+  printLogLabel();
+  std::cout << "Tokenize time: " << elapsed.count() << "ms" << std::endl;
+}
+
+void loadParameters(const std::string &paramFilePath,
+                    MemRef<uint16_t, 1> &params) {
+  const auto loadStart = std::chrono::high_resolution_clock::now();
+  std::ifstream paramFile(paramFilePath, std::ios::in | std::ios::binary);
+  if (!paramFile.is_open()) {
+    throw std::runtime_error("[Error] Failed to open params file!");
+  }
+  printLogLabel();
+  std::cout << "Loading params..." << std::endl;
+  printLogLabel();
+  std::cout << "Params file: " << std::filesystem::canonical(paramFilePath)
+            << std::endl;
+  paramFile.read(reinterpret_cast<char *>(params.getData()),
+                 sizeof(uint16_t) * params.getSize());
+  if (paramFile.fail()) {
+    throw std::runtime_error("Error occurred while reading params file!");
+  }
+  paramFile.close();
+  const auto loadEnd = std::chrono::high_resolution_clock::now();
+  const std::chrono::duration<double, std::milli> loadTime =
+      loadEnd - loadStart;
+  printLogLabel();
+  std::cout << "Params load time: " << (double)(loadTime.count()) / 1000
+            << "s\n"
+            << std::endl;
+}
+
+// IEEE 754 half precision -> single precision decode for argmax
+float decode_f16(uint16_t h) {
+  uint16_t h_exp = (h & 0x7C00) >> 10;
+  uint16_t h_sig = h & 0x03FF;
+  uint16_t h_sign = h >> 15;
+  if (h_exp == 0) {
+    float f = std::ldexp((float)h_sig, -24);
+    return h_sign ? -f : f;
+  } else if (h_exp == 0x1F) {
+    return h_sig ? std::numeric_limits<float>::quiet_NaN()
+                 : (h_sign ? -INFINITY : INFINITY);
+  } else {
+    float f = std::ldexp((float)(h_sig | 0x0400), h_exp - 25);
+    return h_sign ? -f : f;
+  }
+}
+
+int findMaxIndex(const uint16_t *start, size_t length) {
+  int maxIdx = 0;
+  float maxVal = decode_f16(start[0]);
+  for (size_t i = 1; i < length; ++i) {
+    float val = decode_f16(start[i]);
+    if (val > maxVal) {
+      maxVal = val;
+      maxIdx = (int)i;
+    }
+  }
+  return maxIdx;
+}
+
+void copyKVFromPrefill(MemRefContainer &prefill, MemRefContainer &decode,
+                       int cachePos) {
+  auto copyOne = [&](MemRef<uint16_t, 4> &dst, MemRef<uint16_t, 4> &src) {
+    int headDim = dst.getSizes()[3];
+    int copyLen = std::min(cachePos, (int)dst.getSizes()[2]);
+    for (int h = 0; h < (int)KVHeadNum; h++) {
+      std::memcpy(dst.getData() + h * dst.getSizes()[2] * headDim,
+                  src.getData() + h * src.getSizes()[2] * headDim,
+                  sizeof(uint16_t) * copyLen * headDim);
+    }
+  };
+  // Sliding KV
+  copyOne(decode.sk0k, prefill.sk0k);
+  copyOne(decode.sk0v, prefill.sk0v);
+  copyOne(decode.sk1k, prefill.sk1k);
+  copyOne(decode.sk1v, prefill.sk1v);
+  copyOne(decode.sk2k, prefill.sk2k);
+  copyOne(decode.sk2v, prefill.sk2v);
+  copyOne(decode.sk3k, prefill.sk3k);
+  copyOne(decode.sk3v, prefill.sk3v);
+  copyOne(decode.sk4k, prefill.sk4k);
+  copyOne(decode.sk4v, prefill.sk4v);
+  copyOne(decode.sk5k, prefill.sk5k);
+  copyOne(decode.sk5v, prefill.sk5v);
+  copyOne(decode.sk6k, prefill.sk6k);
+  copyOne(decode.sk6v, prefill.sk6v);
+  copyOne(decode.sk7k, prefill.sk7k);
+  copyOne(decode.sk7v, prefill.sk7v);
+  copyOne(decode.sk8k, prefill.sk8k);
+  copyOne(decode.sk8v, prefill.sk8v);
+  copyOne(decode.sk9k, prefill.sk9k);
+  copyOne(decode.sk9v, prefill.sk9v);
+  copyOne(decode.sk10k, prefill.sk10k);
+  copyOne(decode.sk10v, prefill.sk10v);
+  copyOne(decode.sk11k, prefill.sk11k);
+  copyOne(decode.sk11v, prefill.sk11v);
+  // Full KV
+  copyOne(decode.fk0k, prefill.fk0k);
+  copyOne(decode.fk0v, prefill.fk0v);
+  copyOne(decode.fk1k, prefill.fk1k);
+  copyOne(decode.fk1v, prefill.fk1v);
+  copyOne(decode.fk2k, prefill.fk2k);
+  copyOne(decode.fk2v, prefill.fk2v);
+  // Cumlens
+  decode.cl0.getData()[0] = cachePos;
+  decode.cl1.getData()[0] = cachePos;
+  decode.cl2.getData()[0] = cachePos;
+  decode.cl3.getData()[0] = cachePos;
+  decode.cl4.getData()[0] = cachePos;
+  decode.cl5.getData()[0] = cachePos;
+  decode.cl6.getData()[0] = cachePos;
+  decode.cl7.getData()[0] = cachePos;
+  decode.cl8.getData()[0] = cachePos;
+  decode.cl9.getData()[0] = cachePos;
+  decode.cl10.getData()[0] = cachePos;
+  decode.cl11.getData()[0] = cachePos;
+  decode.fcl0.getData()[0] = cachePos;
+  decode.fcl1.getData()[0] = cachePos;
+  decode.fcl2.getData()[0] = cachePos;
+}
+
+#define SLIDING_KV {1, KVHeadNum, SlidingCacheLen, SlidingHeadDim}
+#define FULL_KV {1, KVHeadNum, FullCacheLen, FullHeadDim}
+
+// -----------------------------------------------------------------------------
+// Gemma4-E2B F16 Inference Main Entry
+// -----------------------------------------------------------------------------
+
+int main() {
+  const std::string title =
+      "Gemma4-E2B F16 Inference Powered by Buddy Compiler";
+  std::cout << "\033[33;1m" << title << "\033[0m" << std::endl;
+
+  std::string exampleDir = GEMMA4_E2B_EXAMPLE_PATH;
+  std::string buildDir = GEMMA4_E2B_EXAMPLE_BUILD_PATH;
+  const std::string vocabDir = buildDir + "vocab.txt";
+  const std::string paramsDir = buildDir + "arg0_e2b-f16.data";
+
+  std::string inputStr;
+  getUserInput(inputStr);
+
+  Text<size_t, 2> outputContainer;
+  Text<size_t, 2> inputContainerPrefill(inputStr);
+  MemRef<long long, 2> inputContainerDecode({1, 1}, 0LL);
+  MemRef<uint16_t, 1> ParamsContainer({ParamsSize});
+  MemRef<long long, 1> cachePosition({1}, 0LL);
+
+  MemRef<uint16_t, 3> logitsPrefill({1, MaxTokenLength, MaxVocabSize});
+
+  // KV cache buffers for prefill input (zero-initialized)
+  MemRef<uint16_t, 4> sk0k(SLIDING_KV, (uint16_t)0),
+      sk0v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk1k(SLIDING_KV, (uint16_t)0),
+      sk1v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk2k(SLIDING_KV, (uint16_t)0),
+      sk2v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk3k(SLIDING_KV, (uint16_t)0),
+      sk3v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk4k(SLIDING_KV, (uint16_t)0),
+      sk4v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk5k(SLIDING_KV, (uint16_t)0),
+      sk5v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk6k(SLIDING_KV, (uint16_t)0),
+      sk6v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk7k(SLIDING_KV, (uint16_t)0),
+      sk7v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk8k(SLIDING_KV, (uint16_t)0),
+      sk8v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk9k(SLIDING_KV, (uint16_t)0),
+      sk9v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk10k(SLIDING_KV, (uint16_t)0),
+      sk10v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> sk11k(SLIDING_KV, (uint16_t)0),
+      sk11v(SLIDING_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> fk0k(FULL_KV, (uint16_t)0), fk0v(FULL_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> fk1k(FULL_KV, (uint16_t)0), fk1v(FULL_KV, (uint16_t)0);
+  MemRef<uint16_t, 4> fk2k(FULL_KV, (uint16_t)0), fk2v(FULL_KV, (uint16_t)0);
+  MemRef<long long, 1> cl0({1}, 0LL), cl1({1}, 0LL), cl2({1}, 0LL),
+      cl3({1}, 0LL), cl4({1}, 0LL), cl5({1}, 0LL), cl6({1}, 0LL), cl7({1}, 0LL),
+      cl8({1}, 0LL), cl9({1}, 0LL), cl10({1}, 0LL), cl11({1}, 0LL),
+      fcl0({1}, 0LL), fcl1({1}, 0LL), fcl2({1}, 0LL);
+
+  MemRefContainer prefillResultContainer = {{SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {{1}, 0LL},
+                                            {FULL_KV, (uint16_t)0},
+                                            {FULL_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {{1}, 0LL},
+                                            {FULL_KV, (uint16_t)0},
+                                            {FULL_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {SLIDING_KV, (uint16_t)0},
+                                            {{1}, 0LL},
+                                            {{1}, 0LL},
+                                            {FULL_KV, (uint16_t)0},
+                                            {FULL_KV, (uint16_t)0},
+                                            logitsPrefill};
+
+  tokenizeInput(vocabDir, inputContainerPrefill);
+  outputContainer.loadVocab(vocabDir);
+  loadParameters(paramsDir, ParamsContainer);
+
+  // ---- Prefill ----
+  double prefillTokensPerSec = 0.0;
+  const auto inferenceStart = std::chrono::high_resolution_clock::now();
+  _mlir_ciface_forward_prefill(
+      &prefillResultContainer, &ParamsContainer, &inputContainerPrefill, &cl0,
+      &sk0k, &sk0v, &cl1, &sk1k, &sk1v, &cl2, &sk2k, &sk2v, &cl3, &sk3k, &sk3v,
+      &fcl0, &fk0k, &fk0v, &cl4, &sk4k, &sk4v, &cl5, &sk5k, &sk5v, &cl6, &sk6k,
+      &sk6v, &cl7, &sk7k, &sk7v, &fcl1, &fk1k, &fk1v, &cl8, &sk8k, &sk8v, &cl9,
+      &sk9k, &sk9v, &cl10, &sk10k, &sk10v, &cl11, &sk11k, &sk11v, &fcl2, &fk2k,
+      &fk2v);
+  const auto inferenceEnd = std::chrono::high_resolution_clock::now();
+  const std::chrono::duration<double, std::milli> inferenceTime =
+      inferenceEnd - inferenceStart;
+
+  int tokenIndex = inputContainerPrefill.getTokenCnt() - 1;
+  const uint16_t *startPtr =
+      prefillResultContainer.logits.getData() + tokenIndex * MaxVocabSize;
+  int maxIndex = findMaxIndex(startPtr, MaxVocabSize);
+
+  std::string tok = inputContainerPrefill.getStr(maxIndex);
+  printIterInfo(0, tok, inferenceTime.count() / 1000);
+
+  const double prefillSeconds = inferenceTime.count() / 1000.0;
+  if (prefillSeconds > 0.0)
+    prefillTokensPerSec = static_cast<double>(MaxTokenLength) / prefillSeconds;
+  inputContainerDecode.getData()[0] = (long long)maxIndex;
+  outputContainer.appendTokenIdx(maxIndex);
+
+  // ---- Copy KV from prefill to decode ----
+  MemRef<uint16_t, 3> logitsDecode({1, 1, MaxVocabSize});
+  MemRefContainer decodeResultContainer = {{SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {{1}, 0LL},
+                                           {FULL_KV, (uint16_t)0},
+                                           {FULL_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {{1}, 0LL},
+                                           {FULL_KV, (uint16_t)0},
+                                           {FULL_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {SLIDING_KV, (uint16_t)0},
+                                           {{1}, 0LL},
+                                           {{1}, 0LL},
+                                           {FULL_KV, (uint16_t)0},
+                                           {FULL_KV, (uint16_t)0},
+                                           logitsDecode};
+  MemRefContainer *ptrDecodeResultContainer = &decodeResultContainer;
+
+  copyKVFromPrefill(prefillResultContainer, decodeResultContainer,
+                    inputContainerPrefill.getTokenCnt() + 1);
+
+  // ---- Decode loop ----
+  cachePosition.getData()[0] = inputContainerPrefill.getTokenCnt() + 1;
+  int generateLen = MaxTokenLength - inputContainerPrefill.getTokenCnt();
+  double decodeTimeAccumMs = 0.0;
+  size_t decodeTokens = 0;
+
+  for (int i = 1; i <= generateLen; i++) {
+    const auto decStart = std::chrono::high_resolution_clock::now();
+    _mlir_ciface_forward_decode(
+        ptrDecodeResultContainer, &ParamsContainer, &inputContainerDecode,
+        &cachePosition, &ptrDecodeResultContainer->sk0k,
+        &ptrDecodeResultContainer->sk0v, &ptrDecodeResultContainer->cl0,
+        &ptrDecodeResultContainer->sk1k, &ptrDecodeResultContainer->sk1v,
+        &ptrDecodeResultContainer->cl1, &ptrDecodeResultContainer->sk2k,
+        &ptrDecodeResultContainer->sk2v, &ptrDecodeResultContainer->cl2,
+        &ptrDecodeResultContainer->sk3k, &ptrDecodeResultContainer->sk3v,
+        &ptrDecodeResultContainer->cl3, &ptrDecodeResultContainer->fk0k,
+        &ptrDecodeResultContainer->fk0v, &ptrDecodeResultContainer->fcl0,
+        &ptrDecodeResultContainer->sk4k, &ptrDecodeResultContainer->sk4v,
+        &ptrDecodeResultContainer->cl4, &ptrDecodeResultContainer->sk5k,
+        &ptrDecodeResultContainer->sk5v, &ptrDecodeResultContainer->cl5,
+        &ptrDecodeResultContainer->sk6k, &ptrDecodeResultContainer->sk6v,
+        &ptrDecodeResultContainer->cl6, &ptrDecodeResultContainer->sk7k,
+        &ptrDecodeResultContainer->sk7v, &ptrDecodeResultContainer->cl7,
+        &ptrDecodeResultContainer->fk1k, &ptrDecodeResultContainer->fk1v,
+        &ptrDecodeResultContainer->fcl1, &ptrDecodeResultContainer->sk8k,
+        &ptrDecodeResultContainer->sk8v, &ptrDecodeResultContainer->cl8,
+        &ptrDecodeResultContainer->sk9k, &ptrDecodeResultContainer->sk9v,
+        &ptrDecodeResultContainer->cl9, &ptrDecodeResultContainer->sk10k,
+        &ptrDecodeResultContainer->sk10v, &ptrDecodeResultContainer->cl10,
+        &ptrDecodeResultContainer->sk11k, &ptrDecodeResultContainer->sk11v,
+        &ptrDecodeResultContainer->cl11, &ptrDecodeResultContainer->fk2k,
+        &ptrDecodeResultContainer->fk2v);
+    const auto decEnd = std::chrono::high_resolution_clock::now();
+    const std::chrono::duration<double, std::milli> decTime = decEnd - decStart;
+    decodeTimeAccumMs += decTime.count();
+    decodeTokens += 1;
+
+    const uint16_t *logitStart = ptrDecodeResultContainer->logits.getData();
+    maxIndex = findMaxIndex(logitStart, MaxVocabSize);
+    tok = inputContainerPrefill.getStr(maxIndex);
+    printIterInfo(i, tok, decTime.count() / 1000);
+
+    print_timing_report();
+    clear_timing_data();
+
+    if (maxIndex == 1 || maxIndex == 106) {
+      break;
+    }
+    inputContainerDecode.getData()[0] = maxIndex;
+    outputContainer.appendTokenIdx(maxIndex);
+    cachePosition.getData()[0] += 1;
+  }
+
+  const double decodeSeconds = decodeTimeAccumMs / 1000.0;
+  const double decodeTokensPerSec =
+      decodeSeconds > 0.0 ? static_cast<double>(decodeTokens) / decodeSeconds
+                          : 0.0;
+
+  std::cout << "\n\033[33;1m[Total time]\033[0m " << total_time << std::endl;
+  std::cout << "\033[33;1m[Prefilling]\033[0m " << prefillTokensPerSec
+            << " tokens/s" << std::endl;
+  std::cout << "\033[33;1m[Decoding]\033[0m " << decodeTokensPerSec
+            << " tokens/s" << std::endl;
+  std::cout << "\033[33;1m[Input]\033[0m " << inputStr << std::endl;
+  std::cout << "\033[33;1m[Output]\033[0m " << outputContainer.revertGemma4()
+            << std::endl;
+
+  return 0;
+}

--- a/examples/BuddyGemma4/import-gemma4.py
+++ b/examples/BuddyGemma4/import-gemma4.py
@@ -59,8 +59,11 @@ parser.add_argument(
     "--precision",
     type=str,
     default="f32",
-    choices=["f32"],
-    help="Precision mode for generated MLIR and input data.",
+    choices=["f32", "f16"],
+    help=(
+        "Precision mode for generated MLIR and input data. "
+        "Choose from 'f32' or 'f16'."
+    ),
 )
 args = parser.parse_args()
 
@@ -75,7 +78,9 @@ MaxTokenLength = 512
 
 # Load the full multimodal model and extract language model weights.
 print("Loading full model from:", model_path)
-full_model = AutoModelForCausalLM.from_pretrained(model_path, dtype=torch.float32, low_cpu_mem_usage=True)
+full_model = AutoModelForCausalLM.from_pretrained(
+    model_path, dtype=torch.float32, low_cpu_mem_usage=True
+)
 full_sd = full_model.state_dict()
 
 causal_sd = {}
@@ -85,7 +90,10 @@ for k, v in full_sd.items():
     elif k.startswith("lm_head."):
         causal_sd[k] = v
 
-if "lm_head.weight" not in causal_sd and "model.embed_tokens.weight" in causal_sd:
+if (
+    "lm_head.weight" not in causal_sd
+    and "model.embed_tokens.weight" in causal_sd
+):
     causal_sd["lm_head.weight"] = causal_sd["model.embed_tokens.weight"]
 
 full_config = AutoConfig.from_pretrained(model_path)
@@ -93,12 +101,62 @@ tc = full_config.text_config
 model = Gemma4ForCausalLM(tc)
 model.load_state_dict(causal_sd, strict=True)
 model.eval()
+if args.precision == "f16":
+    model = model.half()
 model.config.use_cache = False
 del full_model, full_sd, causal_sd
 
+# Patch f32 upcasts to keep computation in f16.
+# Gemma4RMSNorm and Gemma4TextRotaryEmbedding both explicitly cast to float32
+# for numerical stability, producing a graph dominated by f32 ops even when the
+# model weights are f16. Patching them here forces all computation to stay in
+# the input dtype so that the traced graph is genuinely f16.
+if args.precision == "f16":
+    from transformers.models.gemma4.modeling_gemma4 import (
+        Gemma4RMSNorm,
+        Gemma4TextRotaryEmbedding,
+    )
+
+    def _rms_norm_forward_f16(
+        self, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        # mean() promotes f16→f32 on CPU, so hidden_states * f32_norm_factor
+        # would produce a mixed-type tosa.mul that fails MLIR validation.
+        # Explicitly upcast, compute, downcast to keep types consistent.
+        input_dtype = hidden_states.dtype
+        hidden_f32 = hidden_states.float()
+        mean_sq = hidden_f32.pow(2).mean(-1, keepdim=True) + self.eps
+        normed_output = (hidden_f32 * torch.pow(mean_sq, -0.5)).to(input_dtype)
+        if self.with_scale:
+            normed_output = normed_output * self.weight.to(input_dtype)
+        return normed_output
+
+    @torch.no_grad()
+    def _rope_forward_f16(self, x, position_ids, layer_type=None):
+        inv_freq = getattr(self, f"{layer_type}_inv_freq")
+        attention_scaling = getattr(self, f"{layer_type}_attention_scaling")
+        dtype = x.dtype
+        inv_freq_expanded = (
+            inv_freq[None, :, None]
+            .to(dtype)
+            .expand(position_ids.shape[0], -1, 1)
+            .to(x.device)
+        )
+        position_ids_expanded = position_ids[:, None, :].to(dtype)
+        freqs = (inv_freq_expanded @ position_ids_expanded).transpose(1, 2)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        cos = emb.cos() * attention_scaling
+        sin = emb.sin() * attention_scaling
+        return cos, sin
+
+    Gemma4RMSNorm.forward = _rms_norm_forward_f16
+    Gemma4TextRotaryEmbedding.forward = _rope_forward_f16
+
 # Pre-initialize StaticCache to avoid Dynamo graph breaks.
 print("Pre-initializing StaticCache for prefill...")
-cache_prefill = StaticCache(config=tc, max_cache_len=MaxTokenLength, batch_size=1)
+cache_prefill = StaticCache(
+    config=tc, max_cache_len=MaxTokenLength, batch_size=1
+)
 with torch.no_grad():
     model(
         input_ids=torch.zeros((1, 1), dtype=torch.int64),
@@ -136,7 +194,9 @@ with torch.no_grad():
     )
 
     print("Pre-initializing StaticCache for decode...")
-    cache_decode = StaticCache(config=tc, max_cache_len=MaxTokenLength, batch_size=1)
+    cache_decode = StaticCache(
+        config=tc, max_cache_len=MaxTokenLength, batch_size=1
+    )
     model(
         input_ids=torch.zeros((1, 1), dtype=torch.int64),
         past_key_values=cache_decode,
@@ -164,15 +224,23 @@ with torch.no_grad():
         past_key_values=cache_decode,
     )
 
-assert len(graphs_prefill) == 1, f"Expected 1 prefill graph, got {len(graphs_prefill)}"
-assert len(graphs_decode) == 1, f"Expected 1 decode graph, got {len(graphs_decode)}"
+assert len(graphs_prefill) == 1, (
+    f"Expected 1 prefill graph, got {len(graphs_prefill)}"
+)
+assert len(graphs_decode) == 1, (
+    f"Expected 1 decode graph, got {len(graphs_decode)}"
+)
 graph_prefill = graphs_prefill[0]
 graph_decode = graphs_decode[0]
 
 params = dynamo_compiler_prefill.imported_params[graph_prefill]
 
-graphs_prefill[0].perform([eliminate_transpose, eliminate_matmul_transpose_reshape])
-graphs_decode[0].perform([eliminate_transpose, eliminate_matmul_transpose_reshape])
+graphs_prefill[0].perform(
+    [eliminate_transpose, eliminate_matmul_transpose_reshape]
+)
+graphs_decode[0].perform(
+    [eliminate_transpose, eliminate_matmul_transpose_reshape]
+)
 pattern_list_prefill = [
     simply_fuse,
     apply_classic_fusion,
@@ -188,10 +256,14 @@ pattern_list_decode = [
 graphs_prefill[0].fuse_ops(pattern_list_prefill)
 graphs_decode[0].fuse_ops(pattern_list_decode)
 
-graph_prefill.op_groups["subgraph0_prefill"] = graph_prefill.op_groups.pop("subgraph0")
+graph_prefill.op_groups["subgraph0_prefill"] = graph_prefill.op_groups.pop(
+    "subgraph0"
+)
 graph_prefill.group_map_device["subgraph0_prefill"] = DeviceType.CPU
 
-graph_decode.op_groups["subgraph0_decode"] = graph_decode.op_groups.pop("subgraph0")
+graph_decode.op_groups["subgraph0_decode"] = graph_decode.op_groups.pop(
+    "subgraph0"
+)
 graph_decode.group_map_device["subgraph0_decode"] = DeviceType.CPU
 
 driver_prefill = GraphDriver(graphs_prefill[0])
@@ -200,16 +272,28 @@ driver_prefill.subgraphs[0].lower_to_top_level_ir()
 driver_decode = GraphDriver(graphs_decode[0])
 driver_decode.subgraphs[0].lower_to_top_level_ir()
 
-with open(os.path.join(output_dir, "subgraph0_prefill_e2b.mlir"), "w") as module_file:
-    print(driver_prefill.subgraphs[0]._imported_module, file=module_file)
-with open(os.path.join(output_dir, "forward_prefill_e2b.mlir"), "w") as module_file:
-    print(driver_prefill.construct_main_graph(True), file=module_file)
-all_param = numpy.concatenate([param.detach().numpy().reshape([-1]) for param in params])
-all_param.tofile(os.path.join(output_dir, "arg0_e2b.data"))
+suffix = "-f16" if args.precision == "f16" else ""
 
-with open(os.path.join(output_dir, "subgraph0_decode_e2b.mlir"), "w") as module_file:
+with open(
+    os.path.join(output_dir, f"subgraph0_prefill_e2b{suffix}.mlir"), "w"
+) as module_file:
+    print(driver_prefill.subgraphs[0]._imported_module, file=module_file)
+with open(
+    os.path.join(output_dir, f"forward_prefill_e2b{suffix}.mlir"), "w"
+) as module_file:
+    print(driver_prefill.construct_main_graph(True), file=module_file)
+all_param = numpy.concatenate(
+    [param.detach().numpy().reshape([-1]) for param in params]
+)
+all_param.tofile(os.path.join(output_dir, f"arg0_e2b{suffix}.data"))
+
+with open(
+    os.path.join(output_dir, f"subgraph0_decode_e2b{suffix}.mlir"), "w"
+) as module_file:
     print(driver_decode.subgraphs[0]._imported_module, file=module_file)
-with open(os.path.join(output_dir, "forward_decode_e2b.mlir"), "w") as module_file:
+with open(
+    os.path.join(output_dir, f"forward_decode_e2b{suffix}.mlir"), "w"
+) as module_file:
     print(driver_decode.construct_main_graph(True), file=module_file)
 
 # Export vocabulary file for the C++ tokenizer.
@@ -228,7 +312,7 @@ print("All files saved to:", output_dir)
 # torch._dynamo bakes cumulative_length as a compile-time constant, but it must
 # be dynamic for correct attention masking across different cache positions.
 patch_script = os.path.join(os.path.dirname(__file__), "patch_decode_mlir.py")
-decode_mlir = os.path.join(output_dir, "subgraph0_decode_e2b.mlir")
+decode_mlir = os.path.join(output_dir, f"subgraph0_decode_e2b{suffix}.mlir")
 if os.path.exists(patch_script) and os.path.exists(decode_mlir):
     print("Patching constant-folded cumulative_length in decode subgraph...")
     subprocess.run(["python3", patch_script, decode_mlir], check=True)

--- a/examples/BuddyGemma4/patch_decode_mlir.py
+++ b/examples/BuddyGemma4/patch_decode_mlir.py
@@ -22,68 +22,112 @@ Only the first attention block still bakes constants; later layers already use
 const on the previous line (not an existing %argN).
 """
 
+import argparse
+import os
 import re
 import sys
 
-CUMLEN_ARG = "%arg16"
 
-mlir_path = (
-    sys.argv[1]
-    if len(sys.argv) > 1
-    else (
-        "/home/zhuxinye/buddy-mlir/build/examples/BuddyGemma4/"
-        "subgraph0_decode_e2b.mlir"
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Patch Gemma4 decode MLIR to use runtime cumulative length."
     )
-)
+    parser.add_argument("mlir_path", type=str, help="Path to decode MLIR file.")
+    parser.add_argument(
+        "--cumlen-arg",
+        type=str,
+        default="%arg16",
+        help="SSA value to use for runtime cumulative length.",
+    )
+    parser.add_argument(
+        "--strict-no-change",
+        action="store_true",
+        help="Return non-zero when no modifications were applied.",
+    )
+    return parser.parse_args()
+
+
+args = parse_args()
+CUMLEN_ARG = args.cumlen_arg
+mlir_path = args.mlir_path
+
+if not os.path.exists(mlir_path):
+    print(f"ERROR: file does not exist: {mlir_path}")
+    sys.exit(2)
 
 with open(mlir_path) as f:
     content = f.read()
 
 lines = content.split("\n")
 
-# Regex: tosa.add %generated..., %op : (tensor<1xi64>, tensor<1xi64>) [-> ...]
-RE_ADD_GEN = re.compile(
-    r"(%\w+) = tosa\.add (%generated(?:_\d+)?), (%\w+) : "
-    r"\(tensor<1xi64>, tensor<1xi64>\)(?: -> tensor<1xi64>)?"
-)
+# --- Pass 1: collect all SSA values that are tensor.generate results ---
+# Handles both:
+#   %generated = tensor.generate  { ... }         (unquoted, named)
+#   %N = "tensor.generate"() ({ ... })            (quoted, numeric SSA)
+RE_GEN_UNQUOTED = re.compile(r"(%\w+) = tensor\.generate\b")
+RE_GEN_QUOTED = re.compile(r'(%\w+) = "tensor\.generate"\(\)')
+generate_vars: set[str] = set()
+for line in lines:
+    s = line.strip()
+    for pat in (RE_GEN_UNQUOTED, RE_GEN_QUOTED):
+        m = pat.match(s)
+        if m:
+            generate_vars.add(m.group(1))
+
 # Previous line: const 1 for cumlen offset (kv_length = 1 at trace)
 RE_CONST_ONE = re.compile(
-    r'(%\w+) = "tosa\.const"\(\) <\{values = dense<1> : tensor<1xi64>\}>'
+    r'(%\w+) = (?:"tosa\.const"\(\)|tosa\.const) '
+    r"<\{values = dense<1> : tensor<1xi64>\}>"
+)
+
+# tosa.add with unquoted syntax:  %R = tosa.add %A, %B : (...)
+RE_ADD_UNQUOTED = re.compile(
+    r"(%\w+) = tosa\.add (%\w+), (%\w+) : "
+    r"\(tensor<1xi64>, tensor<1xi64>\)(?: -> tensor<1xi64>)?"
+)
+# tosa.add with quoted syntax:  %R = "tosa.add"(%A, %B) : (...)
+RE_ADD_QUOTED = re.compile(
+    r'(%\w+) = "tosa\.add"\((%\w+), (%\w+)\) : '
+    r"\(tensor<1xi64>, tensor<1xi64>\)(?: -> tensor<1xi64>)?"
 )
 
 patch_count = 0
 i = 0
 while i < len(lines):
-    # --- New IR: tensor.generate + const1 + tosa.add ---
-    m_add = RE_ADD_GEN.match(lines[i].strip())
-    if m_add and i > 0:
-        _result, gen, op2 = m_add.groups()
-        m_const = RE_CONST_ONE.match(lines[i - 1].strip())
-        if m_const and m_const.group(1) == op2:
-            old_line = lines[i]
-            new_line = old_line.replace(
-                f"tosa.add {gen}, {op2}",
-                f"tosa.add {CUMLEN_ARG}, {op2}",
-            )
-            lines[i] = new_line
-            patch_count += 1
-            print(f"  Line {i + 1}: {old_line.strip()} -> {new_line.strip()}")
-            i += 1
-            continue
+    s = line_strip = lines[i].strip()
 
-    # --- Legacy: const0 + const1 + add (dense<0> / dense<1> on 1xi64) ---
+    # --- Pattern A: tensor.generate + const1 + tosa.add (any syntax) ---
+    for re_add in (RE_ADD_UNQUOTED, RE_ADD_QUOTED):
+        m_add = re_add.match(line_strip)
+        if m_add and i > 0:
+            _result, lhs, rhs = m_add.groups()
+            m_const = RE_CONST_ONE.match(lines[i - 1].strip())
+            if m_const and m_const.group(1) == rhs and lhs in generate_vars:
+                old_line = lines[i]
+                # Replace first occurrence of the lhs variable in the add
+                new_line = old_line.replace(lhs, CUMLEN_ARG, 1)
+                lines[i] = new_line
+                patch_count += 1
+                print(
+                    f"  Line {i + 1}: {old_line.strip()} -> {new_line.strip()}"
+                )
+                break
+
+    # --- Pattern B: const0 + const1 + unquoted add (legacy f32 style) ---
     if i + 2 < len(lines):
         l0 = lines[i].strip()
         l1 = lines[i + 1].strip()
         l2 = lines[i + 2].strip()
 
         m0 = re.match(
-            r'(%\w+) = "tosa\.const"\(\) <\{values = dense<0> : '
+            r'(%\w+) = (?:"tosa\.const"\(\)|tosa\.const) '
+            r"<\{values = dense<0> : "
             r"tensor<1xi64>\}>",
             l0,
         )
         m1 = re.match(
-            r'(%\w+) = "tosa\.const"\(\) <\{values = dense<1> : '
+            r'(%\w+) = (?:"tosa\.const"\(\)|tosa\.const) '
+            r"<\{values = dense<1> : "
             r"tensor<1xi64>\}>",
             l1,
         )
@@ -110,8 +154,17 @@ while i < len(lines):
     i += 1
 
 if patch_count == 0:
-    print("WARNING: No patches applied!")
-    sys.exit(1)
+    # Already-patched files are expected on incremental rebuilds.
+    already_patched = CUMLEN_ARG in content
+    if already_patched and not args.strict_no_change:
+        print("No patch needed (file appears already patched).")
+        sys.exit(0)
+    else:
+        print("WARNING: No patches applied!")
+        if args.strict_no_change:
+            sys.exit(1)
+        print("Continuing without changes.")
+        sys.exit(0)
 
 print(f"\nApplied {patch_count} patches")
 

--- a/examples/BuddyNextGPU/batch-matmul-attn.mlir
+++ b/examples/BuddyNextGPU/batch-matmul-attn.mlir
@@ -1,0 +1,10 @@
+// Batch matmul from DeepSeek attention: Attn_scores × V
+// Shape: [12, 1024, 1024] × [12, 1024, 128] → [12, 1024, 128]
+// 28 calls per prefill (one per layer), currently 1 thread/block → 11.8s total
+func.func @batch_matmul_attn(%A: memref<12x1024x1024xf32>,
+                              %B: memref<12x1024x128xf32>,
+                              %C: memref<12x1024x128xf32>) {
+  linalg.batch_matmul ins(%A, %B : memref<12x1024x1024xf32>, memref<12x1024x128xf32>)
+                      outs(%C : memref<12x1024x128xf32>)
+  return
+}

--- a/examples/BuddyNextGPU/broadcast-add-optimized.mlir
+++ b/examples/BuddyNextGPU/broadcast-add-optimized.mlir
@@ -1,0 +1,26 @@
+// Optimized: nest 4D parallel into 3D(block) + 1D(thread)
+// blocks=(2, 6, 1024) threads=(128, 1, 1) — all 128 hidden elements parallel
+func.func @broadcast_add_opt(%A: memref<2x1x1024x128xf32>,
+                              %B: memref<2x6x1024x128xf32>,
+                              %C: memref<2x6x1024x128xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c6 = arith.constant 6 : index
+  %c1024 = arith.constant 1024 : index
+  %c128 = arith.constant 128 : index
+
+  // Outer 3D → blocks
+  scf.parallel (%head, %group, %seq) = (%c0, %c0, %c0) to (%c2, %c6, %c1024) step (%c1, %c1, %c1) {
+    // Inner 1D → threads
+    scf.parallel (%hid) = (%c0) to (%c128) step (%c1) {
+      %a = memref.load %A[%head, %c0, %seq, %hid] : memref<2x1x1024x128xf32>
+      %b = memref.load %B[%head, %group, %seq, %hid] : memref<2x6x1024x128xf32>
+      %sum = arith.addf %a, %b : f32
+      memref.store %sum, %C[%head, %group, %seq, %hid] : memref<2x6x1024x128xf32>
+      scf.reduce
+    }
+    scf.reduce
+  }
+  return
+}

--- a/examples/BuddyNextGPU/broadcast-add.mlir
+++ b/examples/BuddyNextGPU/broadcast-add.mlir
@@ -1,0 +1,29 @@
+// Decode bottleneck: broadcast add for attention KV cache
+// Shape: [1,2,1,1024,128] + [1,2,6,1024,128] → [1,2,6,1024,128]
+// In e2e: grid=(2,6,1024) block=(1,1,1) with scf.for over 128 → 42.8% of decode time
+//
+// This is a linalg.generic that broadcasts dim 2 (group) of A.
+// After convert-linalg-to-parallel-loops, all dims are scf.parallel except
+// the innermost (128) which becomes scf.for because gpu-map-parallel-loops
+// only maps 3 dims to blocks and ignores the rest.
+
+func.func @broadcast_add(%A: memref<2x1x1024x128xf32>,
+                          %B: memref<2x6x1024x128xf32>,
+                          %C: memref<2x6x1024x128xf32>) {
+  // Simplified: removed batch=1 dim for clarity.
+  // This is the core linalg.generic from the e2e graph.
+  linalg.generic {
+    indexing_maps = [
+      affine_map<(d0, d1, d2, d3) -> (d0, 0, d2, d3)>,  // A: broadcast d1
+      affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,  // B
+      affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>   // C
+    ],
+    iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+  } ins(%A, %B : memref<2x1x1024x128xf32>, memref<2x6x1024x128xf32>)
+    outs(%C : memref<2x6x1024x128xf32>) {
+  ^bb0(%a: f32, %b: f32, %c: f32):
+    %sum = arith.addf %a, %b : f32
+    linalg.yield %sum : f32
+  }
+  return
+}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,6 +12,10 @@ if(BUDDY_DEEPSEEKR1_EXAMPLES)
   add_subdirectory(BuddyDeepSeekR1)
 endif()
 
+if(BUDDY_DEEPSEEKR1_GPU_EXAMPLES)
+  add_subdirectory(BuddyDeepSeekR1-GPU)
+endif()
+
 if(BUDDY_QWEN3_EXAMPLES)
   add_subdirectory(BuddyQwen3)
 endif()

--- a/midend/lib/Conversion/MLIRGPU/CMakeLists.txt
+++ b/midend/lib/Conversion/MLIRGPU/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_mlir_library(MLIRGPUPasses
   ConvertMemcpyToGPU.cpp
+  ConvertStridedCopyToParallel.cpp
   LegalizeShmemOutlining.cpp
+  MatMulGPUTiling.cpp
+  NestParallelLoops.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Bufferization

--- a/midend/lib/Conversion/MLIRGPU/ConvertMemcpyToGPU.cpp
+++ b/midend/lib/Conversion/MLIRGPU/ConvertMemcpyToGPU.cpp
@@ -18,6 +18,7 @@
 //
 //===---------------------------------------------------------------------===//
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/AffineMap.h"
@@ -80,6 +81,56 @@ MemRefType stripMemRefLayout(const MemRefType &base) {
                          base.getMemorySpace());
 }
 
+// Returns true if `v` is (directly or through view ops) an argument to a
+// gpu::LaunchFuncOp.
+static bool hasGPULaunchUser(Value v) {
+  for (auto *user : v.getUsers()) {
+    if (isa<gpu::LaunchFuncOp, func::CallOp>(user))
+      return true;
+    if (isa<memref::ExpandShapeOp, memref::CollapseShapeOp, memref::SubViewOp,
+            memref::CastOp, memref::ReinterpretCastOp>(user)) {
+      for (auto res : user->getResults())
+        if (isa<MemRefType>(res.getType()) && hasGPULaunchUser(res))
+          return true;
+    }
+  }
+  return false;
+}
+
+// Returns true if `v` has any user that is NOT a GPU operation, memory
+// deallocation, memcpy (which the pass will convert), or a pure view op.
+// Such users are host-side (CPU) compute operations.
+static bool hasCPUComputeUser(Value v) {
+  for (auto *user : v.getUsers()) {
+    if (isa<gpu::LaunchFuncOp, gpu::MemcpyOp, memref::DeallocOp, memref::CopyOp,
+            func::CallOp, func::ReturnOp>(user))
+      continue;
+    if (isa<memref::ExpandShapeOp, memref::CollapseShapeOp, memref::SubViewOp,
+            memref::CastOp, memref::ReinterpretCastOp>(user)) {
+      for (auto res : user->getResults())
+        if (isa<MemRefType>(res.getType()) && hasCPUComputeUser(res))
+          return true;
+      continue;
+    }
+    return true;
+  }
+  return false;
+}
+
+static bool isReturnedByFunction(Value v) {
+  for (auto *user : v.getUsers()) {
+    if (isa<func::ReturnOp>(user))
+      return true;
+    if (isa<memref::ExpandShapeOp, memref::CollapseShapeOp, memref::SubViewOp,
+            memref::CastOp, memref::ReinterpretCastOp>(user)) {
+      for (auto res : user->getResults())
+        if (isa<MemRefType>(res.getType()) && isReturnedByFunction(res))
+          return true;
+    }
+  }
+  return false;
+}
+
 void ConvertMemcpyToGPUPass::runOnOperation() {
   auto funcOp = getOperation();
 
@@ -95,6 +146,10 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
   });
 
   std::vector<Value> unDeallocatedValue;
+  // Maps original memref.alloc results to their gpu.alloc replacements.
+  // Only populated for non-mixed (pure GPU) allocs where the original
+  // memref.alloc was erased.
+  DenseMap<Value, Value> erasedAllocToGpuMap;
   OpBuilder builder(funcOp->getContext());
 
   // Copy all function arguments to gpu, needs deallocation
@@ -106,15 +161,36 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
       // Create a gpu.alloc op, then copy memory to it
       // TODO: Move this out of operation, make the copy process async
       auto memrefType = dyn_cast<MemRefType>(arg.getType());
+      if (!memrefType)
+        continue;
+      if (llvm::any_of(memrefType.getShape(), ShapedType::isDynamic) ||
+          memrefType.getElementType().isIndex() ||
+          memrefType.getElementType().isInteger(1))
+        continue;
+      // Skip strided (non-contiguous) args. gpu::MemcpyOp requires both
+      // operands to be contiguous. Strided args typically point into managed
+      // memory (e.g. param subviews) and are GPU-accessible as-is.
+      if (!memrefType.getLayout().isIdentity())
+        continue;
 
+      auto contiguousType = stripMemRefLayout(memrefType);
+      bool returned = isReturnedByFunction(arg);
       auto gpuAllocOp = builder.create<gpu::AllocOp>(
-          builder.getUnknownLoc(), TypeRange({stripMemRefLayout(memrefType)}),
-          ValueRange({}));
-      unDeallocatedValue.push_back(gpuAllocOp->getResult(0));
+          builder.getUnknownLoc(), TypeRange({contiguousType}), ValueRange({}));
+      if (!returned)
+        unDeallocatedValue.push_back(gpuAllocOp->getResult(0));
       auto gpuMemcpyOp = builder.create<gpu::MemcpyOp>(
           gpuAllocOp.getLoc(), TypeRange(), ValueRange(),
           gpuAllocOp.getResult(0), arg);
-      arg.replaceAllUsesExcept(gpuAllocOp->getResult(0), gpuMemcpyOp);
+      // If the arg has a non-identity layout (e.g. dynamic strides), the
+      // gpu.alloc has a different type (identity layout). Cast back to the
+      // original strided type so that gpu.launch_func and other users keep
+      // the same operand type and pass verification.
+      Value replacement = gpuAllocOp->getResult(0);
+      if (contiguousType != memrefType)
+        replacement = builder.create<memref::CastOp>(gpuAllocOp.getLoc(),
+                                                     memrefType, replacement);
+      arg.replaceAllUsesExcept(replacement, gpuMemcpyOp);
     }
   }
 
@@ -126,6 +202,10 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
       auto result = allocOp->getResult(0);
       auto memrefType = dyn_cast<MemRefType>(result.getType());
       auto memorySpace = memrefType.getMemorySpace();
+
+      // Skip index-typed memrefs (bookkeeping buffers, not compute data).
+      if (memrefType.getElementType().isIndex())
+        return WalkResult::advance();
 
       // Filter operations.
       if (memorySpace) {
@@ -142,10 +222,19 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
           return WalkResult::advance();
       }
 
+      // Note: we process ALL allocs to ensure they use managed memory,
+      // even if not directly used by GPU kernels. Allocs that flow through
+      // func::CallOp to GPU subgraphs need managed memory too.
+
+      bool returned = isReturnedByFunction(result);
       auto gpuAllocOp = builder.create<gpu::AllocOp>(
           allocOp->getLoc(), TypeRange({stripMemRefLayout(memrefType)}),
-          ValueRange({}));
+          allocOp.getDynamicSizes());
 
+      // Replace all uses with the GPU buffer. Since all gpu.alloc use
+      // managed memory (cuMemAllocManaged), CPU code can also read/write
+      // the GPU buffer directly — no need for a separate mixed path.
+      erasedAllocToGpuMap[result] = gpuAllocOp.getResult(0);
       for (auto user : llvm::make_early_inc_range(result.getUsers())) {
         if (auto deallocOp = dyn_cast<memref::DeallocOp>(user)) {
           builder.setInsertionPointAfter(deallocOp);
@@ -154,62 +243,85 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
           deallocOp->erase();
         } else {
           for (auto &opOperand : user->getOpOperands()) {
-            if (opOperand.is(result)) {
+            if (opOperand.is(result))
               opOperand.set(gpuAllocOp.getResult(0));
-            }
           }
         }
       }
       allocOp->erase();
     }
+    // Replace memref.dealloc with gpu.dealloc for GPU-allocated buffers
+    else if (auto deallocOp = dyn_cast<memref::DeallocOp>(nestedOp)) {
+      auto memrefVal = deallocOp.getOperand();
+      // Check if this memref was converted to a GPU allocation.
+      // First check the mapping table (for non-mixed allocs whose original
+      // memref.alloc was erased).
+      Value gpuVal;
+      auto it = erasedAllocToGpuMap.find(memrefVal);
+      if (it != erasedAllocToGpuMap.end()) {
+        gpuVal = it->second;
+      } else if (auto gpuAllocOp = memrefVal.getDefiningOp<gpu::AllocOp>()) {
+        gpuVal = memrefVal;
+      } else if (auto castOp = memrefVal.getDefiningOp<memref::CastOp>()) {
+        if (auto gpuAllocOp =
+                castOp.getSource().getDefiningOp<gpu::AllocOp>()) {
+          gpuVal = castOp.getSource();
+        }
+      }
+      if (gpuVal) {
+        builder.setInsertionPointAfter(deallocOp);
+        builder.create<gpu::DeallocOp>(deallocOp->getLoc(), TypeRange(),
+                                       ValueRange(), gpuVal);
+        deallocOp->erase();
+      }
+    }
     // Replace all memory.copy operations with gpu.memcpy
     else if (auto copyOp = dyn_cast<memref::CopyOp>(nestedOp)) {
       auto src = copyOp.getOperand(0);
       auto dst = copyOp.getOperand(1);
+      auto srcType = dyn_cast<MemRefType>(src.getType());
+      auto dstType = dyn_cast<MemRefType>(dst.getType());
+      // Skip non-contiguous (strided) copies. gpu::MemcpyOp requires both
+      // operands to be contiguous. Strided copies are left as memref.copy and
+      // will be lowered to @memrefCopy by the NVVM pipeline, running on the
+      // CPU side (safe with unified memory).
+      if ((srcType && !srcType.getLayout().isIdentity()) ||
+          (dstType && !dstType.getLayout().isIdentity()))
+        return WalkResult::advance();
       // Notice: GPU.memcpy has a different src dst order
       builder.setInsertionPointAfter(copyOp);
-      auto gpuMemcpyOp = builder.create<gpu::MemcpyOp>(
-          copyOp->getLoc(), TypeRange(), ValueRange(), dst, src);
-      src.replaceAllUsesWith(gpuMemcpyOp->getResult(1));
-      dst.replaceAllUsesWith(gpuMemcpyOp->getResult(0));
+      builder.create<gpu::MemcpyOp>(copyOp->getLoc(), TypeRange(), ValueRange(),
+                                    dst, src);
       copyOp->erase();
     }
-    // Allocate space on GPU and copy global memrefs to GPU, needs deallocation
+    // Allocate/copy globals to GPU only when they are consumed by GPU kernels.
+    // Keep pure CPU global uses untouched to avoid host load/store on GPU
+    // pointers.
     else if (auto getGlobalOp = dyn_cast<memref::GetGlobalOp>(nestedOp)) {
-      builder.setInsertionPointAfter(getGlobalOp);
       auto result = getGlobalOp->getResult(0);
       auto memrefType = dyn_cast<MemRefType>(result.getType());
+
+      builder.setInsertionPointAfter(getGlobalOp);
+      bool returned = isReturnedByFunction(result);
       auto gpuAllocOp = builder.create<gpu::AllocOp>(
           getGlobalOp->getLoc(), TypeRange({stripMemRefLayout(memrefType)}),
           ValueRange({}));
-      unDeallocatedValue.push_back(gpuAllocOp->getResult(0));
+      if (!returned)
+        unDeallocatedValue.push_back(gpuAllocOp->getResult(0));
 
       auto src = result;
       auto dst = gpuAllocOp->getResult(0);
       auto gpuMemcpyOp = builder.create<gpu::MemcpyOp>(
           gpuAllocOp->getLoc(), TypeRange(), ValueRange(), dst, src);
       src.replaceAllUsesExcept(dst, gpuMemcpyOp);
-    }
-    // Copy data back to CPU, deallocate GPU, then return
-    else if (auto returnOp = dyn_cast<func::ReturnOp>(nestedOp)) {
+    } else if (auto returnOp = dyn_cast<func::ReturnOp>(nestedOp)) {
       builder.setInsertionPoint(returnOp);
       llvm::SmallVector<Type> outputTypes(
           funcOp.getFunctionType().getResults());
       for (unsigned i = 0; i < returnOp.getNumOperands(); ++i) {
         auto val = returnOp->getOperand(i);
-        if (auto memrefType = dyn_cast<MemRefType>(val.getType())) {
-          auto identityMemrefType = stripMemRefLayout(memrefType);
-          auto allocOp = builder.create<memref::AllocOp>(returnOp->getLoc(),
-                                                         identityMemrefType);
-          builder.create<gpu::MemcpyOp>(allocOp.getLoc(), TypeRange(),
-                                        ValueRange(), allocOp->getResult(0),
-                                        val);
-          // FIXME: may be leak memory
-          // auto gpuDeallocOp = builder.create<gpu::DeallocOp>(
-          //     gpuMemcpyOp->getLoc(), TypeRange(), ValueRange(), val);
-          outputTypes[i] = identityMemrefType;
-          returnOp->setOperand(i, allocOp->getResult(0));
-        }
+        if (isa<MemRefType>(val.getType()))
+          outputTypes[i] = val.getType();
       }
       for (auto value : unDeallocatedValue) {
         builder.create<gpu::DeallocOp>(returnOp->getLoc(), TypeRange(),
@@ -219,6 +331,45 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
           builder.getFunctionType(funcOp.getArgumentTypes(), outputTypes));
     }
     return WalkResult::advance();
+  });
+
+  // CUDA limits gridY and gridZ to 65535. When gridY exceeds this limit and
+  // gridX is within range, swap the two dimensions in both the launch and the
+  // kernel body (gpu.block_id x ↔ y) so the large dimension uses gridX
+  // (which supports up to 2^31-1).
+  constexpr int64_t kMaxGridYZ = 65535;
+  auto moduleOp = funcOp->getParentOfType<ModuleOp>();
+  if (!moduleOp)
+    return;
+
+  funcOp->walk([&](gpu::LaunchFuncOp launchOp) {
+    Value gridX = launchOp.getGridSizeX();
+    Value gridY = launchOp.getGridSizeY();
+    auto cstY = dyn_cast_or_null<arith::ConstantIndexOp>(gridY.getDefiningOp());
+    if (!cstY || cstY.value() <= kMaxGridYZ)
+      return;
+    auto cstX = dyn_cast_or_null<arith::ConstantIndexOp>(gridX.getDefiningOp());
+    if (!cstX || cstX.value() > kMaxGridYZ)
+      return;
+
+    launchOp.getGridSizeXMutable().assign(gridY);
+    launchOp.getGridSizeYMutable().assign(gridX);
+
+    auto kernelModuleName = launchOp.getKernelModuleName();
+    auto kernelName = launchOp.getKernelName();
+    for (auto gpuModule : moduleOp.getOps<gpu::GPUModuleOp>()) {
+      if (gpuModule.getName() != kernelModuleName)
+        continue;
+      if (auto kernelFunc =
+              gpuModule.lookupSymbol<gpu::GPUFuncOp>(kernelName)) {
+        kernelFunc.walk([](gpu::BlockIdOp blockIdOp) {
+          if (blockIdOp.getDimension() == gpu::Dimension::x)
+            blockIdOp.setDimension(gpu::Dimension::y);
+          else if (blockIdOp.getDimension() == gpu::Dimension::y)
+            blockIdOp.setDimension(gpu::Dimension::x);
+        });
+      }
+    }
   });
 }
 } // end anonymous namespace.

--- a/midend/lib/Conversion/MLIRGPU/MatMulGPUTiling.cpp
+++ b/midend/lib/Conversion/MLIRGPU/MatMulGPUTiling.cpp
@@ -1,0 +1,470 @@
+//===- MatMulGPUTiling.cpp ------------------------------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+//
+// Tile linalg.matmul for GPU execution. Produces a two-level parallel
+// structure so that gpu-map-parallel-loops maps the outer level to GPU blocks
+// and the inner level to GPU threads.
+//
+// Before:
+//   linalg.matmul ins(%A, %B) outs(%C)  // M×K × K×N
+//
+// After:
+//   scf.parallel (bm, bn) step (TM, TN) {        // → GPU blocks
+//     linalg.matmul ins(subview %A, subview %B)
+//                   outs(subview %C)               // TM×K × K×TN
+//   }
+//
+// Then convert-linalg-to-parallel-loops expands the inner matmul:
+//   scf.parallel (bm, bn) {                        // → GPU blocks
+//     scf.parallel (tm, tn) {                      // → GPU threads
+//       scf.for (k) { ... }                        // reduction
+//     }
+//   }
+//
+// Result: blocks=(M/TM, N/TN), threads=(TM, TN), each thread does K MACs.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Pass/Pass.h"
+
+using namespace mlir;
+
+namespace {
+
+class MatMulGPUTilingPass
+    : public PassWrapper<MatMulGPUTilingPass, OperationPass<func::FuncOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MatMulGPUTilingPass)
+  StringRef getArgument() const final { return "matmul-gpu-tiling"; }
+  StringRef getDescription() const final {
+    return "Tile linalg.matmul for GPU block/thread mapping.";
+  }
+
+  MatMulGPUTilingPass() = default;
+  MatMulGPUTilingPass(const MatMulGPUTilingPass &) {}
+
+  Option<int64_t> tileM{*this, "tile-m",
+                        llvm::cl::desc("Block tile size for M dimension"),
+                        llvm::cl::init(16)};
+  Option<int64_t> tileN{*this, "tile-n",
+                        llvm::cl::desc("Block tile size for N dimension"),
+                        llvm::cl::init(16)};
+  Option<int64_t> tileK{*this, "tile-k",
+                        llvm::cl::desc("Shared memory tile size for K (0=off)"),
+                        llvm::cl::init(16)};
+
+  void runOnOperation() override;
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<scf::SCFDialect, memref::MemRefDialect, arith::ArithDialect,
+                    gpu::GPUDialect>();
+  }
+};
+
+void MatMulGPUTilingPass::runOnOperation() {
+  auto funcOp = getOperation();
+  SmallVector<linalg::MatmulOp> matmuls;
+  funcOp->walk([&](linalg::MatmulOp op) { matmuls.push_back(op); });
+
+  for (auto matmulOp : matmuls) {
+    // Only handle buffer semantics (memref, not tensor).
+    auto outType = dyn_cast<MemRefType>(matmulOp.getDpsInits()[0].getType());
+    if (!outType)
+      continue;
+    auto inAType = dyn_cast<MemRefType>(matmulOp.getDpsInputs()[0].getType());
+    auto inBType = dyn_cast<MemRefType>(matmulOp.getDpsInputs()[1].getType());
+    if (!inAType || !inBType)
+      continue;
+
+    // Get static dimensions M, K, N.
+    auto shapeA = inAType.getShape(); // [M, K]
+    auto shapeB = inBType.getShape(); // [K, N]
+    if (shapeA.size() != 2 || shapeB.size() != 2)
+      continue;
+    int64_t M = shapeA[0], K = shapeA[1], N = shapeB[1];
+    if (ShapedType::isDynamic(M) || ShapedType::isDynamic(K) ||
+        ShapedType::isDynamic(N))
+      continue;
+
+    int64_t tm = tileM;
+    int64_t tn = tileN;
+    int64_t tk = tileK;
+    if (tm > M)
+      tm = M;
+    if (tn > N)
+      tn = N;
+    if (M % tm != 0 || N % tn != 0)
+      continue;
+
+    // GEMV path: M==1 with K-parallel reduction in shared memory.
+    // Each block computes one output element C[0,n]. Threads split K.
+    if (M == 1 && tk > 0) {
+      int64_t numThreads = 256;
+      if (numThreads > K)
+        numThreads = K;
+      // Round down to power of 2 for tree reduction.
+      int64_t nt = 1;
+      while (nt * 2 <= numThreads)
+        nt *= 2;
+      numThreads = nt;
+
+      OpBuilder builder(matmulOp);
+      auto loc = matmulOp.getLoc();
+      Value A = matmulOp.getDpsInputs()[0];
+      Value B = matmulOp.getDpsInputs()[1];
+      Value C = matmulOp.getDpsInits()[0];
+      auto elemType = outType.getElementType();
+
+      Value gridX = builder.create<arith::ConstantIndexOp>(loc, N);
+      Value gridY = builder.create<arith::ConstantIndexOp>(loc, 1);
+      Value gridZ = builder.create<arith::ConstantIndexOp>(loc, 1);
+      Value blockX = builder.create<arith::ConstantIndexOp>(loc, numThreads);
+      Value blockY = builder.create<arith::ConstantIndexOp>(loc, 1);
+      Value blockZ = builder.create<arith::ConstantIndexOp>(loc, 1);
+
+      auto launchOp = builder.create<gpu::LaunchOp>(loc, gridX, gridY, gridZ,
+                                                    blockX, blockY, blockZ);
+      builder.setInsertionPointToStart(&launchOp.getBody().front());
+
+      Value c0 = builder.create<arith::ConstantIndexOp>(loc, 0);
+      Value c1 = builder.create<arith::ConstantIndexOp>(loc, 1);
+      Value cK = builder.create<arith::ConstantIndexOp>(loc, K);
+      Value cNT = builder.create<arith::ConstantIndexOp>(loc, numThreads);
+
+      Value bid = launchOp.getBlockIds().x;  // output column index
+      Value tid = launchOp.getThreadIds().x; // thread within block
+
+      // Shared memory for reduction.
+      auto smemType = MemRefType::get(
+          {numThreads}, elemType, AffineMap(),
+          gpu::AddressSpaceAttr::get(builder.getContext(),
+                                     gpu::AddressSpace::Workgroup));
+      Value smem = builder.create<memref::AllocOp>(loc, smemType);
+
+      // Each thread: partial sum over K with stride numThreads.
+      Value zero = builder.create<arith::ConstantOp>(
+          loc, builder.getFloatAttr(elemType, 0.0));
+      auto sumLoop =
+          builder.create<scf::ForOp>(loc, tid, cK, cNT, ValueRange{zero});
+      {
+        builder.setInsertionPointToStart(sumLoop.getBody());
+        Value k = sumLoop.getInductionVar();
+        Value acc = sumLoop.getRegionIterArg(0);
+        Value a = builder.create<memref::LoadOp>(loc, A, ValueRange{c0, k});
+        Value b = builder.create<memref::LoadOp>(loc, B, ValueRange{k, bid});
+        Value prod = builder.create<arith::MulFOp>(loc, a, b);
+        Value newAcc = builder.create<arith::AddFOp>(loc, acc, prod);
+        builder.create<scf::YieldOp>(loc, ValueRange{newAcc});
+      }
+      builder.setInsertionPointAfter(sumLoop);
+
+      // Store partial sum to shared memory.
+      builder.create<memref::StoreOp>(loc, sumLoop.getResult(0), smem,
+                                      ValueRange{tid});
+      builder.create<gpu::BarrierOp>(loc);
+
+      // Tree reduction in shared memory.
+      int64_t stride = numThreads / 2;
+      while (stride > 0) {
+        Value cStride = builder.create<arith::ConstantIndexOp>(loc, stride);
+        Value cond = builder.create<arith::CmpIOp>(
+            loc, arith::CmpIPredicate::ult, tid, cStride);
+        auto ifOp = builder.create<scf::IfOp>(loc, cond, /*else=*/false);
+        builder.setInsertionPointToStart(&ifOp.getThenRegion().front());
+        Value partner = builder.create<arith::AddIOp>(loc, tid, cStride);
+        Value myVal =
+            builder.create<memref::LoadOp>(loc, smem, ValueRange{tid});
+        Value otherVal =
+            builder.create<memref::LoadOp>(loc, smem, ValueRange{partner});
+        Value reduced = builder.create<arith::AddFOp>(loc, myVal, otherVal);
+        builder.create<memref::StoreOp>(loc, reduced, smem, ValueRange{tid});
+        builder.setInsertionPointAfter(ifOp);
+        builder.create<gpu::BarrierOp>(loc);
+        stride /= 2;
+      }
+
+      // Thread 0 writes result.
+      Value isTid0 =
+          builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, tid, c0);
+      auto writeIf = builder.create<scf::IfOp>(loc, isTid0, /*else=*/false);
+      builder.setInsertionPointToStart(&writeIf.getThenRegion().front());
+      Value result = builder.create<memref::LoadOp>(loc, smem, ValueRange{c0});
+      Value cOld = builder.create<memref::LoadOp>(loc, C, ValueRange{c0, bid});
+      Value cNew = builder.create<arith::AddFOp>(loc, cOld, result);
+      builder.create<memref::StoreOp>(loc, cNew, C, ValueRange{c0, bid});
+
+      builder.setInsertionPointAfter(writeIf);
+      builder.create<gpu::TerminatorOp>(loc);
+      matmulOp->erase();
+      continue;
+    }
+
+    // When tile-k > 0: generate gpu.launch with shared memory tiling.
+    // When tile-k == 0: fall back to scf.parallel (no shared memory).
+    if (tk > 0 && K % tk == 0 && tm >= tk && tn >= tk) {
+      OpBuilder builder(matmulOp);
+      auto loc = matmulOp.getLoc();
+      Value A = matmulOp.getDpsInputs()[0];
+      Value B = matmulOp.getDpsInputs()[1];
+      Value C = matmulOp.getDpsInits()[0];
+      auto elemType = outType.getElementType();
+
+      // Grid/block sizes must be defined OUTSIDE the launch.
+      Value gridX = builder.create<arith::ConstantIndexOp>(loc, M / tm);
+      Value gridY = builder.create<arith::ConstantIndexOp>(loc, N / tn);
+      Value gridZ = builder.create<arith::ConstantIndexOp>(loc, 1);
+      Value blockX = builder.create<arith::ConstantIndexOp>(loc, tm);
+      Value blockY = builder.create<arith::ConstantIndexOp>(loc, tn);
+      Value blockZ = builder.create<arith::ConstantIndexOp>(loc, 1);
+
+      auto launchOp = builder.create<gpu::LaunchOp>(loc, gridX, gridY, gridZ,
+                                                    blockX, blockY, blockZ);
+      builder.setInsertionPointToStart(&launchOp.getBody().front());
+
+      // ALL constants inside the launch body so they don't become kernel args.
+      Value c0 = builder.create<arith::ConstantIndexOp>(loc, 0);
+      Value c1 = builder.create<arith::ConstantIndexOp>(loc, 1);
+      Value cTM = builder.create<arith::ConstantIndexOp>(loc, tm);
+      Value cTN = builder.create<arith::ConstantIndexOp>(loc, tn);
+      Value cKval = builder.create<arith::ConstantIndexOp>(loc, K);
+      Value cTKval = builder.create<arith::ConstantIndexOp>(loc, tk);
+
+      Value bx = launchOp.getBlockIds().x;
+      Value by = launchOp.getBlockIds().y;
+      Value tx = launchOp.getThreadIds().x;
+      Value ty = launchOp.getThreadIds().y;
+
+      Value globalM = builder.create<arith::AddIOp>(
+          loc, builder.create<arith::MulIOp>(loc, bx, cTM), tx);
+      Value globalN = builder.create<arith::AddIOp>(
+          loc, builder.create<arith::MulIOp>(loc, by, cTN), ty);
+
+      // Shared memory (workgroup address space).
+      auto smemAType = MemRefType::get(
+          {tm, tk}, elemType, AffineMap(),
+          gpu::AddressSpaceAttr::get(builder.getContext(),
+                                     gpu::AddressSpace::Workgroup));
+      auto smemBType = MemRefType::get(
+          {tk, tn}, elemType, AffineMap(),
+          gpu::AddressSpaceAttr::get(builder.getContext(),
+                                     gpu::AddressSpace::Workgroup));
+      Value smemA = builder.create<memref::AllocOp>(loc, smemAType);
+      Value smemB = builder.create<memref::AllocOp>(loc, smemBType);
+
+      Value zero = builder.create<arith::ConstantOp>(
+          loc, builder.getFloatAttr(elemType, 0.0));
+
+      // K-tile loop.
+      auto kLoop =
+          builder.create<scf::ForOp>(loc, c0, cKval, cTKval, ValueRange{zero});
+      builder.setInsertionPointToStart(kLoop.getBody());
+      Value kt = kLoop.getInductionVar();
+      Value acc = kLoop.getRegionIterArg(0);
+
+      // Cooperative load: each thread loads one element.
+      Value aCol = builder.create<arith::AddIOp>(loc, kt, ty);
+      Value aVal =
+          builder.create<memref::LoadOp>(loc, A, ValueRange{globalM, aCol});
+      builder.create<memref::StoreOp>(loc, aVal, smemA, ValueRange{tx, ty});
+
+      Value bRow = builder.create<arith::AddIOp>(loc, kt, tx);
+      Value bVal =
+          builder.create<memref::LoadOp>(loc, B, ValueRange{bRow, globalN});
+      builder.create<memref::StoreOp>(loc, bVal, smemB, ValueRange{tx, ty});
+
+      builder.create<gpu::BarrierOp>(loc);
+
+      // Inner accumulation from shared memory.
+      auto kkLoop =
+          builder.create<scf::ForOp>(loc, c0, cTKval, c1, ValueRange{acc});
+      builder.setInsertionPointToStart(kkLoop.getBody());
+      Value kk = kkLoop.getInductionVar();
+      Value accIn = kkLoop.getRegionIterArg(0);
+      Value sa = builder.create<memref::LoadOp>(loc, smemA, ValueRange{tx, kk});
+      Value sb = builder.create<memref::LoadOp>(loc, smemB, ValueRange{kk, ty});
+      Value prod = builder.create<arith::MulFOp>(loc, sa, sb);
+      Value sum = builder.create<arith::AddFOp>(loc, accIn, prod);
+      builder.create<scf::YieldOp>(loc, ValueRange{sum});
+
+      builder.setInsertionPointAfter(kkLoop);
+      builder.create<gpu::BarrierOp>(loc);
+      builder.create<scf::YieldOp>(loc, ValueRange{kkLoop.getResult(0)});
+
+      // Store result.
+      builder.setInsertionPointAfter(kLoop);
+      Value finalAcc = kLoop.getResult(0);
+      Value cOld =
+          builder.create<memref::LoadOp>(loc, C, ValueRange{globalM, globalN});
+      Value cNew = builder.create<arith::AddFOp>(loc, cOld, finalAcc);
+      builder.create<memref::StoreOp>(loc, cNew, C,
+                                      ValueRange{globalM, globalN});
+
+      builder.create<gpu::TerminatorOp>(loc);
+      matmulOp->erase();
+      continue;
+    }
+
+    // Fallback: scf.parallel tiling (no shared memory).
+    OpBuilder builder(matmulOp);
+    auto loc = matmulOp.getLoc();
+
+    Value A = matmulOp.getDpsInputs()[0];
+    Value B = matmulOp.getDpsInputs()[1];
+    Value C = matmulOp.getDpsInits()[0];
+
+    auto elemType = outType.getElementType();
+
+    Value c0 = builder.create<arith::ConstantIndexOp>(loc, 0);
+    Value cM = builder.create<arith::ConstantIndexOp>(loc, M);
+    Value cN = builder.create<arith::ConstantIndexOp>(loc, N);
+    Value cTM = builder.create<arith::ConstantIndexOp>(loc, tm);
+    Value cTN = builder.create<arith::ConstantIndexOp>(loc, tn);
+
+    auto ploop = builder.create<scf::ParallelOp>(
+        loc, ValueRange{c0, c0}, ValueRange{cM, cN}, ValueRange{cTM, cTN});
+
+    builder.setInsertionPointToStart(ploop.getBody());
+    Value bm = ploop.getInductionVars()[0];
+    Value bn = ploop.getInductionVars()[1];
+
+    auto subA = builder.create<memref::SubViewOp>(
+        loc, A, SmallVector<OpFoldResult>{bm, c0},
+        SmallVector<OpFoldResult>{builder.getIndexAttr(tm),
+                                  builder.getIndexAttr(K)},
+        SmallVector<OpFoldResult>{builder.getIndexAttr(1),
+                                  builder.getIndexAttr(1)});
+
+    auto subB = builder.create<memref::SubViewOp>(
+        loc, B, SmallVector<OpFoldResult>{c0, bn},
+        SmallVector<OpFoldResult>{builder.getIndexAttr(K),
+                                  builder.getIndexAttr(tn)},
+        SmallVector<OpFoldResult>{builder.getIndexAttr(1),
+                                  builder.getIndexAttr(1)});
+
+    auto subC = builder.create<memref::SubViewOp>(
+        loc, C, SmallVector<OpFoldResult>{bm, bn},
+        SmallVector<OpFoldResult>{builder.getIndexAttr(tm),
+                                  builder.getIndexAttr(tn)},
+        SmallVector<OpFoldResult>{builder.getIndexAttr(1),
+                                  builder.getIndexAttr(1)});
+
+    builder.create<linalg::MatmulOp>(
+        loc, ValueRange{subA.getResult(), subB.getResult()},
+        ValueRange{subC.getResult()});
+
+    matmulOp->erase();
+  }
+
+  // --- Tile linalg.batch_matmul: [B,M,K] x [B,K,N] -> [B,M,N] ---
+  // Outer parallel over B (kept as-is), tile M and N for block/thread mapping.
+  SmallVector<linalg::BatchMatmulOp> batchMatmuls;
+  funcOp->walk([&](linalg::BatchMatmulOp op) { batchMatmuls.push_back(op); });
+
+  for (auto bmOp : batchMatmuls) {
+    auto outType = dyn_cast<MemRefType>(bmOp.getDpsInits()[0].getType());
+    if (!outType)
+      continue;
+    auto inAType = dyn_cast<MemRefType>(bmOp.getDpsInputs()[0].getType());
+    auto inBType = dyn_cast<MemRefType>(bmOp.getDpsInputs()[1].getType());
+    if (!inAType || !inBType)
+      continue;
+
+    auto shapeA = inAType.getShape(); // [B, M, K]
+    auto shapeB = inBType.getShape(); // [B, K, N]
+    if (shapeA.size() != 3 || shapeB.size() != 3)
+      continue;
+    int64_t B = shapeA[0], M = shapeA[1], K = shapeA[2], N = shapeB[2];
+    if (ShapedType::isDynamic(B) || ShapedType::isDynamic(M) ||
+        ShapedType::isDynamic(K) || ShapedType::isDynamic(N))
+      continue;
+
+    int64_t tm = tileM, tn = tileN;
+    if (tm > M)
+      tm = M;
+    if (tn > N)
+      tn = N;
+    if (M % tm != 0 || N % tn != 0)
+      continue;
+
+    OpBuilder builder(bmOp);
+    auto loc = bmOp.getLoc();
+
+    Value A = bmOp.getDpsInputs()[0];
+    Value Bv = bmOp.getDpsInputs()[1];
+    Value C = bmOp.getDpsInits()[0];
+
+    Value c0 = builder.create<arith::ConstantIndexOp>(loc, 0);
+    Value cB = builder.create<arith::ConstantIndexOp>(loc, B);
+    Value cM = builder.create<arith::ConstantIndexOp>(loc, M);
+    Value cN = builder.create<arith::ConstantIndexOp>(loc, N);
+    Value c1step = builder.create<arith::ConstantIndexOp>(loc, 1);
+    Value cTM = builder.create<arith::ConstantIndexOp>(loc, tm);
+    Value cTN = builder.create<arith::ConstantIndexOp>(loc, tn);
+
+    // scf.parallel (b, bm, bn) = (0,0,0) to (B,M,N) step (1,TM,TN)
+    auto ploop = builder.create<scf::ParallelOp>(loc, ValueRange{c0, c0, c0},
+                                                 ValueRange{cB, cM, cN},
+                                                 ValueRange{c1step, cTM, cTN});
+
+    builder.setInsertionPointToStart(ploop.getBody());
+    Value bidx = ploop.getInductionVars()[0];
+    Value bm = ploop.getInductionVars()[1];
+    Value bn = ploop.getInductionVars()[2];
+
+    auto i1 = builder.getIndexAttr(1);
+    auto iK = builder.getIndexAttr(K);
+    auto iTM = builder.getIndexAttr(tm);
+    auto iTN = builder.getIndexAttr(tn);
+
+    // subview A[b, bm:bm+TM, 0:K]
+    auto subA = builder.create<memref::SubViewOp>(
+        loc, A, SmallVector<OpFoldResult>{bidx, bm, c0},
+        SmallVector<OpFoldResult>{i1, iTM, iK},
+        SmallVector<OpFoldResult>{i1, i1, i1});
+    // subview B[b, 0:K, bn:bn+TN]
+    auto subB = builder.create<memref::SubViewOp>(
+        loc, Bv, SmallVector<OpFoldResult>{bidx, c0, bn},
+        SmallVector<OpFoldResult>{i1, iK, iTN},
+        SmallVector<OpFoldResult>{i1, i1, i1});
+    // subview C[b, bm:bm+TM, bn:bn+TN]
+    auto subC = builder.create<memref::SubViewOp>(
+        loc, C, SmallVector<OpFoldResult>{bidx, bm, bn},
+        SmallVector<OpFoldResult>{i1, iTM, iTN},
+        SmallVector<OpFoldResult>{i1, i1, i1});
+
+    builder.create<linalg::BatchMatmulOp>(
+        loc, ValueRange{subA.getResult(), subB.getResult()},
+        ValueRange{subC.getResult()});
+
+    bmOp->erase();
+  }
+}
+
+} // namespace
+
+namespace mlir {
+namespace buddy {
+void registerMatMulGPUTilingPass() { PassRegistration<MatMulGPUTilingPass>(); }
+} // namespace buddy
+} // namespace mlir

--- a/midend/lib/Conversion/MLIRGPU/NestParallelLoops.cpp
+++ b/midend/lib/Conversion/MLIRGPU/NestParallelLoops.cpp
@@ -1,0 +1,116 @@
+//===- NestParallelLoops.cpp ----------------------------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+//
+// Split scf.parallel loops with >3 dimensions into nested loops so that
+// gpu-map-parallel-loops can map outer dims to blocks and inner dims to
+// threads. Without this, dims beyond the 3rd become sequential scf.for.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+
+using namespace mlir;
+
+namespace {
+
+class NestParallelLoopsPass
+    : public PassWrapper<NestParallelLoopsPass, OperationPass<func::FuncOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(NestParallelLoopsPass)
+  StringRef getArgument() const final { return "nest-parallel-loops-for-gpu"; }
+  StringRef getDescription() const final {
+    return "Split >3D scf.parallel into nested 3D(block)+remaining(thread).";
+  }
+  NestParallelLoopsPass() = default;
+  NestParallelLoopsPass(const NestParallelLoopsPass &) {}
+
+  void runOnOperation() override {
+    SmallVector<scf::ParallelOp> targets;
+    getOperation()->walk([&](scf::ParallelOp op) {
+      if (op.getNumLoops() > 3)
+        targets.push_back(op);
+    });
+
+    for (auto ploop : targets) {
+      unsigned numLoops = ploop.getNumLoops();
+      // Split into first 3 dims (block) and remaining dims (thread).
+      unsigned outerDims = 3;
+      unsigned innerDims = numLoops - outerDims;
+
+      auto lbs = ploop.getLowerBound();
+      auto ubs = ploop.getUpperBound();
+      auto steps = ploop.getStep();
+
+      OpBuilder builder(ploop);
+      auto loc = ploop.getLoc();
+
+      // Create outer scf.parallel with first 3 dims.
+      SmallVector<Value> outerLBs(lbs.begin(), lbs.begin() + outerDims);
+      SmallVector<Value> outerUBs(ubs.begin(), ubs.begin() + outerDims);
+      SmallVector<Value> outerSteps(steps.begin(), steps.begin() + outerDims);
+
+      auto outerLoop =
+          builder.create<scf::ParallelOp>(loc, outerLBs, outerUBs, outerSteps);
+      builder.setInsertionPointToStart(outerLoop.getBody());
+
+      // Create inner scf.parallel with remaining dims.
+      SmallVector<Value> innerLBs(lbs.begin() + outerDims, lbs.end());
+      SmallVector<Value> innerUBs(ubs.begin() + outerDims, ubs.end());
+      SmallVector<Value> innerSteps(steps.begin() + outerDims, steps.end());
+
+      auto innerLoop =
+          builder.create<scf::ParallelOp>(loc, innerLBs, innerUBs, innerSteps);
+
+      // Move the original loop body into the inner loop.
+      // The original body uses induction vars [0..numLoops-1].
+      // Map them: [0..2] → outer IVs, [3..N-1] → inner IVs.
+      Block *origBody = ploop.getBody();
+      Block *innerBody = innerLoop.getBody();
+
+      // Build mapping from old IVs to new IVs.
+      IRMapping mapping;
+      for (unsigned i = 0; i < outerDims; ++i)
+        mapping.map(origBody->getArgument(i), outerLoop.getInductionVars()[i]);
+      for (unsigned i = 0; i < innerDims; ++i)
+        mapping.map(origBody->getArgument(outerDims + i),
+                    innerLoop.getInductionVars()[i]);
+
+      // Clone all ops from the original body (except the terminator) into
+      // the inner loop body (before its terminator).
+      builder.setInsertionPoint(innerBody->getTerminator());
+      for (auto &op : llvm::make_early_inc_range(*origBody)) {
+        if (isa<scf::ReduceOp>(&op))
+          continue;
+        builder.clone(op, mapping);
+      }
+
+      ploop->erase();
+    }
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace buddy {
+void registerNestParallelLoopsPass() {
+  PassRegistration<NestParallelLoopsPass>();
+}
+} // namespace buddy
+} // namespace mlir

--- a/tools/buddy-opt/buddy-opt.cpp
+++ b/tools/buddy-opt/buddy-opt.cpp
@@ -100,6 +100,9 @@ void registerLowerXTAMEPass();
 void registerAssumeTightMemRefLayoutPass();
 void registerStaticizeMemRefLayoutPass();
 void registerConvertMemcpyToGPUPass();
+void registerConvertStridedCopyToParallelPass();
+void registerMatMulGPUTilingPass();
+void registerNestParallelLoopsPass();
 void registerLegalizeShmemOutliningPass();
 void registerMatMulTransposeBVecPass();
 void registerLegalizeShmemOutliningPass();
@@ -172,6 +175,9 @@ int main(int argc, char **argv) {
   mlir::buddy::registerSiLUFusionPass();
   // Register gpu passes
   mlir::buddy::registerConvertMemcpyToGPUPass();
+  mlir::buddy::registerConvertStridedCopyToParallelPass();
+  mlir::buddy::registerMatMulGPUTilingPass();
+  mlir::buddy::registerNestParallelLoopsPass();
   mlir::buddy::registerLegalizeShmemOutliningPass();
 
   mlir::DialectRegistry registry;


### PR DESCRIPTION
## Summary
  - Add end-to-end GPU inference for DeepSeek-R1-Distill-Qwen-1.5B via MLIR GPU/NVVM pipeline
  - Add `matmul-gpu-tiling` pass: block/thread tiling, shared memory K-tiling, GEMV K-parallel reduction
  - Add `nest-parallel-loops-for-gpu` pass: split >3D parallel loops for proper GPU block/thread mapping
  - Modify `convert-memcpy-to-gpu` pass: managed memory for all allocs, simplified ReturnOp, grid dimension fix
<img width="824" height="450" alt="image" src="https://github.com/user-attachments/assets/506cf99f-1e26-4265-87ad-f98cfe317e76" />
