### PR TITLE
[mlir] Use `OpTy::create` instead of `OpBuilder::create`

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,3 +27,22 @@ jobs:
       - uses: pre-commit/action@v3.0.0
         with:
           extra_args: ${{ env.PRE_COMMIT_ARGS }}
+
+      - name: Check deprecated MLIR op builder API
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          matches="$(
+            find . \
+              -path './llvm' -prune -o \
+              -path './backend' -prune -o \
+              -name '*.cpp' -type f \
+              -exec grep -nE '^[[:space:]]*[^/[:space:]].*(\w+)[[:space:]]*\.[[:space:]]*create<([^>]*)>\(' {} + \
+              || true
+          )"
+          if [ -n "$matches" ]; then
+            echo "$matches"
+            echo "::error::Deprecated MLIR OpBuilder::create<OpTy> API found. Use OpTy::create(builder, ...) instead."
+            exit 1
+          fi

--- a/examples/ToyDSL/include/MLIRToyVisitor.h
+++ b/examples/ToyDSL/include/MLIRToyVisitor.h
@@ -136,7 +136,7 @@ private:
     mlir::Location loaction =
         loc(ctx->start->getLine(), ctx->start->getCharPositionInLine());
     mlir::Value value =
-        builder.create<mlir::toy::ConstantOp>(loaction, type, dataAttribute);
+        mlir::toy::ConstantOp::create(builder, loaction, type, dataAttribute);
     return value;
   }
   // Emit a constant for a literal/constant array.
@@ -281,7 +281,7 @@ private:
     if (!returnOp) {
       mlir::Location location =
           loc(ctx->start->getLine(), ctx->start->getCharPositionInLine());
-      builder.create<mlir::toy::ReturnOp>(location);
+      mlir::toy::ReturnOp::create(builder, location);
     } else if (returnOp.hasOperand()) {
       // Otherwise, if this return operation has an operand then add a result to
       // the function.
@@ -325,8 +325,8 @@ private:
       }
     }
     auto funType = builder.getFunctionType(argTypes, std::nullopt);
-    auto func = builder.create<mlir::toy::FuncOp>(
-        location, ctx->Identifier()->toString(), funType);
+    auto func = mlir::toy::FuncOp::create(
+        builder, location, ctx->Identifier()->toString(), funType);
     return func;
   }
   /// Build a struct value.
@@ -337,8 +337,8 @@ private:
     std::tie(dataAttr, dataType) = getConstantAttr(ctx);
     mlir::Location location =
         loc(ctx->start->getLine(), ctx->start->getCharPositionInLine());
-    mlir::Value value = builder.create<mlir::toy::StructConstantOp>(
-        location, dataType, dataAttr);
+    mlir::Value value = mlir::toy::StructConstantOp::create(builder, location,
+                                                            dataType, dataAttr);
     return value;
   }
 
@@ -401,16 +401,16 @@ private:
       mlir::Location loaction =
           loc(ctx->start->getLine(), ctx->start->getCharPositionInLine());
       if (ctx->Add())
-        value = builder.create<mlir::toy::AddOp>(loaction, lhs, rhs);
+        value = mlir::toy::AddOp::create(builder, loaction, lhs, rhs);
       else
-        value = builder.create<mlir::toy::MulOp>(loaction, lhs, rhs);
+        value = mlir::toy::MulOp::create(builder, loaction, lhs, rhs);
       return value;
     } else if (ctx->Number()) {
       mlir::Location location =
           loc(ctx->Number()->getSymbol()->getLine(),
               ctx->Number()->getSymbol()->getCharPositionInLine());
       double number = std::stod(ctx->Number()->toString());
-      value = builder.create<mlir::toy::ConstantOp>(location, number);
+      value = mlir::toy::ConstantOp::create(builder, location, number);
       return value;
     } else if (ctx->structLiteral()) {
       // Get struct value.
@@ -421,8 +421,8 @@ private:
       mlir::Location location =
           loc(ctx->start->getLine(), ctx->start->getCharPositionInLine());
       std::optional<size_t> accessIndex = getMemberIndex(ctx);
-      value = builder.create<mlir::toy::StructAccessOp>(location, value,
-                                                        *accessIndex);
+      value = mlir::toy::StructAccessOp::create(builder, location, value,
+                                                *accessIndex);
       return value;
     }
     return value;
@@ -447,7 +447,7 @@ private:
           loc(ctx->Identifier(0)->getSymbol()->getLine(),
               ctx->Identifier(0)->getSymbol()->getCharPositionInLine());
       value =
-          builder.create<mlir::toy::ReshapeOp>(location, getType(v0), value);
+          mlir::toy::ReshapeOp::create(builder, location, getType(v0), value);
     }
     // Register the variable into the symbol table.
     mlir::failed(declare(ctx->idName, value, ctx));
@@ -482,7 +482,7 @@ private:
           return nullptr;
         }
         mlir::Value arg = oprands[0];
-        builder.create<mlir::toy::PrintOp>(location, arg);
+        mlir::toy::PrintOp::create(builder, location, arg);
         return 0;
       } else if (ctx->Identifier()->toString() == "transpose") {
         if (argsNumber != 1) {
@@ -491,7 +491,7 @@ private:
           return nullptr;
         }
         mlir::Value arg = oprands[0];
-        value = builder.create<mlir::toy::TransposeOp>(location, arg);
+        value = mlir::toy::TransposeOp::create(builder, location, arg);
         return value;
       }
       // Otherwise this is a call to a user-defined function. Calls to
@@ -512,8 +512,8 @@ private:
       // If the function call cannot be mapped to the built-in operation, create
       // the GenericCallOp.
       mlir::toy::FuncOp calledFunc = callee->second;
-      value = builder.create<mlir::toy::GenericCallOp>(
-          location, calledFunc.getFunctionType().getResult(0),
+      value = mlir::toy::GenericCallOp::create(
+          builder, location, calledFunc.getFunctionType().getResult(0),
           mlir::SymbolRefAttr::get(builder.getContext(),
                                    ctx->Identifier()->toString()),
           oprands);
@@ -536,8 +536,9 @@ private:
     }
     // Generate return operation based on whether the function has the return
     // value.
-    builder.create<mlir::toy::ReturnOp>(
-        location, expr ? llvm::ArrayRef(expr) : llvm::ArrayRef<mlir::Value>());
+    mlir::toy::ReturnOp::create(builder, location,
+                                expr ? llvm::ArrayRef(expr)
+                                     : llvm::ArrayRef<mlir::Value>());
     return 0;
   }
   // Make the struct type store in the map.

--- a/frontend/FrontendGen/lib/CGModule.cpp
+++ b/frontend/FrontendGen/lib/CGModule.cpp
@@ -344,9 +344,8 @@ void CGModule::emitOp(Op *op, int index) {
     llvm::StringRef cppNameSpace(
         module->getDialect()->getCppNamespace().data() + 1,
         module->getDialect()->getCppNamespace().size() - 2);
-    os << "  "
-       << "builder.create<" << cppNameSpace << "::" << op->getOpName()
-       << ">(location";
+    os << "  " << cppNameSpace << "::" << op->getOpName()
+       << "::create(builder, location";
     if (opArguments.size())
       os << ", ";
     for (size_t index = 0; index < opArguments.size(); index++) {
@@ -387,9 +386,8 @@ void CGModule::emitOp(Op *op, int index) {
     llvm::StringRef cppNameSpace(
         module->getDialect()->getCppNamespace().data() + 1,
         module->getDialect()->getCppNamespace().size() - 2);
-    os << "  "
-       << "builder.create<" << cppNameSpace << "::" << op->getOpName()
-       << ">(location";
+    os << "  " << cppNameSpace << "::" << op->getOpName()
+       << "::create(builder, location";
     if (!operandNames.empty()) {
       os << ", ";
       for (size_t index = 0; index < opArguments.size(); index++) {

--- a/midend/lib/Conversion/AssumeTightMemRefLayout/AssumeTightMemRefLayout.cpp
+++ b/midend/lib/Conversion/AssumeTightMemRefLayout/AssumeTightMemRefLayout.cpp
@@ -109,8 +109,8 @@ public:
         builder.setInsertionPointToStart(value.getParentBlock());
 
       // Extract the current layout metadata so we can rebuild a tighter view.
-      auto metadata = builder.create<memref::ExtractStridedMetadataOp>(
-          value.getLoc(), value);
+      auto metadata = memref::ExtractStridedMetadataOp::create(
+          builder, value.getLoc(), value);
 
       SmallVector<OpFoldResult> sizes;
       sizes.reserve(type.getRank());
@@ -153,9 +153,9 @@ public:
           MemRefType::get(type.getShape(), type.getElementType(),
                           tightenedLayout, type.getMemorySpace());
 
-      auto reinterpret = builder.create<memref::ReinterpretCastOp>(
-          value.getLoc(), tightenedType, metadata.getBaseBuffer(), offset,
-          sizes, stridesOfr);
+      auto reinterpret = memref::ReinterpretCastOp::create(
+          builder, value.getLoc(), tightenedType, metadata.getBaseBuffer(),
+          offset, sizes, stridesOfr);
 
       for (OpOperand *operand : toUpdate)
         operand->set(reinterpret);

--- a/midend/lib/Conversion/ConvOptimization/ConvNhwcFhwcOptimize.cpp
+++ b/midend/lib/Conversion/ConvOptimization/ConvNhwcFhwcOptimize.cpp
@@ -50,12 +50,12 @@ public:
 
     // Some constant we need.
     const Value c0 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(0));
     const Value c1 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(1));
 
-    const Value vecSizeValue =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(vecSize));
+    const Value vecSizeValue = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getIndexAttr(vecSize));
     const AffineExpr d0 = rewriter.getAffineDimExpr(0);
     const AffineExpr d1 = rewriter.getAffineDimExpr(1);
     const AffineExpr s0 = rewriter.getAffineSymbolExpr(0);
@@ -91,22 +91,23 @@ public:
     VectorType vecTy = VectorType::get(vecSize, elemTy);
 
     const Value zeroElementType =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getZeroAttr(elemTy));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getZeroAttr(elemTy));
 
     // Dims
-    Value N = rewriter.create<memref::DimOp>(loc, output, 0);  // N
-    Value OH = rewriter.create<memref::DimOp>(loc, output, 1); // OH
-    Value OW = rewriter.create<memref::DimOp>(loc, output, 2); // OW
-    Value OC = rewriter.create<memref::DimOp>(loc, output, 3); // OC
-    Value IC = rewriter.create<memref::DimOp>(loc, input, 3);  // IC
-    Value FH = rewriter.create<memref::DimOp>(loc, filter, 1); // FH
-    Value FW = rewriter.create<memref::DimOp>(loc, filter, 2); // FW
+    Value N = memref::DimOp::create(rewriter, loc, output, 0);  // N
+    Value OH = memref::DimOp::create(rewriter, loc, output, 1); // OH
+    Value OW = memref::DimOp::create(rewriter, loc, output, 2); // OW
+    Value OC = memref::DimOp::create(rewriter, loc, output, 3); // OC
+    Value IC = memref::DimOp::create(rewriter, loc, input, 3);  // IC
+    Value FH = memref::DimOp::create(rewriter, loc, filter, 1); // FH
+    Value FW = memref::DimOp::create(rewriter, loc, filter, 2); // FW
 
     // clang format off
     //  Step 1: Create outer most loops.
     // Create the scf::ForallOp operation For N,OH,OW,OC
-    rewriter.create<scf::ForallOp>(
-        loc, SmallVector<OpFoldResult, 4>({N, OH, OW, OC}), ValueRange{},
+    scf::ForallOp::create(
+        rewriter, loc, SmallVector<OpFoldResult, 4>({N, OH, OW, OC}),
+        ValueRange{},
         std::nullopt, // No mapping specified in this example
         [&](OpBuilder &nestedBuilder, Location nestedLoc,
             ValueRange loopIndices) {
@@ -115,78 +116,80 @@ public:
           Value ivOW = loopIndices[2]; // Index for the third dimension OW
           Value ivOC = loopIndices[3]; // Index for the third dimension OC
 
-          Value addRes = nestedBuilder.create<memref::LoadOp>(
-              loc, output, ValueRange{ivN, ivOH, ivOW, ivOC});
+          Value addRes = memref::LoadOp::create(
+              nestedBuilder, loc, output, ValueRange{ivN, ivOH, ivOW, ivOC});
           // IC
-          auto forOp = nestedBuilder.create<scf::ForOp>(
-              nestedLoc, c0, IC, vecSizeValue, ValueRange{addRes},
+          auto forOp = scf::ForOp::create(
+              nestedBuilder, nestedLoc, c0, IC, vecSizeValue,
+              ValueRange{addRes},
               [&](OpBuilder &builder, Location loc, Value ivIC,
                   ValueRange iargs) {
                 Value tVec;
                 if (isa<IntegerType>(elemTy)) {
-                  tVec = builder.create<vector::BroadcastOp>(loc, vecTy,
-                                                             zeroElementType);
+                  tVec = vector::BroadcastOp::create(builder, loc, vecTy,
+                                                     zeroElementType);
                 } else {
-                  tVec = builder.create<vector::BroadcastOp>(loc, vecTy,
-                                                             zeroElementType);
+                  tVec = vector::BroadcastOp::create(builder, loc, vecTy,
+                                                     zeroElementType);
                 }
 
-                Value remainLen = builder.create<affine::AffineMinOp>(
-                    loc,
+                Value remainLen = affine::AffineMinOp::create(
+                    builder, loc,
                     AffineMap::get(2, 1, {-d0 + s0, d1}, builder.getContext()),
                     ValueRange{ivIC, vecSizeValue, IC});
-                Value remainMask = builder.create<vector::CreateMaskOp>(
-                    loc, VectorType::get({vecSize}, rewriter.getI1Type()),
+                Value remainMask = vector::CreateMaskOp::create(
+                    builder, loc,
+                    VectorType::get({vecSize}, rewriter.getI1Type()),
                     ValueRange{remainLen});
 
                 // FH
-                auto forOp = builder.create<scf::ForOp>(
-                    loc, c0, FH, c1, ValueRange{tVec},
+                auto forOp = scf::ForOp::create(
+                    builder, loc, c0, FH, c1, ValueRange{tVec},
                     [&](OpBuilder &builder, Location loc, Value ivFH,
                         ValueRange iargs) {
-                      Value rowInput = builder.create<affine::AffineApplyOp>(
-                          loc,
+                      Value rowInput = affine::AffineApplyOp::create(
+                          builder, loc,
                           AffineMap::get(2, 0, d0 * strHeight + d1 * dilHeight),
                           ValueRange{ivOH, ivFH});
                       Value rowFilter = ivFH;
                       // FW
-                      auto forOp = builder.create<scf::ForOp>(
-                          loc, c0, FW, c1, ValueRange{iargs[0]},
+                      auto forOp = scf::ForOp::create(
+                          builder, loc, c0, FW, c1, ValueRange{iargs[0]},
                           [&](OpBuilder &builder, Location loc, Value ivFW,
                               ValueRange iargs) {
-                            Value columnInput =
-                                builder.create<affine::AffineApplyOp>(
-                                    loc,
-                                    AffineMap::get(
-                                        2, 0, d0 * strWidth + d1 * dilWidth),
-                                    ValueRange{ivOW, ivFW});
+                            Value columnInput = affine::AffineApplyOp::create(
+                                builder, loc,
+                                AffineMap::get(2, 0,
+                                               d0 * strWidth + d1 * dilWidth),
+                                ValueRange{ivOW, ivFW});
                             Value columnFilter = ivFW;
-                            Value iVec = builder.create<vector::LoadOp>(
-                                loc, vecTy, input,
+                            Value iVec = vector::LoadOp::create(
+                                builder, loc, vecTy, input,
                                 ValueRange{ivN, rowInput, columnInput, ivIC});
-                            Value fVec = builder.create<vector::LoadOp>(
-                                loc, vecTy, filter,
+                            Value fVec = vector::LoadOp::create(
+                                builder, loc, vecTy, filter,
                                 ValueRange{ivOC, rowFilter, columnFilter,
                                            ivIC});
                             Value tVecNext;
                             if (isa<IntegerType>(elemTy)) {
-                              Value mulVec = builder.create<arith::MulIOp>(
-                                  loc, iVec, fVec);
-                              tVecNext = builder.create<arith::AddIOp>(
-                                  loc, mulVec, iargs[0]);
+                              Value mulVec = arith::MulIOp::create(builder, loc,
+                                                                   iVec, fVec);
+                              tVecNext = arith::AddIOp::create(
+                                  builder, loc, mulVec, iargs[0]);
                             } else {
-                              tVecNext = builder.create<vector::FMAOp>(
-                                  loc, vecTy, iVec, fVec, iargs[0]);
+                              tVecNext = vector::FMAOp::create(
+                                  builder, loc, vecTy, iVec, fVec, iargs[0]);
                             }
 
-                            builder.create<scf::YieldOp>(loc,
-                                                         ValueRange{tVecNext});
+                            scf::YieldOp::create(builder, loc,
+                                                 ValueRange{tVecNext});
                           });
-                      builder.create<scf::YieldOp>(
-                          loc, ValueRange{forOp.getResult(0)});
+                      scf::YieldOp::create(builder, loc,
+                                           ValueRange{forOp.getResult(0)});
                     });
-                auto reduceVecOp = builder.create<vector::ReductionOp>(
-                    loc, vector::CombiningKind::ADD, forOp.getResult(0));
+                auto reduceVecOp = vector::ReductionOp::create(
+                    builder, loc, vector::CombiningKind::ADD,
+                    forOp.getResult(0));
                 auto maskedOp =
                     cast<vector::MaskOp>(mlir::vector::maskOperation(
                         builder, reduceVecOp, remainMask));
@@ -194,18 +197,17 @@ public:
                 Value addNext;
                 if (isa<IntegerType>(elemTy)) {
                   addNext =
-                      builder.create<arith::AddIOp>(loc, iargs[0], reduceVec);
+                      arith::AddIOp::create(builder, loc, iargs[0], reduceVec);
                 } else {
                   addNext =
-                      builder.create<arith::AddFOp>(loc, iargs[0], reduceVec);
+                      arith::AddFOp::create(builder, loc, iargs[0], reduceVec);
                 }
-                builder.create<scf::YieldOp>(loc, ValueRange{addNext});
+                scf::YieldOp::create(builder, loc, ValueRange{addNext});
               });
 
-          nestedBuilder.create<memref::StoreOp>(
-              loc, forOp.getResult(0), output,
-              ValueRange{ivN, ivOH, ivOW, ivOC});
-          nestedBuilder.create<scf::InParallelOp>(nestedLoc);
+          memref::StoreOp::create(nestedBuilder, loc, forOp.getResult(0),
+                                  output, ValueRange{ivN, ivOH, ivOW, ivOC});
+          scf::InParallelOp::create(nestedBuilder, nestedLoc);
         });
     // clang format on
 

--- a/midend/lib/Conversion/ConvOptimization/ConvNhwcFhwcTileOptimize.cpp
+++ b/midend/lib/Conversion/ConvOptimization/ConvNhwcFhwcTileOptimize.cpp
@@ -56,12 +56,12 @@ public:
 
     // Some constant we need.
     const Value c0 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(0));
     const Value c1 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(1));
 
-    const Value vecSizeValue =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(vecSize));
+    const Value vecSizeValue = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getIndexAttr(vecSize));
     const AffineExpr d0 = rewriter.getAffineDimExpr(0);
     const AffineExpr d1 = rewriter.getAffineDimExpr(1);
     const AffineExpr s0 = rewriter.getAffineSymbolExpr(0);
@@ -97,32 +97,32 @@ public:
     VectorType vecTy = VectorType::get(vecSize, elemTy);
 
     const Value zeroElementType =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getZeroAttr(elemTy));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getZeroAttr(elemTy));
 
     // Dims
-    Value N = rewriter.create<memref::DimOp>(loc, output, 0);  // N
-    Value OH = rewriter.create<memref::DimOp>(loc, output, 1); // OH
-    Value OW = rewriter.create<memref::DimOp>(loc, output, 2); // OW
-    Value OC = rewriter.create<memref::DimOp>(loc, output, 3); // OC
-    Value IC = rewriter.create<memref::DimOp>(loc, input, 3);  // IC
-    Value FH = rewriter.create<memref::DimOp>(loc, filter, 1); // FH
-    Value FW = rewriter.create<memref::DimOp>(loc, filter, 2); // FW
+    Value N = memref::DimOp::create(rewriter, loc, output, 0);  // N
+    Value OH = memref::DimOp::create(rewriter, loc, output, 1); // OH
+    Value OW = memref::DimOp::create(rewriter, loc, output, 2); // OW
+    Value OC = memref::DimOp::create(rewriter, loc, output, 3); // OC
+    Value IC = memref::DimOp::create(rewriter, loc, input, 3);  // IC
+    Value FH = memref::DimOp::create(rewriter, loc, filter, 1); // FH
+    Value FW = memref::DimOp::create(rewriter, loc, filter, 2); // FW
 
     auto tilingUpperBound =
         AffineMap::get(2, 1, {d0 + d1, s0}, rewriter.getContext());
 
-    Value stepOH = rewriter.create<affine::AffineApplyOp>(
-        loc, AffineMap::get(1, 0, d0.ceilDiv(tilingOH)), OH);
-    Value stepOW = rewriter.create<affine::AffineApplyOp>(
-        loc, AffineMap::get(1, 0, d0.ceilDiv(tilingOW)), OW);
-    Value stepOC = rewriter.create<affine::AffineApplyOp>(
-        loc, AffineMap::get(1, 0, d0.ceilDiv(tilingOC)), OC);
+    Value stepOH = affine::AffineApplyOp::create(
+        rewriter, loc, AffineMap::get(1, 0, d0.ceilDiv(tilingOH)), OH);
+    Value stepOW = affine::AffineApplyOp::create(
+        rewriter, loc, AffineMap::get(1, 0, d0.ceilDiv(tilingOW)), OW);
+    Value stepOC = affine::AffineApplyOp::create(
+        rewriter, loc, AffineMap::get(1, 0, d0.ceilDiv(tilingOC)), OC);
 
     // clang format off
     //  Step 1: Create outer most loops.
     // Create the scf::ForallOp operation For N,OH,OW,OC
-    rewriter.create<scf::ForallOp>(
-        loc, SmallVector<OpFoldResult, 4>{c0, c0, c0, c0},
+    scf::ForallOp::create(
+        rewriter, loc, SmallVector<OpFoldResult, 4>{c0, c0, c0, c0},
         SmallVector<OpFoldResult, 4>({N, OH, OW, OC}),
         SmallVector<OpFoldResult, 4>({c1, stepOH, stepOW, stepOC}),
         ValueRange{},
@@ -131,21 +131,21 @@ public:
             ValueRange loopIndices) {
           Value ivN = loopIndices[0]; // Index for the first dimension N
 
-          Value ubOH = nestedBuilder.create<affine::AffineMinOp>(
-              loc, tilingUpperBound,
+          Value ubOH = affine::AffineMinOp::create(
+              nestedBuilder, loc, tilingUpperBound,
               ValueRange{loopIndices[1], stepOH,
                          OH}); // ub for the second dimension OH
-          Value ubOW = nestedBuilder.create<affine::AffineMinOp>(
-              loc, tilingUpperBound,
+          Value ubOW = affine::AffineMinOp::create(
+              nestedBuilder, loc, tilingUpperBound,
               ValueRange{loopIndices[2], stepOW,
                          OW}); // ub for the second dimension OW
-          Value ubOC = nestedBuilder.create<affine::AffineMinOp>(
-              loc, tilingUpperBound,
+          Value ubOC = affine::AffineMinOp::create(
+              nestedBuilder, loc, tilingUpperBound,
               ValueRange{loopIndices[3], stepOC,
                          OC}); // ub for the second dimension OC
 
-          rewriter.create<scf::ForallOp>(
-              loc,
+          scf::ForallOp::create(
+              rewriter, loc,
               SmallVector<OpFoldResult, 3>{loopIndices[1], loopIndices[2],
                                            loopIndices[3]},
               SmallVector<OpFoldResult, 3>({ubOH, ubOW, ubOC}),
@@ -157,107 +157,111 @@ public:
                 Value ivOW = loopIndices[1]; // Index for the first dimension OW
                 Value ivOC = loopIndices[2]; // Index for the first dimension OC
 
-                Value addRes = nestedBuilder.create<memref::LoadOp>(
-                    loc, output, ValueRange{ivN, ivOH, ivOW, ivOC});
+                Value addRes =
+                    memref::LoadOp::create(nestedBuilder, loc, output,
+                                           ValueRange{ivN, ivOH, ivOW, ivOC});
                 // IC
-                auto forOp = nestedBuilder.create<scf::ForOp>(
-                    nestedLoc, c0, IC, vecSizeValue, ValueRange{addRes},
+                auto forOp = scf::ForOp::create(
+                    nestedBuilder, nestedLoc, c0, IC, vecSizeValue,
+                    ValueRange{addRes},
                     [&](OpBuilder &builder, Location loc, Value ivIC,
                         ValueRange iargs) {
                       Value tVec;
                       if (isa<IntegerType>(elemTy)) {
-                        tVec = builder.create<vector::BroadcastOp>(
-                            loc, vecTy, zeroElementType);
+                        tVec = vector::BroadcastOp::create(builder, loc, vecTy,
+                                                           zeroElementType);
                       } else {
-                        tVec = builder.create<vector::BroadcastOp>(
-                            loc, vecTy, zeroElementType);
+                        tVec = vector::BroadcastOp::create(builder, loc, vecTy,
+                                                           zeroElementType);
                       }
 
-                      Value remainLen = builder.create<affine::AffineMinOp>(
-                          loc,
+                      Value remainLen = affine::AffineMinOp::create(
+                          builder, loc,
                           AffineMap::get(2, 1, {-d0 + s0, d1},
                                          builder.getContext()),
                           ValueRange{ivIC, vecSizeValue, IC});
-                      Value remainMask = builder.create<vector::CreateMaskOp>(
-                          loc, VectorType::get({vecSize}, rewriter.getI1Type()),
+                      Value remainMask = vector::CreateMaskOp::create(
+                          builder, loc,
+                          VectorType::get({vecSize}, rewriter.getI1Type()),
                           ValueRange{remainLen});
 
                       // FH
-                      auto forOp = builder.create<scf::ForOp>(
-                          loc, c0, FH, c1, ValueRange{tVec},
+                      auto forOp = scf::ForOp::create(
+                          builder, loc, c0, FH, c1, ValueRange{tVec},
                           [&](OpBuilder &builder, Location loc, Value ivFH,
                               ValueRange iargs) {
-                            Value rowInput =
-                                builder.create<affine::AffineApplyOp>(
-                                    loc,
-                                    AffineMap::get(
-                                        2, 0, d0 * strHeight + d1 * dilHeight),
-                                    ValueRange{ivOH, ivFH});
+                            Value rowInput = affine::AffineApplyOp::create(
+                                builder, loc,
+                                AffineMap::get(2, 0,
+                                               d0 * strHeight + d1 * dilHeight),
+                                ValueRange{ivOH, ivFH});
                             Value rowFilter = ivFH;
                             // FW
-                            auto forOp = builder.create<scf::ForOp>(
-                                loc, c0, FW, c1, ValueRange{iargs[0]},
+                            auto forOp = scf::ForOp::create(
+                                builder, loc, c0, FW, c1, ValueRange{iargs[0]},
                                 [&](OpBuilder &builder, Location loc,
                                     Value ivFW, ValueRange iargs) {
                                   Value columnInput =
-                                      builder.create<affine::AffineApplyOp>(
-                                          loc,
+                                      affine::AffineApplyOp::create(
+                                          builder, loc,
                                           AffineMap::get(2, 0,
                                                          d0 * strWidth +
                                                              d1 * dilWidth),
                                           ValueRange{ivOW, ivFW});
                                   Value columnFilter =
-                                      builder.create<affine::AffineApplyOp>(
-                                          loc, AffineMap::get(1, 0, d0), ivFW);
-                                  Value iVec = builder.create<vector::LoadOp>(
-                                      loc, vecTy, input,
+                                      affine::AffineApplyOp::create(
+                                          builder, loc,
+                                          AffineMap::get(1, 0, d0), ivFW);
+                                  Value iVec = vector::LoadOp::create(
+                                      builder, loc, vecTy, input,
                                       ValueRange{ivN, rowInput, columnInput,
                                                  ivIC});
-                                  Value fVec = builder.create<vector::LoadOp>(
-                                      loc, vecTy, filter,
+                                  Value fVec = vector::LoadOp::create(
+                                      builder, loc, vecTy, filter,
                                       ValueRange{ivOC, rowFilter, columnFilter,
                                                  ivIC});
                                   Value tVecNext;
                                   if (isa<IntegerType>(elemTy)) {
-                                    Value mulVec =
-                                        builder.create<arith::MulIOp>(loc, iVec,
-                                                                      fVec);
-                                    tVecNext = builder.create<arith::AddIOp>(
-                                        loc, mulVec, iargs[0]);
+                                    Value mulVec = arith::MulIOp::create(
+                                        builder, loc, iVec, fVec);
+                                    tVecNext = arith::AddIOp::create(
+                                        builder, loc, mulVec, iargs[0]);
                                   } else {
-                                    tVecNext = builder.create<vector::FMAOp>(
-                                        loc, vecTy, iVec, fVec, iargs[0]);
+                                    tVecNext = vector::FMAOp::create(
+                                        builder, loc, vecTy, iVec, fVec,
+                                        iargs[0]);
                                   }
 
-                                  builder.create<scf::YieldOp>(
-                                      loc, ValueRange{tVecNext});
+                                  scf::YieldOp::create(builder, loc,
+                                                       ValueRange{tVecNext});
                                 });
-                            builder.create<scf::YieldOp>(
-                                loc, ValueRange{forOp.getResult(0)});
+                            scf::YieldOp::create(
+                                builder, loc, ValueRange{forOp.getResult(0)});
                           });
-                      auto reduceVecOp = builder.create<vector::ReductionOp>(
-                          loc, vector::CombiningKind::ADD, forOp.getResult(0));
+                      auto reduceVecOp = vector::ReductionOp::create(
+                          builder, loc, vector::CombiningKind::ADD,
+                          forOp.getResult(0));
                       auto maskedOp =
                           cast<vector::MaskOp>(mlir::vector::maskOperation(
                               builder, reduceVecOp, remainMask));
                       Value reduceVec = maskedOp->getResult(0);
                       Value addNext;
                       if (isa<IntegerType>(elemTy)) {
-                        addNext = builder.create<arith::AddIOp>(loc, iargs[0],
-                                                                reduceVec);
+                        addNext = arith::AddIOp::create(builder, loc, iargs[0],
+                                                        reduceVec);
                       } else {
-                        addNext = builder.create<arith::AddFOp>(loc, iargs[0],
-                                                                reduceVec);
+                        addNext = arith::AddFOp::create(builder, loc, iargs[0],
+                                                        reduceVec);
                       }
-                      builder.create<scf::YieldOp>(loc, ValueRange{addNext});
+                      scf::YieldOp::create(builder, loc, ValueRange{addNext});
                     });
 
-                nestedBuilder.create<memref::StoreOp>(
-                    loc, forOp.getResult(0), output,
-                    ValueRange{ivN, ivOH, ivOW, ivOC});
-                nestedBuilder.create<scf::InParallelOp>(nestedLoc);
+                memref::StoreOp::create(nestedBuilder, loc, forOp.getResult(0),
+                                        output,
+                                        ValueRange{ivN, ivOH, ivOW, ivOC});
+                scf::InParallelOp::create(nestedBuilder, nestedLoc);
               });
-          nestedBuilder.create<scf::InParallelOp>(nestedLoc);
+          scf::InParallelOp::create(nestedBuilder, nestedLoc);
         });
     // clang format on
 

--- a/midend/lib/Conversion/ConvOptimization/ConvOptimize.cpp
+++ b/midend/lib/Conversion/ConvOptimization/ConvOptimize.cpp
@@ -51,9 +51,9 @@ public:
 
     // Some constant we need.
     const Value c0 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(0));
     const Value cf0 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getF32FloatAttr(0.));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getF32FloatAttr(0.));
 
     const AffineExpr d0 = rewriter.getAffineDimExpr(0);
     const AffineExpr d1 = rewriter.getAffineDimExpr(1);
@@ -69,17 +69,17 @@ public:
     VectorType vecTy = VectorType::get(vecSize, elemTy);
 
     // Dims
-    Value a = rewriter.create<memref::DimOp>(loc, output, 0);
-    Value b = rewriter.create<memref::DimOp>(loc, output, 1);
-    Value c = rewriter.create<memref::DimOp>(loc, output, 2);
-    Value d = rewriter.create<memref::DimOp>(loc, output, 3);
-    Value e = rewriter.create<memref::DimOp>(loc, input, 1);
-    Value f = rewriter.create<memref::DimOp>(loc, filter, 2);
-    Value g = rewriter.create<memref::DimOp>(loc, filter, 3);
+    Value a = memref::DimOp::create(rewriter, loc, output, 0);
+    Value b = memref::DimOp::create(rewriter, loc, output, 1);
+    Value c = memref::DimOp::create(rewriter, loc, output, 2);
+    Value d = memref::DimOp::create(rewriter, loc, output, 3);
+    Value e = memref::DimOp::create(rewriter, loc, input, 1);
+    Value f = memref::DimOp::create(rewriter, loc, filter, 2);
+    Value g = memref::DimOp::create(rewriter, loc, filter, 3);
 
     // memref<1xvector<vecsize x elemTy>>
     MemRefType bufferTy = MemRefType::get(1, vecTy);
-    Value buffer = rewriter.create<memref::AllocOp>(loc, bufferTy);
+    Value buffer = memref::AllocOp::create(rewriter, loc, bufferTy);
 
     // Step 1: Create outer most loops.
     affine::buildAffineLoopNest(
@@ -99,22 +99,21 @@ public:
                           [&](OpBuilder &builder, Location loc,
                               ValueRange ivRange) {
                             Value ivC = ivRange.front();
-                            Value t = builder.create<vector::BroadcastOp>(
-                                loc, vecTy, cf0);
-                            builder.create<memref::StoreOp>(loc, t, buffer, c0);
+                            Value t = vector::BroadcastOp::create(builder, loc,
+                                                                  vecTy, cf0);
+                            memref::StoreOp::create(builder, loc, t, buffer,
+                                                    c0);
                             affine::buildAffineLoopNest(
                                 rewriter, loc, c0, e, 1,
                                 [&](OpBuilder &builder, Location loc,
                                     ValueRange ivRange) {
                                   Value ivE = ivRange.front();
 
-                                  Value fixed =
-                                      builder.create<affine::AffineApplyOp>(
-                                          loc,
-                                          AffineMap::get(1, 0,
-                                                         d0.ceilDiv(kernelM) *
-                                                             kernelM),
-                                          ValueRange{f});
+                                  Value fixed = affine::AffineApplyOp::create(
+                                      builder, loc,
+                                      AffineMap::get(
+                                          1, 0, d0.ceilDiv(kernelM) * kernelM),
+                                      ValueRange{f});
 
                                   affine::buildAffineLoopNest(
                                       rewriter, loc, c0, fixed, kernelM,
@@ -133,55 +132,51 @@ public:
                                               SmallVector<Value> fList;
                                               for (int i = 0; i < kernelM;
                                                    ++i) {
-                                                Value rowInput = builder.create<
-                                                    affine::AffineApplyOp>(
-                                                    loc,
-                                                    AffineMap::get(2, 0,
-                                                                   d0 + i + d1),
-                                                    ValueRange{ivC, ivF});
-                                                Value rowFilter =
-                                                    builder.create<
-                                                        affine::AffineApplyOp>(
-                                                        loc,
+                                                Value rowInput = affine::
+                                                    AffineApplyOp::create(
+                                                        builder, loc,
+                                                        AffineMap::get(
+                                                            2, 0, d0 + i + d1),
+                                                        ValueRange{ivC, ivF});
+                                                Value rowFilter = affine::
+                                                    AffineApplyOp::create(
+                                                        builder, loc,
                                                         AffineMap::get(1, 0,
                                                                        d0 + i),
                                                         ivF);
                                                 for (int j = 0; j < kernelN;
                                                      ++j) {
-                                                  Value columnInput =
-                                                      builder.create<
-                                                          affine::
-                                                              AffineApplyOp>(
-                                                          loc,
+                                                  Value columnInput = affine::
+                                                      AffineApplyOp::create(
+                                                          builder, loc,
                                                           AffineMap::get(
                                                               2, 0,
                                                               d0 + d1 +
                                                                   j * vecSize),
                                                           ValueRange{ivD, ivG});
-                                                  Value columnFilter =
-                                                      builder.create<
-                                                          affine::
-                                                              AffineApplyOp>(
-                                                          loc,
+                                                  Value columnFilter = affine::
+                                                      AffineApplyOp::create(
+                                                          builder, loc,
                                                           AffineMap::get(
                                                               1, 0,
                                                               d0 + j * vecSize),
                                                           ivG);
 
-                                                  Value i = builder.create<
-                                                      TransferReadOp>(
-                                                      loc, vecTy, input,
-                                                      ValueRange{ivA, ivE,
-                                                                 rowInput,
-                                                                 columnInput},
-                                                      /*padding=*/nullptr,
-                                                      /*inBounds=*/nullptr,
-                                                      /*mask=*/nullptr);
+                                                  Value i =
+                                                      TransferReadOp::create(
+                                                          builder, loc, vecTy,
+                                                          input,
+                                                          ValueRange{
+                                                              ivA, ivE,
+                                                              rowInput,
+                                                              columnInput},
+                                                          /*padding=*/nullptr,
+                                                          /*inBounds=*/nullptr,
+                                                          /*mask=*/nullptr);
 
-                                                  auto protectedF =
-                                                      builder.create<
-                                                          affine::AffineIfOp>(
-                                                          loc, vecTy,
+                                                  auto protectedF = affine::
+                                                      AffineIfOp::create(
+                                                          builder, loc, vecTy,
                                                           IntegerSet::get(
                                                               1, 1,
                                                               {s0 - 1 - d0},
@@ -196,9 +191,9 @@ public:
                                                       protectedF
                                                           .getThenBodyBuilder();
                                                   Value normalReadVec =
-                                                      thenBuilder.create<
-                                                          TransferReadOp>(
-                                                          loc, vecTy, filter,
+                                                      TransferReadOp::create(
+                                                          thenBuilder, loc,
+                                                          vecTy, filter,
                                                           ValueRange{
                                                               ivB, ivE,
                                                               rowFilter,
@@ -206,9 +201,9 @@ public:
                                                           /*padding=*/nullptr,
                                                           /*inBounds=*/nullptr,
                                                           /*mask=*/nullptr);
-                                                  thenBuilder.create<
-                                                      affine::AffineYieldOp>(
-                                                      loc, normalReadVec);
+                                                  affine::AffineYieldOp::create(
+                                                      thenBuilder, loc,
+                                                      normalReadVec);
 
                                                   // if row out of range, give
                                                   // back a empty vector.
@@ -216,12 +211,13 @@ public:
                                                       protectedF
                                                           .getElseBodyBuilder();
                                                   Value emptyVec =
-                                                      elseBuilder.create<
-                                                          vector::BroadcastOp>(
-                                                          loc, vecTy, cf0);
-                                                  elseBuilder.create<
-                                                      affine::AffineYieldOp>(
-                                                      loc, emptyVec);
+                                                      vector::BroadcastOp::
+                                                          create(elseBuilder,
+                                                                 loc, vecTy,
+                                                                 cf0);
+                                                  affine::AffineYieldOp::create(
+                                                      elseBuilder, loc,
+                                                      emptyVec);
 
                                                   iList.push_back(i);
                                                   fList.push_back(
@@ -230,46 +226,49 @@ public:
                                                 }
                                               }
                                               Value lastResult =
-                                                  builder
-                                                      .create<memref::LoadOp>(
-                                                          loc, buffer, c0);
+                                                  memref::LoadOp::create(
+                                                      builder, loc, buffer, c0);
                                               for (int i = 0; i < kernelM;
                                                    ++i) {
                                                 for (int j = 0; j < kernelN;
                                                      ++j) {
-                                                  lastResult = builder.create<
-                                                      vector::FMAOp>(
-                                                      loc, vecTy,
-                                                      iList[i * kernelN + j],
-                                                      fList[i * kernelN + j],
-                                                      lastResult);
+                                                  lastResult =
+                                                      vector::FMAOp::create(
+                                                          builder, loc, vecTy,
+                                                          iList[i * kernelN +
+                                                                j],
+                                                          fList[i * kernelN +
+                                                                j],
+                                                          lastResult);
                                                 }
                                               }
 
-                                              builder.create<memref::StoreOp>(
-                                                  loc, lastResult, buffer, c0);
+                                              memref::StoreOp::create(
+                                                  builder, loc, lastResult,
+                                                  buffer, c0);
                                             });
                                       });
                                 });
 
-                            Value reduceVec =
-                                builder.create<memref::LoadOp>(loc, buffer, c0);
-                            Value reducedRes =
-                                builder.create<vector::ReductionOp>(
-                                    loc, vector::CombiningKind::ADD, reduceVec);
-                            Value bias = builder.create<memref::LoadOp>(
-                                loc, output, ValueRange{ivA, ivB, ivC, ivD});
-                            Value addRes = builder.create<arith::AddFOp>(
-                                loc, bias, reducedRes);
-                            builder.create<memref::StoreOp>(
-                                loc, addRes, output,
+                            Value reduceVec = memref::LoadOp::create(
+                                builder, loc, buffer, c0);
+                            Value reducedRes = vector::ReductionOp::create(
+                                builder, loc, vector::CombiningKind::ADD,
+                                reduceVec);
+                            Value bias = memref::LoadOp::create(
+                                builder, loc, output,
+                                ValueRange{ivA, ivB, ivC, ivD});
+                            Value addRes = arith::AddFOp::create(
+                                builder, loc, bias, reducedRes);
+                            memref::StoreOp::create(
+                                builder, loc, addRes, output,
                                 ValueRange{ivA, ivB, ivC, ivD});
                           });
                     });
               });
         });
 
-    rewriter.create<memref::DeallocOp>(loc, buffer);
+    memref::DeallocOp::create(rewriter, loc, buffer);
 
     rewriter.eraseOp(op);
     return success();

--- a/midend/lib/Conversion/ConvVectorization/CBConvVectorization.cpp
+++ b/midend/lib/Conversion/ConvVectorization/CBConvVectorization.cpp
@@ -50,23 +50,23 @@ void populateCBSplitingPattern(Operation *op, int64_t stride,
   VectorType vectorTy32 = mlir::VectorType::get({stride}, f32);
   VectorType vectorMaskTy = VectorType::get({stride}, i1);
   // Create constant index.
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-  Value cStride = rewriter.create<arith::ConstantIndexOp>(loc, stride);
-  Value f0 = rewriter.create<arith::ConstantFloatOp>(
-      loc, f32, APFloat::getZero(f32.getFloatSemantics()));
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+  Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+  Value cStride = arith::ConstantIndexOp::create(rewriter, loc, stride);
+  Value f0 = arith::ConstantFloatOp::create(
+      rewriter, loc, f32, APFloat::getZero(f32.getFloatSemantics()));
   // Create pass through vector.
   Value passThroughVec =
-      rewriter.create<vector::BroadcastOp>(loc, vectorTy32, f0);
+      vector::BroadcastOp::create(rewriter, loc, vectorTy32, f0);
   // Get input, kernel and output.
   Value input = op->getOperand(0);
   Value kernel = op->getOperand(1);
   Value output = op->getOperand(2);
   // Create DimOp.
-  Value kernelRow = rewriter.create<memref::DimOp>(loc, kernel, c0);
-  Value kernelCol = rewriter.create<memref::DimOp>(loc, kernel, c1);
-  Value outputRow = rewriter.create<memref::DimOp>(loc, output, c0);
-  Value outputCol = rewriter.create<memref::DimOp>(loc, output, c1);
+  Value kernelRow = memref::DimOp::create(rewriter, loc, kernel, c0);
+  Value kernelCol = memref::DimOp::create(rewriter, loc, kernel, c1);
+  Value outputRow = memref::DimOp::create(rewriter, loc, output, c0);
+  Value outputCol = memref::DimOp::create(rewriter, loc, output, c1);
   // Size of strip mining.
   AffineExpr d0;
   bindDims(ctx, d0);
@@ -78,23 +78,23 @@ void populateCBSplitingPattern(Operation *op, int64_t stride,
       rewriter, loc, lowerBounds, uperBounds, steps,
       [&](OpBuilder &builder, Location loc, ValueRange ivs) {
         // Create strip mining loop.
-        builder.create<affine::AffineForOp>(
-            loc, ValueRange{c0}, builder.getDimIdentityMap(),
+        affine::AffineForOp::create(
+            builder, loc, ValueRange{c0}, builder.getDimIdentityMap(),
             ValueRange{outputCol}, stripMap, /*Step=*/1, ValueRange{},
             [&](OpBuilder &nestedBuilder, Location nestedLoc, Value iv,
                 ValueRange itrArgs) {
               // Vectorize the kernel.
               // Broadcast element of the kernel.
-              Value kernelValue = builder.create<memref::LoadOp>(
-                  loc, kernel, ValueRange{ivs[1], ivs[2]});
+              Value kernelValue = memref::LoadOp::create(
+                  builder, loc, kernel, ValueRange{ivs[1], ivs[2]});
               Value kernelNonZeroCond =
                   buddy::zeroCond(builder, loc, f32, kernelValue,
                                   buddy::indexToF32(builder, loc, c0));
-              builder.create<scf::IfOp>(
-                  loc, kernelNonZeroCond,
+              scf::IfOp::create(
+                  builder, loc, kernelNonZeroCond,
                   [&](OpBuilder &builder, Location loc) {
-                    Value kernelVector = builder.create<vector::BroadcastOp>(
-                        loc, vectorTy32, kernelValue);
+                    Value kernelVector = vector::BroadcastOp::create(
+                        builder, loc, vectorTy32, kernelValue);
                     // Load input vector from memref.
                     AffineExpr m, n, k, j;
                     bindDims(ctx, m, n, k, j);
@@ -103,18 +103,20 @@ void populateCBSplitingPattern(Operation *op, int64_t stride,
                         {m + n, k + j * stride}, ctx);
                     // Calculate the tail.
                     Value currCol =
-                        nestedBuilder.create<arith::MulIOp>(loc, iv, cStride);
-                    Value tail = nestedBuilder.create<arith::SubIOp>(
-                        loc, outputCol, currCol);
-                    Value tailCond = rewriter.create<arith::CmpIOp>(
-                        loc, arith::CmpIPredicate::sge, tail, cStride);
+                        arith::MulIOp::create(nestedBuilder, loc, iv, cStride);
+                    Value tail = arith::SubIOp::create(nestedBuilder, loc,
+                                                       outputCol, currCol);
+                    Value tailCond = arith::CmpIOp::create(
+                        rewriter, loc, arith::CmpIPredicate::sge, tail,
+                        cStride);
                     // If the current column does not reach the tail.
-                    builder.create<scf::IfOp>(
-                        loc, tailCond,
+                    scf::IfOp::create(
+                        builder, loc, tailCond,
                         [&](OpBuilder &builder, Location loc) {
                           Value inputVector =
-                              nestedBuilder.create<affine::AffineVectorLoadOp>(
-                                  loc, vectorTy32, input, inputVectorMap,
+                              affine::AffineVectorLoadOp::create(
+                                  nestedBuilder, loc, vectorTy32, input,
+                                  inputVectorMap,
                                   ValueRange{ivs[0], ivs[1], ivs[2], iv});
                           // Define AffineMap.
                           // The `outputVector` and `resultVector` share the
@@ -125,52 +127,53 @@ void populateCBSplitingPattern(Operation *op, int64_t stride,
                               /*dimCount=*/2, /*symbolCount=*/0,
                               {x, y * stride}, ctx);
                           Value outputVector =
-                              nestedBuilder.create<affine::AffineVectorLoadOp>(
-                                  loc, vectorTy32, output, outputVectorMap,
-                                  ValueRange{ivs[0], iv});
+                              affine::AffineVectorLoadOp::create(
+                                  nestedBuilder, loc, vectorTy32, output,
+                                  outputVectorMap, ValueRange{ivs[0], iv});
                           // FMA = Fused Multiply + Add
-                          Value resultVector = nestedBuilder.create<FMAOp>(
-                              loc, inputVector, kernelVector, outputVector);
-                          nestedBuilder.create<affine::AffineVectorStoreOp>(
-                              loc, resultVector, output, outputVectorMap,
-                              ValueRange{ivs[0], iv});
-                          builder.create<scf::YieldOp>(loc);
+                          Value resultVector =
+                              FMAOp::create(nestedBuilder, loc, inputVector,
+                                            kernelVector, outputVector);
+                          affine::AffineVectorStoreOp::create(
+                              nestedBuilder, loc, resultVector, output,
+                              outputVectorMap, ValueRange{ivs[0], iv});
+                          scf::YieldOp::create(builder, loc);
                         },
                         // The else branch (the current column reaches the
                         // tail).
                         [&](OpBuilder &builder, Location loc) {
                           // Create mask according to the tail.
-                          Value tailMask = builder.create<CreateMaskOp>(
-                              loc, vectorMaskTy, tail);
+                          Value tailMask = CreateMaskOp::create(
+                              builder, loc, vectorMaskTy, tail);
                           // Calculate the index of the input and output.
-                          Value inputRow = nestedBuilder.create<arith::AddIOp>(
-                              loc, ivs[0], ivs[1]);
-                          Value outputCol = nestedBuilder.create<arith::MulIOp>(
-                              loc, iv, cStride);
-                          Value inputCol = nestedBuilder.create<arith::AddIOp>(
-                              loc, ivs[2], outputCol);
+                          Value inputRow = arith::AddIOp::create(
+                              nestedBuilder, loc, ivs[0], ivs[1]);
+                          Value outputCol = arith::MulIOp::create(
+                              nestedBuilder, loc, iv, cStride);
+                          Value inputCol = arith::AddIOp::create(
+                              nestedBuilder, loc, ivs[2], outputCol);
                           // Masked load input and output.
-                          Value maskedInputVec = builder.create<MaskedLoadOp>(
-                              loc, vectorTy32, input,
+                          Value maskedInputVec = MaskedLoadOp::create(
+                              builder, loc, vectorTy32, input,
                               ValueRange{inputRow, inputCol}, tailMask,
                               passThroughVec);
-                          Value maskedOutputVec = builder.create<MaskedLoadOp>(
-                              loc, vectorTy32, output,
+                          Value maskedOutputVec = MaskedLoadOp::create(
+                              builder, loc, vectorTy32, output,
                               ValueRange{ivs[0], outputCol}, tailMask,
                               passThroughVec);
                           // FMA.
-                          Value resultVec = builder.create<FMAOp>(
-                              loc, maskedInputVec, kernelVector,
-                              maskedOutputVec);
+                          Value resultVec =
+                              FMAOp::create(builder, loc, maskedInputVec,
+                                            kernelVector, maskedOutputVec);
                           // Masked store the result to output.
-                          builder.create<MaskedStoreOp>(
-                              loc, output, ValueRange{ivs[0], outputCol},
-                              tailMask, resultVec);
-                          builder.create<scf::YieldOp>(loc);
+                          MaskedStoreOp::create(builder, loc, output,
+                                                ValueRange{ivs[0], outputCol},
+                                                tailMask, resultVec);
+                          scf::YieldOp::create(builder, loc);
                         });
-                    builder.create<scf::YieldOp>(loc);
+                    scf::YieldOp::create(builder, loc);
                   });
-              nestedBuilder.create<affine::AffineYieldOp>(nestedLoc);
+              affine::AffineYieldOp::create(nestedBuilder, nestedLoc);
             });
       });
   // Remove the origin convolution operation.
@@ -189,18 +192,18 @@ void populateCBTilingPattern(Operation *op, ArrayRef<int64_t> tileSizes,
   // 2D vector type.
   VectorType vectorTy32 = mlir::VectorType::get(tileSizes, f32);
   // Create constant index.
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+  Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
   // Get input, kernel and output.
   Value input = op->getOperand(0);
   Value kernel = op->getOperand(1);
   Value output = op->getOperand(2);
   // Create DimOp.
-  Value kernelRow = rewriter.create<memref::DimOp>(loc, kernel, c0);
-  Value kernelCol = rewriter.create<memref::DimOp>(loc, kernel, c1);
+  Value kernelRow = memref::DimOp::create(rewriter, loc, kernel, c0);
+  Value kernelCol = memref::DimOp::create(rewriter, loc, kernel, c1);
   // Define padding value.
-  Value f0 = rewriter.create<arith::ConstantFloatOp>(
-      loc, f32, APFloat::getZero(f32.getFloatSemantics()));
+  Value f0 = arith::ConstantFloatOp::create(
+      rewriter, loc, f32, APFloat::getZero(f32.getFloatSemantics()));
   // Size of strip mining.
   AffineExpr d0;
   bindDims(ctx, d0);
@@ -212,21 +215,21 @@ void populateCBTilingPattern(Operation *op, ArrayRef<int64_t> tileSizes,
       [&](OpBuilder &builder, Location loc, ValueRange ivs) {
         // Vectorize the kernel.
         // Broadcast element of the kernel into 2D vector.
-        Value kernelValue = builder.create<affine::AffineVectorLoadOp>(
-            loc, vectorTy1, kernel, ValueRange{ivs[0], ivs[1]});
+        Value kernelValue = affine::AffineVectorLoadOp::create(
+            builder, loc, vectorTy1, kernel, ValueRange{ivs[0], ivs[1]});
         Value kernelVector =
-            builder.create<vector::BroadcastOp>(loc, vectorTy32, kernelValue);
+            vector::BroadcastOp::create(builder, loc, vectorTy32, kernelValue);
         // Load input and output as 2D vector.
-        Value inputVector = builder.create<TransferReadOp>(
-            loc, vectorTy32, input, ValueRange{ivs[0], ivs[1]}, f0);
-        Value outputVector = builder.create<TransferReadOp>(
-            loc, vectorTy32, output, ValueRange{c0, c0}, f0);
+        Value inputVector = TransferReadOp::create(
+            builder, loc, vectorTy32, input, ValueRange{ivs[0], ivs[1]}, f0);
+        Value outputVector = TransferReadOp::create(
+            builder, loc, vectorTy32, output, ValueRange{c0, c0}, f0);
         // FMA.
-        Value resultVector =
-            builder.create<FMAOp>(loc, inputVector, kernelVector, outputVector);
+        Value resultVector = FMAOp::create(builder, loc, inputVector,
+                                           kernelVector, outputVector);
         // 2D vector write back to memory.
-        builder.create<TransferWriteOp>(loc, resultVector, output,
-                                        ValueRange{c0, c0});
+        TransferWriteOp::create(builder, loc, resultVector, output,
+                                ValueRange{c0, c0});
       });
   // Remove the origin convolution operation.
   rewriter.eraseOp(op);

--- a/midend/lib/Conversion/ConvVectorization/GEMMPointwiseConv2DNhwcHwcf.cpp
+++ b/midend/lib/Conversion/ConvVectorization/GEMMPointwiseConv2DNhwcHwcf.cpp
@@ -92,20 +92,21 @@ public:
         RankedTensorType::get({outputShape[1] * outputShape[2], outputShape[3]},
                               outputShapeType.getElementType());
 
-    Value reshapedInput = rewriter.create<tensor::CollapseShapeOp>(
-        loc, reshapedInputType, input, reassociationIndices);
-    Value reshapedFilter = rewriter.create<tensor::CollapseShapeOp>(
-        loc, reshapedFilterType, kernel, reassociationIndices);
-    Value reshapedOutput = rewriter.create<tensor::CollapseShapeOp>(
-        loc, reshapedOutputType, output, reassociationIndices);
+    Value reshapedInput = tensor::CollapseShapeOp::create(
+        rewriter, loc, reshapedInputType, input, reassociationIndices);
+    Value reshapedFilter = tensor::CollapseShapeOp::create(
+        rewriter, loc, reshapedFilterType, kernel, reassociationIndices);
+    Value reshapedOutput = tensor::CollapseShapeOp::create(
+        rewriter, loc, reshapedOutputType, output, reassociationIndices);
 
     // Create MutmulOp
-    auto matmulResult = rewriter.create<linalg::MatmulOp>(
-        loc, reshapedOutputType, ArrayRef<Value>{reshapedInput, reshapedFilter},
-        ArrayRef<Value>{reshapedOutput});
+    auto matmulResult =
+        linalg::MatmulOp::create(rewriter, loc, reshapedOutputType,
+                                 ArrayRef<Value>{reshapedInput, reshapedFilter},
+                                 ArrayRef<Value>{reshapedOutput});
 
-    auto reshapedResult = rewriter.create<tensor::ExpandShapeOp>(
-        loc, outputShapeType, matmulResult.getResults()[0],
+    auto reshapedResult = tensor::ExpandShapeOp::create(
+        rewriter, loc, outputShapeType, matmulResult.getResults()[0],
         reassociationIndices);
 
     // Remove the origin convolution operation.

--- a/midend/lib/Conversion/ConvVectorization/PoolingNhwcMaxVectorization.cpp
+++ b/midend/lib/Conversion/ConvVectorization/PoolingNhwcMaxVectorization.cpp
@@ -94,8 +94,8 @@ public:
     }
     bool stride1 = strides[0] != 1;
     bool stride2 = strides[1] != 1;
-    Value strHeight = rewriter.create<arith::ConstantIndexOp>(loc, strides[0]);
-    Value strWidth = rewriter.create<arith::ConstantIndexOp>(loc, strides[1]);
+    Value strHeight = arith::ConstantIndexOp::create(rewriter, loc, strides[0]);
+    Value strWidth = arith::ConstantIndexOp::create(rewriter, loc, strides[1]);
 
     // // Get dilations.
     SmallVector<int64_t, 2> dilations = {1, 1};
@@ -111,8 +111,9 @@ public:
     bool dilated1 = dilations[0] != 1;
     bool dilated2 = dilations[1] != 1;
     Value dilHeight =
-        rewriter.create<arith::ConstantIndexOp>(loc, dilations[0]);
-    Value dilWidth = rewriter.create<arith::ConstantIndexOp>(loc, dilations[1]);
+        arith::ConstantIndexOp::create(rewriter, loc, dilations[0]);
+    Value dilWidth =
+        arith::ConstantIndexOp::create(rewriter, loc, dilations[1]);
 
     // Get ElementType of input.
     Type elementTy =
@@ -120,34 +121,35 @@ public:
     VectorType vectorTy = mlir::VectorType::get({strip}, elementTy);
 
     // Get Constants.
-    const Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    const Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    const Value c2 = rewriter.create<arith::ConstantIndexOp>(loc, 2);
-    const Value c3 = rewriter.create<arith::ConstantIndexOp>(loc, 3);
-    const Value vlStep = rewriter.create<arith::ConstantIndexOp>(loc, strip);
+    const Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    const Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    const Value c2 = arith::ConstantIndexOp::create(rewriter, loc, 2);
+    const Value c3 = arith::ConstantIndexOp::create(rewriter, loc, 3);
+    const Value vlStep = arith::ConstantIndexOp::create(rewriter, loc, strip);
     const Value zero =
         buddy::insertZeroConstantOp(ctx, rewriter, loc, elementTy);
 
     // Create pass through vector.
     Value passThroughVec =
-        rewriter.create<vector::BroadcastOp>(loc, vectorTy, zero);
+        vector::BroadcastOp::create(rewriter, loc, vectorTy, zero);
 
     // Get Dimensions of Kernel.
-    Value kernelHeight = rewriter.create<memref::DimOp>(loc, kernel, c0);
-    Value kernelWidth = rewriter.create<memref::DimOp>(loc, kernel, c1);
+    Value kernelHeight = memref::DimOp::create(rewriter, loc, kernel, c0);
+    Value kernelWidth = memref::DimOp::create(rewriter, loc, kernel, c1);
 
     // Get Dimensions of Outputs.
-    Value batch = rewriter.create<memref::DimOp>(loc, output, c0);
-    Value height = rewriter.create<memref::DimOp>(loc, output, c1);
-    Value width = rewriter.create<memref::DimOp>(loc, output, c2);
-    Value channels = rewriter.create<memref::DimOp>(loc, output, c3);
+    Value batch = memref::DimOp::create(rewriter, loc, output, c0);
+    Value height = memref::DimOp::create(rewriter, loc, output, c1);
+    Value width = memref::DimOp::create(rewriter, loc, output, c2);
+    Value channels = memref::DimOp::create(rewriter, loc, output, c3);
 
     // Calculate the upper bound for vectorized processing
     // - Subtract `vlStep` is to avoid overflow at the vectorization tail.
     // - Add 1 to ensure the final loop runs when the workload length
     //   is divisible by the vector size.
-    Value upperBoundTmp = rewriter.create<arith::SubIOp>(loc, channels, vlStep);
-    Value upperBound = rewriter.create<arith::AddIOp>(loc, upperBoundTmp, c1);
+    Value upperBoundTmp =
+        arith::SubIOp::create(rewriter, loc, channels, vlStep);
+    Value upperBound = arith::AddIOp::create(rewriter, loc, upperBoundTmp, c1);
 
     SmallVector<Value, 8> lowerBounds(3, c0);
     SmallVector<Value, 8> uperBounds{batch, height, width};
@@ -158,24 +160,25 @@ public:
           // Create strides variables.
           Value tmpIvs1 = ivs[1];
           if (stride1) {
-            tmpIvs1 = builder.create<arith::MulIOp>(loc, ivs[1], strHeight);
+            tmpIvs1 = arith::MulIOp::create(builder, loc, ivs[1], strHeight);
           }
           Value tmpIvs2 = ivs[2];
           if (stride2) {
-            tmpIvs2 = builder.create<arith::MulIOp>(loc, ivs[2], strWidth);
+            tmpIvs2 = arith::MulIOp::create(builder, loc, ivs[2], strWidth);
           }
           // Create strip mining loop.
-          auto iterIdx = builder.create<scf::ForOp>(
-              loc, c0, upperBound, /*Step=*/vlStep, ValueRange{c0},
+          auto iterIdx = scf::ForOp::create(
+              builder, loc, c0, upperBound, /*Step=*/vlStep, ValueRange{c0},
               [&](OpBuilder &nestedBuilder, Location nestedLoc, Value iv,
                   ValueRange itrArgs) {
-                Value outputVector = nestedBuilder.create<vector::LoadOp>(
-                    loc, vectorTy, output,
+                Value outputVector = vector::LoadOp::create(
+                    nestedBuilder, loc, vectorTy, output,
                     ValueRange{ivs[0], ivs[1], ivs[2], iv});
 
-                auto tmp0 = nestedBuilder.create<affine::AffineForOp>(
-                    loc, ValueRange{c0}, builder.getDimIdentityMap(),
-                    ValueRange{kernelHeight}, builder.getDimIdentityMap(),
+                auto tmp0 = affine::AffineForOp::create(
+                    nestedBuilder, loc, ValueRange{c0},
+                    builder.getDimIdentityMap(), ValueRange{kernelHeight},
+                    builder.getDimIdentityMap(),
                     /*Step=*/1, ValueRange{outputVector},
                     [&](OpBuilder &builder, Location loc, Value iv0,
                         ValueRange itrArgs0) {
@@ -183,121 +186,127 @@ public:
                       Value tmpIvs3 = iv0;
                       if (dilated1) {
                         tmpIvs3 =
-                            builder.create<arith::MulIOp>(loc, iv0, dilHeight);
+                            arith::MulIOp::create(builder, loc, iv0, dilHeight);
                       }
                       Value inputHeight =
-                          builder.create<arith::AddIOp>(loc, tmpIvs1, tmpIvs3);
-                      auto tmp1 = builder.create<affine::AffineForOp>(
-                          loc, ValueRange{c0}, builder.getDimIdentityMap(),
-                          ValueRange{kernelWidth}, builder.getDimIdentityMap(),
+                          arith::AddIOp::create(builder, loc, tmpIvs1, tmpIvs3);
+                      auto tmp1 = affine::AffineForOp::create(
+                          builder, loc, ValueRange{c0},
+                          builder.getDimIdentityMap(), ValueRange{kernelWidth},
+                          builder.getDimIdentityMap(),
                           /*Step=*/1, ValueRange{itrArgs0[0]},
                           [&](OpBuilder &builder, Location loc, Value iv1,
                               ValueRange itrArgs1) {
                             // Create dilated[1] variables.
                             Value tmpIvs4 = iv1;
                             if (dilated2) {
-                              tmpIvs4 = builder.create<arith::MulIOp>(loc, iv1,
-                                                                      dilWidth);
+                              tmpIvs4 = arith::MulIOp::create(builder, loc, iv1,
+                                                              dilWidth);
                             }
-                            Value inputWidth = builder.create<arith::AddIOp>(
-                                loc, tmpIvs2, tmpIvs4);
-                            Value inputVector = builder.create<vector::LoadOp>(
-                                loc, vectorTy, input,
+                            Value inputWidth = arith::AddIOp::create(
+                                builder, loc, tmpIvs2, tmpIvs4);
+                            Value inputVector = vector::LoadOp::create(
+                                builder, loc, vectorTy, input,
                                 ValueRange{ivs[0], inputHeight, inputWidth,
                                            iv});
                             // Max
                             Value resultVector;
                             if (auto ty =
                                     llvm::dyn_cast<IntegerType>(elementTy)) {
-                              resultVector = builder.create<arith::MaxSIOp>(
-                                  loc, inputVector, itrArgs1[0]);
+                              resultVector = arith::MaxSIOp::create(
+                                  builder, loc, inputVector, itrArgs1[0]);
                             } else {
-                              resultVector = builder.create<arith::MaximumFOp>(
-                                  loc, inputVector, itrArgs1[0]);
+                              resultVector = arith::MaximumFOp::create(
+                                  builder, loc, inputVector, itrArgs1[0]);
                             }
-                            builder.create<affine::AffineYieldOp>(loc,
-                                                                  resultVector);
+                            affine::AffineYieldOp::create(builder, loc,
+                                                          resultVector);
                           });
-                      nestedBuilder.create<affine::AffineYieldOp>(
-                          loc, tmp1.getResult(0));
+                      affine::AffineYieldOp::create(nestedBuilder, loc,
+                                                    tmp1.getResult(0));
                     });
-                builder.create<vector::StoreOp>(
-                    loc, tmp0.getResult(0), output,
-                    ValueRange{ivs[0], ivs[1], ivs[2], iv});
+                vector::StoreOp::create(builder, loc, tmp0.getResult(0), output,
+                                        ValueRange{ivs[0], ivs[1], ivs[2], iv});
                 Value idx =
-                    builder.create<arith::AddIOp>(loc, itrArgs[0], vlStep);
-                builder.create<scf::YieldOp>(loc, idx);
+                    arith::AddIOp::create(builder, loc, itrArgs[0], vlStep);
+                scf::YieldOp::create(builder, loc, idx);
               });
           // Compute the tail size and Process the remaining elements
           // using masked vector operations.
           Value idx = iterIdx.getResult(0);
-          Value tailSize = builder.create<arith::SubIOp>(loc, channels, idx);
-          Value tailCond = rewriter.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::sgt, tailSize, c0);
+          Value tailSize = arith::SubIOp::create(builder, loc, channels, idx);
+          Value tailCond = arith::CmpIOp::create(
+              rewriter, loc, arith::CmpIPredicate::sgt, tailSize, c0);
           // If the current column does not reach the tail.
-          builder.create<
-              scf::IfOp>(loc, tailCond, [&](OpBuilder &builder, Location loc) {
-            // Create mask according to the tail.
-            Value tailMask =
-                builder.create<CreateMaskOp>(loc, vectorMaskTy, tailSize);
-            // Masked load output.
-            Value maskedOutputVec = builder.create<MaskedLoadOp>(
-                loc, vectorTy, output, ValueRange{ivs[0], ivs[1], ivs[2], idx},
-                tailMask, passThroughVec);
-            auto tmp0 = builder.create<affine::AffineForOp>(
-                loc, ValueRange{c0}, builder.getDimIdentityMap(),
-                ValueRange{kernelHeight}, builder.getDimIdentityMap(),
-                /*Step=*/1, ValueRange{maskedOutputVec},
-                [&](OpBuilder &builder, Location loc, Value iv0,
-                    ValueRange itrArgs0) {
-                  // Create dilated[0] variables.
-                  Value tmpIvs3 = iv0;
-                  if (dilated1) {
-                    tmpIvs3 =
-                        builder.create<arith::MulIOp>(loc, iv0, dilHeight);
-                  }
-                  Value inputHeight =
-                      builder.create<arith::AddIOp>(loc, tmpIvs1, tmpIvs3);
-                  auto tmp1 = builder.create<affine::AffineForOp>(
-                      loc, ValueRange{c0}, builder.getDimIdentityMap(),
-                      ValueRange{kernelWidth}, builder.getDimIdentityMap(),
-                      /*Step=*/1, ValueRange{itrArgs0[0]},
-                      [&](OpBuilder &builder, Location loc, Value iv1,
-                          ValueRange itrArgs1) {
-                        // Calculate the index of the input and
-                        // output.
-                        // Create dilated[1] variables.
-                        Value tmpIvs4 = iv1;
-                        if (dilated2) {
-                          tmpIvs4 =
-                              builder.create<arith::MulIOp>(loc, iv1, dilWidth);
-                        }
-                        Value inputWidth =
-                            builder.create<arith::AddIOp>(loc, iv1, tmpIvs2);
-                        // Masked load input and output.
-                        Value maskedInputVec = builder.create<MaskedLoadOp>(
-                            loc, vectorTy, input,
-                            ValueRange{ivs[0], inputHeight, inputWidth, idx},
-                            tailMask, passThroughVec);
-                        // Max
-                        Value resultVec;
-                        if (auto ty = llvm::dyn_cast<IntegerType>(elementTy)) {
-                          resultVec = builder.create<arith::MaxSIOp>(
-                              loc, maskedInputVec, itrArgs1[0]);
-                        } else {
-                          resultVec = builder.create<arith::MaximumFOp>(
-                              loc, maskedInputVec, itrArgs1[0]);
-                        }
-                        builder.create<affine::AffineYieldOp>(loc, resultVec);
-                      });
-                  builder.create<affine::AffineYieldOp>(loc, tmp1.getResult(0));
-                });
-            // Masked store the result to output.
-            builder.create<MaskedStoreOp>(
-                loc, output, ValueRange{ivs[0], ivs[1], ivs[2], idx}, tailMask,
-                tmp0.getResult(0));
-            builder.create<scf::YieldOp>(loc);
-          });
+          scf::IfOp::create(
+              builder, loc, tailCond, [&](OpBuilder &builder, Location loc) {
+                // Create mask according to the tail.
+                Value tailMask =
+                    CreateMaskOp::create(builder, loc, vectorMaskTy, tailSize);
+                // Masked load output.
+                Value maskedOutputVec = MaskedLoadOp::create(
+                    builder, loc, vectorTy, output,
+                    ValueRange{ivs[0], ivs[1], ivs[2], idx}, tailMask,
+                    passThroughVec);
+                auto tmp0 = affine::AffineForOp::create(
+                    builder, loc, ValueRange{c0}, builder.getDimIdentityMap(),
+                    ValueRange{kernelHeight}, builder.getDimIdentityMap(),
+                    /*Step=*/1, ValueRange{maskedOutputVec},
+                    [&](OpBuilder &builder, Location loc, Value iv0,
+                        ValueRange itrArgs0) {
+                      // Create dilated[0] variables.
+                      Value tmpIvs3 = iv0;
+                      if (dilated1) {
+                        tmpIvs3 =
+                            arith::MulIOp::create(builder, loc, iv0, dilHeight);
+                      }
+                      Value inputHeight =
+                          arith::AddIOp::create(builder, loc, tmpIvs1, tmpIvs3);
+                      auto tmp1 = affine::AffineForOp::create(
+                          builder, loc, ValueRange{c0},
+                          builder.getDimIdentityMap(), ValueRange{kernelWidth},
+                          builder.getDimIdentityMap(),
+                          /*Step=*/1, ValueRange{itrArgs0[0]},
+                          [&](OpBuilder &builder, Location loc, Value iv1,
+                              ValueRange itrArgs1) {
+                            // Calculate the index of the input and
+                            // output.
+                            // Create dilated[1] variables.
+                            Value tmpIvs4 = iv1;
+                            if (dilated2) {
+                              tmpIvs4 = arith::MulIOp::create(builder, loc, iv1,
+                                                              dilWidth);
+                            }
+                            Value inputWidth = arith::AddIOp::create(
+                                builder, loc, iv1, tmpIvs2);
+                            // Masked load input and output.
+                            Value maskedInputVec = MaskedLoadOp::create(
+                                builder, loc, vectorTy, input,
+                                ValueRange{ivs[0], inputHeight, inputWidth,
+                                           idx},
+                                tailMask, passThroughVec);
+                            // Max
+                            Value resultVec;
+                            if (auto ty =
+                                    llvm::dyn_cast<IntegerType>(elementTy)) {
+                              resultVec = arith::MaxSIOp::create(
+                                  builder, loc, maskedInputVec, itrArgs1[0]);
+                            } else {
+                              resultVec = arith::MaximumFOp::create(
+                                  builder, loc, maskedInputVec, itrArgs1[0]);
+                            }
+                            affine::AffineYieldOp::create(builder, loc,
+                                                          resultVec);
+                          });
+                      affine::AffineYieldOp::create(builder, loc,
+                                                    tmp1.getResult(0));
+                    });
+                // Masked store the result to output.
+                MaskedStoreOp::create(builder, loc, output,
+                                      ValueRange{ivs[0], ivs[1], ivs[2], idx},
+                                      tailMask, tmp0.getResult(0));
+                scf::YieldOp::create(builder, loc);
+              });
         });
     // Remove the origin convolution operation.
     rewriter.eraseOp(op);

--- a/midend/lib/Conversion/ConvVectorization/PoolingVectorization.cpp
+++ b/midend/lib/Conversion/ConvVectorization/PoolingVectorization.cpp
@@ -70,20 +70,20 @@ public:
     // Element type.
     FloatType fTy = dyn_cast<FloatType>(inputMemRefTy.getElementType());
     // Constants.
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    Value c2 = rewriter.create<arith::ConstantIndexOp>(loc, 2);
-    Value c3 = rewriter.create<arith::ConstantIndexOp>(loc, 3);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    Value c2 = arith::ConstantIndexOp::create(rewriter, loc, 2);
+    Value c3 = arith::ConstantIndexOp::create(rewriter, loc, 3);
     // Dimensions of the input.
-    Value batch = rewriter.create<memref::DimOp>(loc, input, c0);
-    Value height = rewriter.create<memref::DimOp>(loc, input, c1);
-    Value width = rewriter.create<memref::DimOp>(loc, input, c2);
-    Value channels = rewriter.create<memref::DimOp>(loc, input, c3);
+    Value batch = memref::DimOp::create(rewriter, loc, input, c0);
+    Value height = memref::DimOp::create(rewriter, loc, input, c1);
+    Value width = memref::DimOp::create(rewriter, loc, input, c2);
+    Value channels = memref::DimOp::create(rewriter, loc, input, c3);
     // Strides.
     auto strides = op->getAttrOfType<mlir::DenseIntElementsAttr>("strides")
                        .getValues<int64_t>();
-    Value strHeight = rewriter.create<arith::ConstantIndexOp>(loc, strides[0]);
-    Value strWidth = rewriter.create<arith::ConstantIndexOp>(loc, strides[1]);
+    Value strHeight = arith::ConstantIndexOp::create(rewriter, loc, strides[0]);
+    Value strWidth = arith::ConstantIndexOp::create(rewriter, loc, strides[1]);
     // Dilations.
     auto dilations = op->getAttrOfType<mlir::DenseIntElementsAttr>("dilations")
                          .getValues<int64_t>();
@@ -104,19 +104,20 @@ public:
       return failure();
     }
     // Pooling window shape.
-    Value winHeight = rewriter.create<arith::ConstantIndexOp>(
-        loc, dilations[0] * (kernelShape[0] - 1) + 1);
-    Value winWidth = rewriter.create<arith::ConstantIndexOp>(
-        loc, dilations[1] * (kernelShape[1] - 1) + 1);
+    Value winHeight = arith::ConstantIndexOp::create(
+        rewriter, loc, dilations[0] * (kernelShape[0] - 1) + 1);
+    Value winWidth = arith::ConstantIndexOp::create(
+        rewriter, loc, dilations[1] * (kernelShape[1] - 1) + 1);
     // Output shape.
-    Value w0 = rewriter.create<arith::SubIOp>(loc, height, winHeight);
-    Value w1 = rewriter.create<arith::SubIOp>(loc, width, winWidth);
-    Value ubHeight = rewriter.create<arith::AddIOp>(loc, w0, strHeight);
-    Value ubWidth = rewriter.create<arith::AddIOp>(loc, w1, strWidth);
+    Value w0 = arith::SubIOp::create(rewriter, loc, height, winHeight);
+    Value w1 = arith::SubIOp::create(rewriter, loc, width, winWidth);
+    Value ubHeight = arith::AddIOp::create(rewriter, loc, w0, strHeight);
+    Value ubWidth = arith::AddIOp::create(rewriter, loc, w1, strWidth);
     // Kernel width.
     Value kHeight =
-        rewriter.create<arith::ConstantIndexOp>(loc, kernelShape[0]);
-    Value kWidth = rewriter.create<arith::ConstantIndexOp>(loc, kernelShape[1]);
+        arith::ConstantIndexOp::create(rewriter, loc, kernelShape[0]);
+    Value kWidth =
+        arith::ConstantIndexOp::create(rewriter, loc, kernelShape[1]);
     // Kernel size.
     int64_t kSize = kernelShape[0] * kernelShape[1];
     // Vector type.
@@ -127,7 +128,7 @@ public:
     SmallVector<Value, 4> steps{c1, strHeight, strWidth, c1};
     // Allocate pooling window.
     Value window =
-        rewriter.create<memref::AllocOp>(loc, MemRefType::get({kSize}, fTy));
+        memref::AllocOp::create(rewriter, loc, MemRefType::get({kSize}, fTy));
     if (dilated) {
       mlir::scf::buildLoopNest(
           rewriter, loc, lowerBounds, upperBounds, steps, {},
@@ -135,14 +136,14 @@ public:
               ValueRange args) -> scf::ValueVector {
             // Dialtions.
             Value dilHeight =
-                rewriter.create<arith::ConstantIndexOp>(loc, dilations[0]);
+                arith::ConstantIndexOp::create(rewriter, loc, dilations[0]);
             Value dilWidth =
-                rewriter.create<arith::ConstantIndexOp>(loc, dilations[1]);
+                arith::ConstantIndexOp::create(rewriter, loc, dilations[1]);
             SmallVector<Value, 2> nestedLowerBounds{ivs[1], ivs[2]};
             Value uHeight =
-                rewriter.create<arith::AddIOp>(loc, ivs[1], winHeight);
+                arith::AddIOp::create(rewriter, loc, ivs[1], winHeight);
             Value uWidth =
-                rewriter.create<arith::AddIOp>(loc, ivs[2], winWidth);
+                arith::AddIOp::create(rewriter, loc, ivs[2], winWidth);
             SmallVector<Value, 2> nestedUpperBounds{uHeight, uWidth};
             SmallVector<Value, 2> nestedSteps{dilHeight, dilWidth};
             mlir::scf::buildLoopNest(
@@ -152,37 +153,37 @@ public:
                     ValueRange nestedIvs,
                     ValueRange nestedArgs) -> scf::ValueVector {
                   // Load value from pooling window.
-                  Value val = builder.create<memref::LoadOp>(
-                      loc, input,
+                  Value val = memref::LoadOp::create(
+                      builder, loc, input,
                       ValueRange{ivs[0], nestedIvs[0], nestedIvs[1], ivs[3]});
                   // Compute index.
                   Value i0 =
-                      builder.create<arith::SubIOp>(loc, nestedIvs[0], ivs[1]);
-                  Value i = builder.create<arith::DivUIOp>(loc, i0, dilHeight);
+                      arith::SubIOp::create(builder, loc, nestedIvs[0], ivs[1]);
+                  Value i = arith::DivUIOp::create(builder, loc, i0, dilHeight);
                   Value j0 =
-                      builder.create<arith::SubIOp>(loc, nestedIvs[1], ivs[2]);
-                  Value j = builder.create<arith::DivUIOp>(loc, j0, dilWidth);
-                  Value index0 = builder.create<arith::MulIOp>(loc, i, kWidth);
-                  Value index = builder.create<arith::AddIOp>(loc, index0, j);
+                      arith::SubIOp::create(builder, loc, nestedIvs[1], ivs[2]);
+                  Value j = arith::DivUIOp::create(builder, loc, j0, dilWidth);
+                  Value index0 = arith::MulIOp::create(builder, loc, i, kWidth);
+                  Value index = arith::AddIOp::create(builder, loc, index0, j);
                   // Store value into memref.
-                  builder.create<memref::StoreOp>(loc, val, window, index);
+                  memref::StoreOp::create(builder, loc, val, window, index);
                   return {};
                 });
             // Load into a vector.
-            Value vec = rewriter.create<vector::TransferReadOp>(
-                loc, vecTy, window, ValueRange{c0},
+            Value vec = vector::TransferReadOp::create(
+                rewriter, loc, vecTy, window, ValueRange{c0},
                 /*padding=*/nullptr, /*inBounds=*/nullptr, /*mask=*/nullptr);
             // Reduce vector.
-            Value res = rewriter.create<vector::ReductionOp>(
-                loc, vector::CombiningKind::ADD, vec);
+            Value res = vector::ReductionOp::create(
+                rewriter, loc, vector::CombiningKind::ADD, vec);
             // Output indices.
             Value outHeight =
-                rewriter.create<arith::DivUIOp>(loc, ivs[1], strHeight);
+                arith::DivUIOp::create(rewriter, loc, ivs[1], strHeight);
             Value outWidth =
-                rewriter.create<arith::DivUIOp>(loc, ivs[2], strWidth);
+                arith::DivUIOp::create(rewriter, loc, ivs[2], strWidth);
             // Store value into output.
-            rewriter.create<memref::StoreOp>(
-                loc, res, output,
+            memref::StoreOp::create(
+                rewriter, loc, res, output,
                 ValueRange{ivs[0], outHeight, outWidth, ivs[3]});
             return {};
           });
@@ -193,8 +194,8 @@ public:
               ValueRange args) -> scf::ValueVector {
             SmallVector<Value, 2> nestedLowerBounds{ivs[1], ivs[2]};
             Value uHeight =
-                rewriter.create<arith::AddIOp>(loc, ivs[1], kHeight);
-            Value uWidth = rewriter.create<arith::AddIOp>(loc, ivs[2], kWidth);
+                arith::AddIOp::create(rewriter, loc, ivs[1], kHeight);
+            Value uWidth = arith::AddIOp::create(rewriter, loc, ivs[2], kWidth);
             SmallVector<Value, 2> nestedUpperBounds{uHeight, uWidth};
             SmallVector<Value, 2> nestedSteps{c1, c1};
             mlir::scf::buildLoopNest(
@@ -204,41 +205,41 @@ public:
                     ValueRange nestedIvs,
                     ValueRange nestedArgs) -> scf::ValueVector {
                   // Load value from pooling window.
-                  Value val = builder.create<memref::LoadOp>(
-                      loc, input,
+                  Value val = memref::LoadOp::create(
+                      builder, loc, input,
                       ValueRange{ivs[0], nestedIvs[0], nestedIvs[1], ivs[3]});
                   // Compute index.
                   Value i =
-                      builder.create<arith::SubIOp>(loc, nestedIvs[0], ivs[1]);
+                      arith::SubIOp::create(builder, loc, nestedIvs[0], ivs[1]);
                   Value j =
-                      builder.create<arith::SubIOp>(loc, nestedIvs[1], ivs[2]);
-                  Value index0 = builder.create<arith::MulIOp>(loc, i, kWidth);
-                  Value index = builder.create<arith::AddIOp>(loc, index0, j);
+                      arith::SubIOp::create(builder, loc, nestedIvs[1], ivs[2]);
+                  Value index0 = arith::MulIOp::create(builder, loc, i, kWidth);
+                  Value index = arith::AddIOp::create(builder, loc, index0, j);
                   // Store value into memref.
-                  builder.create<memref::StoreOp>(loc, val, window, index);
+                  memref::StoreOp::create(builder, loc, val, window, index);
                   return {};
                 });
             // Load into a vector.
-            Value vec = rewriter.create<vector::TransferReadOp>(
-                loc, vecTy, window, ValueRange{c0},
+            Value vec = vector::TransferReadOp::create(
+                rewriter, loc, vecTy, window, ValueRange{c0},
                 /*padding=*/nullptr, /*inBounds=*/nullptr, /*mask=*/nullptr);
             // Reduce vector.
-            Value res = rewriter.create<vector::ReductionOp>(
-                loc, vector::CombiningKind::ADD, vec);
+            Value res = vector::ReductionOp::create(
+                rewriter, loc, vector::CombiningKind::ADD, vec);
             // Output indices.
             Value outHeight =
-                rewriter.create<arith::DivUIOp>(loc, ivs[1], strHeight);
+                arith::DivUIOp::create(rewriter, loc, ivs[1], strHeight);
             Value outWidth =
-                rewriter.create<arith::DivUIOp>(loc, ivs[2], strWidth);
+                arith::DivUIOp::create(rewriter, loc, ivs[2], strWidth);
             // Store value into output.
-            rewriter.create<memref::StoreOp>(
-                loc, res, output,
+            memref::StoreOp::create(
+                rewriter, loc, res, output,
                 ValueRange{ivs[0], outHeight, outWidth, ivs[3]});
             return {};
           });
     }
     // Deallocate pooling window.
-    rewriter.create<memref::DeallocOp>(loc, window);
+    memref::DeallocOp::create(rewriter, loc, window);
     // Remove the origin pooling operation.
     rewriter.eraseOp(op);
     return success();

--- a/midend/lib/Conversion/DAPVectorization/DAPVectorization.cpp
+++ b/midend/lib/Conversion/DAPVectorization/DAPVectorization.cpp
@@ -60,18 +60,18 @@ public:
     Value kernel = op->getOperand(1);
     Value output = op->getOperand(2);
 
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-    Value c2 = rewriter.create<ConstantIndexOp>(loc, 2);
+    Value c0 = ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = ConstantIndexOp::create(rewriter, loc, 1);
+    Value c2 = ConstantIndexOp::create(rewriter, loc, 2);
 
     // 1. Get the total length of the workload.
-    Value inputSize = rewriter.create<memref::DimOp>(loc, input, c0);
-    Value kernelSize = rewriter.create<memref::DimOp>(loc, kernel, c0);
+    Value inputSize = memref::DimOp::create(rewriter, loc, input, c0);
+    Value kernelSize = memref::DimOp::create(rewriter, loc, kernel, c0);
 
     // 2. Set the iteration step (tile size and vector size).
-    Value tileStep = rewriter.create<ConstantIndexOp>(loc, 2048);
-    Value vlStep = rewriter.create<ConstantIndexOp>(loc, 16);
-    Value vlStepMinusOne = rewriter.create<arith::SubIOp>(loc, vlStep, c1);
+    Value tileStep = ConstantIndexOp::create(rewriter, loc, 2048);
+    Value vlStep = ConstantIndexOp::create(rewriter, loc, 16);
+    Value vlStepMinusOne = arith::SubIOp::create(rewriter, loc, vlStep, c1);
     FloatType f32 = Float32Type::get(ctx);
     VectorType vecTy = VectorType::get(16, f32);
 
@@ -81,107 +81,104 @@ public:
     // `lastKernelElementUsedInputSize` = `inputSize` - `kernelSize` + 1
     // `inputUpbound` = `lastKernelElementUsedInputSize` - `tileStep` + 1
     Value lastKernelElementUsedInputSize_ =
-        rewriter.create<arith::SubIOp>(loc, inputSize, kernelSize);
-    Value inputUpbound_ = rewriter.create<arith::SubIOp>(
-        loc, lastKernelElementUsedInputSize_, tileStep);
-    Value inputUpbound = rewriter.create<arith::AddIOp>(loc, inputUpbound_, c2);
+        arith::SubIOp::create(rewriter, loc, inputSize, kernelSize);
+    Value inputUpbound_ = arith::SubIOp::create(
+        rewriter, loc, lastKernelElementUsedInputSize_, tileStep);
+    Value inputUpbound =
+        arith::AddIOp::create(rewriter, loc, inputUpbound_, c2);
 
     Value inputOffset =
-        rewriter
-            .create<scf::ForOp>(
-                loc, c0, inputUpbound, tileStep, ValueRange{c0},
-                [&](OpBuilder &builder, Location loc, Value address,
-                    ValueRange iargs) {
-                  Value upbound =
-                      builder.create<arith::AddIOp>(loc, address, tileStep);
-                  // 3.2 Broadcast each kernel element to a vector.
-                  builder.create<scf::ForOp>(
-                      loc, c0, kernelSize, c1, ValueRange{},
-                      [&](OpBuilder &b, Location loc, Value iv_n,
-                          ValueRange iargs) {
-                        Value kElem =
-                            b.create<memref::LoadOp>(loc, kernel, iv_n);
-                        Value kVec =
-                            b.create<vector::BroadcastOp>(loc, vecTy, kElem);
-                        // 3.3 Vectorized computation.
-                        b.create<scf::ForOp>(
-                            loc, address, upbound, vlStep, ValueRange{},
-                            [&](OpBuilder &b, Location loc, Value iv_i,
-                                ValueRange iargs) {
-                              Value inVec = b.create<vector::LoadOp>(
-                                  loc, vecTy, input, ValueRange{iv_i});
-                              Value outOffset =
-                                  b.create<arith::AddIOp>(loc, iv_i, iv_n);
-                              Value outVec = b.create<vector::LoadOp>(
-                                  loc, vecTy, output, ValueRange{outOffset});
-                              Value fmaVec = b.create<vector::FMAOp>(
-                                  loc, kVec, inVec, outVec);
-                              b.create<vector::StoreOp>(loc, fmaVec, output,
-                                                        ValueRange{outOffset});
-                              b.create<scf::YieldOp>(loc);
-                            });
+        scf::ForOp::create(
+            rewriter, loc, c0, inputUpbound, tileStep, ValueRange{c0},
+            [&](OpBuilder &builder, Location loc, Value address,
+                ValueRange iargs) {
+              Value upbound =
+                  arith::AddIOp::create(builder, loc, address, tileStep);
+              // 3.2 Broadcast each kernel element to a vector.
+              scf::ForOp::create(
+                  builder, loc, c0, kernelSize, c1, ValueRange{},
+                  [&](OpBuilder &b, Location loc, Value iv_n,
+                      ValueRange iargs) {
+                    Value kElem = memref::LoadOp::create(b, loc, kernel, iv_n);
+                    Value kVec =
+                        vector::BroadcastOp::create(b, loc, vecTy, kElem);
+                    // 3.3 Vectorized computation.
+                    scf::ForOp::create(
+                        b, loc, address, upbound, vlStep, ValueRange{},
+                        [&](OpBuilder &b, Location loc, Value iv_i,
+                            ValueRange iargs) {
+                          Value inVec = vector::LoadOp::create(
+                              b, loc, vecTy, input, ValueRange{iv_i});
+                          Value outOffset =
+                              arith::AddIOp::create(b, loc, iv_i, iv_n);
+                          Value outVec = vector::LoadOp::create(
+                              b, loc, vecTy, output, ValueRange{outOffset});
+                          Value fmaVec = vector::FMAOp::create(b, loc, kVec,
+                                                               inVec, outVec);
+                          vector::StoreOp::create(b, loc, fmaVec, output,
+                                                  ValueRange{outOffset});
+                          scf::YieldOp::create(b, loc);
+                        });
 
-                        b.create<scf::YieldOp>(loc);
-                      });
-                  builder.create<scf::YieldOp>(loc, ValueRange{upbound});
-                })
+                    scf::YieldOp::create(b, loc);
+                  });
+              scf::YieldOp::create(builder, loc, ValueRange{upbound});
+            })
             .getResult(0);
 
     // 4. Calculate tail processing part.
     // 4.1 Calculate upbound for tail processing
-    Value tailUpbound_ = rewriter.create<arith::SubIOp>(loc, inputSize, vlStep);
+    Value tailUpbound_ =
+        arith::SubIOp::create(rewriter, loc, inputSize, vlStep);
     Value tailUpboundInit =
-        rewriter.create<arith::AddIOp>(loc, tailUpbound_, c1);
+        arith::AddIOp::create(rewriter, loc, tailUpbound_, c1);
 
     // 4.2 Loop through each kernel element.
-    rewriter.create<scf::ForOp>(
-        loc, c0, kernelSize, c1, ValueRange{tailUpboundInit},
+    scf::ForOp::create(
+        rewriter, loc, c0, kernelSize, c1, ValueRange{tailUpboundInit},
         [&](OpBuilder &builder, Location loc, Value iv_n, ValueRange iargs) {
-          Value kElem = builder.create<memref::LoadOp>(loc, kernel, iv_n);
-          Value kVec = builder.create<vector::BroadcastOp>(loc, vecTy, kElem);
+          Value kElem = memref::LoadOp::create(builder, loc, kernel, iv_n);
+          Value kVec = vector::BroadcastOp::create(builder, loc, vecTy, kElem);
 
           // 4.3 Perform the vectorization body (for tail process).
           Value iterIdx =
-              builder
-                  .create<scf::ForOp>(
-                      loc, inputOffset, iargs[0], vlStep,
-                      ValueRange{inputOffset},
-                      [&](OpBuilder &b, Location loc, Value iv_i,
-                          ValueRange iargs) {
-                        Value inVec = b.create<vector::LoadOp>(
-                            loc, vecTy, input, ValueRange{iv_i});
-                        Value outOffset =
-                            b.create<arith::AddIOp>(loc, iv_i, iv_n);
-                        Value outVec = b.create<vector::LoadOp>(
-                            loc, vecTy, output, ValueRange{outOffset});
-                        Value fmaVec =
-                            b.create<vector::FMAOp>(loc, kVec, inVec, outVec);
-                        b.create<vector::StoreOp>(loc, fmaVec, output,
-                                                  ValueRange{outOffset});
-                        Value iNext =
-                            b.create<arith::AddIOp>(loc, iv_i, vlStep);
-                        b.create<scf::YieldOp>(loc, ValueRange{iNext});
-                      })
+              scf::ForOp::create(
+                  builder, loc, inputOffset, iargs[0], vlStep,
+                  ValueRange{inputOffset},
+                  [&](OpBuilder &b, Location loc, Value iv_i,
+                      ValueRange iargs) {
+                    Value inVec = vector::LoadOp::create(b, loc, vecTy, input,
+                                                         ValueRange{iv_i});
+                    Value outOffset = arith::AddIOp::create(b, loc, iv_i, iv_n);
+                    Value outVec = vector::LoadOp::create(
+                        b, loc, vecTy, output, ValueRange{outOffset});
+                    Value fmaVec =
+                        vector::FMAOp::create(b, loc, kVec, inVec, outVec);
+                    vector::StoreOp::create(b, loc, fmaVec, output,
+                                            ValueRange{outOffset});
+                    Value iNext = arith::AddIOp::create(b, loc, iv_i, vlStep);
+                    scf::YieldOp::create(b, loc, ValueRange{iNext});
+                  })
                   .getResult(0);
 
           // 4.4 Process the remainder of tail process with scalar operations.
           Value tailUpboundScalar =
-              builder.create<arith::AddIOp>(loc, iargs[0], vlStepMinusOne);
-          builder.create<scf::ForOp>(
-              loc, iterIdx, tailUpboundScalar, c1, ValueRange{},
+              arith::AddIOp::create(builder, loc, iargs[0], vlStepMinusOne);
+          scf::ForOp::create(
+              builder, loc, iterIdx, tailUpboundScalar, c1, ValueRange{},
               [&](OpBuilder &b, Location loc, Value iv_i, ValueRange iargs) {
-                Value inElem = b.create<memref::LoadOp>(loc, input, iv_i);
-                Value outOffset = b.create<arith::AddIOp>(loc, iv_i, iv_n);
+                Value inElem = memref::LoadOp::create(b, loc, input, iv_i);
+                Value outOffset = arith::AddIOp::create(b, loc, iv_i, iv_n);
                 Value outElem =
-                    b.create<memref::LoadOp>(loc, output, outOffset);
-                Value mulElem = b.create<arith::MulFOp>(loc, inElem, kElem);
-                Value addElem = b.create<arith::AddFOp>(loc, mulElem, outElem);
-                b.create<memref::StoreOp>(loc, addElem, output, outOffset);
-                b.create<scf::YieldOp>(loc);
+                    memref::LoadOp::create(b, loc, output, outOffset);
+                Value mulElem = arith::MulFOp::create(b, loc, inElem, kElem);
+                Value addElem = arith::AddFOp::create(b, loc, mulElem, outElem);
+                memref::StoreOp::create(b, loc, addElem, output, outOffset);
+                scf::YieldOp::create(b, loc);
               });
           Value tailUpboundNext =
-              builder.create<arith::SubIOp>(loc, iargs[0], c1);
-          builder.create<scf::YieldOp>(loc, ValueRange{tailUpboundNext});
+              arith::SubIOp::create(builder, loc, iargs[0], c1);
+          scf::YieldOp::create(builder, loc, ValueRange{tailUpboundNext});
         });
 
     rewriter.eraseOp(op);
@@ -205,44 +202,44 @@ public:
     Value kernel = op->getOperand(1);
     Value output = op->getOperand(2);
 
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-    Value c2 = rewriter.create<ConstantIndexOp>(loc, 2);
-    Value c4 = rewriter.create<ConstantIndexOp>(loc, 4);
-    Value c5 = rewriter.create<ConstantIndexOp>(loc, 5);
-    Value c8 = rewriter.create<ConstantIndexOp>(loc, 8);
-    Value c16 = rewriter.create<ConstantIndexOp>(loc, 16);
-    Value c32 = rewriter.create<ConstantIndexOp>(loc, 32);
+    Value c0 = ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = ConstantIndexOp::create(rewriter, loc, 1);
+    Value c2 = ConstantIndexOp::create(rewriter, loc, 2);
+    Value c4 = ConstantIndexOp::create(rewriter, loc, 4);
+    Value c5 = ConstantIndexOp::create(rewriter, loc, 5);
+    Value c8 = ConstantIndexOp::create(rewriter, loc, 8);
+    Value c16 = ConstantIndexOp::create(rewriter, loc, 16);
+    Value c32 = ConstantIndexOp::create(rewriter, loc, 32);
 
-    Value N = rewriter.create<memref::DimOp>(loc, input, c0);
-    Value filterSize = rewriter.create<memref::DimOp>(loc, kernel, c0);
+    Value N = memref::DimOp::create(rewriter, loc, input, c0);
+    Value filterSize = memref::DimOp::create(rewriter, loc, kernel, c0);
 
     FloatType f32 = Float32Type::get(ctx);
-    Value f0 = rewriter.create<ConstantFloatOp>(loc, f32, APFloat(0.0f));
-    Value f1 = rewriter.create<ConstantFloatOp>(loc, f32, APFloat(1.0f));
+    Value f0 = ConstantFloatOp::create(rewriter, loc, f32, APFloat(0.0f));
+    Value f1 = ConstantFloatOp::create(rewriter, loc, f32, APFloat(1.0f));
 
     Value cond4 =
-        rewriter.create<CmpIOp>(loc, CmpIPredicate::ule, filterSize, c4);
+        CmpIOp::create(rewriter, loc, CmpIPredicate::ule, filterSize, c4);
     Value cond8 =
-        rewriter.create<CmpIOp>(loc, CmpIPredicate::ule, filterSize, c8);
+        CmpIOp::create(rewriter, loc, CmpIPredicate::ule, filterSize, c8);
     Value cond16 =
-        rewriter.create<CmpIOp>(loc, CmpIPredicate::ule, filterSize, c16);
+        CmpIOp::create(rewriter, loc, CmpIPredicate::ule, filterSize, c16);
     Value cond32 =
-        rewriter.create<CmpIOp>(loc, CmpIPredicate::ule, filterSize, c32);
+        CmpIOp::create(rewriter, loc, CmpIPredicate::ule, filterSize, c32);
 
     // clang-format off
-    rewriter.create<scf::IfOp>(loc, cond4,
+    scf::IfOp::create(rewriter, loc, cond4,
     /*thenBuilder=*/
     [&](OpBuilder &builder, Location loc) {
         dap::iirVectorizationProcess(builder, loc, 4, f32, f0, f1, c0, c1, c2, c4, c5,
                                      filterSize, kernel, ArrayRef<int64_t>{0, 0, 1, 2},
                                      N, input, output);
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
     },
     /*elseBuilder=*/
     [&](OpBuilder &builder, Location loc) {
-        builder.create<scf::IfOp>(loc, cond8,
+        scf::IfOp::create(builder, loc, cond8,
         /*thenBuilder=*/
         [&](OpBuilder &builder, Location loc){
             dap::iirVectorizationProcess(builder, loc, 8, f32, f0, f1, c0, c1, c2, c4, c5,
@@ -250,11 +247,11 @@ public:
                                          ArrayRef<int64_t>{0, 0, 1, 2, 3, 4, 5, 6}, N,
                                          input, output);
 
-            builder.create<scf::YieldOp>(loc);
+            scf::YieldOp::create(builder, loc);
         },
         /*elseBuilder=*/
         [&](OpBuilder &builder, Location loc) {
-            builder.create<scf::IfOp>(loc, cond16,
+            scf::IfOp::create(builder, loc, cond16,
             /*thenBuilder=*/
             [&](OpBuilder &builder, Location loc){
                 dap::iirVectorizationProcess(builder, loc, 16, f32, f0, f1, c0, c1, c2, c4, c5,
@@ -262,11 +259,11 @@ public:
                                              3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}, N,
                                              input, output);
 
-                builder.create<scf::YieldOp>(loc);
+                scf::YieldOp::create(builder, loc);
             },
             /*elseBuilder=*/
             [&](OpBuilder &builder, Location loc) {
-                builder.create<scf::IfOp>(loc, cond32,
+                scf::IfOp::create(builder, loc, cond32,
                 /*thenBuilder=*/
                 [&](OpBuilder &builder, Location loc){
                     dap::iirVectorizationProcess(builder, loc, 32, f32, f0, f1, c0, c1, c2, c4, c5,
@@ -275,7 +272,7 @@ public:
                                                  17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
                                                  30}, N, input, output);
 
-                    builder.create<scf::YieldOp>(loc);
+                    scf::YieldOp::create(builder, loc);
                 },
                 /*elseBuilder=*/
                 [&](OpBuilder &builder, Location loc) {
@@ -287,16 +284,16 @@ public:
                                                  48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
                                                  62}, N, input, output);
 
-                    builder.create<scf::YieldOp>(loc);
+                    scf::YieldOp::create(builder, loc);
                 }
                 );
-                builder.create<scf::YieldOp>(loc);
+                scf::YieldOp::create(builder, loc);
             });
 
-            builder.create<scf::YieldOp>(loc);
+            scf::YieldOp::create(builder, loc);
         });
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
     });
     // clang-format on
 

--- a/midend/lib/Conversion/DepthwiseConvOptimization/DepthwiseConvNhwcHwc.cpp
+++ b/midend/lib/Conversion/DepthwiseConvOptimization/DepthwiseConvNhwcHwc.cpp
@@ -51,12 +51,12 @@ public:
 
     // Some constant we need.
     const Value c0 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(0));
     const Value c1 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(1));
 
-    const Value vecSizeValue =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(vecSize));
+    const Value vecSizeValue = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getIndexAttr(vecSize));
     const AffineExpr d0 = rewriter.getAffineDimExpr(0);
     const AffineExpr d1 = rewriter.getAffineDimExpr(1);
     // TODO: remove s0?
@@ -93,38 +93,39 @@ public:
     VectorType vecTy = VectorType::get(vecSize, elemTy);
 
     const Value zeroElementType =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getZeroAttr(elemTy));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getZeroAttr(elemTy));
 
     Value zeroElementTypeVec;
     if (isa<IntegerType>(elemTy)) {
       zeroElementTypeVec =
-          rewriter.create<vector::BroadcastOp>(loc, vecTy, zeroElementType);
+          vector::BroadcastOp::create(rewriter, loc, vecTy, zeroElementType);
     } else {
       zeroElementTypeVec =
-          rewriter.create<vector::BroadcastOp>(loc, vecTy, zeroElementType);
+          vector::BroadcastOp::create(rewriter, loc, vecTy, zeroElementType);
     }
     // Dims
-    Value N = rewriter.create<memref::DimOp>(loc, output, 0);  // N
-    Value OH = rewriter.create<memref::DimOp>(loc, output, 1); // OH
-    Value OW = rewriter.create<memref::DimOp>(loc, output, 2); // OW
-    Value OC = rewriter.create<memref::DimOp>(loc, output, 3); // OC/FC/IC
+    Value N = memref::DimOp::create(rewriter, loc, output, 0);  // N
+    Value OH = memref::DimOp::create(rewriter, loc, output, 1); // OH
+    Value OW = memref::DimOp::create(rewriter, loc, output, 2); // OW
+    Value OC = memref::DimOp::create(rewriter, loc, output, 3); // OC/FC/IC
 
-    Value applyOC = rewriter.create<affine::AffineApplyOp>(
-        loc, AffineMap::get(1, 0, d0.floorDiv(vecSize) * vecSize), OC);
-    Value tailLength = rewriter.create<affine::AffineApplyOp>(
-        loc, AffineMap::get(1, 0, d0 % vecSize), ValueRange{OC});
-    Value maskVector = rewriter.create<vector::CreateMaskOp>(
-        loc, VectorType::get({vecSize}, rewriter.getI1Type()),
+    Value applyOC = affine::AffineApplyOp::create(
+        rewriter, loc, AffineMap::get(1, 0, d0.floorDiv(vecSize) * vecSize),
+        OC);
+    Value tailLength = affine::AffineApplyOp::create(
+        rewriter, loc, AffineMap::get(1, 0, d0 % vecSize), ValueRange{OC});
+    Value maskVector = vector::CreateMaskOp::create(
+        rewriter, loc, VectorType::get({vecSize}, rewriter.getI1Type()),
         ValueRange{tailLength});
 
-    Value FH = rewriter.create<memref::DimOp>(loc, filter, 0); // FH
-    Value FW = rewriter.create<memref::DimOp>(loc, filter, 1); // FW
+    Value FH = memref::DimOp::create(rewriter, loc, filter, 0); // FH
+    Value FW = memref::DimOp::create(rewriter, loc, filter, 1); // FW
 
     // clang format off
     //  Step 1: Create outer most loops.
     // Create the scf::ForallOp operation For N,OH,OW
-    rewriter.create<scf::ForallOp>(
-        loc, SmallVector<OpFoldResult, 3>({N, OH, OW}), ValueRange{},
+    scf::ForallOp::create(
+        rewriter, loc, SmallVector<OpFoldResult, 3>({N, OH, OW}), ValueRange{},
         std::nullopt, // No mapping specified in this example
         [&](OpBuilder &nestedBuilder, Location nestedLoc,
             ValueRange loopIndices) {
@@ -132,131 +133,130 @@ public:
           Value ivOH = loopIndices[1]; // Index for the second dimension OH
           Value ivOW = loopIndices[2]; // Index for the third dimension OW
           // OC
-          nestedBuilder.create<scf::ForOp>(
-              nestedLoc, c0, applyOC, vecSizeValue, ValueRange{},
+          scf::ForOp::create(
+              nestedBuilder, nestedLoc, c0, applyOC, vecSizeValue, ValueRange{},
               [&](OpBuilder &builder, Location loc, Value ivOC,
                   ValueRange iargs) {
-                Value tVec = builder.create<vector::LoadOp>(
-                    loc, vecTy, output, ValueRange{ivN, ivOH, ivOW, ivOC});
+                Value tVec =
+                    vector::LoadOp::create(builder, loc, vecTy, output,
+                                           ValueRange{ivN, ivOH, ivOW, ivOC});
 
                 // FH
-                auto forOp = builder.create<scf::ForOp>(
-                    loc, c0, FH, c1, ValueRange{tVec},
+                auto forOp = scf::ForOp::create(
+                    builder, loc, c0, FH, c1, ValueRange{tVec},
                     [&](OpBuilder &builder, Location loc, Value ivFH,
                         ValueRange iargs) {
-                      Value rowInput = builder.create<affine::AffineApplyOp>(
-                          loc,
+                      Value rowInput = affine::AffineApplyOp::create(
+                          builder, loc,
                           AffineMap::get(2, 0, d0 * strHeight + d1 * dilHeight),
                           ValueRange{ivOH, ivFH});
                       Value rowFilter = ivFH;
                       // FW
-                      auto forOp = builder.create<scf::ForOp>(
-                          loc, c0, FW, c1, ValueRange{iargs[0]},
+                      auto forOp = scf::ForOp::create(
+                          builder, loc, c0, FW, c1, ValueRange{iargs[0]},
                           [&](OpBuilder &builder, Location loc, Value ivFW,
                               ValueRange iargs) {
-                            Value columnInput =
-                                builder.create<affine::AffineApplyOp>(
-                                    loc,
-                                    AffineMap::get(
-                                        2, 0, d0 * strWidth + d1 * dilWidth),
-                                    ValueRange{ivOW, ivFW});
-                            Value columnFilter =
-                                builder.create<affine::AffineApplyOp>(
-                                    loc, AffineMap::get(1, 0, d0), ivFW);
-                            Value iVec = builder.create<vector::LoadOp>(
-                                loc, vecTy, input,
+                            Value columnInput = affine::AffineApplyOp::create(
+                                builder, loc,
+                                AffineMap::get(2, 0,
+                                               d0 * strWidth + d1 * dilWidth),
+                                ValueRange{ivOW, ivFW});
+                            Value columnFilter = affine::AffineApplyOp::create(
+                                builder, loc, AffineMap::get(1, 0, d0), ivFW);
+                            Value iVec = vector::LoadOp::create(
+                                builder, loc, vecTy, input,
                                 ValueRange{ivN, rowInput, columnInput, ivOC});
-                            Value fVec = builder.create<vector::LoadOp>(
-                                loc, vecTy, filter,
+                            Value fVec = vector::LoadOp::create(
+                                builder, loc, vecTy, filter,
                                 ValueRange{rowFilter, columnFilter, ivOC});
                             Value tVecNext;
                             if (isa<IntegerType>(elemTy)) {
-                              Value mulVec = builder.create<arith::MulIOp>(
-                                  loc, iVec, fVec);
-                              tVecNext = builder.create<arith::AddIOp>(
-                                  loc, mulVec, iargs[0]);
+                              Value mulVec = arith::MulIOp::create(builder, loc,
+                                                                   iVec, fVec);
+                              tVecNext = arith::AddIOp::create(
+                                  builder, loc, mulVec, iargs[0]);
                             } else {
-                              tVecNext = builder.create<vector::FMAOp>(
-                                  loc, vecTy, iVec, fVec, iargs[0]);
+                              tVecNext = vector::FMAOp::create(
+                                  builder, loc, vecTy, iVec, fVec, iargs[0]);
                             }
 
-                            builder.create<scf::YieldOp>(loc,
-                                                         ValueRange{tVecNext});
+                            scf::YieldOp::create(builder, loc,
+                                                 ValueRange{tVecNext});
                           });
-                      builder.create<scf::YieldOp>(
-                          loc, ValueRange{forOp.getResult(0)});
+                      scf::YieldOp::create(builder, loc,
+                                           ValueRange{forOp.getResult(0)});
                     });
-                builder.create<vector::StoreOp>(
-                    loc, forOp.getResult(0), output,
-                    ValueRange{ivN, ivOH, ivOW, ivOC});
+                vector::StoreOp::create(builder, loc, forOp.getResult(0),
+                                        output,
+                                        ValueRange{ivN, ivOH, ivOW, ivOC});
 
-                builder.create<scf::YieldOp>(loc, ValueRange{});
+                scf::YieldOp::create(builder, loc, ValueRange{});
               });
 
           // applyOC
-          Value condition = nestedBuilder.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::sgt, tailLength, c0);
-          nestedBuilder.create<scf::IfOp>(
-              loc, condition, [&](OpBuilder &builder, Location loc) {
-                Value tVec = builder.create<vector::MaskedLoadOp>(
-                    loc, vecTy, output, ValueRange{ivN, ivOH, ivOW, applyOC},
-                    maskVector, zeroElementTypeVec);
+          Value condition = arith::CmpIOp::create(
+              nestedBuilder, loc, arith::CmpIPredicate::sgt, tailLength, c0);
+          scf::IfOp::create(
+              nestedBuilder, loc, condition,
+              [&](OpBuilder &builder, Location loc) {
+                Value tVec = vector::MaskedLoadOp::create(
+                    builder, loc, vecTy, output,
+                    ValueRange{ivN, ivOH, ivOW, applyOC}, maskVector,
+                    zeroElementTypeVec);
                 // FH
-                auto forOp = builder.create<scf::ForOp>(
-                    loc, c0, FH, c1, ValueRange{tVec},
+                auto forOp = scf::ForOp::create(
+                    builder, loc, c0, FH, c1, ValueRange{tVec},
                     [&](OpBuilder &builder, Location loc, Value ivFH,
                         ValueRange iargs) {
-                      Value rowInput = builder.create<affine::AffineApplyOp>(
-                          loc,
+                      Value rowInput = affine::AffineApplyOp::create(
+                          builder, loc,
                           AffineMap::get(2, 0, d0 * strHeight + d1 * dilHeight),
                           ValueRange{ivOH, ivFH});
                       Value rowFilter = ivFH;
                       // FW
-                      auto forOp = builder.create<scf::ForOp>(
-                          loc, c0, FW, c1, ValueRange{iargs[0]},
+                      auto forOp = scf::ForOp::create(
+                          builder, loc, c0, FW, c1, ValueRange{iargs[0]},
                           [&](OpBuilder &builder, Location loc, Value ivFW,
                               ValueRange iargs) {
-                            Value columnInput =
-                                builder.create<affine::AffineApplyOp>(
-                                    loc,
-                                    AffineMap::get(
-                                        2, 0, d0 * strWidth + d1 * dilWidth),
-                                    ValueRange{ivOW, ivFW});
-                            Value columnFilter =
-                                builder.create<affine::AffineApplyOp>(
-                                    loc, AffineMap::get(1, 0, d0), ivFW);
-                            Value iVec = builder.create<vector::MaskedLoadOp>(
-                                loc, vecTy, input,
+                            Value columnInput = affine::AffineApplyOp::create(
+                                builder, loc,
+                                AffineMap::get(2, 0,
+                                               d0 * strWidth + d1 * dilWidth),
+                                ValueRange{ivOW, ivFW});
+                            Value columnFilter = affine::AffineApplyOp::create(
+                                builder, loc, AffineMap::get(1, 0, d0), ivFW);
+                            Value iVec = vector::MaskedLoadOp::create(
+                                builder, loc, vecTy, input,
                                 ValueRange{ivN, rowInput, columnInput, applyOC},
                                 maskVector, zeroElementTypeVec);
-                            Value fVec = builder.create<vector::MaskedLoadOp>(
-                                loc, vecTy, filter,
+                            Value fVec = vector::MaskedLoadOp::create(
+                                builder, loc, vecTy, filter,
                                 ValueRange{rowFilter, columnFilter, applyOC},
                                 maskVector, zeroElementTypeVec);
                             Value tVecNext;
                             if (isa<IntegerType>(elemTy)) {
-                              Value mulVec = builder.create<arith::MulIOp>(
-                                  loc, iVec, fVec);
-                              tVecNext = builder.create<arith::AddIOp>(
-                                  loc, mulVec, iargs[0]);
+                              Value mulVec = arith::MulIOp::create(builder, loc,
+                                                                   iVec, fVec);
+                              tVecNext = arith::AddIOp::create(
+                                  builder, loc, mulVec, iargs[0]);
                             } else {
-                              tVecNext = builder.create<vector::FMAOp>(
-                                  loc, vecTy, iVec, fVec, iargs[0]);
+                              tVecNext = vector::FMAOp::create(
+                                  builder, loc, vecTy, iVec, fVec, iargs[0]);
                             }
 
-                            builder.create<scf::YieldOp>(loc,
-                                                         ValueRange{tVecNext});
+                            scf::YieldOp::create(builder, loc,
+                                                 ValueRange{tVecNext});
                           });
-                      builder.create<scf::YieldOp>(
-                          loc, ValueRange{forOp.getResult(0)});
+                      scf::YieldOp::create(builder, loc,
+                                           ValueRange{forOp.getResult(0)});
                     });
-                builder.create<vector::MaskedStoreOp>(
-                    loc, output, ValueRange{ivN, ivOH, ivOW, applyOC},
+                vector::MaskedStoreOp::create(
+                    builder, loc, output, ValueRange{ivN, ivOH, ivOW, applyOC},
                     maskVector, forOp.getResult(0));
-                builder.create<scf::YieldOp>(loc, ValueRange{});
+                scf::YieldOp::create(builder, loc, ValueRange{});
               });
 
-          nestedBuilder.create<scf::InParallelOp>(nestedLoc);
+          scf::InParallelOp::create(nestedBuilder, nestedLoc);
         });
     // clang format on
 

--- a/midend/lib/Conversion/EliminateMemRefCopy/EliminateMemRefCopy.cpp
+++ b/midend/lib/Conversion/EliminateMemRefCopy/EliminateMemRefCopy.cpp
@@ -138,7 +138,7 @@ struct EliminateMemRefCopyPattern : public OpRewritePattern<memref::CopyOp> {
 
           // Extract metadata to get actual stride values
           auto metadata =
-              builder.create<memref::ExtractStridedMetadataOp>(loc, source);
+              memref::ExtractStridedMetadataOp::create(builder, loc, source);
 
           // Get the rank
           int64_t rank = sourceType.getRank();
@@ -189,9 +189,9 @@ struct EliminateMemRefCopyPattern : public OpRewritePattern<memref::CopyOp> {
               tightenedLayout, sourceType.getMemorySpace());
 
           // Create reinterpret_cast with tightened layout
-          Value tightened = builder.create<memref::ReinterpretCastOp>(
-              loc, tightenedType, metadata.getBaseBuffer(), offset, sizes,
-              stridesOfr);
+          Value tightened = memref::ReinterpretCastOp::create(
+              builder, loc, tightenedType, metadata.getBaseBuffer(), offset,
+              sizes, stridesOfr);
 
           // Then cast to static layout type (no layout information)
           // This ensures compatibility with function signatures
@@ -201,7 +201,7 @@ struct EliminateMemRefCopyPattern : public OpRewritePattern<memref::CopyOp> {
               sourceType.getMemorySpace());
 
           replacementValue =
-              builder.create<memref::CastOp>(loc, finalType, tightened);
+              memref::CastOp::create(builder, loc, finalType, tightened);
         }
       }
     }

--- a/midend/lib/Conversion/ExtendDAP/ExtendDAPPass.cpp
+++ b/midend/lib/Conversion/ExtendDAP/ExtendDAPPass.cpp
@@ -178,9 +178,10 @@ Value initMelFilter(PatternRewriter &rewriter, Location loc, Value c0, Value c1,
       0.0031413131931234614,  0.002692554165534394,   0.002243795137945327,
       0.0017950361103562596,  0.001346277082767192,   0.0008975180551781247,
       0.0004487590275890572};
-  Value melFilterData = rewriter.create<arith::ConstantOp>(
-      loc, DenseFPElementsAttr::get(RankedTensorType::get(391, f64Ty),
-                                    ArrayRef<double>(data)));
+  Value melFilterData = arith::ConstantOp::create(
+      rewriter, loc,
+      DenseFPElementsAttr::get(RankedTensorType::get(391, f64Ty),
+                               ArrayRef<double>(data)));
 
   IndexType idxTy = rewriter.getIndexType();
   std::vector<size_t> D1Index{
@@ -211,9 +212,10 @@ Value initMelFilter(PatternRewriter &rewriter, Location loc, Value c0, Value c1,
       181, 181, 182, 182, 183, 183, 184, 184, 185, 185, 186, 186, 187, 187, 188,
       188, 189, 189, 190, 190, 191, 191, 192, 192, 193, 194, 195, 196, 197, 198,
       199};
-  Value dim1Index = rewriter.create<arith::ConstantOp>(
-      loc, DenseElementsAttr::get(RankedTensorType::get(391, idxTy),
-                                  ArrayRef<size_t>(D1Index)));
+  Value dim1Index = arith::ConstantOp::create(
+      rewriter, loc,
+      DenseElementsAttr::get(RankedTensorType::get(391, idxTy),
+                             ArrayRef<size_t>(D1Index)));
 
   std::vector<size_t> D2Index{
       0,  1,  1,  2,  2,  3,  3,  4,  4,  5,  5,  6,  6,  7,  7,  8,  8,  9,
@@ -238,19 +240,20 @@ Value initMelFilter(PatternRewriter &rewriter, Location loc, Value c0, Value c1,
       76, 77, 76, 77, 76, 77, 76, 77, 76, 77, 76, 77, 76, 77, 77, 78, 77, 78,
       77, 78, 77, 78, 77, 78, 77, 78, 77, 78, 78, 79, 78, 79, 78, 79, 78, 79,
       78, 79, 78, 79, 78, 79, 79, 79, 79, 79, 79, 79, 79};
-  Value dim2Index = rewriter.create<arith::ConstantOp>(
-      loc, DenseElementsAttr::get(RankedTensorType::get(391, idxTy),
-                                  ArrayRef<size_t>(D2Index)));
+  Value dim2Index = arith::ConstantOp::create(
+      rewriter, loc,
+      DenseElementsAttr::get(RankedTensorType::get(391, idxTy),
+                             ArrayRef<size_t>(D2Index)));
 
   RankedTensorType melFilterType = RankedTensorType::get({201, 80}, f64Ty);
-  Value melFilter = rewriter.create<tensor::SplatOp>(loc, melFilterType, f0);
+  Value melFilter = tensor::SplatOp::create(rewriter, loc, melFilterType, f0);
   auto mTp =
       MemRefType::get(melFilterType.getShape(), melFilterType.getElementType());
   Value melFilterMemRef =
       bufferization::ToBufferOp::create(rewriter, loc, mTp, melFilter);
 
   // TODO : remove tomemref & totensor, and use insert to replace store. !!
-  Value c391 = rewriter.create<ConstantIndexOp>(loc, 391);
+  Value c391 = ConstantIndexOp::create(rewriter, loc, 391);
   Value number, d1, d2;
   // rewriter.create<scf::ForOp>(loc, c0, c391, c1, ValueRange{},
   //     [&](OpBuilder &builder, Location loc, Value iv, ValueRange iargs) {
@@ -260,15 +263,15 @@ Value initMelFilter(PatternRewriter &rewriter, Location loc, Value c0, Value c1,
   //       builder.create<memref::StoreOp>(loc, number, melFilterMemRef,
   //       ValueRange{d1, d2}); builder.create<scf::YieldOp>(loc);
   //     });
-  auto loopOp = rewriter.create<scf::ForOp>(loc, c0, c391, c1);
+  auto loopOp = scf::ForOp::create(rewriter, loc, c0, c391, c1);
   rewriter.setInsertionPointToStart(loopOp.getBody());
 
   Value iv = loopOp.getInductionVar();
-  number = rewriter.create<tensor::ExtractOp>(loc, melFilterData, iv);
-  d1 = rewriter.create<tensor::ExtractOp>(loc, dim1Index, iv);
-  d2 = rewriter.create<tensor::ExtractOp>(loc, dim2Index, iv);
-  rewriter.create<memref::StoreOp>(loc, number, melFilterMemRef,
-                                   ValueRange{d1, d2});
+  number = tensor::ExtractOp::create(rewriter, loc, melFilterData, iv);
+  d1 = tensor::ExtractOp::create(rewriter, loc, dim1Index, iv);
+  d2 = tensor::ExtractOp::create(rewriter, loc, dim2Index, iv);
+  memref::StoreOp::create(rewriter, loc, number, melFilterMemRef,
+                          ValueRange{d1, d2});
 
   rewriter.setInsertionPointAfter(loopOp);
 
@@ -682,9 +685,10 @@ Value getHanningWindow400(PatternRewriter &rewriter, Location loc) {
                                        0.0005550625190150482,
                                        0.0002467198171342,
                                        6.168375916970614e-05};
-  Value window = rewriter.create<arith::ConstantOp>(
-      loc, DenseFPElementsAttr::get(RankedTensorType::get(400, f64Ty),
-                                    ArrayRef<double>(hanningWindow400)));
+  Value window = arith::ConstantOp::create(
+      rewriter, loc,
+      DenseFPElementsAttr::get(RankedTensorType::get(400, f64Ty),
+                               ArrayRef<double>(hanningWindow400)));
   return window;
 }
 
@@ -692,8 +696,8 @@ Value getHanningWindow400(PatternRewriter &rewriter, Location loc) {
 // padding length
 Value padReflect(PatternRewriter &rewriter, Location loc, Value c0, Value c1,
                  Value input, int64_t low, int64_t high) {
-  Value lowPadLen = rewriter.create<ConstantIndexOp>(loc, low);
-  Value highPadLen = rewriter.create<ConstantIndexOp>(loc, high);
+  Value lowPadLen = ConstantIndexOp::create(rewriter, loc, low);
+  Value highPadLen = ConstantIndexOp::create(rewriter, loc, high);
   SmallVector<OpFoldResult> lowValues;
   SmallVector<OpFoldResult> highValues;
   lowValues.push_back(lowPadLen);
@@ -705,9 +709,9 @@ Value padReflect(PatternRewriter &rewriter, Location loc, Value c0, Value c1,
   int64_t inputSize =
       llvm::cast<RankedTensorType>(input.getType()).getShape()[0];
   int64_t lowPaddedSize = inputSize + low;
-  auto padOp1 = rewriter.create<tensor::PadOp>(
-      loc, RankedTensorType::get(lowPaddedSize, f64Ty), input, lowValues,
-      highValues);
+  auto padOp1 = tensor::PadOp::create(
+      rewriter, loc, RankedTensorType::get(lowPaddedSize, f64Ty), input,
+      lowValues, highValues);
 
   Region *padOpRegion1 = &padOp1.getRegion();
   int64_t sourceRank1 = llvm::cast<RankedTensorType>(input.getType()).getRank();
@@ -719,9 +723,9 @@ Value padReflect(PatternRewriter &rewriter, Location loc, Value c0, Value c1,
   rewriter.createBlock(padOpRegion1, padOpRegion1->end(), blockArgTypes1,
                        blockArgLocs1);
   Value iv1 = padOp1.getRegion().front().getArgument(0);
-  Value idx1 = rewriter.create<arith::SubIOp>(loc, lowPadLen, iv1);
-  Value elem1 = rewriter.create<tensor::ExtractOp>(loc, input, idx1);
-  rewriter.create<tensor::YieldOp>(loc, elem1);
+  Value idx1 = arith::SubIOp::create(rewriter, loc, lowPadLen, iv1);
+  Value elem1 = tensor::ExtractOp::create(rewriter, loc, input, idx1);
+  tensor::YieldOp::create(rewriter, loc, elem1);
   rewriter.restoreInsertionPoint(ip1);
   lowValues.clear();
   highValues.clear();
@@ -733,11 +737,11 @@ Value padReflect(PatternRewriter &rewriter, Location loc, Value c0, Value c1,
   highValues.push_back(highPadLen);
   int64_t highPaddedSize = lowPaddedSize + high;
   Value lowPaddedInputDim =
-      rewriter.create<tensor::DimOp>(loc, lowPaddedInput, c0);
-  Value symIndex = rewriter.create<arith::SubIOp>(loc, lowPaddedInputDim, c1);
-  auto padOp2 = rewriter.create<tensor::PadOp>(
-      loc, RankedTensorType::get(highPaddedSize, f64Ty), lowPaddedInput,
-      lowValues, highValues);
+      tensor::DimOp::create(rewriter, loc, lowPaddedInput, c0);
+  Value symIndex = arith::SubIOp::create(rewriter, loc, lowPaddedInputDim, c1);
+  auto padOp2 = tensor::PadOp::create(
+      rewriter, loc, RankedTensorType::get(highPaddedSize, f64Ty),
+      lowPaddedInput, lowValues, highValues);
   Region *padOpRegion2 = &padOp2.getRegion();
   int64_t sourceRank2 =
       llvm::cast<RankedTensorType>(lowPaddedInput.getType()).getRank();
@@ -748,10 +752,10 @@ Value padReflect(PatternRewriter &rewriter, Location loc, Value c0, Value c1,
   rewriter.createBlock(padOpRegion2, padOpRegion2->end(), blockArgTypes2,
                        blockArgLocs2);
   Value iv2 = padOp2.getRegion().front().getArgument(0);
-  Value sub = rewriter.create<arith::SubIOp>(loc, iv2, symIndex);
-  Value idx2 = rewriter.create<arith::SubIOp>(loc, symIndex, sub);
-  Value elem2 = rewriter.create<tensor::ExtractOp>(loc, lowPaddedInput, idx2);
-  rewriter.create<tensor::YieldOp>(loc, elem2);
+  Value sub = arith::SubIOp::create(rewriter, loc, iv2, symIndex);
+  Value idx2 = arith::SubIOp::create(rewriter, loc, symIndex, sub);
+  Value elem2 = tensor::ExtractOp::create(rewriter, loc, lowPaddedInput, idx2);
+  tensor::YieldOp::create(rewriter, loc, elem2);
   rewriter.restoreInsertionPoint(ip2);
   lowValues.clear();
   highValues.clear();
@@ -762,163 +766,163 @@ Value padReflect(PatternRewriter &rewriter, Location loc, Value c0, Value c1,
 // function to print a memref for debug
 void printMemref(OpBuilder &rewriter, Location loc, Value input, int l) {
 
-  Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-  Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-  Value length = rewriter.create<ConstantIndexOp>(loc, l);
-  rewriter.create<vector::PrintOp>(loc, "Print Start:\n");
+  Value c0 = ConstantIndexOp::create(rewriter, loc, 0);
+  Value c1 = ConstantIndexOp::create(rewriter, loc, 1);
+  Value length = ConstantIndexOp::create(rewriter, loc, l);
+  vector::PrintOp::create(rewriter, loc, "Print Start:\n");
 
-  rewriter.create<scf::ForOp>(
-      loc, c0, length, c1, ValueRange{},
+  scf::ForOp::create(
+      rewriter, loc, c0, length, c1, ValueRange{},
       [&](OpBuilder &b, Location loc, Value i, ValueRange iargs) {
-        Value x = b.create<memref::LoadOp>(loc, input, i);
-        b.create<vector::PrintOp>(loc, x);
+        Value x = memref::LoadOp::create(b, loc, input, i);
+        vector::PrintOp::create(b, loc, x);
 
-        b.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(b, loc);
       });
 
-  rewriter.create<vector::PrintOp>(loc, "\n");
+  vector::PrintOp::create(rewriter, loc, "\n");
 }
 
 // WA CC CH PM MULPM C1 C1w C2 CH2 CH2w CH_radfg CCw CSARR AR AI IANG are helper
 // functions for RFFTP
 inline Value WA(OpBuilder &builder, Location loc, Value wa, Value x, Value i,
                 Value ido, Value c1) {
-  Value idom1 = builder.create<arith::SubIOp>(loc, ido, c1);
-  Value tmp1 = builder.create<arith::MulIOp>(loc, x, idom1);
-  Value index = builder.create<arith::AddIOp>(loc, tmp1, i);
-  return builder.create<memref::LoadOp>(loc, wa, index);
+  Value idom1 = arith::SubIOp::create(builder, loc, ido, c1);
+  Value tmp1 = arith::MulIOp::create(builder, loc, x, idom1);
+  Value index = arith::AddIOp::create(builder, loc, tmp1, i);
+  return memref::LoadOp::create(builder, loc, wa, index);
 }
 
 inline Value CC(OpBuilder &builder, Location loc, Value cc, Value a, Value b,
                 Value c, Value ido, Value l1) {
-  Value tmp1 = builder.create<arith::MulIOp>(loc, l1, c);
-  Value tmp2 = builder.create<arith::AddIOp>(loc, tmp1, b);
-  Value tmp3 = builder.create<arith::MulIOp>(loc, tmp2, ido);
-  Value index = builder.create<arith::AddIOp>(loc, tmp3, a);
-  return builder.create<memref::LoadOp>(loc, cc, index);
+  Value tmp1 = arith::MulIOp::create(builder, loc, l1, c);
+  Value tmp2 = arith::AddIOp::create(builder, loc, tmp1, b);
+  Value tmp3 = arith::MulIOp::create(builder, loc, tmp2, ido);
+  Value index = arith::AddIOp::create(builder, loc, tmp3, a);
+  return memref::LoadOp::create(builder, loc, cc, index);
 }
 
 inline void CH(OpBuilder &builder, Location loc, Value ch, Value a, Value b,
                Value c, Value ido, Value cdim, Value toWrite) {
-  Value tmp1 = builder.create<arith::MulIOp>(loc, cdim, c);
-  Value tmp2 = builder.create<arith::AddIOp>(loc, tmp1, b);
-  Value tmp3 = builder.create<arith::MulIOp>(loc, tmp2, ido);
-  Value index = builder.create<arith::AddIOp>(loc, tmp3, a);
-  builder.create<memref::StoreOp>(loc, toWrite, ch, index);
+  Value tmp1 = arith::MulIOp::create(builder, loc, cdim, c);
+  Value tmp2 = arith::AddIOp::create(builder, loc, tmp1, b);
+  Value tmp3 = arith::MulIOp::create(builder, loc, tmp2, ido);
+  Value index = arith::AddIOp::create(builder, loc, tmp3, a);
+  memref::StoreOp::create(builder, loc, toWrite, ch, index);
   return;
 }
 
 inline std::vector<Value> PM(OpBuilder &builder, Location loc, Value c,
                              Value d) {
-  return {builder.create<arith::AddFOp>(loc, c, d),
-          builder.create<arith::SubFOp>(loc, c, d)};
+  return {arith::AddFOp::create(builder, loc, c, d),
+          arith::SubFOp::create(builder, loc, c, d)};
 }
 
 inline std::vector<Value> MULPM(OpBuilder &builder, Location loc, Value c,
                                 Value d, Value e, Value f) {
-  Value tmp1 = builder.create<arith::MulFOp>(loc, c, e);
-  Value tmp2 = builder.create<arith::MulFOp>(loc, d, f);
-  Value tmp3 = builder.create<arith::MulFOp>(loc, c, f);
-  Value tmp4 = builder.create<arith::MulFOp>(loc, d, e);
-  return {builder.create<arith::AddFOp>(loc, tmp1, tmp2),
-          builder.create<arith::SubFOp>(loc, tmp3, tmp4)};
+  Value tmp1 = arith::MulFOp::create(builder, loc, c, e);
+  Value tmp2 = arith::MulFOp::create(builder, loc, d, f);
+  Value tmp3 = arith::MulFOp::create(builder, loc, c, f);
+  Value tmp4 = arith::MulFOp::create(builder, loc, d, e);
+  return {arith::AddFOp::create(builder, loc, tmp1, tmp2),
+          arith::SubFOp::create(builder, loc, tmp3, tmp4)};
 }
 
 inline Value C1(OpBuilder &builder, Location loc, Value cc, Value a, Value b,
                 Value c, Value ido, Value l1) {
-  Value tmp1 = builder.create<arith::MulIOp>(loc, l1, c);
-  Value tmp2 = builder.create<arith::AddIOp>(loc, tmp1, b);
-  Value tmp3 = builder.create<arith::MulIOp>(loc, tmp2, ido);
-  Value index = builder.create<arith::AddIOp>(loc, tmp3, a);
-  return builder.create<memref::LoadOp>(loc, cc, index);
+  Value tmp1 = arith::MulIOp::create(builder, loc, l1, c);
+  Value tmp2 = arith::AddIOp::create(builder, loc, tmp1, b);
+  Value tmp3 = arith::MulIOp::create(builder, loc, tmp2, ido);
+  Value index = arith::AddIOp::create(builder, loc, tmp3, a);
+  return memref::LoadOp::create(builder, loc, cc, index);
 }
 
 inline void C1w(OpBuilder &builder, Location loc, Value cc, Value a, Value b,
                 Value c, Value ido, Value l1, Value toWrite) {
-  Value tmp1 = builder.create<arith::MulIOp>(loc, l1, c);
-  Value tmp2 = builder.create<arith::AddIOp>(loc, tmp1, b);
-  Value tmp3 = builder.create<arith::MulIOp>(loc, tmp2, ido);
-  Value index = builder.create<arith::AddIOp>(loc, tmp3, a);
-  builder.create<memref::StoreOp>(loc, toWrite, cc, index);
+  Value tmp1 = arith::MulIOp::create(builder, loc, l1, c);
+  Value tmp2 = arith::AddIOp::create(builder, loc, tmp1, b);
+  Value tmp3 = arith::MulIOp::create(builder, loc, tmp2, ido);
+  Value index = arith::AddIOp::create(builder, loc, tmp3, a);
+  memref::StoreOp::create(builder, loc, toWrite, cc, index);
   return;
 }
 
 inline Value C2(OpBuilder &builder, Location loc, Value cc, Value a, Value b,
                 Value idl1) {
-  Value tmp1 = builder.create<arith::MulIOp>(loc, idl1, b);
-  Value index = builder.create<arith::AddIOp>(loc, tmp1, a);
-  return builder.create<memref::LoadOp>(loc, cc, index);
+  Value tmp1 = arith::MulIOp::create(builder, loc, idl1, b);
+  Value index = arith::AddIOp::create(builder, loc, tmp1, a);
+  return memref::LoadOp::create(builder, loc, cc, index);
 }
 
 inline Value CH2(OpBuilder &builder, Location loc, Value ch, Value a, Value b,
                  Value idl1) {
-  Value tmp1 = builder.create<arith::MulIOp>(loc, idl1, b);
-  Value index = builder.create<arith::AddIOp>(loc, tmp1, a);
-  return builder.create<memref::LoadOp>(loc, ch, index);
+  Value tmp1 = arith::MulIOp::create(builder, loc, idl1, b);
+  Value index = arith::AddIOp::create(builder, loc, tmp1, a);
+  return memref::LoadOp::create(builder, loc, ch, index);
 }
 
 inline void CH2w(OpBuilder &builder, Location loc, Value ch, Value a, Value b,
                  Value idl1, Value toWrite) {
-  Value tmp1 = builder.create<arith::MulIOp>(loc, idl1, b);
-  Value index = builder.create<arith::AddIOp>(loc, tmp1, a);
-  builder.create<memref::StoreOp>(loc, toWrite, ch, index);
+  Value tmp1 = arith::MulIOp::create(builder, loc, idl1, b);
+  Value index = arith::AddIOp::create(builder, loc, tmp1, a);
+  memref::StoreOp::create(builder, loc, toWrite, ch, index);
   return;
 }
 
 inline Value CH_radfg(OpBuilder &builder, Location loc, Value ch, Value a,
                       Value b, Value c, Value ido, Value l1) {
-  Value tmp = builder.create<arith::MulIOp>(loc, l1, c);
-  Value tmp1 = builder.create<arith::AddIOp>(loc, b, tmp);
-  Value tmp2 = builder.create<arith::MulIOp>(loc, tmp1, ido);
-  Value index = builder.create<arith::AddIOp>(loc, tmp2, a);
-  return builder.create<memref::LoadOp>(loc, ch, index);
+  Value tmp = arith::MulIOp::create(builder, loc, l1, c);
+  Value tmp1 = arith::AddIOp::create(builder, loc, b, tmp);
+  Value tmp2 = arith::MulIOp::create(builder, loc, tmp1, ido);
+  Value index = arith::AddIOp::create(builder, loc, tmp2, a);
+  return memref::LoadOp::create(builder, loc, ch, index);
 }
 
 inline void CCw(OpBuilder &builder, Location loc, Value cc, Value a, Value b,
                 Value c, Value ido, Value cdim, Value toWrite) {
-  Value tmp = builder.create<arith::MulIOp>(loc, cdim, c);
-  Value tmp1 = builder.create<arith::AddIOp>(loc, b, tmp);
-  Value tmp2 = builder.create<arith::MulIOp>(loc, tmp1, ido);
-  Value index = builder.create<arith::AddIOp>(loc, tmp2, a);
-  builder.create<memref::StoreOp>(loc, toWrite, cc, index);
+  Value tmp = arith::MulIOp::create(builder, loc, cdim, c);
+  Value tmp1 = arith::AddIOp::create(builder, loc, b, tmp);
+  Value tmp2 = arith::MulIOp::create(builder, loc, tmp1, ido);
+  Value index = arith::AddIOp::create(builder, loc, tmp2, a);
+  memref::StoreOp::create(builder, loc, toWrite, cc, index);
   return;
 }
 
 inline Value CSARR(OpBuilder &builder, Location loc, Value csarr, Value index) {
 
-  return builder.create<memref::LoadOp>(loc, csarr, index);
+  return memref::LoadOp::create(builder, loc, csarr, index);
 }
 
 inline Value AR(OpBuilder &builder, Location loc, Value csarr, Value iang) {
-  Value c2 = builder.create<ConstantIndexOp>(loc, 2);
-  Value index = builder.create<arith::MulIOp>(loc, iang, c2);
+  Value c2 = ConstantIndexOp::create(builder, loc, 2);
+  Value index = arith::MulIOp::create(builder, loc, iang, c2);
   return CSARR(builder, loc, csarr, index);
 }
 
 inline Value AI(OpBuilder &builder, Location loc, Value csarr, Value iang) {
-  Value c1 = builder.create<ConstantIndexOp>(loc, 1);
-  Value c2 = builder.create<ConstantIndexOp>(loc, 2);
-  Value tmp = builder.create<arith::MulIOp>(loc, iang, c2);
-  Value index = builder.create<arith::AddIOp>(loc, tmp, c1);
+  Value c1 = ConstantIndexOp::create(builder, loc, 1);
+  Value c2 = ConstantIndexOp::create(builder, loc, 2);
+  Value tmp = arith::MulIOp::create(builder, loc, iang, c2);
+  Value index = arith::AddIOp::create(builder, loc, tmp, c1);
   return CSARR(builder, loc, csarr, index);
 }
 
 inline Value IANG(OpBuilder &builder, Location loc, Value iang, Value l,
                   Value ip) {
 
-  Value iang_new = builder.create<arith::AddIOp>(loc, iang, l);
+  Value iang_new = arith::AddIOp::create(builder, loc, iang, l);
 
-  Value condition = builder.create<arith::CmpIOp>(
-      loc, arith::CmpIPredicate::sge, iang_new, ip);
+  Value condition = arith::CmpIOp::create(
+      builder, loc, arith::CmpIPredicate::sge, iang_new, ip);
 
-  auto result = builder.create<scf::IfOp>(
-      loc, condition,
+  auto result = scf::IfOp::create(
+      builder, loc, condition,
       [&](OpBuilder &b, Location loc) {
-        Value res = b.create<arith::SubIOp>(loc, iang_new, ip);
-        b.create<scf::YieldOp>(loc, ValueRange{res});
+        Value res = arith::SubIOp::create(b, loc, iang_new, ip);
+        scf::YieldOp::create(b, loc, ValueRange{res});
       },
       [&](OpBuilder &b, Location loc) {
-        b.create<scf::YieldOp>(loc, ValueRange{iang_new});
+        scf::YieldOp::create(b, loc, ValueRange{iang_new});
       });
 
   return result.getResult(0);
@@ -927,76 +931,76 @@ inline Value IANG(OpBuilder &builder, Location loc, Value iang, Value l,
 void radfgExtend(OpBuilder &opBuilder, Location loc, Value cc, Value ch,
                  Value wa, Value csarr, Value ido, Value ip, Value l1) {
 
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
-  Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value c2 = ConstantIndexOp::create(opBuilder, loc, 2);
+  Value c3 = ConstantIndexOp::create(opBuilder, loc, 3);
   // TODO: remove c4?
   // Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
 
-  Value cdim = opBuilder.create<arith::SubIOp>(loc, ip, c0);
-  Value tmp0 = opBuilder.create<arith::AddIOp>(loc, ip, c1);
-  Value ipph = opBuilder.create<arith::DivSIOp>(loc, tmp0, c2);
-  Value idom1 = opBuilder.create<arith::SubIOp>(loc, ido, c1);
+  Value cdim = arith::SubIOp::create(opBuilder, loc, ip, c0);
+  Value tmp0 = arith::AddIOp::create(opBuilder, loc, ip, c1);
+  Value ipph = arith::DivSIOp::create(opBuilder, loc, tmp0, c2);
+  Value idom1 = arith::SubIOp::create(opBuilder, loc, ido, c1);
   // TODO: remove the following values?
   // Value idom2 = opBuilder.create<arith::SubIOp>(loc, ido, c2);
-  Value idl1 = opBuilder.create<arith::MulIOp>(loc, ido, l1);
+  Value idl1 = arith::MulIOp::create(opBuilder, loc, ido, l1);
 
-  opBuilder.create<scf::ForOp>(
-      loc, c0, idl1, c1, ValueRange{},
+  scf::ForOp::create(
+      opBuilder, loc, c0, idl1, c1, ValueRange{},
       [&](OpBuilder &builder, Location loc, Value ik, ValueRange ik_args) {
         Value c2ik0 = C2(builder, loc, cc, ik, c0, idl1);
         CH2w(builder, loc, ch, ik, c0, idl1, c2ik0);
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
-  opBuilder.create<scf::ForOp>(
-      loc, c1, ipph, c1, ValueRange{},
+  scf::ForOp::create(
+      opBuilder, loc, c1, ipph, c1, ValueRange{},
       [&](OpBuilder &builder, Location loc, Value j, ValueRange j_args) {
-        builder.create<scf::ForOp>(
-            loc, c0, idl1, c1, ValueRange{},
+        scf::ForOp::create(
+            builder, loc, c0, idl1, c1, ValueRange{},
             [&](OpBuilder &b, Location loc, Value ik, ValueRange ik_args) {
               Value c2ikj = C2(b, loc, cc, ik, j, idl1);
               Value ch2ik0 = CH2(b, loc, ch, ik, c0, idl1);
               Value ch2ik0_updated =
-                  b.create<arith::AddFOp>(loc, ch2ik0, c2ikj);
+                  arith::AddFOp::create(b, loc, ch2ik0, c2ikj);
 
               CH2w(b, loc, ch, ik, c0, idl1, ch2ik0_updated);
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
-  opBuilder.create<scf::ForOp>(
-      loc, c0, l1, c1, ValueRange{},
+  scf::ForOp::create(
+      opBuilder, loc, c0, l1, c1, ValueRange{},
       [&](OpBuilder &builder, Location loc, Value k, ValueRange k_args) {
-        builder.create<scf::ForOp>(
-            loc, c0, ido, c1, ValueRange{},
+        scf::ForOp::create(
+            builder, loc, c0, ido, c1, ValueRange{},
             [&](OpBuilder &b, Location loc, Value i, ValueRange i_args) {
               Value chik0 = CH_radfg(b, loc, ch, i, k, c0, ido, l1);
 
               CCw(b, loc, cc, i, c0, k, ido, cdim, chik0);
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
-  Value j_start_0 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value jc_start_0 = opBuilder.create<arith::SubIOp>(loc, ip, c1);
+  Value j_start_0 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value jc_start_0 = arith::SubIOp::create(opBuilder, loc, ip, c1);
 
-  opBuilder.create<scf::ForOp>(
-      loc, c1, ipph, c1, ValueRange{j_start_0, jc_start_0},
+  scf::ForOp::create(
+      opBuilder, loc, c1, ipph, c1, ValueRange{j_start_0, jc_start_0},
       [&](OpBuilder &builder, Location loc, Value j_loop,
           ValueRange j_loop_args) {
         Value j = j_loop_args[0];
         Value jc = j_loop_args[1];
 
-        Value tmp = builder.create<arith::MulIOp>(loc, j, c2);
-        Value j2 = builder.create<arith::SubIOp>(loc, tmp, c1);
-        Value j2p1 = builder.create<arith::AddIOp>(loc, j2, c1);
+        Value tmp = arith::MulIOp::create(builder, loc, j, c2);
+        Value j2 = arith::SubIOp::create(builder, loc, tmp, c1);
+        Value j2p1 = arith::AddIOp::create(builder, loc, j2, c1);
 
-        builder.create<scf::ForOp>(
-            loc, c0, l1, c1, ValueRange{},
+        scf::ForOp::create(
+            builder, loc, c0, l1, c1, ValueRange{},
             [&](OpBuilder &b, Location loc, Value k, ValueRange k_args) {
               Value ch0kj = CH_radfg(b, loc, ch, c0, k, j, ido, l1);
               CCw(b, loc, cc, idom1, j2, k, ido, cdim, ch0kj);
@@ -1004,56 +1008,57 @@ void radfgExtend(OpBuilder &opBuilder, Location loc, Value cc, Value ch,
               Value ch0kjc = CH_radfg(b, loc, ch, c0, k, jc, ido, l1);
               CCw(b, loc, cc, c0, j2p1, k, ido, cdim, ch0kjc);
 
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
 
-        Value j_next = builder.create<arith::AddIOp>(loc, j, c1);
-        Value jc_next = builder.create<arith::SubIOp>(loc, jc, c1);
-        builder.create<scf::YieldOp>(loc, std::vector<Value>{j_next, jc_next});
+        Value j_next = arith::AddIOp::create(builder, loc, j, c1);
+        Value jc_next = arith::SubIOp::create(builder, loc, jc, c1);
+        scf::YieldOp::create(builder, loc, std::vector<Value>{j_next, jc_next});
       });
 
   Value condition1 =
-      opBuilder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne, ido, l1);
+      arith::CmpIOp::create(opBuilder, loc, arith::CmpIPredicate::ne, ido, l1);
 
-  opBuilder.create<scf::IfOp>(
-      loc, condition1, [&](OpBuilder &builder, Location loc) {
-        Value j_start_1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-        Value jc_start_1 = opBuilder.create<arith::SubIOp>(loc, ip, c1);
+  scf::IfOp::create(
+      opBuilder, loc, condition1, [&](OpBuilder &builder, Location loc) {
+        Value j_start_1 = ConstantIndexOp::create(opBuilder, loc, 1);
+        Value jc_start_1 = arith::SubIOp::create(opBuilder, loc, ip, c1);
 
-        builder.create<scf::ForOp>(
-            loc, c1, ipph, c1, ValueRange{j_start_1, jc_start_1},
+        scf::ForOp::create(
+            builder, loc, c1, ipph, c1, ValueRange{j_start_1, jc_start_1},
             [&](OpBuilder &b, Location loc, Value j_loop,
                 ValueRange j_loop_args) {
               Value j = j_loop_args[0];
               Value jc = j_loop_args[1];
 
-              Value tmp = b.create<arith::MulIOp>(loc, j, c2);
-              Value j2 = b.create<arith::SubIOp>(loc, tmp, c1);
-              Value j2p1 = b.create<arith::AddIOp>(loc, j2, c1);
+              Value tmp = arith::MulIOp::create(b, loc, j, c2);
+              Value j2 = arith::SubIOp::create(b, loc, tmp, c1);
+              Value j2p1 = arith::AddIOp::create(b, loc, j2, c1);
 
-              b.create<scf::ForOp>(
-                  loc, c0, l1, c1, ValueRange{},
+              scf::ForOp::create(
+                  b, loc, c0, l1, c1, ValueRange{},
                   [&](OpBuilder &b2, Location loc, Value k, ValueRange k_args) {
-                    Value i_start_0 = b2.create<ConstantIndexOp>(loc, 1);
-                    Value ic_start_0 = b2.create<arith::SubIOp>(loc, ido, c3);
+                    Value i_start_0 = ConstantIndexOp::create(b2, loc, 1);
+                    Value ic_start_0 = arith::SubIOp::create(b2, loc, ido, c3);
 
-                    b2.create<scf::ForOp>(
-                        loc, c1, idom1, c2, ValueRange{i_start_0, ic_start_0},
+                    scf::ForOp::create(
+                        b2, loc, c1, idom1, c2,
+                        ValueRange{i_start_0, ic_start_0},
                         [&](OpBuilder &b3, Location loc, Value i_loop,
                             ValueRange i_loop_args) {
                           Value i = i_loop_args[0];
                           Value ic = i_loop_args[1];
 
-                          Value ip1 = b3.create<arith::AddIOp>(loc, i, c1);
-                          Value icp1 = b3.create<arith::AddIOp>(loc, ic, c1);
+                          Value ip1 = arith::AddIOp::create(b3, loc, i, c1);
+                          Value icp1 = arith::AddIOp::create(b3, loc, ic, c1);
 
                           Value chikj = CH_radfg(b3, loc, ch, i, k, j, ido, l1);
                           Value chikjc =
                               CH_radfg(b3, loc, ch, i, k, jc, ido, l1);
                           Value tmp2 =
-                              b3.create<arith::AddFOp>(loc, chikj, chikjc);
+                              arith::AddFOp::create(b3, loc, chikj, chikjc);
                           Value tmp3 =
-                              b3.create<arith::SubFOp>(loc, chikj, chikjc);
+                              arith::SubFOp::create(b3, loc, chikj, chikjc);
                           CCw(b3, loc, cc, i, j2p1, k, ido, cdim, tmp2);
                           CCw(b3, loc, cc, ic, j2, k, ido, cdim, tmp3);
 
@@ -1062,25 +1067,26 @@ void radfgExtend(OpBuilder &opBuilder, Location loc, Value cc, Value ch,
                           Value chip1kjc =
                               CH_radfg(b3, loc, ch, ip1, k, jc, ido, l1);
                           Value tmp4 =
-                              b3.create<arith::AddFOp>(loc, chip1kj, chip1kjc);
+                              arith::AddFOp::create(b3, loc, chip1kj, chip1kjc);
                           Value tmp5 =
-                              b3.create<arith::SubFOp>(loc, chip1kjc, chip1kj);
+                              arith::SubFOp::create(b3, loc, chip1kjc, chip1kj);
                           CCw(b3, loc, cc, ip1, j2p1, k, ido, cdim, tmp4);
                           CCw(b3, loc, cc, icp1, j2, k, ido, cdim, tmp5);
 
-                          Value i_next = b3.create<arith::AddIOp>(loc, i, c2);
-                          Value ic_next = b3.create<arith::SubIOp>(loc, ic, c2);
-                          b3.create<scf::YieldOp>(
-                              loc, std::vector<Value>{i_next, ic_next});
+                          Value i_next = arith::AddIOp::create(b3, loc, i, c2);
+                          Value ic_next =
+                              arith::SubIOp::create(b3, loc, ic, c2);
+                          scf::YieldOp::create(
+                              b3, loc, std::vector<Value>{i_next, ic_next});
                         });
-                    b2.create<scf::YieldOp>(loc);
+                    scf::YieldOp::create(b2, loc);
                   });
 
-              Value j_next = b.create<arith::AddIOp>(loc, j, c1);
-              Value jc_next = b.create<arith::SubIOp>(loc, jc, c1);
-              b.create<scf::YieldOp>(loc, std::vector<Value>{j_next, jc_next});
+              Value j_next = arith::AddIOp::create(b, loc, j, c1);
+              Value jc_next = arith::SubIOp::create(b, loc, jc, c1);
+              scf::YieldOp::create(b, loc, std::vector<Value>{j_next, jc_next});
             });
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
   return;
@@ -1090,61 +1096,62 @@ void radfgExtend(OpBuilder &opBuilder, Location loc, Value cc, Value ch,
 void radfg(OpBuilder &opBuilder, Location loc, Value cc, Value ch, Value wa,
            Value csarr, Value ido, Value ip, Value l1) {
 
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
-  Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
-  Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value c2 = ConstantIndexOp::create(opBuilder, loc, 2);
+  Value c3 = ConstantIndexOp::create(opBuilder, loc, 3);
+  Value c4 = ConstantIndexOp::create(opBuilder, loc, 4);
 
-  Value ipm1 = opBuilder.create<arith::SubIOp>(loc, ip, c1);
-  Value ipm2 = opBuilder.create<arith::SubIOp>(loc, ip, c2);
+  Value ipm1 = arith::SubIOp::create(opBuilder, loc, ip, c1);
+  Value ipm2 = arith::SubIOp::create(opBuilder, loc, ip, c2);
 
   // TODO: remove the following values?
   // Value cdim = opBuilder.create<arith::SubIOp>(loc, ip, c0);
-  Value tmp = opBuilder.create<arith::AddIOp>(loc, ip, c1);
-  Value ipph = opBuilder.create<arith::DivSIOp>(loc, tmp, c2);
+  Value tmp = arith::AddIOp::create(opBuilder, loc, ip, c1);
+  Value ipph = arith::DivSIOp::create(opBuilder, loc, tmp, c2);
 
-  Value idl1 = opBuilder.create<arith::MulIOp>(loc, ido, l1);
-  Value idom1 = opBuilder.create<arith::SubIOp>(loc, ido, c1);
+  Value idl1 = arith::MulIOp::create(opBuilder, loc, ido, l1);
+  Value idom1 = arith::SubIOp::create(opBuilder, loc, ido, c1);
   // TODO: remove idom2?
   // Value idom2 = opBuilder.create<arith::SubIOp>(loc, ido, c2);
 
   Value condition =
-      opBuilder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt, ido, l1);
+      arith::CmpIOp::create(opBuilder, loc, arith::CmpIPredicate::sgt, ido, l1);
 
-  opBuilder.create<scf::IfOp>(
-      loc, condition, [&](OpBuilder &builder, Location loc) {
-        Value jc_start = builder.create<arith::SubIOp>(loc, ip, c1);
+  scf::IfOp::create(
+      opBuilder, loc, condition, [&](OpBuilder &builder, Location loc) {
+        Value jc_start = arith::SubIOp::create(builder, loc, ip, c1);
 
-        builder.create<scf::ForOp>(
-            loc, c1, ipph, c1, ValueRange{jc_start},
+        scf::ForOp::create(
+            builder, loc, c1, ipph, c1, ValueRange{jc_start},
             [&](OpBuilder &b, Location loc, Value j, ValueRange j_args) {
               Value jc = j_args[0];
 
-              Value jm1 = b.create<arith::SubIOp>(loc, j, c1);
-              Value jcm1 = b.create<arith::SubIOp>(loc, jc, c1);
+              Value jm1 = arith::SubIOp::create(b, loc, j, c1);
+              Value jcm1 = arith::SubIOp::create(b, loc, jc, c1);
 
-              Value is = b.create<arith::MulIOp>(loc, jm1, idom1);
-              Value is2 = b.create<arith::MulIOp>(loc, jcm1, idom1);
+              Value is = arith::MulIOp::create(b, loc, jm1, idom1);
+              Value is2 = arith::MulIOp::create(b, loc, jcm1, idom1);
 
-              b.create<scf::ForOp>(
-                  loc, c0, l1, c1, ValueRange{},
+              scf::ForOp::create(
+                  b, loc, c0, l1, c1, ValueRange{},
                   [&](OpBuilder &b2, Location loc, Value k, ValueRange k_args) {
-                    Value idij_start = b2.create<arith::SubIOp>(loc, is, c0);
-                    Value idij2_start = b2.create<arith::SubIOp>(loc, is2, c0);
+                    Value idij_start = arith::SubIOp::create(b2, loc, is, c0);
+                    Value idij2_start = arith::SubIOp::create(b2, loc, is2, c0);
 
-                    b2.create<scf::ForOp>(
-                        loc, c1, idom1, c2, ValueRange{idij_start, idij2_start},
+                    scf::ForOp::create(
+                        b2, loc, c1, idom1, c2,
+                        ValueRange{idij_start, idij2_start},
                         [&](OpBuilder &b3, Location loc, Value i,
                             ValueRange i_args) {
                           Value idij = i_args[0];
                           Value idij2 = i_args[1];
 
-                          Value ip1 = b3.create<arith::AddIOp>(loc, i, c1);
+                          Value ip1 = arith::AddIOp::create(b3, loc, i, c1);
                           Value idijp1 =
-                              b3.create<arith::AddIOp>(loc, idij, c1);
+                              arith::AddIOp::create(b3, loc, idij, c1);
                           Value idij2p1 =
-                              b3.create<arith::AddIOp>(loc, idij2, c1);
+                              arith::AddIOp::create(b3, loc, idij2, c1);
 
                           Value t1 = C1(b3, loc, cc, i, k, j, ido, l1);
                           Value t2 = C1(b3, loc, cc, ip1, k, j, ido, l1);
@@ -1152,46 +1159,46 @@ void radfg(OpBuilder &opBuilder, Location loc, Value cc, Value ch, Value wa,
                           Value t4 = C1(b3, loc, cc, ip1, k, jc, ido, l1);
 
                           Value waidij =
-                              b3.create<memref::LoadOp>(loc, wa, idij);
+                              memref::LoadOp::create(b3, loc, wa, idij);
                           Value waidijp1 =
-                              b3.create<memref::LoadOp>(loc, wa, idijp1);
+                              memref::LoadOp::create(b3, loc, wa, idijp1);
                           Value waidij2 =
-                              b3.create<memref::LoadOp>(loc, wa, idij2);
+                              memref::LoadOp::create(b3, loc, wa, idij2);
                           Value waidij2p1 =
-                              b3.create<memref::LoadOp>(loc, wa, idij2p1);
+                              memref::LoadOp::create(b3, loc, wa, idij2p1);
 
                           Value tmp1_x1 =
-                              b3.create<arith::MulFOp>(loc, waidij, t1);
+                              arith::MulFOp::create(b3, loc, waidij, t1);
                           Value tmp2_x1 =
-                              b3.create<arith::MulFOp>(loc, waidijp1, t2);
+                              arith::MulFOp::create(b3, loc, waidijp1, t2);
                           Value x1 =
-                              b3.create<arith::AddFOp>(loc, tmp1_x1, tmp2_x1);
+                              arith::AddFOp::create(b3, loc, tmp1_x1, tmp2_x1);
 
                           Value tmp1_x2 =
-                              b3.create<arith::MulFOp>(loc, waidij, t2);
+                              arith::MulFOp::create(b3, loc, waidij, t2);
                           Value tmp2_x2 =
-                              b3.create<arith::MulFOp>(loc, waidijp1, t1);
+                              arith::MulFOp::create(b3, loc, waidijp1, t1);
                           Value x2 =
-                              b3.create<arith::SubFOp>(loc, tmp1_x2, tmp2_x2);
+                              arith::SubFOp::create(b3, loc, tmp1_x2, tmp2_x2);
 
                           Value tmp1_x3 =
-                              b3.create<arith::MulFOp>(loc, waidij2, t3);
+                              arith::MulFOp::create(b3, loc, waidij2, t3);
                           Value tmp2_x3 =
-                              b3.create<arith::MulFOp>(loc, waidij2p1, t4);
+                              arith::MulFOp::create(b3, loc, waidij2p1, t4);
                           Value x3 =
-                              b3.create<arith::AddFOp>(loc, tmp1_x3, tmp2_x3);
+                              arith::AddFOp::create(b3, loc, tmp1_x3, tmp2_x3);
 
                           Value tmp1_x4 =
-                              b3.create<arith::MulFOp>(loc, waidij2, t4);
+                              arith::MulFOp::create(b3, loc, waidij2, t4);
                           Value tmp2_x4 =
-                              b3.create<arith::MulFOp>(loc, waidij2p1, t3);
+                              arith::MulFOp::create(b3, loc, waidij2p1, t3);
                           Value x4 =
-                              b3.create<arith::SubFOp>(loc, tmp1_x4, tmp2_x4);
+                              arith::SubFOp::create(b3, loc, tmp1_x4, tmp2_x4);
 
-                          Value tmp3 = b3.create<arith::AddFOp>(loc, x1, x3);
-                          Value tmp4 = b3.create<arith::SubFOp>(loc, x2, x4);
-                          Value tmp5 = b3.create<arith::AddFOp>(loc, x2, x4);
-                          Value tmp6 = b3.create<arith::SubFOp>(loc, x3, x1);
+                          Value tmp3 = arith::AddFOp::create(b3, loc, x1, x3);
+                          Value tmp4 = arith::SubFOp::create(b3, loc, x2, x4);
+                          Value tmp5 = arith::AddFOp::create(b3, loc, x2, x4);
+                          Value tmp6 = arith::SubFOp::create(b3, loc, x3, x1);
 
                           C1w(b3, loc, cc, i, k, j, ido, l1, tmp3);
                           C1w(b3, loc, cc, i, k, jc, ido, l1, tmp4);
@@ -1199,64 +1206,65 @@ void radfg(OpBuilder &opBuilder, Location loc, Value cc, Value ch, Value wa,
                           C1w(b3, loc, cc, ip1, k, jc, ido, l1, tmp6);
 
                           Value idij_next =
-                              b3.create<arith::AddIOp>(loc, idij, c2);
+                              arith::AddIOp::create(b3, loc, idij, c2);
                           Value idij2_next =
-                              b3.create<arith::AddIOp>(loc, idij2, c2);
+                              arith::AddIOp::create(b3, loc, idij2, c2);
 
-                          b3.create<scf::YieldOp>(
-                              loc, std::vector<Value>{idij_next, idij2_next});
+                          scf::YieldOp::create(
+                              b3, loc,
+                              std::vector<Value>{idij_next, idij2_next});
                         });
-                    b2.create<scf::YieldOp>(loc);
+                    scf::YieldOp::create(b2, loc);
                   }
 
               );
 
-              Value jc_next = b.create<arith::SubIOp>(loc, jc, c1);
-              b.create<scf::YieldOp>(loc, jc_next);
+              Value jc_next = arith::SubIOp::create(b, loc, jc, c1);
+              scf::YieldOp::create(b, loc, jc_next);
             });
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
-  Value jc_a_start = opBuilder.create<arith::SubIOp>(loc, ip, c1);
+  Value jc_a_start = arith::SubIOp::create(opBuilder, loc, ip, c1);
 
-  opBuilder.create<scf::ForOp>(
-      loc, c1, ipph, c1, ValueRange{jc_a_start},
+  scf::ForOp::create(
+      opBuilder, loc, c1, ipph, c1, ValueRange{jc_a_start},
       [&](OpBuilder &builder, Location loc, Value j_a, ValueRange j_a_args) {
         Value jc_a = j_a_args[0];
 
-        builder.create<scf::ForOp>(
-            loc, c0, l1, c1, ValueRange{},
+        scf::ForOp::create(
+            builder, loc, c0, l1, c1, ValueRange{},
             [&](OpBuilder &b, Location loc, Value k_a, ValueRange k_a_args) {
               Value t1_a = C1(b, loc, cc, c0, k_a, j_a, ido, l1);
               Value t2_a = C1(b, loc, cc, c0, k_a, jc_a, ido, l1);
 
-              Value tmp_a = b.create<arith::AddFOp>(loc, t1_a, t2_a);
-              Value tmp1_a = b.create<arith::SubFOp>(loc, t2_a, t1_a);
+              Value tmp_a = arith::AddFOp::create(b, loc, t1_a, t2_a);
+              Value tmp1_a = arith::SubFOp::create(b, loc, t2_a, t1_a);
 
               C1w(b, loc, cc, c0, k_a, j_a, ido, l1, tmp_a);
               C1w(b, loc, cc, c0, k_a, jc_a, ido, l1, tmp1_a);
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
 
-        Value jc_a_next = builder.create<arith::SubIOp>(loc, jc_a, c1);
-        builder.create<scf::YieldOp>(loc, jc_a_next);
+        Value jc_a_next = arith::SubIOp::create(builder, loc, jc_a, c1);
+        scf::YieldOp::create(builder, loc, jc_a_next);
       });
 
-  Value lc_b_start = opBuilder.create<arith::SubIOp>(loc, ip, c1);
+  Value lc_b_start = arith::SubIOp::create(opBuilder, loc, ip, c1);
 
-  opBuilder.create<scf::ForOp>(
-      loc, c1, ipph, c1, ValueRange{lc_b_start},
+  scf::ForOp::create(
+      opBuilder, loc, c1, ipph, c1, ValueRange{lc_b_start},
       [&](OpBuilder &builder, Location loc, Value l_b, ValueRange l_b_args) {
         Value lc_b = l_b_args[0];
 
-        builder.create<scf::ForOp>(
-            loc, c0, idl1, c1, ValueRange{},
+        scf::ForOp::create(
+            builder, loc, c0, idl1, c1, ValueRange{},
             [&](OpBuilder &b, Location loc, Value ik_b, ValueRange ik_b_args) {
-              Value m2l = b.create<arith::MulIOp>(loc, l_b, c2);
-              Value m4l = b.create<arith::MulIOp>(loc, l_b, c4);
-              Value m2lp1 = b.create<arith::AddIOp>(loc, m2l, c1);
-              Value m4lp1 = b.create<arith::AddIOp>(loc, m4l, c1);
+              Value m2l = arith::MulIOp::create(b, loc, l_b, c2);
+              Value m4l = arith::MulIOp::create(b, loc, l_b, c4);
+              Value m2lp1 = arith::AddIOp::create(b, loc, m2l, c1);
+              Value m4lp1 = arith::AddIOp::create(b, loc, m4l, c1);
 
               Value csarr2l = CSARR(b, loc, csarr, m2l);
               Value csarr4l = CSARR(b, loc, csarr, m4l);
@@ -1270,29 +1278,29 @@ void radfg(OpBuilder &opBuilder, Location loc, Value cc, Value ch, Value wa,
               Value c2ikipm1 = C2(b, loc, cc, ik_b, ipm1, idl1);
               Value c2ikipm2 = C2(b, loc, cc, ik_b, ipm2, idl1);
 
-              Value tmp_b = b.create<arith::MulFOp>(loc, csarr2l, c2ik1);
-              Value tmp1_b = b.create<arith::MulFOp>(loc, csarr4l, c2ik2);
-              Value tmp2_b = b.create<arith::AddFOp>(loc, tmp_b, tmp1_b);
-              Value tmp3_b = b.create<arith::AddFOp>(loc, c2ik0, tmp2_b);
+              Value tmp_b = arith::MulFOp::create(b, loc, csarr2l, c2ik1);
+              Value tmp1_b = arith::MulFOp::create(b, loc, csarr4l, c2ik2);
+              Value tmp2_b = arith::AddFOp::create(b, loc, tmp_b, tmp1_b);
+              Value tmp3_b = arith::AddFOp::create(b, loc, c2ik0, tmp2_b);
 
               CH2w(b, loc, ch, ik_b, l_b, idl1, tmp3_b);
 
-              Value tmp4_b = b.create<arith::MulFOp>(loc, csarr2lp1, c2ikipm1);
-              Value tmp5_b = b.create<arith::MulFOp>(loc, csarr4lp1, c2ikipm2);
-              Value tmp6_b = b.create<arith::AddFOp>(loc, tmp4_b, tmp5_b);
+              Value tmp4_b = arith::MulFOp::create(b, loc, csarr2lp1, c2ikipm1);
+              Value tmp5_b = arith::MulFOp::create(b, loc, csarr4lp1, c2ikipm2);
+              Value tmp6_b = arith::AddFOp::create(b, loc, tmp4_b, tmp5_b);
 
               CH2w(b, loc, ch, ik_b, lc_b, idl1, tmp6_b);
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
 
-        Value iang_start_c = builder.create<arith::MulIOp>(loc, c2, l_b);
-        Value j_start_c = builder.create<ConstantIndexOp>(loc, 3);
-        Value jc_start_c = builder.create<arith::SubIOp>(loc, ip, c3);
-        Value ipphm1 = builder.create<arith::SubIOp>(loc, ipph, c1);
-        Value ipphm3 = builder.create<arith::SubIOp>(loc, ipph, c3);
+        Value iang_start_c = arith::MulIOp::create(builder, loc, c2, l_b);
+        Value j_start_c = ConstantIndexOp::create(builder, loc, 3);
+        Value jc_start_c = arith::SubIOp::create(builder, loc, ip, c3);
+        Value ipphm1 = arith::SubIOp::create(builder, loc, ipph, c1);
+        Value ipphm3 = arith::SubIOp::create(builder, loc, ipph, c3);
 
-        auto loop1 = builder.create<scf::ForOp>(
-            loc, j_start_c, ipphm3, c4,
+        auto loop1 = scf::ForOp::create(
+            builder, loc, j_start_c, ipphm3, c4,
             ValueRange{j_start_c, jc_start_c, iang_start_c},
             [&](OpBuilder &b, Location loc, Value j_loop,
                 ValueRange j_loop_args) {
@@ -1316,13 +1324,13 @@ void radfg(OpBuilder &opBuilder, Location loc, Value cc, Value ch, Value wa,
               Value ar4 = AR(b, loc, csarr, iang_4_c);
               Value ai4 = AI(b, loc, csarr, iang_4_c);
 
-              b.create<scf::ForOp>(
-                  loc, c0, idl1, c1, ValueRange{},
+              scf::ForOp::create(
+                  b, loc, c0, idl1, c1, ValueRange{},
                   [&](OpBuilder &b2, Location loc, Value ik_c,
                       ValueRange ik_c_args) {
-                    Value jp1 = b2.create<arith::AddIOp>(loc, j, c1);
-                    Value jp2 = b2.create<arith::AddIOp>(loc, j, c2);
-                    Value jp3 = b2.create<arith::AddIOp>(loc, j, c3);
+                    Value jp1 = arith::AddIOp::create(b2, loc, j, c1);
+                    Value jp2 = arith::AddIOp::create(b2, loc, j, c2);
+                    Value jp3 = arith::AddIOp::create(b2, loc, j, c3);
                     // TODO: remove the following values?
                     // Value jm1 = b2.create<arith::SubIOp>(loc, j, c1);
                     // Value jm2 = b2.create<arith::SubIOp>(loc, j, c2);
@@ -1333,66 +1341,67 @@ void radfg(OpBuilder &opBuilder, Location loc, Value cc, Value ch, Value wa,
                     Value c2ikjp2 = C2(b2, loc, cc, ik_c, jp2, idl1);
                     Value c2ikjp3 = C2(b2, loc, cc, ik_c, jp3, idl1);
 
-                    Value tmp_c = b2.create<arith::MulFOp>(loc, ar1, c2ikj);
-                    Value tmp1_c = b2.create<arith::MulFOp>(loc, ar2, c2ikjp1);
-                    Value tmp2_c = b2.create<arith::MulFOp>(loc, ar3, c2ikjp2);
-                    Value tmp3_c = b2.create<arith::MulFOp>(loc, ar4, c2ikjp3);
+                    Value tmp_c = arith::MulFOp::create(b2, loc, ar1, c2ikj);
+                    Value tmp1_c = arith::MulFOp::create(b2, loc, ar2, c2ikjp1);
+                    Value tmp2_c = arith::MulFOp::create(b2, loc, ar3, c2ikjp2);
+                    Value tmp3_c = arith::MulFOp::create(b2, loc, ar4, c2ikjp3);
 
-                    Value tmp4_c = b2.create<arith::AddFOp>(loc, tmp_c, tmp1_c);
+                    Value tmp4_c =
+                        arith::AddFOp::create(b2, loc, tmp_c, tmp1_c);
                     Value tmp5_c =
-                        b2.create<arith::AddFOp>(loc, tmp4_c, tmp2_c);
+                        arith::AddFOp::create(b2, loc, tmp4_c, tmp2_c);
                     Value tmp6_c =
-                        b2.create<arith::AddFOp>(loc, tmp5_c, tmp3_c);
+                        arith::AddFOp::create(b2, loc, tmp5_c, tmp3_c);
 
                     Value ch2ikl = CH2(b2, loc, ch, ik_c, l_b, idl1);
                     Value tmp7_c =
-                        b2.create<arith::AddFOp>(loc, tmp6_c, ch2ikl);
+                        arith::AddFOp::create(b2, loc, tmp6_c, ch2ikl);
                     CH2w(b2, loc, ch, ik_c, l_b, idl1, tmp7_c);
 
-                    Value jcm1 = b2.create<arith::SubIOp>(loc, jc, c1);
-                    Value jcm2 = b2.create<arith::SubIOp>(loc, jc, c2);
-                    Value jcm3 = b2.create<arith::SubIOp>(loc, jc, c3);
+                    Value jcm1 = arith::SubIOp::create(b2, loc, jc, c1);
+                    Value jcm2 = arith::SubIOp::create(b2, loc, jc, c2);
+                    Value jcm3 = arith::SubIOp::create(b2, loc, jc, c3);
 
                     Value c2ikjc = C2(b2, loc, cc, ik_c, jc, idl1);
                     Value c2ikjcm1 = C2(b2, loc, cc, ik_c, jcm1, idl1);
                     Value c2ikjcm2 = C2(b2, loc, cc, ik_c, jcm2, idl1);
                     Value c2ikjcm3 = C2(b2, loc, cc, ik_c, jcm3, idl1);
 
-                    Value tmp_ai1 = b2.create<arith::MulFOp>(loc, ai1, c2ikjc);
+                    Value tmp_ai1 = arith::MulFOp::create(b2, loc, ai1, c2ikjc);
                     Value tmp_ai2 =
-                        b2.create<arith::MulFOp>(loc, ai2, c2ikjcm1);
+                        arith::MulFOp::create(b2, loc, ai2, c2ikjcm1);
                     Value tmp_ai3 =
-                        b2.create<arith::MulFOp>(loc, ai3, c2ikjcm2);
+                        arith::MulFOp::create(b2, loc, ai3, c2ikjcm2);
                     Value tmp_ai4 =
-                        b2.create<arith::MulFOp>(loc, ai4, c2ikjcm3);
+                        arith::MulFOp::create(b2, loc, ai4, c2ikjcm3);
 
                     Value tmp_ai5 =
-                        b2.create<arith::AddFOp>(loc, tmp_ai1, tmp_ai2);
+                        arith::AddFOp::create(b2, loc, tmp_ai1, tmp_ai2);
                     Value tmp_ai6 =
-                        b2.create<arith::AddFOp>(loc, tmp_ai5, tmp_ai3);
+                        arith::AddFOp::create(b2, loc, tmp_ai5, tmp_ai3);
                     Value tmp_ai7 =
-                        b2.create<arith::AddFOp>(loc, tmp_ai6, tmp_ai4);
+                        arith::AddFOp::create(b2, loc, tmp_ai6, tmp_ai4);
 
                     Value ch2iklc = CH2(b2, loc, ch, ik_c, lc_b, idl1);
                     Value tmp_ai8 =
-                        b2.create<arith::AddFOp>(loc, tmp_ai7, ch2iklc);
+                        arith::AddFOp::create(b2, loc, tmp_ai7, ch2iklc);
                     CH2w(b2, loc, ch, ik_c, lc_b, idl1, tmp_ai8);
 
-                    b2.create<scf::YieldOp>(loc);
+                    scf::YieldOp::create(b2, loc);
                   });
 
-              Value j_next = b.create<arith::AddIOp>(loc, j, c4);
-              Value jc_next = b.create<arith::SubIOp>(loc, jc, c4);
-              builder.create<scf::YieldOp>(
-                  loc, std::vector<Value>{j_next, jc_next, iang_4_c});
+              Value j_next = arith::AddIOp::create(b, loc, j, c4);
+              Value jc_next = arith::SubIOp::create(b, loc, jc, c4);
+              scf::YieldOp::create(
+                  builder, loc, std::vector<Value>{j_next, jc_next, iang_4_c});
             });
 
         Value j_1_c = loop1.getResults()[0];
         Value jc_1_c = loop1.getResults()[1];
         Value iang1_c = loop1.getResults()[2];
 
-        auto loop2 = builder.create<scf::ForOp>(
-            loc, j_1_c, ipphm1, c2, ValueRange{j_1_c, jc_1_c, iang1_c},
+        auto loop2 = scf::ForOp::create(
+            builder, loc, j_1_c, ipphm1, c2, ValueRange{j_1_c, jc_1_c, iang1_c},
             [&](OpBuilder &b, Location loc, Value j_loop,
                 ValueRange j_loop_args) {
               Value j = j_loop_args[0];
@@ -1407,56 +1416,57 @@ void radfg(OpBuilder &opBuilder, Location loc, Value cc, Value ch, Value wa,
               Value ar2 = AR(b, loc, csarr, iang_2_d);
               Value ai2 = AI(b, loc, csarr, iang_2_d);
 
-              b.create<scf::ForOp>(
-                  loc, c0, idl1, c1, ValueRange{},
+              scf::ForOp::create(
+                  b, loc, c0, idl1, c1, ValueRange{},
                   [&](OpBuilder &b2, Location loc, Value ik_d,
                       ValueRange ik_d_args) {
-                    Value jp1 = b2.create<arith::AddIOp>(loc, j, c1);
+                    Value jp1 = arith::AddIOp::create(b2, loc, j, c1);
                     // TODO: remove jm1?
                     // Value jm1 = b2.create<arith::SubIOp>(loc, j, c1);
 
                     Value c2ikj = C2(b2, loc, cc, ik_d, j, idl1);
                     Value c2ikjp1 = C2(b2, loc, cc, ik_d, jp1, idl1);
 
-                    Value tmp_c = b2.create<arith::MulFOp>(loc, ar1, c2ikj);
-                    Value tmp1_c = b2.create<arith::MulFOp>(loc, ar2, c2ikjp1);
-                    Value tmp2_c = b2.create<arith::AddFOp>(loc, tmp_c, tmp1_c);
+                    Value tmp_c = arith::MulFOp::create(b2, loc, ar1, c2ikj);
+                    Value tmp1_c = arith::MulFOp::create(b2, loc, ar2, c2ikjp1);
+                    Value tmp2_c =
+                        arith::AddFOp::create(b2, loc, tmp_c, tmp1_c);
 
                     Value ch2ikl = CH2(b2, loc, ch, ik_d, l_b, idl1);
                     Value tmp3_c =
-                        b2.create<arith::AddFOp>(loc, tmp2_c, ch2ikl);
+                        arith::AddFOp::create(b2, loc, tmp2_c, ch2ikl);
                     CH2w(b2, loc, ch, ik_d, l_b, idl1, tmp3_c);
 
-                    Value jcm1 = b2.create<arith::SubIOp>(loc, jc, c1);
+                    Value jcm1 = arith::SubIOp::create(b2, loc, jc, c1);
                     Value c2ikjc = C2(b2, loc, cc, ik_d, jc, idl1);
                     Value c2ikjcm1 = C2(b2, loc, cc, ik_d, jcm1, idl1);
 
-                    Value tmp_ai1 = b2.create<arith::MulFOp>(loc, ai1, c2ikjc);
+                    Value tmp_ai1 = arith::MulFOp::create(b2, loc, ai1, c2ikjc);
                     Value tmp_ai2 =
-                        b2.create<arith::MulFOp>(loc, ai2, c2ikjcm1);
+                        arith::MulFOp::create(b2, loc, ai2, c2ikjcm1);
                     Value tmp_ai3 =
-                        b2.create<arith::AddFOp>(loc, tmp_ai1, tmp_ai2);
+                        arith::AddFOp::create(b2, loc, tmp_ai1, tmp_ai2);
 
                     Value ch2iklc = CH2(b2, loc, ch, ik_d, lc_b, idl1);
                     Value tmp_ai4 =
-                        b2.create<arith::AddFOp>(loc, tmp_ai3, ch2iklc);
+                        arith::AddFOp::create(b2, loc, tmp_ai3, ch2iklc);
                     CH2w(b2, loc, ch, ik_d, lc_b, idl1, tmp_ai4);
 
-                    b2.create<scf::YieldOp>(loc);
+                    scf::YieldOp::create(b2, loc);
                   });
 
-              Value j_next = b.create<arith::AddIOp>(loc, j, c2);
-              Value jc_next = b.create<arith::SubIOp>(loc, jc, c2);
-              builder.create<scf::YieldOp>(
-                  loc, std::vector<Value>{j_next, jc_next, iang_2_d});
+              Value j_next = arith::AddIOp::create(b, loc, j, c2);
+              Value jc_next = arith::SubIOp::create(b, loc, jc, c2);
+              scf::YieldOp::create(
+                  builder, loc, std::vector<Value>{j_next, jc_next, iang_2_d});
             });
 
         Value j_2_c = loop2.getResults()[0];
         Value jc_2_c = loop2.getResults()[1];
         Value iang2_c = loop2.getResults()[2];
 
-        builder.create<scf::ForOp>(
-            loc, j_2_c, ipph, c1, ValueRange{j_2_c, jc_2_c, iang2_c},
+        scf::ForOp::create(
+            builder, loc, j_2_c, ipph, c1, ValueRange{j_2_c, jc_2_c, iang2_c},
             [&](OpBuilder &b, Location loc, Value j_loop,
                 ValueRange j_loop_args) {
               Value j = j_loop_args[0];
@@ -1467,34 +1477,35 @@ void radfg(OpBuilder &opBuilder, Location loc, Value cc, Value ch, Value wa,
               Value ar = AR(b, loc, csarr, iang_1_e);
               Value ai = AI(b, loc, csarr, iang_1_e);
 
-              b.create<scf::ForOp>(
-                  loc, c0, idl1, c1, ValueRange{},
+              scf::ForOp::create(
+                  b, loc, c0, idl1, c1, ValueRange{},
                   [&](OpBuilder &b2, Location loc, Value ik_e,
                       ValueRange ik_e_args) {
                     Value c2ikj = C2(b2, loc, cc, ik_e, j, idl1);
-                    Value tmp_c = b2.create<arith::MulFOp>(loc, ar, c2ikj);
+                    Value tmp_c = arith::MulFOp::create(b2, loc, ar, c2ikj);
                     Value ch2ikl = CH2(b2, loc, ch, ik_e, l_b, idl1);
-                    Value tmp2_c = b2.create<arith::AddFOp>(loc, tmp_c, ch2ikl);
+                    Value tmp2_c =
+                        arith::AddFOp::create(b2, loc, tmp_c, ch2ikl);
                     CH2w(b2, loc, ch, ik_e, l_b, idl1, tmp2_c);
 
                     Value c2ikjc = C2(b2, loc, cc, ik_e, jc, idl1);
-                    Value tmp_ai = b2.create<arith::MulFOp>(loc, ai, c2ikjc);
+                    Value tmp_ai = arith::MulFOp::create(b2, loc, ai, c2ikjc);
                     Value ch2iklc = CH2(b2, loc, ch, ik_e, lc_b, idl1);
                     Value tmp2_ai =
-                        b2.create<arith::AddFOp>(loc, tmp_ai, ch2iklc);
+                        arith::AddFOp::create(b2, loc, tmp_ai, ch2iklc);
                     CH2w(b2, loc, ch, ik_e, lc_b, idl1, tmp2_ai);
 
-                    b2.create<scf::YieldOp>(loc);
+                    scf::YieldOp::create(b2, loc);
                   });
 
-              Value j_next = b.create<arith::AddIOp>(loc, j, c2);
-              Value jc_next = b.create<arith::SubIOp>(loc, jc, c2);
-              builder.create<scf::YieldOp>(
-                  loc, std::vector<Value>{j_next, jc_next, iang_1_e});
+              Value j_next = arith::AddIOp::create(b, loc, j, c2);
+              Value jc_next = arith::SubIOp::create(b, loc, jc, c2);
+              scf::YieldOp::create(
+                  builder, loc, std::vector<Value>{j_next, jc_next, iang_1_e});
             });
 
-        Value lc_b_next = builder.create<arith::SubIOp>(loc, lc_b, c1);
-        builder.create<scf::YieldOp>(loc, lc_b_next);
+        Value lc_b_next = arith::SubIOp::create(builder, loc, lc_b, c1);
+        scf::YieldOp::create(builder, loc, lc_b_next);
       });
 
   radfgExtend(opBuilder, loc, cc, ch, wa, csarr, ido, ip, l1);
@@ -1505,9 +1516,9 @@ void radf2Extend(OpBuilder &opBuilder, Location loc, Value cc, Value ch,
   // TODO: remove f64Ty?
   // FloatType f64Ty = opBuilder.getF64Type();
 
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value c2 = ConstantIndexOp::create(opBuilder, loc, 2);
   // TODO: remove the following values?
   // Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
   // Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
@@ -1515,16 +1526,16 @@ void radf2Extend(OpBuilder &opBuilder, Location loc, Value cc, Value ch,
 
   // Value idom1 = opBuilder.create<arith::SubIOp>(loc, ido, c1);
 
-  opBuilder.create<scf::ForOp>(
-      loc, c0, l1, c1, ValueRange{},
+  scf::ForOp::create(
+      opBuilder, loc, c0, l1, c1, ValueRange{},
       [&](OpBuilder &builder, Location loc, Value k, ValueRange k_args) {
-        builder.create<scf::ForOp>(
-            loc, c2, ido, c2, ValueRange{},
+        scf::ForOp::create(
+            builder, loc, c2, ido, c2, ValueRange{},
             [&](OpBuilder &b, Location loc, Value i, ValueRange i_args) {
-              Value ic = b.create<arith::SubIOp>(loc, ido, i);
-              Value icm1 = b.create<arith::SubIOp>(loc, ic, c1);
-              Value im1 = b.create<arith::SubIOp>(loc, i, c1);
-              Value im2 = b.create<arith::SubIOp>(loc, i, c2);
+              Value ic = arith::SubIOp::create(b, loc, ido, i);
+              Value icm1 = arith::SubIOp::create(b, loc, ic, c1);
+              Value im1 = arith::SubIOp::create(b, loc, i, c1);
+              Value im2 = arith::SubIOp::create(b, loc, i, c2);
 
               Value wa0im2 = WA(b, loc, wa, c0, im2, ido, c1);
               Value wa0im1 = WA(b, loc, wa, c0, im1, ido, c1);
@@ -1543,9 +1554,9 @@ void radf2Extend(OpBuilder &opBuilder, Location loc, Value cc, Value ch,
 
               CH(b, loc, ch, i, c0, k, ido, cdim, ti2_ccik0[0]);
               CH(b, loc, ch, ic, c1, k, ido, cdim, ti2_ccik0[1]);
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 }
 
@@ -1554,55 +1565,55 @@ void radf2(OpBuilder &opBuilder, Location loc, Value cc, Value ch, Value wa,
            Value ido, Value l1) {
   // TODO: remove the f64Ty?
   // FloatType f64Ty = opBuilder.getF64Type();
-  Value cdim = opBuilder.create<ConstantIndexOp>(loc, 2);
+  Value cdim = ConstantIndexOp::create(opBuilder, loc, 2);
 
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value c2 = ConstantIndexOp::create(opBuilder, loc, 2);
   // TODO: remove the following values?
   // Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
   // Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
   // Value c20 = opBuilder.create<ConstantIndexOp>(loc, 20);
 
-  Value idom1 = opBuilder.create<arith::SubIOp>(loc, ido, c1);
+  Value idom1 = arith::SubIOp::create(opBuilder, loc, ido, c1);
 
-  opBuilder.create<scf::ForOp>(
-      loc, c0, l1, c1, ValueRange{},
+  scf::ForOp::create(
+      opBuilder, loc, c0, l1, c1, ValueRange{},
       [&](OpBuilder &builder, Location loc, Value iv, ValueRange iv_args) {
         Value cc0k0 = CC(builder, loc, cc, c0, iv, c0, ido, l1);
         Value cc0k1 = CC(builder, loc, cc, c0, iv, c1, ido, l1);
         std::vector<Value> cc0k0_cc0k1 = PM(builder, loc, cc0k0, cc0k1);
         CH(builder, loc, ch, c0, c0, iv, ido, cdim, cc0k0_cc0k1[0]);
         CH(builder, loc, ch, idom1, c1, iv, ido, cdim, cc0k0_cc0k1[1]);
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
-  Value flag = opBuilder.create<arith::RemSIOp>(loc, ido, c2);
+  Value flag = arith::RemSIOp::create(opBuilder, loc, ido, c2);
   Value condition =
-      opBuilder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, flag, c0);
+      arith::CmpIOp::create(opBuilder, loc, arith::CmpIPredicate::eq, flag, c0);
 
-  opBuilder.create<scf::IfOp>(
-      loc, condition, [&](OpBuilder &builder, Location loc) {
-        builder.create<scf::ForOp>(
-            loc, c0, l1, c1, ValueRange{},
+  scf::IfOp::create(
+      opBuilder, loc, condition, [&](OpBuilder &builder, Location loc) {
+        scf::ForOp::create(
+            builder, loc, c0, l1, c1, ValueRange{},
             [&](OpBuilder &b, Location loc, Value k, ValueRange k_args) {
               Value ccidom1k1 = CC(b, loc, cc, idom1, k, c1, ido, l1);
-              Value tmp = b.create<arith::NegFOp>(loc, ccidom1k1);
+              Value tmp = arith::NegFOp::create(b, loc, ccidom1k1);
               CH(b, loc, ch, c0, c1, k, ido, cdim, tmp);
               Value ccidom1k0 = CC(b, loc, cc, idom1, k, c0, ido, l1);
               CH(b, loc, ch, idom1, c0, k, ido, cdim, ccidom1k0);
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
   Value condition1 =
-      opBuilder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt, ido, c2);
-  opBuilder.create<scf::IfOp>(
-      loc, condition1, [&](OpBuilder &builder, Location loc) {
-        radf2Extend(builder, loc, cc, ch, wa, ido, l1, cdim);
-        builder.create<scf::YieldOp>(loc);
-      });
+      arith::CmpIOp::create(opBuilder, loc, arith::CmpIPredicate::sgt, ido, c2);
+  scf::IfOp::create(opBuilder, loc, condition1,
+                    [&](OpBuilder &builder, Location loc) {
+                      radf2Extend(builder, loc, cc, ch, wa, ido, l1, cdim);
+                      scf::YieldOp::create(builder, loc);
+                    });
 }
 
 void radf3Extend(OpBuilder &opBuilder, Location loc, Value cc, Value ch,
@@ -1610,27 +1621,27 @@ void radf3Extend(OpBuilder &opBuilder, Location loc, Value cc, Value ch,
 
   FloatType f64Ty = opBuilder.getF64Type();
   Value taur =
-      opBuilder.create<ConstantFloatOp>(loc, f64Ty, APFloat(double(-0.5)));
-  Value taui = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(0.86602540378443864676)));
+      ConstantFloatOp::create(opBuilder, loc, f64Ty, APFloat(double(-0.5)));
+  Value taui = ConstantFloatOp::create(opBuilder, loc, f64Ty,
+                                       APFloat(double(0.86602540378443864676)));
 
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value c2 = ConstantIndexOp::create(opBuilder, loc, 2);
   // TODO: remove c3 and c4?
   // Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
   // Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
 
-  opBuilder.create<scf::ForOp>(
-      loc, c0, l1, c1, ValueRange{},
+  scf::ForOp::create(
+      opBuilder, loc, c0, l1, c1, ValueRange{},
       [&](OpBuilder &builder, Location loc, Value k, ValueRange k_args) {
-        builder.create<scf::ForOp>(
-            loc, c2, ido, c2, ValueRange{},
+        scf::ForOp::create(
+            builder, loc, c2, ido, c2, ValueRange{},
             [&](OpBuilder &b, Location loc, Value i, ValueRange i_args) {
-              Value ic = b.create<arith::SubIOp>(loc, ido, i);
-              Value icm1 = b.create<arith::SubIOp>(loc, ic, c1);
-              Value im1 = b.create<arith::SubIOp>(loc, i, c1);
-              Value im2 = b.create<arith::SubIOp>(loc, i, c2);
+              Value ic = arith::SubIOp::create(b, loc, ido, i);
+              Value icm1 = arith::SubIOp::create(b, loc, ic, c1);
+              Value im1 = arith::SubIOp::create(b, loc, i, c1);
+              Value im2 = arith::SubIOp::create(b, loc, i, c2);
 
               Value wa0im2 = WA(b, loc, wa, c0, im2, ido, c1);
               Value wa0im1 = WA(b, loc, wa, c0, im1, ido, c1);
@@ -1646,29 +1657,30 @@ void radf3Extend(OpBuilder &opBuilder, Location loc, Value cc, Value ch,
               std::vector<Value> dr3_di3 =
                   MULPM(b, loc, wa1im2, wa1im1, ccim1k2, ccik2);
 
-              Value cr2 = b.create<arith::AddFOp>(loc, dr2_di2[0], dr3_di3[0]);
-              Value ci2 = b.create<arith::AddFOp>(loc, dr2_di2[1], dr3_di3[1]);
+              Value cr2 = arith::AddFOp::create(b, loc, dr2_di2[0], dr3_di3[0]);
+              Value ci2 = arith::AddFOp::create(b, loc, dr2_di2[1], dr3_di3[1]);
 
               Value ccim1k0 = CC(b, loc, cc, im1, k, c0, ido, l1);
-              Value tmp5 = b.create<arith::AddFOp>(loc, ccim1k0, cr2);
+              Value tmp5 = arith::AddFOp::create(b, loc, ccim1k0, cr2);
               CH(builder, loc, ch, im1, c0, k, ido, cdim, tmp5);
 
               Value ccik0 = CC(b, loc, cc, i, k, c0, ido, l1);
-              Value tmp6 = b.create<arith::AddFOp>(loc, ccik0, ci2);
+              Value tmp6 = arith::AddFOp::create(b, loc, ccik0, ci2);
               CH(builder, loc, ch, i, c0, k, ido, cdim, tmp6);
 
-              Value tmp7 = b.create<arith::MulFOp>(loc, taur, cr2);
-              Value tr2 = b.create<arith::AddFOp>(loc, ccim1k0, tmp7);
+              Value tmp7 = arith::MulFOp::create(b, loc, taur, cr2);
+              Value tr2 = arith::AddFOp::create(b, loc, ccim1k0, tmp7);
 
-              Value tmp8 = b.create<arith::MulFOp>(loc, taur, ci2);
-              Value ti2 = b.create<arith::AddFOp>(loc, ccik0, tmp8);
+              Value tmp8 = arith::MulFOp::create(b, loc, taur, ci2);
+              Value ti2 = arith::AddFOp::create(b, loc, ccik0, tmp8);
 
-              Value tmp9 = b.create<arith::SubFOp>(loc, dr2_di2[1], dr3_di3[1]);
-              Value tr3 = b.create<arith::MulFOp>(loc, taui, tmp9);
+              Value tmp9 =
+                  arith::SubFOp::create(b, loc, dr2_di2[1], dr3_di3[1]);
+              Value tr3 = arith::MulFOp::create(b, loc, taui, tmp9);
 
               Value tmp10 =
-                  b.create<arith::SubFOp>(loc, dr3_di3[0], dr2_di2[0]);
-              Value ti3 = b.create<arith::MulFOp>(loc, taui, tmp10);
+                  arith::SubFOp::create(b, loc, dr3_di3[0], dr2_di2[0]);
+              Value ti3 = arith::MulFOp::create(b, loc, taui, tmp10);
 
               std::vector<Value> tr2_tr3 = PM(b, loc, tr2, tr3);
               std::vector<Value> ti3_ti2 = PM(b, loc, ti3, ti2);
@@ -1679,9 +1691,9 @@ void radf3Extend(OpBuilder &opBuilder, Location loc, Value cc, Value ch,
               CH(builder, loc, ch, i, c2, k, ido, cdim, ti3_ti2[0]);
               CH(builder, loc, ch, ic, c1, k, ido, cdim, ti3_ti2[1]);
 
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 }
 
@@ -1690,65 +1702,65 @@ void radf3(OpBuilder &opBuilder, Location loc, Value cc, Value ch, Value wa,
            Value ido, Value l1) {
 
   FloatType f64Ty = opBuilder.getF64Type();
-  Value cdim = opBuilder.create<ConstantIndexOp>(loc, 3);
+  Value cdim = ConstantIndexOp::create(opBuilder, loc, 3);
   Value taur =
-      opBuilder.create<ConstantFloatOp>(loc, f64Ty, APFloat(double(-0.5)));
-  Value taui = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(0.86602540378443864676)));
+      ConstantFloatOp::create(opBuilder, loc, f64Ty, APFloat(double(-0.5)));
+  Value taui = ConstantFloatOp::create(opBuilder, loc, f64Ty,
+                                       APFloat(double(0.86602540378443864676)));
 
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value c2 = ConstantIndexOp::create(opBuilder, loc, 2);
   // TODO: remove c3 and c4?
   // Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
   // Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
 
-  Value idom1 = opBuilder.create<arith::SubIOp>(loc, ido, c1);
+  Value idom1 = arith::SubIOp::create(opBuilder, loc, ido, c1);
 
-  opBuilder.create<scf::ForOp>(
-      loc, c0, l1, c1, ValueRange{},
+  scf::ForOp::create(
+      opBuilder, loc, c0, l1, c1, ValueRange{},
       [&](OpBuilder &builder, Location loc, Value iv, ValueRange iv_args) {
         Value cc0k1 = CC(builder, loc, cc, c0, iv, c1, ido, l1);
         Value cc0k2 = CC(builder, loc, cc, c0, iv, c2, ido, l1);
-        Value cr2 = builder.create<arith::AddFOp>(loc, cc0k1, cc0k2);
+        Value cr2 = arith::AddFOp::create(builder, loc, cc0k1, cc0k2);
 
         Value cc0k0 = CC(builder, loc, cc, c0, iv, c0, ido, l1);
-        Value tmp0 = builder.create<arith::AddFOp>(loc, cc0k0, cr2);
+        Value tmp0 = arith::AddFOp::create(builder, loc, cc0k0, cr2);
         CH(builder, loc, ch, c0, c0, iv, ido, cdim, tmp0);
 
-        Value tmp1 = builder.create<arith::SubFOp>(loc, cc0k2, cc0k1);
-        Value tmp2 = builder.create<arith::MulFOp>(loc, tmp1, taui);
+        Value tmp1 = arith::SubFOp::create(builder, loc, cc0k2, cc0k1);
+        Value tmp2 = arith::MulFOp::create(builder, loc, tmp1, taui);
         CH(builder, loc, ch, c0, c2, iv, ido, cdim, tmp2);
 
-        Value tmp3 = builder.create<arith::MulFOp>(loc, taur, cr2);
-        Value tmp4 = builder.create<arith::AddFOp>(loc, tmp3, cc0k0);
+        Value tmp3 = arith::MulFOp::create(builder, loc, taur, cr2);
+        Value tmp4 = arith::AddFOp::create(builder, loc, tmp3, cc0k0);
         CH(builder, loc, ch, idom1, c1, iv, ido, cdim, tmp4);
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
   Value condition =
-      opBuilder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne, ido, c1);
-  opBuilder.create<scf::IfOp>(
-      loc, condition, [&](OpBuilder &builder, Location loc) {
-        radf3Extend(builder, loc, cc, ch, wa, ido, l1, cdim);
-        builder.create<scf::YieldOp>(loc);
-      });
+      arith::CmpIOp::create(opBuilder, loc, arith::CmpIPredicate::ne, ido, c1);
+  scf::IfOp::create(opBuilder, loc, condition,
+                    [&](OpBuilder &builder, Location loc) {
+                      radf3Extend(builder, loc, cc, ch, wa, ido, l1, cdim);
+                      scf::YieldOp::create(builder, loc);
+                    });
 }
 
 void radf4Extend(OpBuilder &opBuilder, Location loc, Value cc, Value ch,
                  Value wa, Value ido, Value l1, Value cdim, Value c0, Value c1,
                  Value c2, Value c3) {
-  opBuilder.create<scf::ForOp>(
-      loc, c0, l1, c1, ValueRange{},
+  scf::ForOp::create(
+      opBuilder, loc, c0, l1, c1, ValueRange{},
       [&](OpBuilder &builder, Location loc, Value k, ValueRange kargs) {
-        builder.create<scf::ForOp>(
-            loc, c2, ido, c2, ValueRange{},
+        scf::ForOp::create(
+            builder, loc, c2, ido, c2, ValueRange{},
             [&](OpBuilder &b, Location loc, Value i, ValueRange iargs) {
-              Value ic = b.create<arith::SubIOp>(loc, ido, i);
-              Value icm1 = b.create<arith::SubIOp>(loc, ic, c1);
-              Value im1 = b.create<arith::SubIOp>(loc, i, c1);
-              Value im2 = b.create<arith::SubIOp>(loc, i, c2);
+              Value ic = arith::SubIOp::create(b, loc, ido, i);
+              Value icm1 = arith::SubIOp::create(b, loc, ic, c1);
+              Value im1 = arith::SubIOp::create(b, loc, i, c1);
+              Value im2 = arith::SubIOp::create(b, loc, i, c2);
 
               Value wa0im2 = WA(b, loc, wa, c0, im2, ido, c1);
               Value wa0im1 = WA(b, loc, wa, c0, im1, ido, c1);
@@ -1794,10 +1806,10 @@ void radf4Extend(OpBuilder &opBuilder, Location loc, Value cc, Value ch,
               CH(b, loc, ch, i, c2, k, ido, cdim, chtmp3[0]);
               CH(b, loc, ch, ic, c1, k, ido, cdim, chtmp3[1]);
 
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
   return;
@@ -1807,13 +1819,13 @@ void radf4Extend(OpBuilder &opBuilder, Location loc, Value cc, Value ch,
 void radf4(OpBuilder &opBuilder, Location loc, Value cc, Value ch, Value wa,
            Value ido, Value l1, Value c0, Value c1, Value c2, Value c3) {
   FloatType f64Ty = opBuilder.getF64Type();
-  Value cdim = opBuilder.create<ConstantIndexOp>(loc, 4);
-  Value hsqt2 = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(0.70710678118654752440)));
-  Value idom1 = opBuilder.create<arith::SubIOp>(loc, ido, c1);
+  Value cdim = ConstantIndexOp::create(opBuilder, loc, 4);
+  Value hsqt2 = ConstantFloatOp::create(
+      opBuilder, loc, f64Ty, APFloat(double(0.70710678118654752440)));
+  Value idom1 = arith::SubIOp::create(opBuilder, loc, ido, c1);
 
-  opBuilder.create<scf::ForOp>(
-      loc, c0, l1, c1, ValueRange{},
+  scf::ForOp::create(
+      opBuilder, loc, c0, l1, c1, ValueRange{},
       [&](OpBuilder &builder, Location loc, Value iv, ValueRange iargs) {
         Value cc0k3 = CC(builder, loc, cc, c0, iv, c3, ido, l1);
         Value cc0k1 = CC(builder, loc, cc, c0, iv, c1, ido, l1);
@@ -1830,27 +1842,27 @@ void radf4(OpBuilder &opBuilder, Location loc, Value cc, Value ch, Value wa,
         CH(builder, loc, ch, c0, c0, iv, ido, cdim, tmp2_tmp3[0]);
         CH(builder, loc, ch, idom1, c3, iv, ido, cdim, tmp2_tmp3[1]);
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
-  Value reminder = opBuilder.create<arith::RemSIOp>(loc, ido, c2);
-  Value condition0 = opBuilder.create<arith::CmpIOp>(
-      loc, arith::CmpIPredicate::eq, reminder, c0);
-  opBuilder.create<scf::IfOp>(
-      loc, condition0, [&](OpBuilder &builder, Location loc) {
-        Value negHsqt2 = builder.create<ConstantFloatOp>(
-            loc, f64Ty, APFloat(double(-0.70710678118654752440)));
+  Value reminder = arith::RemSIOp::create(opBuilder, loc, ido, c2);
+  Value condition0 = arith::CmpIOp::create(
+      opBuilder, loc, arith::CmpIPredicate::eq, reminder, c0);
+  scf::IfOp::create(
+      opBuilder, loc, condition0, [&](OpBuilder &builder, Location loc) {
+        Value negHsqt2 = ConstantFloatOp::create(
+            builder, loc, f64Ty, APFloat(double(-0.70710678118654752440)));
 
-        builder.create<scf::ForOp>(
-            loc, c0, l1, c1, ValueRange{},
+        scf::ForOp::create(
+            builder, loc, c0, l1, c1, ValueRange{},
             [&](OpBuilder &b, Location loc, Value iv, ValueRange iargs) {
               Value ccidom1k1 = CC(b, loc, cc, idom1, iv, c1, ido, l1);
               Value ccidom1k3 = CC(b, loc, cc, idom1, iv, c3, ido, l1);
-              Value tmp0 = b.create<arith::AddFOp>(loc, ccidom1k1, ccidom1k3);
-              Value ti1 = b.create<arith::MulFOp>(loc, negHsqt2, tmp0);
+              Value tmp0 = arith::AddFOp::create(b, loc, ccidom1k1, ccidom1k3);
+              Value ti1 = arith::MulFOp::create(b, loc, negHsqt2, tmp0);
 
-              Value tmp1 = b.create<arith::SubFOp>(loc, ccidom1k1, ccidom1k3);
-              Value tr1 = b.create<arith::MulFOp>(loc, hsqt2, tmp1);
+              Value tmp1 = arith::SubFOp::create(b, loc, ccidom1k1, ccidom1k3);
+              Value tr1 = arith::MulFOp::create(b, loc, hsqt2, tmp1);
 
               Value ccidom1k0 = CC(b, loc, cc, idom1, iv, c0, ido, l1);
               std::vector<Value> tmp2_tmp3 = PM(b, loc, ccidom1k0, tr1);
@@ -1862,18 +1874,18 @@ void radf4(OpBuilder &opBuilder, Location loc, Value cc, Value ch, Value wa,
               CH(b, loc, ch, c0, c3, iv, ido, cdim, tmp4_tmp5[0]);
               CH(b, loc, ch, c0, c1, iv, ido, cdim, tmp4_tmp5[1]);
 
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
   Value condition1 =
-      opBuilder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt, ido, c2);
-  opBuilder.create<scf::IfOp>(
-      loc, condition1, [&](OpBuilder &builder, Location loc) {
+      arith::CmpIOp::create(opBuilder, loc, arith::CmpIPredicate::sgt, ido, c2);
+  scf::IfOp::create(
+      opBuilder, loc, condition1, [&](OpBuilder &builder, Location loc) {
         radf4Extend(builder, loc, cc, ch, wa, ido, l1, cdim, c0, c1, c2, c3);
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
   return;
@@ -1883,16 +1895,16 @@ void radf5Extend(OpBuilder &opBuilder, Location loc, Value cc, Value ch,
                  Value wa, Value ido, Value l1, Value cdim, Value tr11,
                  Value tr12, Value ti11, Value ti12, Value c0, Value c1,
                  Value c2, Value c3, Value c4) {
-  opBuilder.create<scf::ForOp>(
-      loc, c0, l1, c1, ValueRange{},
+  scf::ForOp::create(
+      opBuilder, loc, c0, l1, c1, ValueRange{},
       [&](OpBuilder &builder, Location loc, Value k, ValueRange kargs) {
-        builder.create<scf::ForOp>(
-            loc, c2, ido, c2, ValueRange{},
+        scf::ForOp::create(
+            builder, loc, c2, ido, c2, ValueRange{},
             [&](OpBuilder &b, Location loc, Value i, ValueRange iargs) {
-              Value ic = b.create<arith::SubIOp>(loc, ido, i);
-              Value icm1 = b.create<arith::SubIOp>(loc, ic, c1);
-              Value im1 = b.create<arith::SubIOp>(loc, i, c1);
-              Value im2 = b.create<arith::SubIOp>(loc, i, c2);
+              Value ic = arith::SubIOp::create(b, loc, ido, i);
+              Value icm1 = arith::SubIOp::create(b, loc, ic, c1);
+              Value im1 = arith::SubIOp::create(b, loc, i, c1);
+              Value im2 = arith::SubIOp::create(b, loc, i, c2);
 
               Value wa0im2 = WA(b, loc, wa, c0, im2, ido, c1);
               Value wa0im1 = WA(b, loc, wa, c0, im1, ido, c1);
@@ -1928,34 +1940,34 @@ void radf5Extend(OpBuilder &opBuilder, Location loc, Value cc, Value ch,
               std::vector<Value> ci3_cr4 = PM(b, loc, dr3_di3[1], dr4_di4[1]);
 
               Value ccim1k0 = CC(b, loc, cc, im1, k, c0, ido, l1);
-              Value tmpch0 = b.create<arith::AddFOp>(loc, ccim1k0, cr2_ci5[0]);
-              Value chim10k = b.create<arith::AddFOp>(loc, tmpch0, cr3_ci4[0]);
+              Value tmpch0 = arith::AddFOp::create(b, loc, ccim1k0, cr2_ci5[0]);
+              Value chim10k = arith::AddFOp::create(b, loc, tmpch0, cr3_ci4[0]);
               CH(b, loc, ch, im1, c0, k, ido, cdim, chim10k);
 
               Value ccik0 = CC(b, loc, cc, i, k, c0, ido, l1);
-              Value tmpch1 = b.create<arith::AddFOp>(loc, ccik0, ci2_cr5[0]);
-              Value chi0k = b.create<arith::AddFOp>(loc, tmpch1, ci3_cr4[0]);
+              Value tmpch1 = arith::AddFOp::create(b, loc, ccik0, ci2_cr5[0]);
+              Value chi0k = arith::AddFOp::create(b, loc, tmpch1, ci3_cr4[0]);
               CH(b, loc, ch, i, c0, k, ido, cdim, chi0k);
 
-              Value tmp0 = b.create<arith::MulFOp>(loc, tr11, cr2_ci5[0]);
-              Value tmp1 = b.create<arith::AddFOp>(loc, ccim1k0, tmp0);
-              Value tmp2 = b.create<arith::MulFOp>(loc, tr12, cr3_ci4[0]);
-              Value tr2 = b.create<arith::AddFOp>(loc, tmp1, tmp2);
+              Value tmp0 = arith::MulFOp::create(b, loc, tr11, cr2_ci5[0]);
+              Value tmp1 = arith::AddFOp::create(b, loc, ccim1k0, tmp0);
+              Value tmp2 = arith::MulFOp::create(b, loc, tr12, cr3_ci4[0]);
+              Value tr2 = arith::AddFOp::create(b, loc, tmp1, tmp2);
 
-              Value tmp3 = b.create<arith::MulFOp>(loc, tr11, ci2_cr5[0]);
-              Value tmp4 = b.create<arith::AddFOp>(loc, ccik0, tmp3);
-              Value tmp5 = b.create<arith::MulFOp>(loc, tr12, ci3_cr4[0]);
-              Value ti2 = b.create<arith::AddFOp>(loc, tmp4, tmp5);
+              Value tmp3 = arith::MulFOp::create(b, loc, tr11, ci2_cr5[0]);
+              Value tmp4 = arith::AddFOp::create(b, loc, ccik0, tmp3);
+              Value tmp5 = arith::MulFOp::create(b, loc, tr12, ci3_cr4[0]);
+              Value ti2 = arith::AddFOp::create(b, loc, tmp4, tmp5);
 
-              Value tmp6 = b.create<arith::MulFOp>(loc, tr12, cr2_ci5[0]);
-              Value tmp7 = b.create<arith::AddFOp>(loc, ccim1k0, tmp6);
-              Value tmp8 = b.create<arith::MulFOp>(loc, tr11, cr3_ci4[0]);
-              Value tr3 = b.create<arith::AddFOp>(loc, tmp7, tmp8);
+              Value tmp6 = arith::MulFOp::create(b, loc, tr12, cr2_ci5[0]);
+              Value tmp7 = arith::AddFOp::create(b, loc, ccim1k0, tmp6);
+              Value tmp8 = arith::MulFOp::create(b, loc, tr11, cr3_ci4[0]);
+              Value tr3 = arith::AddFOp::create(b, loc, tmp7, tmp8);
 
-              Value tmp9 = b.create<arith::MulFOp>(loc, tr12, ci2_cr5[0]);
-              Value tmp10 = b.create<arith::AddFOp>(loc, ccik0, tmp9);
-              Value tmp11 = b.create<arith::MulFOp>(loc, tr11, ci3_cr4[0]);
-              Value ti3 = b.create<arith::AddFOp>(loc, tmp10, tmp11);
+              Value tmp9 = arith::MulFOp::create(b, loc, tr12, ci2_cr5[0]);
+              Value tmp10 = arith::AddFOp::create(b, loc, ccik0, tmp9);
+              Value tmp11 = arith::MulFOp::create(b, loc, tr11, ci3_cr4[0]);
+              Value ti3 = arith::AddFOp::create(b, loc, tmp10, tmp11);
 
               std::vector<Value> tr5_tr4 =
                   MULPM(b, loc, ci2_cr5[1], ci3_cr4[1], ti11, ti12);
@@ -1978,10 +1990,10 @@ void radf5Extend(OpBuilder &opBuilder, Location loc, Value cc, Value ch,
               CH(b, loc, ch, i, c4, k, ido, cdim, chtmp3[0]);
               CH(b, loc, ch, ic, c3, k, ido, cdim, chtmp3[1]);
 
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
   return;
@@ -1993,19 +2005,19 @@ void radf5(OpBuilder &builder, Location loc, Value cc, Value ch, Value wa,
            Value c4) {
 
   FloatType f64Ty = builder.getF64Type();
-  Value cdim = builder.create<ConstantIndexOp>(loc, 5);
-  Value tr11 = builder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(0.3090169943749474241)));
-  Value tr12 = builder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(-0.8090169943749474241)));
-  Value ti11 = builder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(0.95105651629515357212)));
-  Value ti12 = builder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(0.58778525229247312917)));
-  Value idom1 = builder.create<arith::SubIOp>(loc, ido, c1);
+  Value cdim = ConstantIndexOp::create(builder, loc, 5);
+  Value tr11 = ConstantFloatOp::create(builder, loc, f64Ty,
+                                       APFloat(double(0.3090169943749474241)));
+  Value tr12 = ConstantFloatOp::create(builder, loc, f64Ty,
+                                       APFloat(double(-0.8090169943749474241)));
+  Value ti11 = ConstantFloatOp::create(builder, loc, f64Ty,
+                                       APFloat(double(0.95105651629515357212)));
+  Value ti12 = ConstantFloatOp::create(builder, loc, f64Ty,
+                                       APFloat(double(0.58778525229247312917)));
+  Value idom1 = arith::SubIOp::create(builder, loc, ido, c1);
 
-  builder.create<scf::ForOp>(
-      loc, c0, l1, c1, ValueRange{},
+  scf::ForOp::create(
+      builder, loc, c0, l1, c1, ValueRange{},
       [&](OpBuilder &b, Location loc, Value iv, ValueRange iargs) {
         Value cc0k4 = CC(b, loc, cc, c0, iv, c4, ido, l1);
         Value cc0k1 = CC(b, loc, cc, c0, iv, c1, ido, l1);
@@ -2016,41 +2028,41 @@ void radf5(OpBuilder &builder, Location loc, Value cc, Value ch, Value wa,
         std::vector<Value> cr3_ci4 = PM(b, loc, cc0k3, cc0k2);
 
         Value cc0k0 = CC(b, loc, cc, c0, iv, c0, ido, l1);
-        Value tmpch0 = b.create<arith::AddFOp>(loc, cc0k0, cr2_ci5[0]);
-        Value ch0 = b.create<arith::AddFOp>(loc, tmpch0, cr3_ci4[0]);
+        Value tmpch0 = arith::AddFOp::create(b, loc, cc0k0, cr2_ci5[0]);
+        Value ch0 = arith::AddFOp::create(b, loc, tmpch0, cr3_ci4[0]);
         CH(b, loc, ch, c0, c0, iv, ido, cdim, ch0);
 
-        Value tmpch1 = b.create<arith::MulFOp>(loc, tr11, cr2_ci5[0]);
-        Value tmpch2 = b.create<arith::MulFOp>(loc, tr12, cr3_ci4[0]);
-        Value tmpch3 = b.create<arith::AddFOp>(loc, cc0k0, tmpch1);
-        Value ch1 = b.create<arith::AddFOp>(loc, tmpch2, tmpch3);
+        Value tmpch1 = arith::MulFOp::create(b, loc, tr11, cr2_ci5[0]);
+        Value tmpch2 = arith::MulFOp::create(b, loc, tr12, cr3_ci4[0]);
+        Value tmpch3 = arith::AddFOp::create(b, loc, cc0k0, tmpch1);
+        Value ch1 = arith::AddFOp::create(b, loc, tmpch2, tmpch3);
         CH(b, loc, ch, idom1, c1, iv, ido, cdim, ch1);
 
-        Value tmpch4 = b.create<arith::MulFOp>(loc, ti11, cr2_ci5[1]);
-        Value tmpch5 = b.create<arith::MulFOp>(loc, ti12, cr3_ci4[1]);
-        Value ch2 = b.create<arith::AddFOp>(loc, tmpch4, tmpch5);
+        Value tmpch4 = arith::MulFOp::create(b, loc, ti11, cr2_ci5[1]);
+        Value tmpch5 = arith::MulFOp::create(b, loc, ti12, cr3_ci4[1]);
+        Value ch2 = arith::AddFOp::create(b, loc, tmpch4, tmpch5);
         CH(b, loc, ch, c0, c2, iv, ido, cdim, ch2);
 
-        Value tmpch6 = b.create<arith::MulFOp>(loc, tr12, cr2_ci5[0]);
-        Value tmpch7 = b.create<arith::MulFOp>(loc, tr11, cr3_ci4[0]);
-        Value tmpch8 = b.create<arith::AddFOp>(loc, tmpch6, tmpch7);
-        Value ch3 = b.create<arith::AddFOp>(loc, cc0k0, tmpch8);
+        Value tmpch6 = arith::MulFOp::create(b, loc, tr12, cr2_ci5[0]);
+        Value tmpch7 = arith::MulFOp::create(b, loc, tr11, cr3_ci4[0]);
+        Value tmpch8 = arith::AddFOp::create(b, loc, tmpch6, tmpch7);
+        Value ch3 = arith::AddFOp::create(b, loc, cc0k0, tmpch8);
         CH(b, loc, ch, idom1, c3, iv, ido, cdim, ch3);
 
-        Value tmpch9 = b.create<arith::MulFOp>(loc, ti12, cr2_ci5[1]);
-        Value tmpch10 = b.create<arith::MulFOp>(loc, ti11, cr3_ci4[1]);
-        Value ch4 = b.create<arith::SubFOp>(loc, tmpch9, tmpch10);
+        Value tmpch9 = arith::MulFOp::create(b, loc, ti12, cr2_ci5[1]);
+        Value tmpch10 = arith::MulFOp::create(b, loc, ti11, cr3_ci4[1]);
+        Value ch4 = arith::SubFOp::create(b, loc, tmpch9, tmpch10);
         CH(b, loc, ch, c0, c4, iv, ido, cdim, ch4);
 
-        b.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(b, loc);
       });
 
   Value condition =
-      builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne, ido, c1);
-  builder.create<scf::IfOp>(loc, condition, [&](OpBuilder &b, Location loc) {
+      arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::ne, ido, c1);
+  scf::IfOp::create(builder, loc, condition, [&](OpBuilder &b, Location loc) {
     radf5Extend(b, loc, cc, ch, wa, ido, l1, cdim, tr11, tr12, ti11, ti12, c0,
                 c1, c2, c3, c4);
-    b.create<scf::YieldOp>(loc);
+    scf::YieldOp::create(b, loc);
   });
 
   return;
@@ -2058,21 +2070,21 @@ void radf5(OpBuilder &builder, Location loc, Value cc, Value ch, Value wa,
 
 // function to implement ++ operation
 void index_increment(OpBuilder &opBuilder, Location loc, Value target) {
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value a = opBuilder.create<memref::LoadOp>(loc, target, c0);
-  Value b = opBuilder.create<arith::AddIOp>(loc, a, c1);
-  opBuilder.create<memref::StoreOp>(loc, b, target, c0);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value a = memref::LoadOp::create(opBuilder, loc, target, c0);
+  Value b = arith::AddIOp::create(opBuilder, loc, a, c1);
+  memref::StoreOp::create(opBuilder, loc, b, target, c0);
 }
 
 // switch 2 element in an array
 void index_SWAP(OpBuilder &opBuilder, Location loc, Value array, Value target1,
                 Value target2) {
-  Value a = opBuilder.create<memref::LoadOp>(loc, array, target1);
-  Value b = opBuilder.create<memref::LoadOp>(loc, array, target2);
+  Value a = memref::LoadOp::create(opBuilder, loc, array, target1);
+  Value b = memref::LoadOp::create(opBuilder, loc, array, target2);
 
-  opBuilder.create<memref::StoreOp>(loc, a, array, target2);
-  opBuilder.create<memref::StoreOp>(loc, b, array, target1);
+  memref::StoreOp::create(opBuilder, loc, a, array, target2);
+  memref::StoreOp::create(opBuilder, loc, b, array, target1);
 }
 
 // factorize the input length ans store factors in Rfftp_fctdata_fct
@@ -2080,11 +2092,11 @@ Value rfftp_factorize(OpBuilder &opBuilder, Location loc,
                       Value Rfftp_fctdata_fct, Value Rfftp_fctdata_tw,
                       Value Rfftp_fctdata_tws, Value Rfftp_plan_length,
                       Value Rfftp_plan_nfct, Value Rfftp_plan_mem) {
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
-  Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
-  Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value c2 = ConstantIndexOp::create(opBuilder, loc, 2);
+  Value c3 = ConstantIndexOp::create(opBuilder, loc, 3);
+  Value c4 = ConstantIndexOp::create(opBuilder, loc, 4);
   // TODO: remove the following values?
   // Value c_neg1 = opBuilder.create<ConstantIndexOp>(loc, -1);
   // Value NFCT = opBuilder.create<ConstantIndexOp>(loc, 25);
@@ -2093,61 +2105,62 @@ Value rfftp_factorize(OpBuilder &opBuilder, Location loc,
   IndexType indexTy = opBuilder.getIndexType();
 
   Value length =
-      opBuilder.create<memref::AllocOp>(loc, MemRefType::get(1, indexTy));
-  Value length_1 = opBuilder.create<memref::LoadOp>(loc, Rfftp_plan_length, c0);
-  opBuilder.create<memref::StoreOp>(loc, length_1, length, c0);
+      memref::AllocOp::create(opBuilder, loc, MemRefType::get(1, indexTy));
+  Value length_1 =
+      memref::LoadOp::create(opBuilder, loc, Rfftp_plan_length, c0);
+  memref::StoreOp::create(opBuilder, loc, length_1, length, c0);
 
   Value nfct =
-      opBuilder.create<memref::AllocOp>(loc, MemRefType::get(1, indexTy));
+      memref::AllocOp::create(opBuilder, loc, MemRefType::get(1, indexTy));
 
-  opBuilder.create<memref::StoreOp>(loc, c0, nfct, c0);
+  memref::StoreOp::create(opBuilder, loc, c0, nfct, c0);
 
-  opBuilder.create<scf::WhileOp>(
-      loc, TypeRange{indexTy}, ValueRange{length_1},
+  scf::WhileOp::create(
+      opBuilder, loc, TypeRange{indexTy}, ValueRange{length_1},
       [&](OpBuilder &builder, Location loc, ValueRange args) {
         Value length_while = args[0];
 
         Value length_mod_4 =
-            builder.create<arith::RemSIOp>(loc, length_while, c4);
-        Value condition = builder.create<arith::CmpIOp>(
-            loc, arith::CmpIPredicate::eq, length_mod_4, c0);
-        builder.create<scf::ConditionOp>(loc, condition,
-                                         ValueRange{length_while});
+            arith::RemSIOp::create(builder, loc, length_while, c4);
+        Value condition = arith::CmpIOp::create(
+            builder, loc, arith::CmpIPredicate::eq, length_mod_4, c0);
+        scf::ConditionOp::create(builder, loc, condition,
+                                 ValueRange{length_while});
       },
       [&](OpBuilder &builder, Location loc, ValueRange args) {
         Value length_while = args[0];
 
-        Value currnet_nfct = builder.create<memref::LoadOp>(loc, nfct, c0);
-        builder.create<memref::StoreOp>(loc, c4, Rfftp_fctdata_fct,
-                                        currnet_nfct);
+        Value currnet_nfct = memref::LoadOp::create(builder, loc, nfct, c0);
+        memref::StoreOp::create(builder, loc, c4, Rfftp_fctdata_fct,
+                                currnet_nfct);
         index_increment(builder, loc, nfct);
         Value length_next =
-            builder.create<arith::ShRSIOp>(loc, length_while, c2);
-        builder.create<memref::StoreOp>(loc, length_next, length, c0);
+            arith::ShRSIOp::create(builder, loc, length_while, c2);
+        memref::StoreOp::create(builder, loc, length_next, length, c0);
 
-        builder.create<scf::YieldOp>(loc, std::vector<Value>{length_next});
+        scf::YieldOp::create(builder, loc, std::vector<Value>{length_next});
       });
 
-  Value length_if = opBuilder.create<memref::LoadOp>(loc, length, c0);
-  Value length_if_mod_2 = opBuilder.create<arith::RemSIOp>(loc, length_if, c2);
-  Value condition = opBuilder.create<arith::CmpIOp>(
-      loc, arith::CmpIPredicate::eq, length_if_mod_2, c0);
+  Value length_if = memref::LoadOp::create(opBuilder, loc, length, c0);
+  Value length_if_mod_2 = arith::RemSIOp::create(opBuilder, loc, length_if, c2);
+  Value condition = arith::CmpIOp::create(
+      opBuilder, loc, arith::CmpIPredicate::eq, length_if_mod_2, c0);
 
-  opBuilder.create<scf::IfOp>(
-      loc, condition, [&](OpBuilder &builder, Location loc) {
-        Value length_next = builder.create<arith::ShRSIOp>(loc, length_if, c1);
-        builder.create<memref::StoreOp>(loc, length_next, length, c0);
+  scf::IfOp::create(
+      opBuilder, loc, condition, [&](OpBuilder &builder, Location loc) {
+        Value length_next = arith::ShRSIOp::create(builder, loc, length_if, c1);
+        memref::StoreOp::create(builder, loc, length_next, length, c0);
 
-        Value currnet_nfct = builder.create<memref::LoadOp>(loc, nfct, c0);
-        builder.create<memref::StoreOp>(loc, c2, Rfftp_fctdata_fct,
-                                        currnet_nfct);
+        Value currnet_nfct = memref::LoadOp::create(builder, loc, nfct, c0);
+        memref::StoreOp::create(builder, loc, c2, Rfftp_fctdata_fct,
+                                currnet_nfct);
         index_increment(builder, loc, nfct);
 
-        Value currnet_nfct_1 = builder.create<memref::LoadOp>(loc, nfct, c0);
-        Value nfctm1 = builder.create<arith::SubIOp>(loc, currnet_nfct_1, c1);
+        Value currnet_nfct_1 = memref::LoadOp::create(builder, loc, nfct, c0);
+        Value nfctm1 = arith::SubIOp::create(builder, loc, currnet_nfct_1, c1);
         index_SWAP(builder, loc, Rfftp_fctdata_fct, nfctm1, c0);
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
   // TODO: remove type1 and type2?
@@ -2155,114 +2168,116 @@ Value rfftp_factorize(OpBuilder &opBuilder, Location loc,
   // TypeRange type2 = TypeRange{indexTy};
 
   Value maxl =
-      opBuilder.create<memref::AllocOp>(loc, MemRefType::get(1, indexTy));
-  Value current_length2 = opBuilder.create<memref::LoadOp>(loc, length, c0);
-  Value current_length2_i32 = opBuilder.create<arith::IndexCastOp>(
-      loc, opBuilder.getI32Type(), current_length2);
-  Value length_f64 = opBuilder.create<arith::SIToFPOp>(
-      loc, opBuilder.getF64Type(), current_length2_i32);
-  Value sqrt_length = opBuilder.create<math::SqrtOp>(loc, length_f64);
-  Value maxl_index = opBuilder.create<arith::FPToSIOp>(
-      loc, opBuilder.getI32Type(), sqrt_length);
-  Value maxl_index_index = opBuilder.create<arith::IndexCastOp>(
-      loc, opBuilder.getIndexType(), maxl_index);
-  Value maxl_final = opBuilder.create<arith::AddIOp>(loc, maxl_index_index, c1);
-  opBuilder.create<memref::StoreOp>(loc, maxl_final, maxl, c0);
+      memref::AllocOp::create(opBuilder, loc, MemRefType::get(1, indexTy));
+  Value current_length2 = memref::LoadOp::create(opBuilder, loc, length, c0);
+  Value current_length2_i32 = arith::IndexCastOp::create(
+      opBuilder, loc, opBuilder.getI32Type(), current_length2);
+  Value length_f64 = arith::SIToFPOp::create(
+      opBuilder, loc, opBuilder.getF64Type(), current_length2_i32);
+  Value sqrt_length = math::SqrtOp::create(opBuilder, loc, length_f64);
+  Value maxl_index = arith::FPToSIOp::create(
+      opBuilder, loc, opBuilder.getI32Type(), sqrt_length);
+  Value maxl_index_index = arith::IndexCastOp::create(
+      opBuilder, loc, opBuilder.getIndexType(), maxl_index);
+  Value maxl_final =
+      arith::AddIOp::create(opBuilder, loc, maxl_index_index, c1);
+  memref::StoreOp::create(opBuilder, loc, maxl_final, maxl, c0);
 
-  opBuilder.create<scf::WhileOp>(
-      loc, TypeRange{indexTy}, ValueRange{c3},
+  scf::WhileOp::create(
+      opBuilder, loc, TypeRange{indexTy}, ValueRange{c3},
       [&](OpBuilder &builder, Location loc, ValueRange args) {
         Value divisor = args[0];
-        Value length_while = builder.create<memref::LoadOp>(loc, length, c0);
-        Value current_maxl = builder.create<memref::LoadOp>(loc, maxl, c0);
+        Value length_while = memref::LoadOp::create(builder, loc, length, c0);
+        Value current_maxl = memref::LoadOp::create(builder, loc, maxl, c0);
 
-        Value condition1 = builder.create<arith::CmpIOp>(
-            loc, arith::CmpIPredicate::sgt, length_while, c1);
-        Value condition2 = builder.create<arith::CmpIOp>(
-            loc, arith::CmpIPredicate::slt, divisor, current_maxl);
+        Value condition1 = arith::CmpIOp::create(
+            builder, loc, arith::CmpIPredicate::sgt, length_while, c1);
+        Value condition2 = arith::CmpIOp::create(
+            builder, loc, arith::CmpIPredicate::slt, divisor, current_maxl);
         Value and_cond =
-            builder.create<arith::AndIOp>(loc, condition1, condition2);
-        builder.create<scf::ConditionOp>(loc, and_cond, ValueRange{divisor});
+            arith::AndIOp::create(builder, loc, condition1, condition2);
+        scf::ConditionOp::create(builder, loc, and_cond, ValueRange{divisor});
       },
       [&](OpBuilder &builder, Location loc, ValueRange args) {
         Value divisor = args[0];
 
-        Value length_while = builder.create<memref::LoadOp>(loc, length, c0);
+        Value length_while = memref::LoadOp::create(builder, loc, length, c0);
         Value length_mod_divisor =
-            builder.create<arith::RemSIOp>(loc, length_while, divisor);
-        Value condition1 = builder.create<arith::CmpIOp>(
-            loc, arith::CmpIPredicate::eq, length_mod_divisor, c0);
-        builder.create<scf::IfOp>(
-            loc, condition1, [&](OpBuilder &b, Location loc) {
-              b.create<scf::WhileOp>(
-                  loc, TypeRange{indexTy}, ValueRange{c1},
+            arith::RemSIOp::create(builder, loc, length_while, divisor);
+        Value condition1 = arith::CmpIOp::create(
+            builder, loc, arith::CmpIPredicate::eq, length_mod_divisor, c0);
+        scf::IfOp::create(
+            builder, loc, condition1, [&](OpBuilder &b, Location loc) {
+              scf::WhileOp::create(
+                  b, loc, TypeRange{indexTy}, ValueRange{c1},
                   [&](OpBuilder &b2, Location loc, ValueRange args) {
                     Value x = args[0];
 
                     Value length_while_1 =
-                        b2.create<memref::LoadOp>(loc, length, c0);
-                    Value length_mod_divisor_1 =
-                        b2.create<arith::RemSIOp>(loc, length_while_1, divisor);
+                        memref::LoadOp::create(b2, loc, length, c0);
+                    Value length_mod_divisor_1 = arith::RemSIOp::create(
+                        b2, loc, length_while_1, divisor);
 
                     Value condition2 =
-                        b2.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq,
-                                                 length_mod_divisor_1, c0);
-                    b2.create<scf::ConditionOp>(loc, condition2, ValueRange{x});
+                        arith::CmpIOp::create(b2, loc, arith::CmpIPredicate::eq,
+                                              length_mod_divisor_1, c0);
+                    scf::ConditionOp::create(b2, loc, condition2,
+                                             ValueRange{x});
                   },
                   [&](OpBuilder &b2, Location loc, ValueRange args) {
                     Value x = args[0];
 
                     Value currnet_nfct =
-                        b2.create<memref::LoadOp>(loc, nfct, c0);
-                    b2.create<memref::StoreOp>(loc, divisor, Rfftp_fctdata_fct,
-                                               currnet_nfct);
+                        memref::LoadOp::create(b2, loc, nfct, c0);
+                    memref::StoreOp::create(b2, loc, divisor, Rfftp_fctdata_fct,
+                                            currnet_nfct);
                     index_increment(b2, loc, nfct);
 
                     Value length_while_1 =
-                        b2.create<memref::LoadOp>(loc, length, c0);
-                    Value length_new =
-                        b2.create<arith::DivSIOp>(loc, length_while_1, divisor);
-                    b2.create<memref::StoreOp>(loc, length_new, length, c0);
+                        memref::LoadOp::create(b2, loc, length, c0);
+                    Value length_new = arith::DivSIOp::create(
+                        b2, loc, length_while_1, divisor);
+                    memref::StoreOp::create(b2, loc, length_new, length, c0);
 
-                    b2.create<scf::YieldOp>(loc, std::vector<Value>{x});
+                    scf::YieldOp::create(b2, loc, std::vector<Value>{x});
                   });
 
               Value current_length2_1 =
-                  b.create<memref::LoadOp>(loc, length, c0);
-              Value currnet_length2_i32_1 = b.create<arith::IndexCastOp>(
-                  loc, opBuilder.getI32Type(), current_length2_1);
-              Value length_f64_1 = b.create<arith::SIToFPOp>(
-                  loc, opBuilder.getF64Type(), currnet_length2_i32_1);
-              Value sqrt_length_1 = b.create<math::SqrtOp>(loc, length_f64_1);
-              Value maxl_index_1 =
-                  b.create<arith::FPToSIOp>(loc, b.getI32Type(), sqrt_length_1);
-              Value maxl_index_index_1 = b.create<arith::IndexCastOp>(
-                  loc, opBuilder.getIndexType(), maxl_index_1);
+                  memref::LoadOp::create(b, loc, length, c0);
+              Value currnet_length2_i32_1 = arith::IndexCastOp::create(
+                  b, loc, opBuilder.getI32Type(), current_length2_1);
+              Value length_f64_1 = arith::SIToFPOp::create(
+                  b, loc, opBuilder.getF64Type(), currnet_length2_i32_1);
+              Value sqrt_length_1 = math::SqrtOp::create(b, loc, length_f64_1);
+              Value maxl_index_1 = arith::FPToSIOp::create(
+                  b, loc, b.getI32Type(), sqrt_length_1);
+              Value maxl_index_index_1 = arith::IndexCastOp::create(
+                  b, loc, opBuilder.getIndexType(), maxl_index_1);
               Value maxl_final_1 =
-                  b.create<arith::AddIOp>(loc, maxl_index_index_1, c1);
-              b.create<memref::StoreOp>(loc, maxl_final_1, maxl, c0);
+                  arith::AddIOp::create(b, loc, maxl_index_index_1, c1);
+              memref::StoreOp::create(b, loc, maxl_final_1, maxl, c0);
 
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
 
-        Value divisor_next = builder.create<arith::AddIOp>(loc, divisor, c2);
-        builder.create<scf::YieldOp>(loc, std::vector<Value>{divisor_next});
+        Value divisor_next = arith::AddIOp::create(builder, loc, divisor, c2);
+        scf::YieldOp::create(builder, loc, std::vector<Value>{divisor_next});
       });
 
-  Value current_length1 = opBuilder.create<memref::LoadOp>(loc, length, c0);
-  Value condition1 = opBuilder.create<arith::CmpIOp>(
-      loc, arith::CmpIPredicate::sgt, current_length1, c1);
-  opBuilder.create<scf::IfOp>(
-      loc, condition1, [&](OpBuilder &builder, Location loc) {
-        Value current_nfct = builder.create<memref::LoadOp>(loc, nfct, c0);
-        builder.create<memref::StoreOp>(loc, current_length1, Rfftp_fctdata_fct,
-                                        current_nfct);
+  Value current_length1 = memref::LoadOp::create(opBuilder, loc, length, c0);
+  Value condition1 = arith::CmpIOp::create(
+      opBuilder, loc, arith::CmpIPredicate::sgt, current_length1, c1);
+  scf::IfOp::create(
+      opBuilder, loc, condition1, [&](OpBuilder &builder, Location loc) {
+        Value current_nfct = memref::LoadOp::create(builder, loc, nfct, c0);
+        memref::StoreOp::create(builder, loc, current_length1,
+                                Rfftp_fctdata_fct, current_nfct);
         index_increment(builder, loc, nfct);
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
-  Value current_nfct1 = opBuilder.create<memref::LoadOp>(loc, nfct, c0);
-  opBuilder.create<memref::StoreOp>(loc, current_nfct1, Rfftp_plan_nfct, c0);
+  Value current_nfct1 = memref::LoadOp::create(opBuilder, loc, nfct, c0);
+  memref::StoreOp::create(opBuilder, loc, current_nfct1, Rfftp_plan_nfct, c0);
 
   return c0;
 }
@@ -2271,9 +2286,9 @@ Value index_to_f64(OpBuilder &opBuilder, Location loc, Value n) {
   // TODO: remove the following values?
   // TypeRange type = TypeRange{opBuilder.getF64Type()};
   Value n_i32 =
-      opBuilder.create<arith::IndexCastOp>(loc, opBuilder.getI32Type(), n);
+      arith::IndexCastOp::create(opBuilder, loc, opBuilder.getI32Type(), n);
   Value n_f64 =
-      opBuilder.create<arith::SIToFPOp>(loc, opBuilder.getF64Type(), n_i32);
+      arith::SIToFPOp::create(opBuilder, loc, opBuilder.getF64Type(), n_i32);
   return n_f64;
 }
 
@@ -2281,17 +2296,17 @@ Value f64_to_index(OpBuilder &opBuilder, Location loc, Value n_f64) {
   // TODO: remove type?
   // TypeRange type = TypeRange{opBuilder.getI32Type()};
   Value n_i32 =
-      opBuilder.create<arith::FPToSIOp>(loc, opBuilder.getI32Type(), n_f64);
-  Value n_index = opBuilder.create<arith::IndexCastOp>(
-      loc, opBuilder.getIndexType(), n_i32);
+      arith::FPToSIOp::create(opBuilder, loc, opBuilder.getI32Type(), n_f64);
+  Value n_index = arith::IndexCastOp::create(opBuilder, loc,
+                                             opBuilder.getIndexType(), n_i32);
   return n_index;
 }
 
 void my_sincosm1pi(OpBuilder &opBuilder, Location loc, Value a, Value res,
                    Value bias) {
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value c2 = ConstantIndexOp::create(opBuilder, loc, 2);
 
   FloatType f64Ty = opBuilder.getF64Type();
 
@@ -2303,84 +2318,84 @@ void my_sincosm1pi(OpBuilder &opBuilder, Location loc, Value a, Value res,
 
   // memref<?xf64, strided<[?], offset: ?>>
 
-  Value res_raw = opBuilder.create<memref::SubViewOp>(
-      loc, resultType, res, SmallVector<OpFoldResult>{bias},
+  Value res_raw = memref::SubViewOp::create(
+      opBuilder, loc, resultType, res, SmallVector<OpFoldResult>{bias},
       SmallVector<OpFoldResult>{c2}, SmallVector<OpFoldResult>{c1});
 
-  Value s = opBuilder.create<arith::MulFOp>(loc, a, a);
+  Value s = arith::MulFOp::create(opBuilder, loc, a, a);
 
-  Value r1 = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(-1.0369917389758117e-4)));
-  Value r2 = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(1.9294935641298806e-3)));
-  Value r3 = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(-2.5806887942825395e-2)));
-  Value r4 = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(2.3533063028328211e-1)));
-  Value r5 = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(-1.3352627688538006e+0)));
-  Value r6 = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(4.0587121264167623e+0)));
-  Value r7 = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(-4.9348022005446790e+0)));
+  Value r1 = ConstantFloatOp::create(opBuilder, loc, f64Ty,
+                                     APFloat(double(-1.0369917389758117e-4)));
+  Value r2 = ConstantFloatOp::create(opBuilder, loc, f64Ty,
+                                     APFloat(double(1.9294935641298806e-3)));
+  Value r3 = ConstantFloatOp::create(opBuilder, loc, f64Ty,
+                                     APFloat(double(-2.5806887942825395e-2)));
+  Value r4 = ConstantFloatOp::create(opBuilder, loc, f64Ty,
+                                     APFloat(double(2.3533063028328211e-1)));
+  Value r5 = ConstantFloatOp::create(opBuilder, loc, f64Ty,
+                                     APFloat(double(-1.3352627688538006e+0)));
+  Value r6 = ConstantFloatOp::create(opBuilder, loc, f64Ty,
+                                     APFloat(double(4.0587121264167623e+0)));
+  Value r7 = ConstantFloatOp::create(opBuilder, loc, f64Ty,
+                                     APFloat(double(-4.9348022005446790e+0)));
 
-  Value fma1 = opBuilder.create<math::FmaOp>(loc, r1, s, r2);
-  Value fma2 = opBuilder.create<math::FmaOp>(loc, fma1, s, r3);
-  Value fma3 = opBuilder.create<math::FmaOp>(loc, fma2, s, r4);
-  Value fma4 = opBuilder.create<math::FmaOp>(loc, fma3, s, r5);
-  Value fma5 = opBuilder.create<math::FmaOp>(loc, fma4, s, r6);
-  Value fma6 = opBuilder.create<math::FmaOp>(loc, fma5, s, r7);
+  Value fma1 = math::FmaOp::create(opBuilder, loc, r1, s, r2);
+  Value fma2 = math::FmaOp::create(opBuilder, loc, fma1, s, r3);
+  Value fma3 = math::FmaOp::create(opBuilder, loc, fma2, s, r4);
+  Value fma4 = math::FmaOp::create(opBuilder, loc, fma3, s, r5);
+  Value fma5 = math::FmaOp::create(opBuilder, loc, fma4, s, r6);
+  Value fma6 = math::FmaOp::create(opBuilder, loc, fma5, s, r7);
 
-  Value c = opBuilder.create<arith::MulFOp>(loc, fma6, s);
+  Value c = arith::MulFOp::create(opBuilder, loc, fma6, s);
 
-  Value r8 = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(4.6151442520157035e-4)));
-  Value r9 = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(-7.3700183130883555e-3)));
-  Value r10 = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(8.2145868949323936e-2)));
-  Value r11 = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(-5.9926452893214921e-1)));
-  Value r12 = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(2.5501640398732688e+0)));
-  Value r13 = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(-5.1677127800499516e+0)));
+  Value r8 = ConstantFloatOp::create(opBuilder, loc, f64Ty,
+                                     APFloat(double(4.6151442520157035e-4)));
+  Value r9 = ConstantFloatOp::create(opBuilder, loc, f64Ty,
+                                     APFloat(double(-7.3700183130883555e-3)));
+  Value r10 = ConstantFloatOp::create(opBuilder, loc, f64Ty,
+                                      APFloat(double(8.2145868949323936e-2)));
+  Value r11 = ConstantFloatOp::create(opBuilder, loc, f64Ty,
+                                      APFloat(double(-5.9926452893214921e-1)));
+  Value r12 = ConstantFloatOp::create(opBuilder, loc, f64Ty,
+                                      APFloat(double(2.5501640398732688e+0)));
+  Value r13 = ConstantFloatOp::create(opBuilder, loc, f64Ty,
+                                      APFloat(double(-5.1677127800499516e+0)));
 
-  Value fma7 = opBuilder.create<math::FmaOp>(loc, r8, s, r9);
-  Value fma8 = opBuilder.create<math::FmaOp>(loc, fma7, s, r10);
-  Value fma9 = opBuilder.create<math::FmaOp>(loc, fma8, s, r11);
-  Value fma10 = opBuilder.create<math::FmaOp>(loc, fma9, s, r12);
-  Value fma11 = opBuilder.create<math::FmaOp>(loc, fma10, s, r13);
+  Value fma7 = math::FmaOp::create(opBuilder, loc, r8, s, r9);
+  Value fma8 = math::FmaOp::create(opBuilder, loc, fma7, s, r10);
+  Value fma9 = math::FmaOp::create(opBuilder, loc, fma8, s, r11);
+  Value fma10 = math::FmaOp::create(opBuilder, loc, fma9, s, r12);
+  Value fma11 = math::FmaOp::create(opBuilder, loc, fma10, s, r13);
 
-  Value s_new = opBuilder.create<arith::MulFOp>(loc, s, a);
-  Value r = opBuilder.create<arith::MulFOp>(loc, fma11, s_new);
+  Value s_new = arith::MulFOp::create(opBuilder, loc, s, a);
+  Value r = arith::MulFOp::create(opBuilder, loc, fma11, s_new);
 
-  Value pi = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(3.1415926535897931e+0)));
-  Value s_final = opBuilder.create<math::FmaOp>(loc, a, pi, r);
+  Value pi = ConstantFloatOp::create(opBuilder, loc, f64Ty,
+                                     APFloat(double(3.1415926535897931e+0)));
+  Value s_final = math::FmaOp::create(opBuilder, loc, a, pi, r);
 
-  opBuilder.create<memref::StoreOp>(loc, c, res_raw, c0);
-  opBuilder.create<memref::StoreOp>(loc, s_final, res_raw, c1);
+  memref::StoreOp::create(opBuilder, loc, c, res_raw, c0);
+  memref::StoreOp::create(opBuilder, loc, s_final, res_raw, c1);
 
   return;
 }
 
 void calc_first_octant_extend2(OpBuilder &opBuilder, Location loc, Value den,
                                Value res, Value bias) {
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
-  Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
-  Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value c2 = ConstantIndexOp::create(opBuilder, loc, 2);
+  Value c3 = ConstantIndexOp::create(opBuilder, loc, 3);
+  Value c4 = ConstantIndexOp::create(opBuilder, loc, 4);
   // TODO: remove c5 and c50?
   // Value c5 = opBuilder.create<ConstantIndexOp>(loc, 5);
   // Value c50 = opBuilder.create<ConstantIndexOp>(loc, 50);
 
-  Value den_plus_4 = opBuilder.create<arith::AddIOp>(loc, den, c4);
-  Value n = opBuilder.create<arith::ShRUIOp>(loc, den_plus_4, c3);
+  Value den_plus_4 = arith::AddIOp::create(opBuilder, loc, den, c4);
+  Value n = arith::ShRUIOp::create(opBuilder, loc, den_plus_4, c3);
 
-  Value size = opBuilder.create<memref::DimOp>(loc, res, c0);
-  Value remaining_size = opBuilder.create<arith::SubIOp>(loc, size, bias);
+  Value size = memref::DimOp::create(opBuilder, loc, res, c0);
+  Value remaining_size = arith::SubIOp::create(opBuilder, loc, size, bias);
 
   FloatType f64Ty = opBuilder.getF64Type();
 
@@ -2392,114 +2407,116 @@ void calc_first_octant_extend2(OpBuilder &opBuilder, Location loc, Value den,
 
   // memref<?xf64, strided<[?], offset: ?>>
 
-  Value res_raw = opBuilder.create<memref::SubViewOp>(
-      loc, resultType, res, SmallVector<OpFoldResult>{bias},
+  Value res_raw = memref::SubViewOp::create(
+      opBuilder, loc, resultType, res, SmallVector<OpFoldResult>{bias},
       SmallVector<OpFoldResult>{remaining_size}, SmallVector<OpFoldResult>{c1});
 
   Value f2 =
-      opBuilder.create<ConstantFloatOp>(loc, f64Ty, APFloat(double(2.0)));
+      ConstantFloatOp::create(opBuilder, loc, f64Ty, APFloat(double(2.0)));
   Value f1 =
-      opBuilder.create<ConstantFloatOp>(loc, f64Ty, APFloat(double(1.0)));
+      ConstantFloatOp::create(opBuilder, loc, f64Ty, APFloat(double(1.0)));
   // TODO: remove f0?
   // Value f0 =
   //     opBuilder.create<ConstantFloatOp>(loc, f64Ty, APFloat(double(0.0)));
 
   Value n_f64 = index_to_f64(opBuilder, loc, n);
-  Value l1_f64 = opBuilder.create<math::SqrtOp>(loc, n_f64);
+  Value l1_f64 = math::SqrtOp::create(opBuilder, loc, n_f64);
   Value l1 = f64_to_index(opBuilder, loc, l1_f64);
 
-  opBuilder.create<scf::ForOp>(
-      loc, c1, l1, c1, ValueRange{},
+  scf::ForOp::create(
+      opBuilder, loc, c1, l1, c1, ValueRange{},
       [&](OpBuilder &builder, Location loc, Value i, ValueRange iargs) {
         Value i_f64 = index_to_f64(builder, loc, i);
         Value den_f64 = index_to_f64(builder, loc, den);
-        Value arg = builder.create<arith::DivFOp>(loc, i_f64, den_f64);
-        Value arg_scaled = builder.create<arith::MulFOp>(loc, arg, f2);
+        Value arg = arith::DivFOp::create(builder, loc, i_f64, den_f64);
+        Value arg_scaled = arith::MulFOp::create(builder, loc, arg, f2);
 
-        Value im2 = builder.create<arith::MulIOp>(loc, i, c2);
-        Value im2_bias = builder.create<arith::AddIOp>(loc, im2, bias);
+        Value im2 = arith::MulIOp::create(builder, loc, i, c2);
+        Value im2_bias = arith::AddIOp::create(builder, loc, im2, bias);
 
         my_sincosm1pi(builder, loc, arg_scaled, res, im2_bias);
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
-  Value start_start = opBuilder.create<arith::AddIOp>(loc, l1, c0);
+  Value start_start = arith::AddIOp::create(opBuilder, loc, l1, c0);
 
-  opBuilder.create<scf::ForOp>(
-      loc, start_start, n, l1, ValueRange{},
+  scf::ForOp::create(
+      opBuilder, loc, start_start, n, l1, ValueRange{},
       [&](OpBuilder &builder, Location loc, Value start_loop,
           ValueRange start_loop_args) {
         Value start_f64 = index_to_f64(builder, loc, start_loop);
         Value den_f64 = index_to_f64(builder, loc, den);
-        Value arg = builder.create<arith::DivFOp>(loc, start_f64, den_f64);
-        Value arg_scaled = builder.create<arith::MulFOp>(loc, arg, f2);
+        Value arg = arith::DivFOp::create(builder, loc, start_f64, den_f64);
+        Value arg_scaled = arith::MulFOp::create(builder, loc, arg, f2);
 
         Value cs =
-            builder.create<memref::AllocOp>(loc, MemRefType::get(2, f64Ty));
+            memref::AllocOp::create(builder, loc, MemRefType::get(2, f64Ty));
         my_sincosm1pi(builder, loc, arg_scaled, cs, c0);
 
-        Value cs0 = builder.create<memref::LoadOp>(loc, cs, c0);
-        Value cs1 = builder.create<memref::LoadOp>(loc, cs, c1);
+        Value cs0 = memref::LoadOp::create(builder, loc, cs, c0);
+        Value cs1 = memref::LoadOp::create(builder, loc, cs, c1);
 
-        Value cs0_plus_1 = builder.create<arith::AddFOp>(loc, cs0, f1);
+        Value cs0_plus_1 = arith::AddFOp::create(builder, loc, cs0, f1);
 
-        Value start_2 = builder.create<arith::MulIOp>(loc, start_loop, c2);
-        builder.create<memref::StoreOp>(loc, cs0_plus_1, res_raw, start_2);
-        Value start_2_plus_1 = builder.create<arith::AddIOp>(loc, start_2, c1);
-        builder.create<memref::StoreOp>(loc, cs1, res_raw, start_2_plus_1);
+        Value start_2 = arith::MulIOp::create(builder, loc, start_loop, c2);
+        memref::StoreOp::create(builder, loc, cs0_plus_1, res_raw, start_2);
+        Value start_2_plus_1 = arith::AddIOp::create(builder, loc, start_2, c1);
+        memref::StoreOp::create(builder, loc, cs1, res_raw, start_2_plus_1);
 
-        Value n_minus_start = builder.create<arith::SubIOp>(loc, n, start_loop);
-        Value end_1 = builder.create<arith::AddIOp>(loc, l1, c0);
-        Value sum = builder.create<arith::AddIOp>(loc, start_loop, end_1);
-        Value condition = builder.create<arith::CmpIOp>(
-            loc, arith::CmpIPredicate::sgt, sum, n);
-        Value end = builder.create<arith::SelectOp>(loc, condition,
-                                                    n_minus_start, end_1);
+        Value n_minus_start =
+            arith::SubIOp::create(builder, loc, n, start_loop);
+        Value end_1 = arith::AddIOp::create(builder, loc, l1, c0);
+        Value sum = arith::AddIOp::create(builder, loc, start_loop, end_1);
+        Value condition = arith::CmpIOp::create(
+            builder, loc, arith::CmpIPredicate::sgt, sum, n);
+        Value end = arith::SelectOp::create(builder, loc, condition,
+                                            n_minus_start, end_1);
 
-        builder.create<scf::ForOp>(
-            loc, c1, end, c1, ValueRange{},
+        scf::ForOp::create(
+            builder, loc, c1, end, c1, ValueRange{},
             [&](OpBuilder &b, Location loc, Value i, ValueRange i_args) {
-              Value i_2 = b.create<arith::MulIOp>(loc, i, c2);
-              Value csx0 = b.create<memref::LoadOp>(loc, res_raw, i_2);
-              Value i_2_plus_1 = b.create<arith::AddIOp>(loc, i_2, c1);
-              Value csx1 = b.create<memref::LoadOp>(loc, res_raw, i_2_plus_1);
+              Value i_2 = arith::MulIOp::create(b, loc, i, c2);
+              Value csx0 = memref::LoadOp::create(b, loc, res_raw, i_2);
+              Value i_2_plus_1 = arith::AddIOp::create(b, loc, i_2, c1);
+              Value csx1 = memref::LoadOp::create(b, loc, res_raw, i_2_plus_1);
 
-              Value tmp1 = b.create<arith::MulFOp>(loc, cs0, csx0);
-              Value tmp2 = b.create<arith::MulFOp>(loc, cs1, csx1);
-              Value tmp3 = b.create<arith::SubFOp>(loc, tmp1, tmp2);
-              Value tmp4 = b.create<arith::AddFOp>(loc, tmp3, cs0);
-              Value tmp5 = b.create<arith::AddFOp>(loc, tmp4, csx0);
-              Value res_real = b.create<arith::AddFOp>(loc, tmp5, f1);
+              Value tmp1 = arith::MulFOp::create(b, loc, cs0, csx0);
+              Value tmp2 = arith::MulFOp::create(b, loc, cs1, csx1);
+              Value tmp3 = arith::SubFOp::create(b, loc, tmp1, tmp2);
+              Value tmp4 = arith::AddFOp::create(b, loc, tmp3, cs0);
+              Value tmp5 = arith::AddFOp::create(b, loc, tmp4, csx0);
+              Value res_real = arith::AddFOp::create(b, loc, tmp5, f1);
 
-              Value tmp6 = b.create<arith::MulFOp>(loc, cs0, csx1);
-              Value tmp7 = b.create<arith::MulFOp>(loc, cs1, csx0);
-              Value tmp8 = b.create<arith::AddFOp>(loc, tmp6, tmp7);
-              Value tmp9 = b.create<arith::AddFOp>(loc, tmp8, cs1);
-              Value res_imag = b.create<arith::AddFOp>(loc, tmp9, csx1);
+              Value tmp6 = arith::MulFOp::create(b, loc, cs0, csx1);
+              Value tmp7 = arith::MulFOp::create(b, loc, cs1, csx0);
+              Value tmp8 = arith::AddFOp::create(b, loc, tmp6, tmp7);
+              Value tmp9 = arith::AddFOp::create(b, loc, tmp8, cs1);
+              Value res_imag = arith::AddFOp::create(b, loc, tmp9, csx1);
 
-              Value start_plus_i = b.create<arith::AddIOp>(loc, start_loop, i);
+              Value start_plus_i = arith::AddIOp::create(b, loc, start_loop, i);
               Value start_plus_i_2 =
-                  b.create<arith::MulIOp>(loc, start_plus_i, c2);
+                  arith::MulIOp::create(b, loc, start_plus_i, c2);
               Value start_plus_i_2_plus_1 =
-                  b.create<arith::AddIOp>(loc, start_plus_i_2, c1);
-              b.create<memref::StoreOp>(loc, res_real, res_raw, start_plus_i_2);
-              b.create<memref::StoreOp>(loc, res_imag, res_raw,
-                                        start_plus_i_2_plus_1);
-              b.create<scf::YieldOp>(loc);
+                  arith::AddIOp::create(b, loc, start_plus_i_2, c1);
+              memref::StoreOp::create(b, loc, res_real, res_raw,
+                                      start_plus_i_2);
+              memref::StoreOp::create(b, loc, res_imag, res_raw,
+                                      start_plus_i_2_plus_1);
+              scf::YieldOp::create(b, loc);
             });
 
-        builder.create<memref::DeallocOp>(loc, cs);
-        builder.create<scf::YieldOp>(loc);
+        memref::DeallocOp::create(builder, loc, cs);
+        scf::YieldOp::create(builder, loc);
       });
 
-  opBuilder.create<scf::ForOp>(
-      loc, c1, l1, c1, ValueRange{},
+  scf::ForOp::create(
+      opBuilder, loc, c1, l1, c1, ValueRange{},
       [&](OpBuilder &builder, Location loc, Value i, ValueRange i_args) {
-        Value i_2 = builder.create<arith::MulIOp>(loc, i, c2);
-        Value val = builder.create<memref::LoadOp>(loc, res_raw, i_2);
-        Value val_plus_1 = builder.create<arith::AddFOp>(loc, val, f1);
-        builder.create<memref::StoreOp>(loc, val_plus_1, res_raw, i_2);
-        builder.create<scf::YieldOp>(loc);
+        Value i_2 = arith::MulIOp::create(builder, loc, i, c2);
+        Value val = memref::LoadOp::create(builder, loc, res_raw, i_2);
+        Value val_plus_1 = arith::AddFOp::create(builder, loc, val, f1);
+        memref::StoreOp::create(builder, loc, val_plus_1, res_raw, i_2);
+        scf::YieldOp::create(builder, loc);
       });
 
   return;
@@ -2507,19 +2524,19 @@ void calc_first_octant_extend2(OpBuilder &opBuilder, Location loc, Value den,
 
 void calc_first_octant_extend1(OpBuilder &opBuilder, Location loc, Value den,
                                Value res, Value bias) {
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
   // TODO: remove c2 and c5?
   // Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
-  Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
-  Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
+  Value c3 = ConstantIndexOp::create(opBuilder, loc, 3);
+  Value c4 = ConstantIndexOp::create(opBuilder, loc, 4);
   // Value c5 = opBuilder.create<ConstantIndexOp>(loc, 5);
 
-  Value den_plus_4 = opBuilder.create<arith::AddIOp>(loc, den, c4);
-  Value n = opBuilder.create<arith::ShRUIOp>(loc, den_plus_4, c3);
+  Value den_plus_4 = arith::AddIOp::create(opBuilder, loc, den, c4);
+  Value n = arith::ShRUIOp::create(opBuilder, loc, den_plus_4, c3);
 
-  Value size = opBuilder.create<memref::DimOp>(loc, res, c0);
-  Value remaining_size = opBuilder.create<arith::SubIOp>(loc, size, bias);
+  Value size = memref::DimOp::create(opBuilder, loc, res, c0);
+  Value remaining_size = arith::SubIOp::create(opBuilder, loc, size, bias);
 
   FloatType f64Ty = opBuilder.getF64Type();
 
@@ -2531,63 +2548,63 @@ void calc_first_octant_extend1(OpBuilder &opBuilder, Location loc, Value den,
 
   // memref<?xf64, strided<[?], offset: ?>>
 
-  Value res_raw = opBuilder.create<memref::SubViewOp>(
-      loc, resultType, res, SmallVector<OpFoldResult>{bias},
+  Value res_raw = memref::SubViewOp::create(
+      opBuilder, loc, resultType, res, SmallVector<OpFoldResult>{bias},
       SmallVector<OpFoldResult>{remaining_size}, SmallVector<OpFoldResult>{c1});
 
   Value f1 =
-      opBuilder.create<ConstantFloatOp>(loc, f64Ty, APFloat(double(1.0)));
+      ConstantFloatOp::create(opBuilder, loc, f64Ty, APFloat(double(1.0)));
   Value f0 =
-      opBuilder.create<ConstantFloatOp>(loc, f64Ty, APFloat(double(0.0)));
+      ConstantFloatOp::create(opBuilder, loc, f64Ty, APFloat(double(0.0)));
 
-  opBuilder.create<memref::StoreOp>(loc, f1, res_raw, c0);
-  opBuilder.create<memref::StoreOp>(loc, f0, res_raw, c1);
+  memref::StoreOp::create(opBuilder, loc, f1, res_raw, c0);
+  memref::StoreOp::create(opBuilder, loc, f0, res_raw, c1);
 
   Value condition =
-      opBuilder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne, n, c1);
+      arith::CmpIOp::create(opBuilder, loc, arith::CmpIPredicate::ne, n, c1);
 
-  opBuilder.create<scf::IfOp>(
-      loc, condition, [&](OpBuilder &builder, Location loc) {
-        calc_first_octant_extend2(builder, loc, den, res, bias);
-        builder.create<scf::YieldOp>(loc);
-      });
+  scf::IfOp::create(opBuilder, loc, condition,
+                    [&](OpBuilder &builder, Location loc) {
+                      calc_first_octant_extend2(builder, loc, den, res, bias);
+                      scf::YieldOp::create(builder, loc);
+                    });
 }
 
 void calc_first_octant(OpBuilder &opBuilder, Location loc, Value den, Value res,
                        Value bias) {
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
   // TODO: remove c1, c2, and c5?
   // Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
   // Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
-  Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
-  Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
+  Value c3 = ConstantIndexOp::create(opBuilder, loc, 3);
+  Value c4 = ConstantIndexOp::create(opBuilder, loc, 4);
   // Value c5 = opBuilder.create<ConstantIndexOp>(loc, 5);
 
-  Value den_plus_4 = opBuilder.create<arith::AddIOp>(loc, den, c4);
-  Value n = opBuilder.create<arith::ShRUIOp>(loc, den_plus_4, c3);
+  Value den_plus_4 = arith::AddIOp::create(opBuilder, loc, den, c4);
+  Value n = arith::ShRUIOp::create(opBuilder, loc, den_plus_4, c3);
 
   Value condition =
-      opBuilder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne, n, c0);
+      arith::CmpIOp::create(opBuilder, loc, arith::CmpIPredicate::ne, n, c0);
 
-  opBuilder.create<scf::IfOp>(
-      loc, condition, [&](OpBuilder &builder, Location loc) {
-        calc_first_octant_extend1(builder, loc, den, res, bias);
-        builder.create<scf::YieldOp>(loc);
-      });
+  scf::IfOp::create(opBuilder, loc, condition,
+                    [&](OpBuilder &builder, Location loc) {
+                      calc_first_octant_extend1(builder, loc, den, res, bias);
+                      scf::YieldOp::create(builder, loc);
+                    });
 }
 
 void calc_first_quadrant(OpBuilder &opBuilder, Location loc, Value n,
                          Value res) {
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
-  Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value c2 = ConstantIndexOp::create(opBuilder, loc, 2);
+  Value c3 = ConstantIndexOp::create(opBuilder, loc, 3);
   // TODO: remove c4 and c5?
   // Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
   // Value c5 = opBuilder.create<ConstantIndexOp>(loc, 5);
 
-  Value size = opBuilder.create<memref::DimOp>(loc, res, c0);
-  Value remaining_size = opBuilder.create<arith::SubIOp>(loc, size, n);
+  Value size = memref::DimOp::create(opBuilder, loc, res, c0);
+  Value remaining_size = arith::SubIOp::create(opBuilder, loc, size, n);
 
   FloatType f64Ty = opBuilder.getF64Type();
 
@@ -2599,53 +2616,58 @@ void calc_first_quadrant(OpBuilder &opBuilder, Location loc, Value n,
 
   // memref<?xf64, strided<[?], offset: ?>>
 
-  Value p_raw = opBuilder.create<memref::SubViewOp>(
-      loc, resultType, res, SmallVector<OpFoldResult>{n},
+  Value p_raw = memref::SubViewOp::create(
+      opBuilder, loc, resultType, res, SmallVector<OpFoldResult>{n},
       SmallVector<OpFoldResult>{remaining_size}, SmallVector<OpFoldResult>{c1});
 
-  Value n_times_2 = opBuilder.create<arith::ShLIOp>(loc, n, c1);
+  Value n_times_2 = arith::ShLIOp::create(opBuilder, loc, n, c1);
   calc_first_octant(opBuilder, loc, n_times_2, res, n);
 
-  Value n_plus_2 = opBuilder.create<arith::AddIOp>(loc, n, c2);
-  Value ndone = opBuilder.create<arith::ShRUIOp>(loc, n_plus_2, c2);
-  Value ndonem1 = opBuilder.create<arith::SubIOp>(loc, ndone, c1);
-  Value ndone2 = opBuilder.create<arith::MulIOp>(loc, ndone, c2);
-  Value idx2_start = opBuilder.create<arith::SubIOp>(loc, ndone2, c2);
+  Value n_plus_2 = arith::AddIOp::create(opBuilder, loc, n, c2);
+  Value ndone = arith::ShRUIOp::create(opBuilder, loc, n_plus_2, c2);
+  Value ndonem1 = arith::SubIOp::create(opBuilder, loc, ndone, c1);
+  Value ndone2 = arith::MulIOp::create(opBuilder, loc, ndone, c2);
+  Value idx2_start = arith::SubIOp::create(opBuilder, loc, ndone2, c2);
 
-  Value i_start = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value idx1_start = opBuilder.create<ConstantIndexOp>(loc, 0);
+  Value i_start = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value idx1_start = ConstantIndexOp::create(opBuilder, loc, 0);
 
-  auto loop = opBuilder.create<scf::ForOp>(
-      loc, i_start, ndonem1, c2, ValueRange{i_start, idx1_start, idx2_start},
+  auto loop = scf::ForOp::create(
+      opBuilder, loc, i_start, ndonem1, c2,
+      ValueRange{i_start, idx1_start, idx2_start},
       [&](OpBuilder &builder, Location loc, Value i_loop,
           ValueRange i_loop_args) {
         Value i_loop1 = i_loop_args[0];
         Value idx1 = i_loop_args[1];
         Value idx2 = i_loop_args[2];
 
-        Value p_2i = builder.create<arith::MulIOp>(loc, i_loop1, c2);
-        Value p_val = builder.create<memref::LoadOp>(loc, p_raw, p_2i);
-        builder.create<memref::StoreOp>(loc, p_val, res, idx1);
+        Value p_2i = arith::MulIOp::create(builder, loc, i_loop1, c2);
+        Value p_val = memref::LoadOp::create(builder, loc, p_raw, p_2i);
+        memref::StoreOp::create(builder, loc, p_val, res, idx1);
 
-        Value p_2i_plus_1 = builder.create<arith::AddIOp>(loc, p_2i, c1);
-        Value p_val_1 = builder.create<memref::LoadOp>(loc, p_raw, p_2i_plus_1);
-        Value idx1_plus_1 = builder.create<arith::AddIOp>(loc, idx1, c1);
-        builder.create<memref::StoreOp>(loc, p_val_1, res, idx1_plus_1);
+        Value p_2i_plus_1 = arith::AddIOp::create(builder, loc, p_2i, c1);
+        Value p_val_1 =
+            memref::LoadOp::create(builder, loc, p_raw, p_2i_plus_1);
+        Value idx1_plus_1 = arith::AddIOp::create(builder, loc, idx1, c1);
+        memref::StoreOp::create(builder, loc, p_val_1, res, idx1_plus_1);
 
-        Value p_2i_plus_3 = builder.create<arith::AddIOp>(loc, p_2i, c3);
-        Value p_val_3 = builder.create<memref::LoadOp>(loc, p_raw, p_2i_plus_3);
-        builder.create<memref::StoreOp>(loc, p_val_3, res, idx2);
+        Value p_2i_plus_3 = arith::AddIOp::create(builder, loc, p_2i, c3);
+        Value p_val_3 =
+            memref::LoadOp::create(builder, loc, p_raw, p_2i_plus_3);
+        memref::StoreOp::create(builder, loc, p_val_3, res, idx2);
 
-        Value p_2i_plus_2 = builder.create<arith::AddIOp>(loc, p_2i, c2);
-        Value p_val_2 = builder.create<memref::LoadOp>(loc, p_raw, p_2i_plus_2);
-        Value idx2_plus_1 = builder.create<arith::AddIOp>(loc, idx2, c1);
-        builder.create<memref::StoreOp>(loc, p_val_2, res, idx2_plus_1);
+        Value p_2i_plus_2 = arith::AddIOp::create(builder, loc, p_2i, c2);
+        Value p_val_2 =
+            memref::LoadOp::create(builder, loc, p_raw, p_2i_plus_2);
+        Value idx2_plus_1 = arith::AddIOp::create(builder, loc, idx2, c1);
+        memref::StoreOp::create(builder, loc, p_val_2, res, idx2_plus_1);
 
-        Value i_loop1_next = builder.create<arith::AddIOp>(loc, i_loop1, c2);
-        Value idx1_next = builder.create<arith::AddIOp>(loc, idx1, c2);
-        Value idx2_next = builder.create<arith::SubIOp>(loc, idx2, c2);
-        builder.create<scf::YieldOp>(
-            loc, std::vector<Value>{i_loop1_next, idx1_next, idx2_next});
+        Value i_loop1_next = arith::AddIOp::create(builder, loc, i_loop1, c2);
+        Value idx1_next = arith::AddIOp::create(builder, loc, idx1, c2);
+        Value idx2_next = arith::SubIOp::create(builder, loc, idx2, c2);
+        scf::YieldOp::create(
+            builder, loc,
+            std::vector<Value>{i_loop1_next, idx1_next, idx2_next});
       });
 
   Value i_v = loop.getResults()[0];
@@ -2653,31 +2675,32 @@ void calc_first_quadrant(OpBuilder &opBuilder, Location loc, Value n,
   // TODO: remove idx2_v?
   // Value idx2_v = loop.getResults()[2];
 
-  Value condition = opBuilder.create<arith::CmpIOp>(
-      loc, arith::CmpIPredicate::ne, i_v, ndone);
+  Value condition = arith::CmpIOp::create(opBuilder, loc,
+                                          arith::CmpIPredicate::ne, i_v, ndone);
 
-  opBuilder.create<scf::IfOp>(
-      loc, condition, [&](OpBuilder &builder, Location loc) {
-        Value p_2i = builder.create<arith::MulIOp>(loc, i_v, c2);
-        Value p_val = builder.create<memref::LoadOp>(loc, p_raw, p_2i);
-        builder.create<memref::StoreOp>(loc, p_val, res, idx1_v);
+  scf::IfOp::create(
+      opBuilder, loc, condition, [&](OpBuilder &builder, Location loc) {
+        Value p_2i = arith::MulIOp::create(builder, loc, i_v, c2);
+        Value p_val = memref::LoadOp::create(builder, loc, p_raw, p_2i);
+        memref::StoreOp::create(builder, loc, p_val, res, idx1_v);
 
-        Value p_2i_plus_1 = builder.create<arith::AddIOp>(loc, p_2i, c1);
-        Value p_val_1 = builder.create<memref::LoadOp>(loc, p_raw, p_2i_plus_1);
-        Value idx1_plus_1 = builder.create<arith::AddIOp>(loc, idx1_v, c1);
-        builder.create<memref::StoreOp>(loc, p_val_1, res, idx1_plus_1);
-        builder.create<scf::YieldOp>(loc);
+        Value p_2i_plus_1 = arith::AddIOp::create(builder, loc, p_2i, c1);
+        Value p_val_1 =
+            memref::LoadOp::create(builder, loc, p_raw, p_2i_plus_1);
+        Value idx1_plus_1 = arith::AddIOp::create(builder, loc, idx1_v, c1);
+        memref::StoreOp::create(builder, loc, p_val_1, res, idx1_plus_1);
+        scf::YieldOp::create(builder, loc);
       });
 
   return;
 }
 
 void calc_first_half(OpBuilder &opBuilder, Location loc, Value n, Value res) {
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
-  Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
-  Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value c2 = ConstantIndexOp::create(opBuilder, loc, 2);
+  Value c3 = ConstantIndexOp::create(opBuilder, loc, 3);
+  Value c4 = ConstantIndexOp::create(opBuilder, loc, 4);
   // TODO: remove c5?
   // Value c5 = opBuilder.create<ConstantIndexOp>(loc, 5);
 
@@ -2685,20 +2708,20 @@ void calc_first_half(OpBuilder &opBuilder, Location loc, Value n, Value res) {
   FloatType f64Ty = opBuilder.getF64Type();
 
   Value f0 =
-      opBuilder.create<ConstantFloatOp>(loc, f64Ty, APFloat(double(0.0)));
+      ConstantFloatOp::create(opBuilder, loc, f64Ty, APFloat(double(0.0)));
   // TODO: remove f1?
   // Value f1 =
   //     opBuilder.create<ConstantFloatOp>(loc, f64Ty, APFloat(double(1.0)));
 
-  Value n_plus_1 = opBuilder.create<arith::AddIOp>(loc, n, c1);
-  Value ndone = opBuilder.create<arith::ShRUIOp>(loc, n_plus_1, c1);
+  Value n_plus_1 = arith::AddIOp::create(opBuilder, loc, n, c1);
+  Value ndone = arith::ShRUIOp::create(opBuilder, loc, n_plus_1, c1);
 
-  Value size = opBuilder.create<memref::DimOp>(loc, res, c0);
-  Value remaining_size = opBuilder.create<arith::SubIOp>(loc, size, n);
+  Value size = memref::DimOp::create(opBuilder, loc, res, c0);
+  Value remaining_size = arith::SubIOp::create(opBuilder, loc, size, n);
   Value remaining_size_p1 =
-      opBuilder.create<arith::AddIOp>(loc, remaining_size, c1);
+      arith::AddIOp::create(opBuilder, loc, remaining_size, c1);
 
-  Value nm1 = opBuilder.create<arith::SubIOp>(loc, n, c1);
+  Value nm1 = arith::SubIOp::create(opBuilder, loc, n, c1);
 
   FailureOr<StridedLayoutAttr> computelayout = StridedLayoutAttr::get(
       opBuilder.getContext(),
@@ -2708,159 +2731,163 @@ void calc_first_half(OpBuilder &opBuilder, Location loc, Value n, Value res) {
 
   // memref<?xf64, strided<[?], offset: ?>>
 
-  Value p_raw = opBuilder.create<memref::SubViewOp>(
-      loc, resultType, res, SmallVector<OpFoldResult>{nm1},
+  Value p_raw = memref::SubViewOp::create(
+      opBuilder, loc, resultType, res, SmallVector<OpFoldResult>{nm1},
       SmallVector<OpFoldResult>{remaining_size_p1},
       SmallVector<OpFoldResult>{c1});
 
-  Value n_times_4 = opBuilder.create<arith::ShLIOp>(loc, n, c2);
+  Value n_times_4 = arith::ShLIOp::create(opBuilder, loc, n, c2);
   calc_first_octant(opBuilder, loc, n_times_4, res, nm1);
 
-  Value i4_start = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value i_start = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value in = opBuilder.create<arith::AddIOp>(loc, n, c0);
+  Value i4_start = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value i_start = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value in = arith::AddIOp::create(opBuilder, loc, n, c0);
 
-  auto loop = opBuilder.create<scf::WhileOp>(
-      loc, TypeRange{indexTy, indexTy}, ValueRange{i4_start, i_start},
+  auto loop = scf::WhileOp::create(
+      opBuilder, loc, TypeRange{indexTy, indexTy},
+      ValueRange{i4_start, i_start},
       [&](OpBuilder &builder, Location loc, ValueRange args) {
         Value i4 = args[0];
         Value i = args[1];
 
-        Value in_minus_i4 = builder.create<arith::SubIOp>(loc, in, i4);
-        Value condition = builder.create<arith::CmpIOp>(
-            loc, arith::CmpIPredicate::sle, i4, in_minus_i4);
-        builder.create<scf::ConditionOp>(loc, condition, ValueRange{i4, i});
+        Value in_minus_i4 = arith::SubIOp::create(builder, loc, in, i4);
+        Value condition = arith::CmpIOp::create(
+            builder, loc, arith::CmpIPredicate::sle, i4, in_minus_i4);
+        scf::ConditionOp::create(builder, loc, condition, ValueRange{i4, i});
       },
       [&](OpBuilder &builder, Location loc, ValueRange args) {
         Value i4 = args[0];
         Value i = args[1];
 
-        Value i4_2 = builder.create<arith::MulIOp>(loc, i4, c2);
-        Value i_2 = builder.create<arith::MulIOp>(loc, i, c2);
-        Value i4_2_p1 = builder.create<arith::AddIOp>(loc, i4_2, c1);
-        Value i_2_p1 = builder.create<arith::AddIOp>(loc, i_2, c1);
+        Value i4_2 = arith::MulIOp::create(builder, loc, i4, c2);
+        Value i_2 = arith::MulIOp::create(builder, loc, i, c2);
+        Value i4_2_p1 = arith::AddIOp::create(builder, loc, i4_2, c1);
+        Value i_2_p1 = arith::AddIOp::create(builder, loc, i_2, c1);
 
-        Value p_i4_2 = builder.create<memref::LoadOp>(loc, p_raw, i4_2);
-        Value p_i4_2_p1 = builder.create<memref::LoadOp>(loc, p_raw, i4_2_p1);
+        Value p_i4_2 = memref::LoadOp::create(builder, loc, p_raw, i4_2);
+        Value p_i4_2_p1 = memref::LoadOp::create(builder, loc, p_raw, i4_2_p1);
 
-        builder.create<memref::StoreOp>(loc, p_i4_2, res, i_2);
-        builder.create<memref::StoreOp>(loc, p_i4_2_p1, res, i_2_p1);
+        memref::StoreOp::create(builder, loc, p_i4_2, res, i_2);
+        memref::StoreOp::create(builder, loc, p_i4_2_p1, res, i_2_p1);
 
-        Value i4_next = builder.create<arith::AddIOp>(loc, i4, c4);
-        Value i_next = builder.create<arith::AddIOp>(loc, i, c1);
-        builder.create<scf::YieldOp>(loc, std::vector<Value>{i4_next, i_next});
+        Value i4_next = arith::AddIOp::create(builder, loc, i4, c4);
+        Value i_next = arith::AddIOp::create(builder, loc, i, c1);
+        scf::YieldOp::create(builder, loc, std::vector<Value>{i4_next, i_next});
       });
 
   Value final_i4_0 = loop.getResults()[0];
   Value final_i_0 = loop.getResults()[1];
 
-  auto loop1 = opBuilder.create<scf::WhileOp>(
-      loc, TypeRange{indexTy, indexTy}, ValueRange{final_i4_0, final_i_0},
+  auto loop1 = scf::WhileOp::create(
+      opBuilder, loc, TypeRange{indexTy, indexTy},
+      ValueRange{final_i4_0, final_i_0},
       [&](OpBuilder &builder, Location loc, ValueRange args) {
         Value i4 = args[0];
         Value i = args[1];
 
-        Value i4_minus_in = builder.create<arith::SubIOp>(loc, i4, in);
-        Value condition = builder.create<arith::CmpIOp>(
-            loc, arith::CmpIPredicate::sle, i4_minus_in, c0);
-        builder.create<scf::ConditionOp>(loc, condition, ValueRange{i4, i});
+        Value i4_minus_in = arith::SubIOp::create(builder, loc, i4, in);
+        Value condition = arith::CmpIOp::create(
+            builder, loc, arith::CmpIPredicate::sle, i4_minus_in, c0);
+        scf::ConditionOp::create(builder, loc, condition, ValueRange{i4, i});
       },
       [&](OpBuilder &builder, Location loc, ValueRange args) {
         Value i4 = args[0];
         Value i = args[1];
 
-        Value xm = builder.create<arith::SubIOp>(loc, in, i4);
-        Value xm_2 = builder.create<arith::MulIOp>(loc, xm, c2);
-        Value i_2 = builder.create<arith::MulIOp>(loc, i, c2);
-        Value xm_2_p1 = builder.create<arith::AddIOp>(loc, xm_2, c1);
-        Value i_2_p1 = builder.create<arith::AddIOp>(loc, i_2, c1);
+        Value xm = arith::SubIOp::create(builder, loc, in, i4);
+        Value xm_2 = arith::MulIOp::create(builder, loc, xm, c2);
+        Value i_2 = arith::MulIOp::create(builder, loc, i, c2);
+        Value xm_2_p1 = arith::AddIOp::create(builder, loc, xm_2, c1);
+        Value i_2_p1 = arith::AddIOp::create(builder, loc, i_2, c1);
 
-        Value p_xm_2_p1 = builder.create<memref::LoadOp>(loc, p_raw, xm_2_p1);
-        Value p_xm_2 = builder.create<memref::LoadOp>(loc, p_raw, xm_2);
+        Value p_xm_2_p1 = memref::LoadOp::create(builder, loc, p_raw, xm_2_p1);
+        Value p_xm_2 = memref::LoadOp::create(builder, loc, p_raw, xm_2);
 
-        builder.create<memref::StoreOp>(loc, p_xm_2_p1, res, i_2);
-        builder.create<memref::StoreOp>(loc, p_xm_2, res, i_2_p1);
+        memref::StoreOp::create(builder, loc, p_xm_2_p1, res, i_2);
+        memref::StoreOp::create(builder, loc, p_xm_2, res, i_2_p1);
 
-        Value i4_next = builder.create<arith::AddIOp>(loc, i4, c4);
-        Value i_next = builder.create<arith::AddIOp>(loc, i, c1);
-        builder.create<scf::YieldOp>(loc, std::vector<Value>{i4_next, i_next});
+        Value i4_next = arith::AddIOp::create(builder, loc, i4, c4);
+        Value i_next = arith::AddIOp::create(builder, loc, i, c1);
+        scf::YieldOp::create(builder, loc, std::vector<Value>{i4_next, i_next});
       });
 
   Value final_i4_1 = loop1.getResults()[0];
   Value final_i_1 = loop1.getResults()[1];
 
-  auto loop2 = opBuilder.create<scf::WhileOp>(
-      loc, TypeRange{indexTy, indexTy}, ValueRange{final_i4_1, final_i_1},
+  auto loop2 = scf::WhileOp::create(
+      opBuilder, loc, TypeRange{indexTy, indexTy},
+      ValueRange{final_i4_1, final_i_1},
       [&](OpBuilder &builder, Location loc, ValueRange args) {
         Value i4 = args[0];
         Value i = args[1];
 
-        Value in_3 = builder.create<arith::MulIOp>(loc, in, c3);
-        Value in_3_m_i4 = builder.create<arith::SubIOp>(loc, in_3, i4);
-        Value condition = builder.create<arith::CmpIOp>(
-            loc, arith::CmpIPredicate::sle, i4, in_3_m_i4);
-        builder.create<scf::ConditionOp>(loc, condition, ValueRange{i4, i});
+        Value in_3 = arith::MulIOp::create(builder, loc, in, c3);
+        Value in_3_m_i4 = arith::SubIOp::create(builder, loc, in_3, i4);
+        Value condition = arith::CmpIOp::create(
+            builder, loc, arith::CmpIPredicate::sle, i4, in_3_m_i4);
+        scf::ConditionOp::create(builder, loc, condition, ValueRange{i4, i});
       },
       [&](OpBuilder &builder, Location loc, ValueRange args) {
         Value i4 = args[0];
         Value i = args[1];
 
-        Value xm = builder.create<arith::SubIOp>(loc, i4, in);
-        Value xm_2 = builder.create<arith::MulIOp>(loc, xm, c2);
-        Value i_2 = builder.create<arith::MulIOp>(loc, i, c2);
-        Value xm_2_p1 = builder.create<arith::AddIOp>(loc, xm_2, c1);
-        Value i_2_p1 = builder.create<arith::AddIOp>(loc, i_2, c1);
+        Value xm = arith::SubIOp::create(builder, loc, i4, in);
+        Value xm_2 = arith::MulIOp::create(builder, loc, xm, c2);
+        Value i_2 = arith::MulIOp::create(builder, loc, i, c2);
+        Value xm_2_p1 = arith::AddIOp::create(builder, loc, xm_2, c1);
+        Value i_2_p1 = arith::AddIOp::create(builder, loc, i_2, c1);
 
-        Value p_xm_2_p1 = builder.create<memref::LoadOp>(loc, p_raw, xm_2_p1);
-        Value p_xm_2 = builder.create<memref::LoadOp>(loc, p_raw, xm_2);
+        Value p_xm_2_p1 = memref::LoadOp::create(builder, loc, p_raw, xm_2_p1);
+        Value p_xm_2 = memref::LoadOp::create(builder, loc, p_raw, xm_2);
 
-        Value m_p_xm_2_p1 = builder.create<arith::SubFOp>(loc, f0, p_xm_2_p1);
+        Value m_p_xm_2_p1 = arith::SubFOp::create(builder, loc, f0, p_xm_2_p1);
 
-        builder.create<memref::StoreOp>(loc, m_p_xm_2_p1, res, i_2);
-        builder.create<memref::StoreOp>(loc, p_xm_2, res, i_2_p1);
+        memref::StoreOp::create(builder, loc, m_p_xm_2_p1, res, i_2);
+        memref::StoreOp::create(builder, loc, p_xm_2, res, i_2_p1);
 
-        Value i4_next = builder.create<arith::AddIOp>(loc, i4, c4);
-        Value i_next = builder.create<arith::AddIOp>(loc, i, c1);
-        builder.create<scf::YieldOp>(loc, std::vector<Value>{i4_next, i_next});
+        Value i4_next = arith::AddIOp::create(builder, loc, i4, c4);
+        Value i_next = arith::AddIOp::create(builder, loc, i, c1);
+        scf::YieldOp::create(builder, loc, std::vector<Value>{i4_next, i_next});
       });
 
   Value final_i4_2 = loop2.getResults()[0];
   Value final_i_2 = loop2.getResults()[1];
 
-  opBuilder.create<scf::WhileOp>(
-      loc, TypeRange{indexTy, indexTy}, ValueRange{final_i4_2, final_i_2},
+  scf::WhileOp::create(
+      opBuilder, loc, TypeRange{indexTy, indexTy},
+      ValueRange{final_i4_2, final_i_2},
       [&](OpBuilder &builder, Location loc, ValueRange args) {
         Value i4 = args[0];
         Value i = args[1];
 
-        Value condition = builder.create<arith::CmpIOp>(
-            loc, arith::CmpIPredicate::slt, i, ndone);
-        builder.create<scf::ConditionOp>(loc, condition, ValueRange{i4, i});
+        Value condition = arith::CmpIOp::create(
+            builder, loc, arith::CmpIPredicate::slt, i, ndone);
+        scf::ConditionOp::create(builder, loc, condition, ValueRange{i4, i});
       },
       [&](OpBuilder &builder, Location loc, ValueRange args) {
         Value i4 = args[0];
         Value i = args[1];
 
-        Value in_2 = builder.create<arith::MulIOp>(loc, in, c2);
+        Value in_2 = arith::MulIOp::create(builder, loc, in, c2);
 
-        Value xm = builder.create<arith::SubIOp>(loc, in_2, i4);
-        Value xm_2 = builder.create<arith::MulIOp>(loc, xm, c2);
-        Value i_2 = builder.create<arith::MulIOp>(loc, i, c2);
-        Value xm_2_p1 = builder.create<arith::AddIOp>(loc, xm_2, c1);
-        Value i_2_p1 = builder.create<arith::AddIOp>(loc, i_2, c1);
+        Value xm = arith::SubIOp::create(builder, loc, in_2, i4);
+        Value xm_2 = arith::MulIOp::create(builder, loc, xm, c2);
+        Value i_2 = arith::MulIOp::create(builder, loc, i, c2);
+        Value xm_2_p1 = arith::AddIOp::create(builder, loc, xm_2, c1);
+        Value i_2_p1 = arith::AddIOp::create(builder, loc, i_2, c1);
 
-        Value p_xm_2_p1 = builder.create<memref::LoadOp>(loc, p_raw, xm_2_p1);
-        Value p_xm_2 = builder.create<memref::LoadOp>(loc, p_raw, xm_2);
+        Value p_xm_2_p1 = memref::LoadOp::create(builder, loc, p_raw, xm_2_p1);
+        Value p_xm_2 = memref::LoadOp::create(builder, loc, p_raw, xm_2);
 
-        Value m_p_xm_2 = builder.create<arith::SubFOp>(loc, f0, p_xm_2);
+        Value m_p_xm_2 = arith::SubFOp::create(builder, loc, f0, p_xm_2);
 
-        builder.create<memref::StoreOp>(loc, m_p_xm_2, res, i_2);
-        builder.create<memref::StoreOp>(loc, p_xm_2_p1, res, i_2_p1);
+        memref::StoreOp::create(builder, loc, m_p_xm_2, res, i_2);
+        memref::StoreOp::create(builder, loc, p_xm_2_p1, res, i_2_p1);
 
-        Value i4_next = builder.create<arith::AddIOp>(loc, i4, c4);
-        Value i_next = builder.create<arith::AddIOp>(loc, i, c1);
+        Value i4_next = arith::AddIOp::create(builder, loc, i4, c4);
+        Value i_next = arith::AddIOp::create(builder, loc, i, c1);
 
-        builder.create<scf::YieldOp>(loc, std::vector<Value>{i4_next, i_next});
+        scf::YieldOp::create(builder, loc, std::vector<Value>{i4_next, i_next});
       });
 
   return;
@@ -2869,122 +2896,127 @@ void calc_first_half(OpBuilder &opBuilder, Location loc, Value n, Value res) {
 void fill_first_quadrant(OpBuilder &opBuilder, Location loc, Value n,
                          Value res) {
 
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value c2 = ConstantIndexOp::create(opBuilder, loc, 2);
   // TODO: remove c3, c4, and c5?
   // Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
   // Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
   // Value c5 = opBuilder.create<ConstantIndexOp>(loc, 5);
-  Value c8 = opBuilder.create<ConstantIndexOp>(loc, 8);
+  Value c8 = ConstantIndexOp::create(opBuilder, loc, 8);
 
   FloatType f64Ty = opBuilder.getF64Type();
 
-  Value hsqt2 = opBuilder.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(0.707106781186547524400844362104849)));
+  Value hsqt2 = ConstantFloatOp::create(
+      opBuilder, loc, f64Ty,
+      APFloat(double(0.707106781186547524400844362104849)));
 
-  Value quart = opBuilder.create<arith::ShRUIOp>(loc, n, c2);
-  Value n_mod_8 = opBuilder.create<arith::RemUIOp>(loc, n, c8);
+  Value quart = arith::ShRUIOp::create(opBuilder, loc, n, c2);
+  Value n_mod_8 = arith::RemUIOp::create(opBuilder, loc, n, c8);
 
-  Value condition = opBuilder.create<arith::CmpIOp>(
-      loc, arith::CmpIPredicate::eq, n_mod_8, c0);
+  Value condition = arith::CmpIOp::create(
+      opBuilder, loc, arith::CmpIPredicate::eq, n_mod_8, c0);
 
-  opBuilder.create<scf::IfOp>(
-      loc, condition, [&](OpBuilder &builder, Location loc) {
-        Value quart_plus_1 = builder.create<arith::AddIOp>(loc, quart, c1);
-        builder.create<memref::StoreOp>(loc, hsqt2, res, quart);
-        builder.create<memref::StoreOp>(loc, hsqt2, res, quart_plus_1);
-        builder.create<scf::YieldOp>(loc);
+  scf::IfOp::create(
+      opBuilder, loc, condition, [&](OpBuilder &builder, Location loc) {
+        Value quart_plus_1 = arith::AddIOp::create(builder, loc, quart, c1);
+        memref::StoreOp::create(builder, loc, hsqt2, res, quart);
+        memref::StoreOp::create(builder, loc, hsqt2, res, quart_plus_1);
+        scf::YieldOp::create(builder, loc);
       });
 
-  Value two_quart = opBuilder.create<arith::MulIOp>(loc, quart, c2);
-  Value two_quart_minus_2 = opBuilder.create<arith::SubIOp>(loc, two_quart, c2);
+  Value two_quart = arith::MulIOp::create(opBuilder, loc, quart, c2);
+  Value two_quart_minus_2 =
+      arith::SubIOp::create(opBuilder, loc, two_quart, c2);
 
-  opBuilder.create<scf::ForOp>(
-      loc, c2, quart, c2, ValueRange{two_quart_minus_2},
+  scf::ForOp::create(
+      opBuilder, loc, c2, quart, c2, ValueRange{two_quart_minus_2},
       [&](OpBuilder &builder, Location loc, Value i, ValueRange i_args) {
         Value j = i_args[0];
 
-        Value i_plus_1 = builder.create<arith::AddIOp>(loc, i, c1);
-        Value j_plus_1 = builder.create<arith::AddIOp>(loc, j, c1);
+        Value i_plus_1 = arith::AddIOp::create(builder, loc, i, c1);
+        Value j_plus_1 = arith::AddIOp::create(builder, loc, j, c1);
 
-        Value val_i = builder.create<memref::LoadOp>(loc, res, i);
-        Value val_i_plus_1 = builder.create<memref::LoadOp>(loc, res, i_plus_1);
+        Value val_i = memref::LoadOp::create(builder, loc, res, i);
+        Value val_i_plus_1 =
+            memref::LoadOp::create(builder, loc, res, i_plus_1);
 
-        builder.create<memref::StoreOp>(loc, val_i_plus_1, res, j);
-        builder.create<memref::StoreOp>(loc, val_i, res, j_plus_1);
+        memref::StoreOp::create(builder, loc, val_i_plus_1, res, j);
+        memref::StoreOp::create(builder, loc, val_i, res, j_plus_1);
 
-        Value j_next = builder.create<arith::SubIOp>(loc, j, c2);
-        builder.create<scf::YieldOp>(loc, j_next);
+        Value j_next = arith::SubIOp::create(builder, loc, j, c2);
+        scf::YieldOp::create(builder, loc, j_next);
       });
 
   return;
 }
 
 void fill_first_half(OpBuilder &opBuilder, Location loc, Value n, Value res) {
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value c2 = ConstantIndexOp::create(opBuilder, loc, 2);
   // TODO: remove c3 and c5?
   // Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
-  Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
+  Value c4 = ConstantIndexOp::create(opBuilder, loc, 4);
   // Value c5 = opBuilder.create<ConstantIndexOp>(loc, 5);
 
   FloatType f64Ty = opBuilder.getF64Type();
   Value c_1 =
-      opBuilder.create<ConstantFloatOp>(loc, f64Ty, APFloat(double(-1.0)));
+      ConstantFloatOp::create(opBuilder, loc, f64Ty, APFloat(double(-1.0)));
 
-  Value half = opBuilder.create<arith::ShRUIOp>(loc, n, c1);
-  Value n_mod_4 = opBuilder.create<arith::RemUIOp>(loc, n, c4);
+  Value half = arith::ShRUIOp::create(opBuilder, loc, n, c1);
+  Value n_mod_4 = arith::RemUIOp::create(opBuilder, loc, n, c4);
 
-  Value condition = opBuilder.create<arith::CmpIOp>(
-      loc, arith::CmpIPredicate::eq, n_mod_4, c0);
+  Value condition = arith::CmpIOp::create(
+      opBuilder, loc, arith::CmpIPredicate::eq, n_mod_4, c0);
 
-  opBuilder.create<scf::IfOp>(
-      loc, condition,
+  scf::IfOp::create(
+      opBuilder, loc, condition,
       [&](OpBuilder &builder, Location loc) {
-        builder.create<scf::ForOp>(
-            loc, c0, half, c2, ValueRange{},
+        scf::ForOp::create(
+            builder, loc, c0, half, c2, ValueRange{},
             [&](OpBuilder &b, Location loc, Value i, ValueRange i_args) {
-              Value i_plus_1 = b.create<arith::AddIOp>(loc, i, c1);
-              Value i_plus_half = b.create<arith::AddIOp>(loc, i, half);
+              Value i_plus_1 = arith::AddIOp::create(b, loc, i, c1);
+              Value i_plus_half = arith::AddIOp::create(b, loc, i, half);
               Value i_plus_half_plus_1 =
-                  b.create<arith::AddIOp>(loc, i_plus_half, c1);
+                  arith::AddIOp::create(b, loc, i_plus_half, c1);
 
-              Value val_i = b.create<memref::LoadOp>(loc, res, i);
-              Value val_i_plus_1 = b.create<memref::LoadOp>(loc, res, i_plus_1);
+              Value val_i = memref::LoadOp::create(b, loc, res, i);
+              Value val_i_plus_1 =
+                  memref::LoadOp::create(b, loc, res, i_plus_1);
 
               Value neg_val_i_plus_1 =
-                  b.create<arith::MulFOp>(loc, val_i_plus_1, c_1);
-              b.create<memref::StoreOp>(loc, neg_val_i_plus_1, res,
-                                        i_plus_half);
-              b.create<memref::StoreOp>(loc, val_i, res, i_plus_half_plus_1);
-              b.create<scf::YieldOp>(loc);
+                  arith::MulFOp::create(b, loc, val_i_plus_1, c_1);
+              memref::StoreOp::create(b, loc, neg_val_i_plus_1, res,
+                                      i_plus_half);
+              memref::StoreOp::create(b, loc, val_i, res, i_plus_half_plus_1);
+              scf::YieldOp::create(b, loc);
             });
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       },
       [&](OpBuilder &builder, Location loc) {
-        Value two_half_minus_2 = builder.create<arith::SubIOp>(loc, half, c1);
+        Value two_half_minus_2 = arith::SubIOp::create(builder, loc, half, c1);
         Value two_half_minus_2_mul_2 =
-            builder.create<arith::MulIOp>(loc, two_half_minus_2, c2);
+            arith::MulIOp::create(builder, loc, two_half_minus_2, c2);
 
-        builder.create<scf::ForOp>(
-            loc, c2, half, c2, ValueRange{two_half_minus_2_mul_2},
+        scf::ForOp::create(
+            builder, loc, c2, half, c2, ValueRange{two_half_minus_2_mul_2},
             [&](OpBuilder &b, Location loc, Value i, ValueRange i_args) {
               Value j = i_args[0];
-              Value i_plus_1 = builder.create<arith::AddIOp>(loc, i, c1);
-              Value j_plus_1 = builder.create<arith::AddIOp>(loc, j, c1);
-              Value val_i = b.create<memref::LoadOp>(loc, res, i);
-              Value val_i_plus_1 = b.create<memref::LoadOp>(loc, res, i_plus_1);
-              Value neg_val_i = b.create<arith::MulFOp>(loc, val_i, c_1);
-              b.create<memref::StoreOp>(loc, neg_val_i, res, j);
-              b.create<memref::StoreOp>(loc, val_i_plus_1, res, j_plus_1);
+              Value i_plus_1 = arith::AddIOp::create(builder, loc, i, c1);
+              Value j_plus_1 = arith::AddIOp::create(builder, loc, j, c1);
+              Value val_i = memref::LoadOp::create(b, loc, res, i);
+              Value val_i_plus_1 =
+                  memref::LoadOp::create(b, loc, res, i_plus_1);
+              Value neg_val_i = arith::MulFOp::create(b, loc, val_i, c_1);
+              memref::StoreOp::create(b, loc, neg_val_i, res, j);
+              memref::StoreOp::create(b, loc, val_i_plus_1, res, j_plus_1);
 
-              Value j_next = builder.create<arith::SubIOp>(loc, j, c2);
-              b.create<scf::YieldOp>(loc, j_next);
+              Value j_next = arith::SubIOp::create(builder, loc, j, c2);
+              scf::YieldOp::create(b, loc, j_next);
             });
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
   return;
@@ -2992,28 +3024,28 @@ void fill_first_half(OpBuilder &opBuilder, Location loc, Value n, Value res) {
 
 void sincos_2pibyn_half(OpBuilder &opBuilder, Location loc, Value n,
                         Value res) {
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
   // TODO: remove the following values?
   // Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
   // Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
   // Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
-  Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
+  Value c4 = ConstantIndexOp::create(opBuilder, loc, 4);
   // Value c5 = opBuilder.create<ConstantIndexOp>(loc, 5);
   // Value c50 = opBuilder.create<ConstantIndexOp>(loc, 50);
 
-  Value n_mod_4 = opBuilder.create<arith::RemUIOp>(loc, n, c4);
+  Value n_mod_4 = arith::RemUIOp::create(opBuilder, loc, n, c4);
 
-  Value condition = opBuilder.create<arith::CmpIOp>(
-      loc, arith::CmpIPredicate::eq, n_mod_4, c0);
+  Value condition = arith::CmpIOp::create(
+      opBuilder, loc, arith::CmpIPredicate::eq, n_mod_4, c0);
 
-  opBuilder.create<scf::IfOp>(
-      loc, condition,
+  scf::IfOp::create(
+      opBuilder, loc, condition,
       [&](OpBuilder &builder, Location loc) {
         calc_first_octant(builder, loc, n, res, c0);
 
         fill_first_quadrant(builder, loc, n, res);
         fill_first_half(builder, loc, n, res);
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       },
       [&](OpBuilder &builder, Location loc) {
         // TODO: remove the following values?
@@ -3023,18 +3055,18 @@ void sincos_2pibyn_half(OpBuilder &opBuilder, Location loc, Value n,
         // Value condition1 = builder.create<arith::CmpIOp>(
         //     loc, arith::CmpIPredicate::eq, n_mod_2, c0);
 
-        opBuilder.create<scf::IfOp>(
-            loc, condition,
+        scf::IfOp::create(
+            opBuilder, loc, condition,
             [&](OpBuilder &b, Location loc) {
               calc_first_quadrant(b, loc, n, res);
               fill_first_half(b, loc, n, res);
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             },
             [&](OpBuilder &b, Location loc) {
               calc_first_half(b, loc, n, res);
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 }
 
@@ -3043,150 +3075,152 @@ Value rfftp_comp_twiddle(OpBuilder &opBuilder, Location loc, Value length,
                          Value Rfftp_fctdata_fct, Value Rfftp_fctdata_tw,
                          Value Rfftp_fctdata_tws, Value Rfftp_plan_length,
                          Value Rfftp_plan_nfct, Value Rfftp_plan_mem) {
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
   // TODO: remove the following values?
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value c2 = ConstantIndexOp::create(opBuilder, loc, 2);
   // Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
   // Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
-  Value c5 = opBuilder.create<ConstantIndexOp>(loc, 5);
+  Value c5 = ConstantIndexOp::create(opBuilder, loc, 5);
   // Value c50 = opBuilder.create<ConstantIndexOp>(loc, 50);
 
-  Value length_2 = opBuilder.create<arith::MulIOp>(loc, length, c2);
+  Value length_2 = arith::MulIOp::create(opBuilder, loc, length, c2);
   FloatType f64Ty = opBuilder.getF64Type();
 
-  Value twid = opBuilder.create<memref::AllocOp>(
-      loc, MemRefType::get(ShapedType::kDynamic, f64Ty),
+  Value twid = memref::AllocOp::create(
+      opBuilder, loc, MemRefType::get(ShapedType::kDynamic, f64Ty),
       /*dynamicOperands=*/length_2);
 
-  Value plan_nfct = opBuilder.create<memref::LoadOp>(loc, Rfftp_plan_nfct, c0);
+  Value plan_nfct = memref::LoadOp::create(opBuilder, loc, Rfftp_plan_nfct, c0);
 
   sincos_2pibyn_half(opBuilder, loc, length, twid);
 
-  Value l1_start = opBuilder.create<ConstantIndexOp>(loc, 1);
+  Value l1_start = ConstantIndexOp::create(opBuilder, loc, 1);
 
-  opBuilder.create<scf::ForOp>(
-      loc, c0, plan_nfct, c1, ValueRange{l1_start},
+  scf::ForOp::create(
+      opBuilder, loc, c0, plan_nfct, c1, ValueRange{l1_start},
       [&](OpBuilder &builder, Location loc, Value k, ValueRange k_args) {
         Value l1 = k_args[0];
 
-        Value ip = builder.create<memref::LoadOp>(loc, Rfftp_fctdata_fct, k);
+        Value ip = memref::LoadOp::create(builder, loc, Rfftp_fctdata_fct, k);
 
-        Value l1_m_ip = builder.create<arith::MulIOp>(loc, l1, ip);
-        Value ido = builder.create<arith::DivSIOp>(loc, length, l1_m_ip);
-        Value plan_nfct_m1 = builder.create<arith::SubIOp>(loc, plan_nfct, c1);
+        Value l1_m_ip = arith::MulIOp::create(builder, loc, l1, ip);
+        Value ido = arith::DivSIOp::create(builder, loc, length, l1_m_ip);
+        Value plan_nfct_m1 = arith::SubIOp::create(builder, loc, plan_nfct, c1);
 
-        Value condition1 = builder.create<arith::CmpIOp>(
-            loc, arith::CmpIPredicate::slt, k, plan_nfct_m1);
+        Value condition1 = arith::CmpIOp::create(
+            builder, loc, arith::CmpIPredicate::slt, k, plan_nfct_m1);
 
-        builder.create<scf::IfOp>(
-            loc, condition1, [&](OpBuilder &b, Location loc) {
-              Value ido_m1 = b.create<arith::SubIOp>(loc, ido, c1);
-              Value ido_m1_d2 = b.create<arith::DivSIOp>(loc, ido_m1, c2);
-              Value ido_m1_d2_p1 = b.create<arith::AddIOp>(loc, ido_m1_d2, c1);
+        scf::IfOp::create(
+            builder, loc, condition1, [&](OpBuilder &b, Location loc) {
+              Value ido_m1 = arith::SubIOp::create(b, loc, ido, c1);
+              Value ido_m1_d2 = arith::DivSIOp::create(b, loc, ido_m1, c2);
+              Value ido_m1_d2_p1 = arith::AddIOp::create(b, loc, ido_m1_d2, c1);
 
-              b.create<scf::ForOp>(
-                  loc, c1, ip, c1, ValueRange{},
+              scf::ForOp::create(
+                  b, loc, c1, ip, c1, ValueRange{},
                   [&](OpBuilder &b2, Location loc, Value j, ValueRange j_args) {
-                    b2.create<scf::ForOp>(
-                        loc, c1, ido_m1_d2_p1, c1, ValueRange{},
+                    scf::ForOp::create(
+                        b2, loc, c1, ido_m1_d2_p1, c1, ValueRange{},
                         [&](OpBuilder &b3, Location loc, Value i,
                             ValueRange i_args) {
-                          Value j2 = b3.create<arith::MulIOp>(loc, j, c2);
-                          Value j2_l1 = b3.create<arith::MulIOp>(loc, j2, l1);
+                          Value j2 = arith::MulIOp::create(b3, loc, j, c2);
+                          Value j2_l1 = arith::MulIOp::create(b3, loc, j2, l1);
                           Value j2_l1_i =
-                              b3.create<arith::MulIOp>(loc, j2_l1, i);
+                              arith::MulIOp::create(b3, loc, j2_l1, i);
                           Value j2_l1_i_p1 =
-                              b3.create<arith::AddIOp>(loc, j2_l1_i, c1);
+                              arith::AddIOp::create(b3, loc, j2_l1_i, c1);
 
-                          Value j_m1 = b3.create<arith::SubIOp>(loc, j, c1);
+                          Value j_m1 = arith::SubIOp::create(b3, loc, j, c1);
                           Value ido_m1_j_m1 =
-                              b3.create<arith::MulIOp>(loc, ido_m1, j_m1);
+                              arith::MulIOp::create(b3, loc, ido_m1, j_m1);
 
-                          Value i2 = b3.create<arith::MulIOp>(loc, i, c2);
-                          Value i2_m1 = b3.create<arith::SubIOp>(loc, i2, c1);
-                          Value i2_m2 = b3.create<arith::SubIOp>(loc, i2, c2);
+                          Value i2 = arith::MulIOp::create(b3, loc, i, c2);
+                          Value i2_m1 = arith::SubIOp::create(b3, loc, i2, c1);
+                          Value i2_m2 = arith::SubIOp::create(b3, loc, i2, c2);
 
-                          Value tw_a =
-                              b3.create<arith::AddIOp>(loc, ido_m1_j_m1, i2_m2);
-                          Value tw_b =
-                              b3.create<arith::AddIOp>(loc, ido_m1_j_m1, i2_m1);
+                          Value tw_a = arith::AddIOp::create(
+                              b3, loc, ido_m1_j_m1, i2_m2);
+                          Value tw_b = arith::AddIOp::create(
+                              b3, loc, ido_m1_j_m1, i2_m1);
 
                           Value twid_a =
-                              b3.create<memref::LoadOp>(loc, twid, j2_l1_i);
+                              memref::LoadOp::create(b3, loc, twid, j2_l1_i);
                           Value twid_b =
-                              b3.create<memref::LoadOp>(loc, twid, j2_l1_i_p1);
+                              memref::LoadOp::create(b3, loc, twid, j2_l1_i_p1);
 
-                          Value fct_k = b3.create<memref::LoadOp>(
-                              loc, Rfftp_fctdata_tw, k);
+                          Value fct_k = memref::LoadOp::create(
+                              b3, loc, Rfftp_fctdata_tw, k);
 
-                          b3.create<memref::StoreOp>(loc, twid_a, fct_k, tw_a);
-                          b3.create<memref::StoreOp>(loc, twid_b, fct_k, tw_b);
+                          memref::StoreOp::create(b3, loc, twid_a, fct_k, tw_a);
+                          memref::StoreOp::create(b3, loc, twid_b, fct_k, tw_b);
 
-                          b3.create<scf::YieldOp>(loc);
+                          scf::YieldOp::create(b3, loc);
                         });
-                    b2.create<scf::YieldOp>(loc);
+                    scf::YieldOp::create(b2, loc);
                   });
 
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
 
-        Value condition2 = builder.create<arith::CmpIOp>(
-            loc, arith::CmpIPredicate::sgt, ip, c5);
+        Value condition2 = arith::CmpIOp::create(
+            builder, loc, arith::CmpIPredicate::sgt, ip, c5);
 
-        builder.create<scf::IfOp>(
-            loc, condition2, [&](OpBuilder &b, Location loc) {
-              Value fct_k = b.create<memref::LoadOp>(loc, Rfftp_fctdata_tws, k);
+        scf::IfOp::create(
+            builder, loc, condition2, [&](OpBuilder &b, Location loc) {
+              Value fct_k =
+                  memref::LoadOp::create(b, loc, Rfftp_fctdata_tws, k);
               Value c_f0 =
-                  b.create<ConstantFloatOp>(loc, f64Ty, APFloat(double(0.0)));
+                  ConstantFloatOp::create(b, loc, f64Ty, APFloat(double(0.0)));
               Value c_f1 =
-                  b.create<ConstantFloatOp>(loc, f64Ty, APFloat(double(1.0)));
+                  ConstantFloatOp::create(b, loc, f64Ty, APFloat(double(1.0)));
 
-              b.create<memref::StoreOp>(loc, c_f1, fct_k, c0);
-              b.create<memref::StoreOp>(loc, c_f0, fct_k, c1);
+              memref::StoreOp::create(b, loc, c_f1, fct_k, c0);
+              memref::StoreOp::create(b, loc, c_f0, fct_k, c1);
 
-              Value ip_div_2 = b.create<arith::ShRSIOp>(loc, ip, c1);
-              Value ip_div_2_p1 = b.create<arith::AddIOp>(loc, ip_div_2, c1);
+              Value ip_div_2 = arith::ShRSIOp::create(b, loc, ip, c1);
+              Value ip_div_2_p1 = arith::AddIOp::create(b, loc, ip_div_2, c1);
 
-              b.create<scf::ForOp>(
-                  loc, c1, ip_div_2_p1, c1, ValueRange{},
+              scf::ForOp::create(
+                  b, loc, c1, ip_div_2_p1, c1, ValueRange{},
                   [&](OpBuilder &b2, Location loc, Value i, ValueRange i_args) {
-                    Value i2 = b2.create<arith::MulIOp>(loc, i, c2);
-                    Value i2_p1 = b2.create<arith::AddIOp>(loc, i2, c1);
-                    Value ip_m_i = b2.create<arith::SubIOp>(loc, ip, i);
-                    Value ip_m_i_2 = b2.create<arith::MulIOp>(loc, ip_m_i, c2);
+                    Value i2 = arith::MulIOp::create(b2, loc, i, c2);
+                    Value i2_p1 = arith::AddIOp::create(b2, loc, i2, c1);
+                    Value ip_m_i = arith::SubIOp::create(b2, loc, ip, i);
+                    Value ip_m_i_2 = arith::MulIOp::create(b2, loc, ip_m_i, c2);
                     Value ip_m_i_2_p1 =
-                        b2.create<arith::AddIOp>(loc, ip_m_i_2, c1);
+                        arith::AddIOp::create(b2, loc, ip_m_i_2, c1);
 
                     Value length_div_ip =
-                        b2.create<arith::DivSIOp>(loc, length, ip);
+                        arith::DivSIOp::create(b2, loc, length, ip);
                     Value i2_length_div_ip =
-                        b2.create<arith::MulIOp>(loc, i2, length_div_ip);
+                        arith::MulIOp::create(b2, loc, i2, length_div_ip);
                     Value i2_length_div_ip_p1 =
-                        b2.create<arith::AddIOp>(loc, i2_length_div_ip, c1);
+                        arith::AddIOp::create(b2, loc, i2_length_div_ip, c1);
 
                     Value twid_a =
-                        b2.create<memref::LoadOp>(loc, twid, i2_length_div_ip);
-                    Value twid_b = b2.create<memref::LoadOp>(
-                        loc, twid, i2_length_div_ip_p1);
-                    Value twid_c = b2.create<arith::AddFOp>(loc, c_f0, twid_a);
-                    Value twid_d = b2.create<arith::SubFOp>(loc, c_f0, twid_b);
+                        memref::LoadOp::create(b2, loc, twid, i2_length_div_ip);
+                    Value twid_b = memref::LoadOp::create(b2, loc, twid,
+                                                          i2_length_div_ip_p1);
+                    Value twid_c = arith::AddFOp::create(b2, loc, c_f0, twid_a);
+                    Value twid_d = arith::SubFOp::create(b2, loc, c_f0, twid_b);
 
-                    b2.create<memref::StoreOp>(loc, twid_a, fct_k, i2);
-                    b2.create<memref::StoreOp>(loc, twid_b, fct_k, i2_p1);
-                    b2.create<memref::StoreOp>(loc, twid_c, fct_k, ip_m_i_2);
-                    b2.create<memref::StoreOp>(loc, twid_d, fct_k, ip_m_i_2_p1);
-                    b2.create<scf::YieldOp>(loc);
+                    memref::StoreOp::create(b2, loc, twid_a, fct_k, i2);
+                    memref::StoreOp::create(b2, loc, twid_b, fct_k, i2_p1);
+                    memref::StoreOp::create(b2, loc, twid_c, fct_k, ip_m_i_2);
+                    memref::StoreOp::create(b2, loc, twid_d, fct_k,
+                                            ip_m_i_2_p1);
+                    scf::YieldOp::create(b2, loc);
                   });
 
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
 
-        Value l1_next = builder.create<arith::MulIOp>(loc, l1, ip);
-        builder.create<scf::YieldOp>(loc, l1_next);
+        Value l1_next = arith::MulIOp::create(builder, loc, l1, ip);
+        scf::YieldOp::create(builder, loc, l1_next);
       });
 
-  opBuilder.create<memref::DeallocOp>(loc, twid);
+  memref::DeallocOp::create(opBuilder, loc, twid);
 
   return c0;
 }
@@ -3196,21 +3230,21 @@ Value rfftp_comp_twiddle(OpBuilder &opBuilder, Location loc, Value length,
 std::vector<Value> make_rfftp_plan(OpBuilder &opBuilder, Location loc,
                                    Value length) {
 
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value c2 = ConstantIndexOp::create(opBuilder, loc, 2);
   // TODO: remove the following values?
   // Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
   // Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
   // Value c5 = opBuilder.create<ConstantIndexOp>(loc, 5);
 
   int64_t NFCT_num = 25;
-  Value NFCT = opBuilder.create<ConstantIndexOp>(loc, NFCT_num);
+  Value NFCT = ConstantIndexOp::create(opBuilder, loc, NFCT_num);
 
   FloatType f64Ty = opBuilder.getF64Type();
   IndexType indexTy = opBuilder.getIndexType();
 
-  Value length_2 = opBuilder.create<arith::MulIOp>(loc, length, c2);
+  Value length_2 = arith::MulIOp::create(opBuilder, loc, length, c2);
 
   MemRefType type = MemRefType::get(NFCT_num, indexTy);
   //   MemRefType type1 = MemRefType::get(length_num2, f64Ty);
@@ -3219,36 +3253,36 @@ std::vector<Value> make_rfftp_plan(OpBuilder &opBuilder, Location loc,
   MemRefType type3 = MemRefType::get(1, indexTy);
   MemRefType type4 = MemRefType::get(1, f64Ty);
 
-  Value Rfftp_fctdata_fct = opBuilder.create<memref::AllocOp>(loc, type);
-  Value Rfftp_fctdata_tw = opBuilder.create<memref::AllocOp>(loc, type2);
-  Value Rfftp_fctdata_tws = opBuilder.create<memref::AllocOp>(loc, type2);
-  Value Rfftp_plan_length = opBuilder.create<memref::AllocOp>(loc, type3);
-  Value Rfftp_plan_nfct = opBuilder.create<memref::AllocOp>(loc, type3);
-  Value Rfftp_plan_mem = opBuilder.create<memref::AllocOp>(loc, type4);
+  Value Rfftp_fctdata_fct = memref::AllocOp::create(opBuilder, loc, type);
+  Value Rfftp_fctdata_tw = memref::AllocOp::create(opBuilder, loc, type2);
+  Value Rfftp_fctdata_tws = memref::AllocOp::create(opBuilder, loc, type2);
+  Value Rfftp_plan_length = memref::AllocOp::create(opBuilder, loc, type3);
+  Value Rfftp_plan_nfct = memref::AllocOp::create(opBuilder, loc, type3);
+  Value Rfftp_plan_mem = memref::AllocOp::create(opBuilder, loc, type4);
 
-  opBuilder.create<memref::StoreOp>(loc, length, Rfftp_plan_length, c0);
-  opBuilder.create<memref::StoreOp>(loc, c0, Rfftp_plan_nfct, c0);
+  memref::StoreOp::create(opBuilder, loc, length, Rfftp_plan_length, c0);
+  memref::StoreOp::create(opBuilder, loc, c0, Rfftp_plan_nfct, c0);
 
-  opBuilder.create<scf::ForOp>(
-      loc, c0, NFCT, c1, ValueRange{},
+  scf::ForOp::create(
+      opBuilder, loc, c0, NFCT, c1, ValueRange{},
       [&](OpBuilder &builder, Location loc, Value i, ValueRange iargs) {
-        builder.create<memref::StoreOp>(loc, c0, Rfftp_fctdata_fct, i);
+        memref::StoreOp::create(builder, loc, c0, Rfftp_fctdata_fct, i);
 
-        Value tw_i = builder.create<memref::AllocOp>(
-            loc, type1, /*dynamicOperands=*/length_2);
-        builder.create<memref::StoreOp>(loc, tw_i, Rfftp_fctdata_tw, i);
-        Value tws_i = builder.create<memref::AllocOp>(
-            loc, type1, /*dynamicOperands=*/length_2);
-        builder.create<memref::StoreOp>(loc, tws_i, Rfftp_fctdata_tws, i);
+        Value tw_i = memref::AllocOp::create(builder, loc, type1,
+                                             /*dynamicOperands=*/length_2);
+        memref::StoreOp::create(builder, loc, tw_i, Rfftp_fctdata_tw, i);
+        Value tws_i = memref::AllocOp::create(builder, loc, type1,
+                                              /*dynamicOperands=*/length_2);
+        memref::StoreOp::create(builder, loc, tws_i, Rfftp_fctdata_tws, i);
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
-  Value condition = opBuilder.create<arith::CmpIOp>(
-      loc, arith::CmpIPredicate::ne, length, c1);
+  Value condition = arith::CmpIOp::create(opBuilder, loc,
+                                          arith::CmpIPredicate::ne, length, c1);
 
-  opBuilder.create<scf::IfOp>(
-      loc, condition, [&](OpBuilder &builder, Location loc) {
+  scf::IfOp::create(
+      opBuilder, loc, condition, [&](OpBuilder &builder, Location loc) {
         // TODO: remove xxx?
         // Value xxx = builder.create<ConstantIndexOp>(loc, 1);
         rfftp_factorize(builder, loc, Rfftp_fctdata_fct, Rfftp_fctdata_tw,
@@ -3257,7 +3291,7 @@ std::vector<Value> make_rfftp_plan(OpBuilder &opBuilder, Location loc,
         rfftp_comp_twiddle(builder, loc, length, Rfftp_fctdata_fct,
                            Rfftp_fctdata_tw, Rfftp_fctdata_tws,
                            Rfftp_plan_length, Rfftp_plan_nfct, Rfftp_plan_mem);
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
   return {Rfftp_fctdata_fct, Rfftp_fctdata_tw, Rfftp_fctdata_tws,
@@ -3265,102 +3299,102 @@ std::vector<Value> make_rfftp_plan(OpBuilder &opBuilder, Location loc,
 }
 
 void memref_SWAP(OpBuilder &opBuilder, Location loc, Value p, Value p1) {
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
   // TODO: remove the following values?
   // Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
   // Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
   // Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
   // Value c5 = opBuilder.create<ConstantIndexOp>(loc, 5);
 
-  Value length = opBuilder.create<memref::DimOp>(loc, p, c0);
+  Value length = memref::DimOp::create(opBuilder, loc, p, c0);
 
-  opBuilder.create<scf::ForOp>(
-      loc, c0, length, c1, ValueRange{},
+  scf::ForOp::create(
+      opBuilder, loc, c0, length, c1, ValueRange{},
       [&](OpBuilder builder, Location loc, Value i, ValueRange i_args) {
-        Value val_p = builder.create<memref::LoadOp>(loc, p, i);
-        Value val_p1 = builder.create<memref::LoadOp>(loc, p1, i);
+        Value val_p = memref::LoadOp::create(builder, loc, p, i);
+        Value val_p1 = memref::LoadOp::create(builder, loc, p1, i);
 
-        builder.create<memref::StoreOp>(loc, val_p, p1, i);
-        builder.create<memref::StoreOp>(loc, val_p1, p, i);
-        builder.create<scf::YieldOp>(loc);
+        memref::StoreOp::create(builder, loc, val_p, p1, i);
+        memref::StoreOp::create(builder, loc, val_p1, p, i);
+        scf::YieldOp::create(builder, loc);
       });
 }
 
 void flag_SWAP(OpBuilder &opBuilder, Location loc, Value flag) {
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
 
-  Value val = opBuilder.create<memref::LoadOp>(loc, flag, c0);
+  Value val = memref::LoadOp::create(opBuilder, loc, flag, c0);
   Value condition =
-      opBuilder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, val, c0);
+      arith::CmpIOp::create(opBuilder, loc, arith::CmpIPredicate::eq, val, c0);
 
-  Value x = opBuilder.create<arith::SelectOp>(loc, condition, c1, c0);
+  Value x = arith::SelectOp::create(opBuilder, loc, condition, c1, c0);
 
-  opBuilder.create<memref::StoreOp>(loc, x, flag, c0);
+  memref::StoreOp::create(opBuilder, loc, x, flag, c0);
 }
 
 void copy_and_norm(OpBuilder &opBuilder, Location loc, Value c, Value p1,
                    Value n, Value fct, Value flag) {
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
   // TODO: remove the following values?
   // Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
   // Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
   FloatType f64Ty = opBuilder.getF64Type();
   Value f1 =
-      opBuilder.create<ConstantFloatOp>(loc, f64Ty, APFloat(double(1.0)));
+      ConstantFloatOp::create(opBuilder, loc, f64Ty, APFloat(double(1.0)));
 
-  Value flag_val = opBuilder.create<memref::LoadOp>(loc, flag, c0);
-  Value condition = opBuilder.create<arith::CmpIOp>(
-      loc, arith::CmpIPredicate::eq, flag_val, c0);
+  Value flag_val = memref::LoadOp::create(opBuilder, loc, flag, c0);
+  Value condition = arith::CmpIOp::create(
+      opBuilder, loc, arith::CmpIPredicate::eq, flag_val, c0);
 
-  opBuilder.create<scf::IfOp>(
-      loc, condition,
+  scf::IfOp::create(
+      opBuilder, loc, condition,
       [&](OpBuilder &builder, Location loc) {
-        Value condition1 = builder.create<arith::CmpFOp>(
-            loc, arith::CmpFPredicate::ONE, fct, f1);
-        builder.create<scf::IfOp>(
-            loc, condition1,
+        Value condition1 = arith::CmpFOp::create(
+            builder, loc, arith::CmpFPredicate::ONE, fct, f1);
+        scf::IfOp::create(
+            builder, loc, condition1,
             [&](OpBuilder &b, Location loc) {
-              b.create<scf::ForOp>(
-                  loc, c0, n, c1, ValueRange{},
+              scf::ForOp::create(
+                  b, loc, c0, n, c1, ValueRange{},
                   [&](OpBuilder b2, Location loc, Value i, ValueRange i_args) {
-                    Value p1_i = b2.create<memref::LoadOp>(loc, p1, i);
-                    Value v = b2.create<arith::MulFOp>(loc, fct, p1_i);
-                    b2.create<memref::StoreOp>(loc, v, c, i);
-                    b2.create<scf::YieldOp>(loc);
+                    Value p1_i = memref::LoadOp::create(b2, loc, p1, i);
+                    Value v = arith::MulFOp::create(b2, loc, fct, p1_i);
+                    memref::StoreOp::create(b2, loc, v, c, i);
+                    scf::YieldOp::create(b2, loc);
                   });
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             },
             [&](OpBuilder &b, Location loc) {
-              b.create<scf::ForOp>(
-                  loc, c0, n, c1, ValueRange{},
+              scf::ForOp::create(
+                  b, loc, c0, n, c1, ValueRange{},
                   [&](OpBuilder b2, Location loc, Value i, ValueRange i_args) {
-                    Value val = b2.create<memref::LoadOp>(loc, p1, i);
-                    b2.create<memref::StoreOp>(loc, val, c, i);
-                    b2.create<scf::YieldOp>(loc);
+                    Value val = memref::LoadOp::create(b2, loc, p1, i);
+                    memref::StoreOp::create(b2, loc, val, c, i);
+                    scf::YieldOp::create(b2, loc);
                   });
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       },
       [&](OpBuilder &builder, Location loc) {
-        Value condition2 = builder.create<arith::CmpFOp>(
-            loc, arith::CmpFPredicate::ONE, fct, f1);
-        builder.create<scf::IfOp>(
-            loc, condition2, [&](OpBuilder &b, Location loc) {
-              b.create<scf::ForOp>(
-                  loc, c0, n, c1, ValueRange{},
+        Value condition2 = arith::CmpFOp::create(
+            builder, loc, arith::CmpFPredicate::ONE, fct, f1);
+        scf::IfOp::create(
+            builder, loc, condition2, [&](OpBuilder &b, Location loc) {
+              scf::ForOp::create(
+                  b, loc, c0, n, c1, ValueRange{},
                   [&](OpBuilder &b2, Location loc, Value i, ValueRange i_args) {
-                    Value c_i = b2.create<memref::LoadOp>(loc, c, i);
-                    Value newC = b2.create<arith::MulFOp>(loc, fct, c_i);
-                    b2.create<memref::StoreOp>(loc, newC, c, i);
-                    b2.create<scf::YieldOp>(loc);
+                    Value c_i = memref::LoadOp::create(b2, loc, c, i);
+                    Value newC = arith::MulFOp::create(b2, loc, fct, c_i);
+                    memref::StoreOp::create(b2, loc, newC, c, i);
+                    scf::YieldOp::create(b2, loc);
                   });
-              b.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(b, loc);
             });
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 }
 
@@ -3370,33 +3404,33 @@ void rfftp_forward(OpBuilder &opBuilder, Location loc, Value Rfftp_fctdata_fct,
                    Value Rfftp_plan_length, Value Rfftp_plan_nfct,
                    Value Rfftp_plan_mem, Value c, Value fct) {
 
-  Value c0 = opBuilder.create<ConstantIndexOp>(loc, 0);
-  Value c1 = opBuilder.create<ConstantIndexOp>(loc, 1);
-  Value c2 = opBuilder.create<ConstantIndexOp>(loc, 2);
-  Value c3 = opBuilder.create<ConstantIndexOp>(loc, 3);
-  Value c4 = opBuilder.create<ConstantIndexOp>(loc, 4);
-  Value c5 = opBuilder.create<ConstantIndexOp>(loc, 5);
+  Value c0 = ConstantIndexOp::create(opBuilder, loc, 0);
+  Value c1 = ConstantIndexOp::create(opBuilder, loc, 1);
+  Value c2 = ConstantIndexOp::create(opBuilder, loc, 2);
+  Value c3 = ConstantIndexOp::create(opBuilder, loc, 3);
+  Value c4 = ConstantIndexOp::create(opBuilder, loc, 4);
+  Value c5 = ConstantIndexOp::create(opBuilder, loc, 5);
   // TODO: remove the following values?
   // Value c20 = opBuilder.create<ConstantIndexOp>(loc, 20);
   FloatType f64Ty = opBuilder.getF64Type();
 
-  Value n = opBuilder.create<memref::LoadOp>(loc, Rfftp_plan_length, c0);
+  Value n = memref::LoadOp::create(opBuilder, loc, Rfftp_plan_length, c0);
 
   Value condition =
-      opBuilder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne, n, c1);
+      arith::CmpIOp::create(opBuilder, loc, arith::CmpIPredicate::ne, n, c1);
 
-  opBuilder.create<scf::IfOp>(
-      loc, condition, [&](OpBuilder &builder, Location loc) {
-        Value flag = builder.create<memref::AllocOp>(
-            loc, MemRefType::get(1, builder.getIndexType()));
-        builder.create<memref::StoreOp>(loc, c1, flag, c0);
-        Value l1_raw = builder.create<arith::AddIOp>(loc, n, c0);
-        Value nf = builder.create<memref::LoadOp>(loc, Rfftp_plan_nfct, c0);
+  scf::IfOp::create(
+      opBuilder, loc, condition, [&](OpBuilder &builder, Location loc) {
+        Value flag = memref::AllocOp::create(
+            builder, loc, MemRefType::get(1, builder.getIndexType()));
+        memref::StoreOp::create(builder, loc, c1, flag, c0);
+        Value l1_raw = arith::AddIOp::create(builder, loc, n, c0);
+        Value nf = memref::LoadOp::create(builder, loc, Rfftp_plan_nfct, c0);
 
         MemRefType cType = dyn_cast<MemRefType>(c.getType());
-        Value dimSize = builder.create<memref::DimOp>(loc, c, 0);
-        Value ch = builder.create<memref::AllocOp>(loc, cType,
-                                                   /*dynamicOperands=*/dimSize);
+        Value dimSize = memref::DimOp::create(builder, loc, c, 0);
+        Value ch = memref::AllocOp::create(builder, loc, cType,
+                                           /*dynamicOperands=*/dimSize);
 
         // Value ch = builder.create<memref::AllocOp>(
         //     loc, MemRefType::get(cType.getShape(), f64Ty));
@@ -3410,91 +3444,91 @@ void rfftp_forward(OpBuilder &opBuilder, Location loc, Value Rfftp_fctdata_fct,
 
         // memref<?xf64, strided<[?], offset: ?>>
 
-        Value p1_raw = builder.create<memref::SubViewOp>(
-            loc, resultType, c, SmallVector<OpFoldResult>{c0},
+        Value p1_raw = memref::SubViewOp::create(
+            builder, loc, resultType, c, SmallVector<OpFoldResult>{c0},
             SmallVector<OpFoldResult>{n}, SmallVector<OpFoldResult>{c1});
 
-        Value p2_raw = builder.create<memref::SubViewOp>(
-            loc, resultType, ch, SmallVector<OpFoldResult>{c0},
+        Value p2_raw = memref::SubViewOp::create(
+            builder, loc, resultType, ch, SmallVector<OpFoldResult>{c0},
             SmallVector<OpFoldResult>{n}, SmallVector<OpFoldResult>{c1});
 
-        builder.create<scf::ForOp>(
-            loc, c0, nf, c1, ValueRange{l1_raw},
+        scf::ForOp::create(
+            builder, loc, c0, nf, c1, ValueRange{l1_raw},
             [&](OpBuilder b, Location loc, Value k1, ValueRange k1_args) {
               Value l1_old = k1_args[0];
 
-              Value nf_m_k1 = b.create<arith::SubIOp>(loc, nf, k1);
-              Value k = b.create<arith::SubIOp>(loc, nf_m_k1, c1);
-              Value ip = b.create<memref::LoadOp>(loc, Rfftp_fctdata_fct, k);
-              Value ido = b.create<arith::DivSIOp>(loc, n, l1_old);
-              Value l1 = b.create<arith::DivSIOp>(loc, l1_old, ip);
+              Value nf_m_k1 = arith::SubIOp::create(b, loc, nf, k1);
+              Value k = arith::SubIOp::create(b, loc, nf_m_k1, c1);
+              Value ip = memref::LoadOp::create(b, loc, Rfftp_fctdata_fct, k);
+              Value ido = arith::DivSIOp::create(b, loc, n, l1_old);
+              Value l1 = arith::DivSIOp::create(b, loc, l1_old, ip);
 
-              Value tw = b.create<memref::LoadOp>(loc, Rfftp_fctdata_tw, k);
+              Value tw = memref::LoadOp::create(b, loc, Rfftp_fctdata_tw, k);
 
-              Value condition1 = b.create<arith::CmpIOp>(
-                  loc, arith::CmpIPredicate::eq, ip, c4);
+              Value condition1 = arith::CmpIOp::create(
+                  b, loc, arith::CmpIPredicate::eq, ip, c4);
 
-              b.create<scf::IfOp>(
-                  loc, condition1,
+              scf::IfOp::create(
+                  b, loc, condition1,
                   [&](OpBuilder &b2, Location loc) {
                     radf4(b2, loc, p1_raw, p2_raw, tw, ido, l1, c0, c1, c2, c3);
-                    b2.create<scf::YieldOp>(loc);
+                    scf::YieldOp::create(b2, loc);
                   },
                   [&](OpBuilder &b2, Location loc) {
-                    Value condition2 = b2.create<arith::CmpIOp>(
-                        loc, arith::CmpIPredicate::eq, ip, c2);
-                    b2.create<scf::IfOp>(
-                        loc, condition2,
+                    Value condition2 = arith::CmpIOp::create(
+                        b2, loc, arith::CmpIPredicate::eq, ip, c2);
+                    scf::IfOp::create(
+                        b2, loc, condition2,
                         [&](OpBuilder &b3, Location loc) {
                           radf2(b3, loc, p1_raw, p2_raw, tw, ido, l1);
-                          b3.create<scf::YieldOp>(loc);
+                          scf::YieldOp::create(b3, loc);
                         },
                         [&](OpBuilder &b3, Location loc) {
-                          Value condition3 = b3.create<arith::CmpIOp>(
-                              loc, arith::CmpIPredicate::eq, ip, c3);
-                          b3.create<scf::IfOp>(
-                              loc, condition3,
+                          Value condition3 = arith::CmpIOp::create(
+                              b3, loc, arith::CmpIPredicate::eq, ip, c3);
+                          scf::IfOp::create(
+                              b3, loc, condition3,
                               [&](OpBuilder &b4, Location loc) {
                                 radf3(b4, loc, p1_raw, p2_raw, tw, ido, l1);
-                                b4.create<scf::YieldOp>(loc);
+                                scf::YieldOp::create(b4, loc);
                               },
                               [&](OpBuilder &b4, Location loc) {
-                                Value condition4 = b4.create<arith::CmpIOp>(
-                                    loc, arith::CmpIPredicate::eq, ip, c5);
-                                b4.create<scf::IfOp>(
-                                    loc, condition4,
+                                Value condition4 = arith::CmpIOp::create(
+                                    b4, loc, arith::CmpIPredicate::eq, ip, c5);
+                                scf::IfOp::create(
+                                    b4, loc, condition4,
                                     [&](OpBuilder &b5, Location loc) {
                                       radf5(b5, loc, p1_raw, p2_raw, tw, ido,
                                             l1, c0, c1, c2, c3, c4);
-                                      b5.create<scf::YieldOp>(loc);
+                                      scf::YieldOp::create(b5, loc);
                                     },
                                     [&](OpBuilder &b5, Location loc) {
-                                      Value tws = b5.create<memref::LoadOp>(
-                                          loc, Rfftp_fctdata_tws, k);
+                                      Value tws = memref::LoadOp::create(
+                                          b5, loc, Rfftp_fctdata_tws, k);
                                       radfg(b5, loc, p1_raw, p2_raw, tw, tws,
                                             ido, ip, l1);
                                       memref_SWAP(b5, loc, p1_raw, p2_raw);
                                       flag_SWAP(b5, loc, flag);
-                                      b5.create<scf::YieldOp>(loc);
+                                      scf::YieldOp::create(b5, loc);
                                     });
-                                b4.create<scf::YieldOp>(loc);
+                                scf::YieldOp::create(b4, loc);
                               });
-                          b3.create<scf::YieldOp>(loc);
+                          scf::YieldOp::create(b3, loc);
                         }
 
                     );
-                    b2.create<scf::YieldOp>(loc);
+                    scf::YieldOp::create(b2, loc);
                   });
 
               memref_SWAP(b, loc, p1_raw, p2_raw);
               flag_SWAP(b, loc, flag);
 
-              b.create<scf::YieldOp>(loc, l1);
+              scf::YieldOp::create(b, loc, l1);
             });
 
         copy_and_norm(builder, loc, c, p1_raw, n, fct, flag);
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 }
 
@@ -3502,36 +3536,36 @@ void rfftp_forward(OpBuilder &opBuilder, Location loc, Value Rfftp_fctdata_fct,
 // resultMem
 void absPower(OpBuilder &builder, Location loc, Value bufferMem,
               Value resultMem, Value idx, Value c0, Value c1, Value c2) {
-  Value c200 = builder.create<ConstantIndexOp>(loc, 200);
-  Value c398 = builder.create<ConstantIndexOp>(loc, 398);
-  Value c399 = builder.create<ConstantIndexOp>(loc, 399);
-  Value power = builder.create<ConstantIndexOp>(loc, 2);
+  Value c200 = ConstantIndexOp::create(builder, loc, 200);
+  Value c398 = ConstantIndexOp::create(builder, loc, 398);
+  Value c399 = ConstantIndexOp::create(builder, loc, 399);
+  Value power = ConstantIndexOp::create(builder, loc, 2);
 
-  Value firstNum = builder.create<memref::LoadOp>(loc, bufferMem, c0);
-  Value firstPow = builder.create<math::FPowIOp>(loc, firstNum, power);
-  builder.create<memref::StoreOp>(loc, firstPow, resultMem,
-                                  ValueRange{idx, c0});
+  Value firstNum = memref::LoadOp::create(builder, loc, bufferMem, c0);
+  Value firstPow = math::FPowIOp::create(builder, loc, firstNum, power);
+  memref::StoreOp::create(builder, loc, firstPow, resultMem,
+                          ValueRange{idx, c0});
 
-  Value lastNum = builder.create<memref::LoadOp>(loc, bufferMem, c399);
-  Value lastPow = builder.create<math::FPowIOp>(loc, lastNum, power);
-  builder.create<memref::StoreOp>(loc, lastPow, resultMem,
-                                  ValueRange{idx, c200});
+  Value lastNum = memref::LoadOp::create(builder, loc, bufferMem, c399);
+  Value lastPow = math::FPowIOp::create(builder, loc, lastNum, power);
+  memref::StoreOp::create(builder, loc, lastPow, resultMem,
+                          ValueRange{idx, c200});
 
-  builder.create<scf::ForOp>(
-      loc, c1, c398, c2, ValueRange{c1},
+  scf::ForOp::create(
+      builder, loc, c1, c398, c2, ValueRange{c1},
       [&](OpBuilder &b, Location loc, Value iv, ValueRange iargs) {
-        Value j = b.create<arith::AddIOp>(loc, iv, c1);
-        Value num1 = b.create<memref::LoadOp>(loc, bufferMem, iv);
-        Value num2 = b.create<memref::LoadOp>(loc, bufferMem, j);
-        Value pow1 = b.create<math::FPowIOp>(loc, num1, power);
-        Value pow2 = b.create<math::FPowIOp>(loc, num2, power);
-        Value add = b.create<arith::AddFOp>(loc, pow1, pow2);
-        b.create<memref::StoreOp>(loc, add, resultMem,
-                                  ValueRange{idx, iargs[0]});
+        Value j = arith::AddIOp::create(b, loc, iv, c1);
+        Value num1 = memref::LoadOp::create(b, loc, bufferMem, iv);
+        Value num2 = memref::LoadOp::create(b, loc, bufferMem, j);
+        Value pow1 = math::FPowIOp::create(b, loc, num1, power);
+        Value pow2 = math::FPowIOp::create(b, loc, num2, power);
+        Value add = arith::AddFOp::create(b, loc, pow1, pow2);
+        memref::StoreOp::create(b, loc, add, resultMem,
+                                ValueRange{idx, iargs[0]});
 
-        Value indexNext = b.create<arith::AddIOp>(loc, iargs[0], c1);
+        Value indexNext = arith::AddIOp::create(b, loc, iargs[0], c1);
 
-        b.create<scf::YieldOp>(loc, indexNext);
+        scf::YieldOp::create(b, loc, indexNext);
       });
 
   return;
@@ -3543,12 +3577,12 @@ Value spectrogram(PatternRewriter &rewriter, Location loc, Value f0, Value c0,
                   Value window, Value melFilters) {
   FloatType f64Ty = rewriter.getF64Type();
 
-  Value numFrames = rewriter.create<ConstantIndexOp>(loc, 3001);
-  Value hopLength = rewriter.create<ConstantIndexOp>(loc, 160);
-  Value c400 = rewriter.create<ConstantIndexOp>(loc, 400);
+  Value numFrames = ConstantIndexOp::create(rewriter, loc, 3001);
+  Value hopLength = ConstantIndexOp::create(rewriter, loc, 160);
+  Value c400 = ConstantIndexOp::create(rewriter, loc, 400);
 
   MemRefType spectrogramTy = MemRefType::get({3001, 201}, f64Ty);
-  Value spectrogram = rewriter.create<memref::AllocOp>(loc, spectrogramTy);
+  Value spectrogram = memref::AllocOp::create(rewriter, loc, spectrogramTy);
 
   RankedTensorType tensorTy0 = RankedTensorType::get({400}, f64Ty);
   MemRefType mTp = MemRefType::get({400}, f64Ty);
@@ -3560,23 +3594,23 @@ Value spectrogram(PatternRewriter &rewriter, Location loc, Value f0, Value c0,
   SmallVector<utils::IteratorType> mulFIteratorTypes = {
       utils::IteratorType::parallel};
 
-  rewriter.create<scf::ForOp>(
-      loc, c0, numFrames, c1, ValueRange{c0},
+  scf::ForOp::create(
+      rewriter, loc, c0, numFrames, c1, ValueRange{c0},
       [&](OpBuilder &builder, Location loc, Value iv, ValueRange iargs) {
-        auto extractSliceOp = rewriter.create<tensor::ExtractSliceOp>(
-            loc, input, iargs[0], c400, c1);
+        auto extractSliceOp = tensor::ExtractSliceOp::create(
+            rewriter, loc, input, iargs[0], c400, c1);
         Value buffer400 = extractSliceOp.getResult();
         Value buffer =
-            rewriter.create<tensor::CastOp>(loc, tensorTy0, buffer400);
+            tensor::CastOp::create(rewriter, loc, tensorTy0, buffer400);
 
         // 'linalg.generic' operation use #mulf_trait.
-        auto mulfOp = rewriter.create<linalg::GenericOp>(
-            loc, /*resultTensorTypes=*/tensorTy0,
+        auto mulfOp = linalg::GenericOp::create(
+            rewriter, loc, /*resultTensorTypes=*/tensorTy0,
             /*inputs=*/ValueRange{buffer, window},
             /*outputs=*/ValueRange{buffer}, mulFIndexingMaps, mulFIteratorTypes,
             [&](OpBuilder &b, Location loc, ValueRange args) {
-              Value elem = b.create<arith::MulFOp>(loc, args[0], args[1]);
-              b.create<linalg::YieldOp>(loc, elem);
+              Value elem = arith::MulFOp::create(b, loc, args[0], args[1]);
+              linalg::YieldOp::create(b, loc, elem);
             });
         Value multiplied = mulfOp.getResult(0);
 
@@ -3587,21 +3621,21 @@ Value spectrogram(PatternRewriter &rewriter, Location loc, Value f0, Value c0,
         MemRefType type1 = MemRefType::get(ShapedType::kDynamic, f64Ty);
 
         Value bufferMem_rfft =
-            builder.create<memref::CastOp>(loc, type1, bufferMem_raw);
+            memref::CastOp::create(builder, loc, type1, bufferMem_raw);
 
         // Compute 'dap.rfft' operation, result stores in `bufferMem`.
-        builder.create<dap::RFFTOp>(loc, bufferMem_rfft);
+        dap::RFFTOp::create(builder, loc, bufferMem_rfft);
 
         Value bufferMem =
-            builder.create<memref::CastOp>(loc, type0, bufferMem_rfft);
+            memref::CastOp::create(builder, loc, type0, bufferMem_rfft);
 
         // Store the result in a single line specified by `iv`.
         absPower(builder, loc, bufferMem, spectrogram, iv, c0, c1, c2);
 
         Value timestepNext =
-            builder.create<arith::AddIOp>(loc, iargs[0], hopLength);
+            arith::AddIOp::create(builder, loc, iargs[0], hopLength);
 
-        builder.create<scf::YieldOp>(loc, timestepNext);
+        scf::YieldOp::create(builder, loc, timestepNext);
       });
 
   // TODO: check alloc and dealloc
@@ -3610,41 +3644,41 @@ Value spectrogram(PatternRewriter &rewriter, Location loc, Value f0, Value c0,
   // melFiltersTransposeTy); Value init0 =
   // rewriter.create<bufferization::ToTensorOp>(loc, alloc0);
   Value init0 =
-      rewriter.create<tensor::EmptyOp>(loc, ArrayRef<int64_t>{80, 201}, f64Ty);
-  auto transposeOp0 = rewriter.create<linalg::TransposeOp>(
-      loc, /*input=*/melFilters,
-      /*init=*/init0,
-      /*permutation=*/ArrayRef<int64_t>{1, 0});
+      tensor::EmptyOp::create(rewriter, loc, ArrayRef<int64_t>{80, 201}, f64Ty);
+  auto transposeOp0 =
+      linalg::TransposeOp::create(rewriter, loc, /*input=*/melFilters,
+                                  /*init=*/init0,
+                                  /*permutation=*/ArrayRef<int64_t>{1, 0});
   Value melFiltersT = transposeOp0.getResult()[0];
 
   Value gram = bufferization::ToTensorOp::create(
       rewriter, loc, memref::getTensorTypeFromMemRefType(spectrogram.getType()),
       spectrogram, /*restrict=*/true, /*writable=*/false);
-  Value init1 = rewriter.create<tensor::EmptyOp>(
-      loc, ArrayRef<int64_t>{201, 3001}, f64Ty);
-  auto transposeOp1 = rewriter.create<linalg::TransposeOp>(
-      loc, /*input=*/gram,
-      /*init=*/init1,
-      /*permutation=*/ArrayRef<int64_t>{1, 0});
+  Value init1 = tensor::EmptyOp::create(rewriter, loc,
+                                        ArrayRef<int64_t>{201, 3001}, f64Ty);
+  auto transposeOp1 =
+      linalg::TransposeOp::create(rewriter, loc, /*input=*/gram,
+                                  /*init=*/init1,
+                                  /*permutation=*/ArrayRef<int64_t>{1, 0});
   Value spectrogramT = transposeOp1.getResult()[0];
 
-  rewriter.create<memref::DeallocOp>(loc, spectrogram);
+  memref::DeallocOp::create(rewriter, loc, spectrogram);
 
-  Value init2 =
-      rewriter.create<tensor::EmptyOp>(loc, ArrayRef<int64_t>{80, 3001}, f64Ty);
-  auto matmulOp = rewriter.create<linalg::MatmulOp>(
-      loc, /*inputs=*/ValueRange{melFiltersT, spectrogramT},
+  Value init2 = tensor::EmptyOp::create(rewriter, loc,
+                                        ArrayRef<int64_t>{80, 3001}, f64Ty);
+  auto matmulOp = linalg::MatmulOp::create(
+      rewriter, loc, /*inputs=*/ValueRange{melFiltersT, spectrogramT},
       /*outputs=*/ValueRange{init2});
   Value matMulResult = matmulOp.getResultTensors()[0];
 
   // Initialize a tensor with constant `1e-10`.
   RankedTensorType tensorTy1 = RankedTensorType::get({80, 3001}, f64Ty);
-  Value cMelFloor = rewriter.create<ConstantFloatOp>(
-      loc, f64Ty, APFloat(double(0.0000000001)));
-  Value melFloor = rewriter.create<tensor::SplatOp>(loc, tensorTy1, cMelFloor);
+  Value cMelFloor = ConstantFloatOp::create(rewriter, loc, f64Ty,
+                                            APFloat(double(0.0000000001)));
+  Value melFloor = tensor::SplatOp::create(rewriter, loc, tensorTy1, cMelFloor);
 
-  auto linalgMaxOp = rewriter.create<linalg::MaxOp>(
-      loc, /*input=*/ValueRange{melFloor, matMulResult},
+  auto linalgMaxOp = linalg::MaxOp::create(
+      rewriter, loc, /*input=*/ValueRange{melFloor, matMulResult},
       /*outputs=*/ValueRange{melFloor});
   Value spectrogramMax = linalgMaxOp.getResultTensors()[0];
 
@@ -3656,13 +3690,13 @@ Value spectrogram(PatternRewriter &rewriter, Location loc, Value f0, Value c0,
       utils::IteratorType::parallel, utils::IteratorType::parallel};
 
   // 'linalg.generic' operation use #log10_trait.
-  auto log10Op = rewriter.create<linalg::GenericOp>(
-      loc, /*resultTensorTypes=*/tensorTy1,
+  auto log10Op = linalg::GenericOp::create(
+      rewriter, loc, /*resultTensorTypes=*/tensorTy1,
       /*inputs=*/ValueRange{spectrogramMax},
       /*outputs=*/ValueRange{spectrogramMax}, log10IndexingMaps,
       log10IteratorTypes, [&](OpBuilder &b, Location loc, ValueRange args) {
-        Value elem = b.create<math::Log10Op>(loc, args[0]);
-        b.create<linalg::YieldOp>(loc, elem);
+        Value elem = math::Log10Op::create(b, loc, args[0]);
+        linalg::YieldOp::create(b, loc, elem);
       });
   Value spectrogramLog10 = log10Op.getResult(0);
 
@@ -3683,7 +3717,7 @@ public:
     // auto ctx = op->getContext();
     Value bufferMem = op->getOperand(0);
 
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
+    Value c0 = ConstantIndexOp::create(rewriter, loc, 0);
     // TODO: remove the following values?
     // Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
     // Value c2 = rewriter.create<ConstantIndexOp>(loc, 2);
@@ -3700,7 +3734,7 @@ public:
         bufferMem,
         /*restrict=*/true, /*writable=*/true);
     Value inputFeaturesSize =
-        rewriter.create<tensor::DimOp>(loc, inputFeatures, c0);
+        tensor::DimOp::create(rewriter, loc, inputFeatures, c0);
 
     FloatType f64Ty = rewriter.getF64Type();
 
@@ -3708,7 +3742,7 @@ public:
     // Value f0 =
     //     rewriter.create<ConstantFloatOp>(loc, f64Ty, APFloat(double(0.0)));
     Value f1 =
-        rewriter.create<ConstantFloatOp>(loc, f64Ty, APFloat(double(1.0)));
+        ConstantFloatOp::create(rewriter, loc, f64Ty, APFloat(double(1.0)));
 
     std::vector<Value> plan = make_rfftp_plan(rewriter, loc, inputFeaturesSize);
 
@@ -3742,15 +3776,15 @@ public:
     auto ctx = op->getContext();
     Value input = op->getOperand(0);
 
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-    Value c2 = rewriter.create<ConstantIndexOp>(loc, 2);
-    Value c3 = rewriter.create<ConstantIndexOp>(loc, 3);
-    Value c4 = rewriter.create<ConstantIndexOp>(loc, 4);
-    Value c5 = rewriter.create<ConstantIndexOp>(loc, 5);
-    Value c80 = rewriter.create<ConstantIndexOp>(loc, 80);
-    Value c3000 = rewriter.create<ConstantIndexOp>(loc, 3000);
-    Value c480000 = rewriter.create<ConstantIndexOp>(loc, 480000);
+    Value c0 = ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = ConstantIndexOp::create(rewriter, loc, 1);
+    Value c2 = ConstantIndexOp::create(rewriter, loc, 2);
+    Value c3 = ConstantIndexOp::create(rewriter, loc, 3);
+    Value c4 = ConstantIndexOp::create(rewriter, loc, 4);
+    Value c5 = ConstantIndexOp::create(rewriter, loc, 5);
+    Value c80 = ConstantIndexOp::create(rewriter, loc, 80);
+    Value c3000 = ConstantIndexOp::create(rewriter, loc, 3000);
+    Value c480000 = ConstantIndexOp::create(rewriter, loc, 480000);
 
     FloatType f32 = Float32Type::get(ctx);
     FloatType f64 = Float64Type::get(ctx);
@@ -3759,9 +3793,9 @@ public:
         rewriter, loc, memref::getTensorTypeFromMemRefType(input.getType()),
         input, /*restrict=*/true, /*writable=*/false);
     Value inputFeaturesSize =
-        rewriter.create<tensor::DimOp>(loc, inputFeatures, c0);
+        tensor::DimOp::create(rewriter, loc, inputFeatures, c0);
     Value padConstantHigh =
-        rewriter.create<arith::SubIOp>(loc, c480000, inputFeaturesSize);
+        arith::SubIOp::create(rewriter, loc, c480000, inputFeaturesSize);
 
     // Pad inputFeatures to MaxLength = 480000
     SmallVector<int64_t> paddedShape;
@@ -3772,11 +3806,11 @@ public:
     lowValues.push_back(c0);
     highValues.push_back(padConstantHigh);
 
-    Value f0 =
-        rewriter.create<arith::ConstantFloatOp>(loc, f64, APFloat(double(0.0)));
-    auto padConstantOp = rewriter.create<tensor::PadOp>(
-        loc, RankedTensorType::get(paddedShape, f64), inputFeatures, lowValues,
-        highValues, f0);
+    Value f0 = arith::ConstantFloatOp::create(rewriter, loc, f64,
+                                              APFloat(double(0.0)));
+    auto padConstantOp = tensor::PadOp::create(
+        rewriter, loc, RankedTensorType::get(paddedShape, f64), inputFeatures,
+        lowValues, highValues, f0);
     Value paddedInput = padConstantOp.getResult();
 
     // Generate melFilter with 391 numbers
@@ -3791,49 +3825,51 @@ public:
     Value logSpec = spectrogram(rewriter, loc, f0, c0, c1, c2, c3, c4, c5,
                                 finalPaddedInput, window, melFilter);
 
-    auto extractSliceOp = rewriter.create<tensor::ExtractSliceOp>(
-        loc, /*source=*/logSpec,
-        /*offsets=*/ValueRange{c0, c0},
-        /*sizes=*/ValueRange{c80, c3000},
-        /*strides=*/ValueRange{c1, c1});
+    auto extractSliceOp =
+        tensor::ExtractSliceOp::create(rewriter, loc, /*source=*/logSpec,
+                                       /*offsets=*/ValueRange{c0, c0},
+                                       /*sizes=*/ValueRange{c80, c3000},
+                                       /*strides=*/ValueRange{c1, c1});
     Value logSpecCut = extractSliceOp.getResult();
 
     Value maxInit =
-        rewriter.create<ConstantFloatOp>(loc, f64, APFloat(double(-10.0)));
-    auto forOp0 = rewriter.create<scf::ForOp>(
-        loc, c0, c80, c1, maxInit,
+        ConstantFloatOp::create(rewriter, loc, f64, APFloat(double(-10.0)));
+    auto forOp0 = scf::ForOp::create(
+        rewriter, loc, c0, c80, c1, maxInit,
         [&](OpBuilder &builder, Location loc, Value i, ValueRange iargs0) {
-          auto forOp1 = builder.create<scf::ForOp>(
-              loc, c0, c3000, c1, iargs0[0],
+          auto forOp1 = scf::ForOp::create(
+              builder, loc, c0, c3000, c1, iargs0[0],
               [&](OpBuilder &b, Location loc, Value j, ValueRange iargs1) {
-                Value elem = b.create<tensor::ExtractOp>(loc, logSpecCut,
-                                                         ValueRange{i, j});
+                Value elem = tensor::ExtractOp::create(b, loc, logSpecCut,
+                                                       ValueRange{i, j});
                 Value larger =
-                    b.create<arith::MaximumFOp>(loc, elem, iargs1[0]);
-                b.create<scf::YieldOp>(loc, larger);
+                    arith::MaximumFOp::create(b, loc, elem, iargs1[0]);
+                scf::YieldOp::create(b, loc, larger);
               });
 
           Value maxNext = forOp1.getResults()[0];
-          builder.create<scf::YieldOp>(loc, maxNext);
+          scf::YieldOp::create(builder, loc, maxNext);
         });
     Value maxNum = forOp0.getResults()[0];
 
-    Value f8 = rewriter.create<ConstantFloatOp>(loc, f64, APFloat(double(8.0)));
-    Value maxNumMinus8 = rewriter.create<arith::SubFOp>(loc, maxNum, f8);
-    Value logSpecFloor = rewriter.create<tensor::SplatOp>(
-        loc, RankedTensorType::get({80, 3000}, f64), maxNumMinus8);
+    Value f8 =
+        ConstantFloatOp::create(rewriter, loc, f64, APFloat(double(8.0)));
+    Value maxNumMinus8 = arith::SubFOp::create(rewriter, loc, maxNum, f8);
+    Value logSpecFloor = tensor::SplatOp::create(
+        rewriter, loc, RankedTensorType::get({80, 3000}, f64), maxNumMinus8);
 
-    auto linalgMaxOp = rewriter.create<linalg::MaxOp>(
-        loc, /*input=*/ValueRange{logSpecCut, logSpecFloor},
+    auto linalgMaxOp = linalg::MaxOp::create(
+        rewriter, loc, /*input=*/ValueRange{logSpecCut, logSpecFloor},
         /*outputs=*/ValueRange{logSpecFloor});
     Value logSpecMax = linalgMaxOp.getResultTensors()[0];
 
     Value f0F32 =
-        rewriter.create<ConstantFloatOp>(loc, f32, APFloat(float(0.0)));
-    Value f4 = rewriter.create<ConstantFloatOp>(loc, f64, APFloat(double(4.0)));
+        ConstantFloatOp::create(rewriter, loc, f32, APFloat(float(0.0)));
+    Value f4 =
+        ConstantFloatOp::create(rewriter, loc, f64, APFloat(double(4.0)));
     RankedTensorType resultTy = RankedTensorType::get({80, 3000}, f32);
     Value InputFeaturesF32 =
-        rewriter.create<tensor::SplatOp>(loc, resultTy, f0F32);
+        tensor::SplatOp::create(rewriter, loc, resultTy, f0F32);
 
     // #tail_processing_trait for 'linalg.generic' operation.
     AffineMap IdMap =
@@ -3843,15 +3879,15 @@ public:
         utils::IteratorType::parallel, utils::IteratorType::parallel};
 
     // 'linalg.generic' operation use #tail_processing_trait.
-    auto tailProcessOp = rewriter.create<linalg::GenericOp>(
-        loc, /*resultTensorTypes=*/resultTy,
+    auto tailProcessOp = linalg::GenericOp::create(
+        rewriter, loc, /*resultTensorTypes=*/resultTy,
         /*inputs=*/ValueRange{logSpecMax},
         /*outputs=*/ValueRange{InputFeaturesF32}, IndexingMaps, IteratorTypes,
         [&](OpBuilder &b, Location loc, ValueRange args) {
-          Value add4 = b.create<arith::AddFOp>(loc, args[0], f4);
-          Value div4 = b.create<arith::DivFOp>(loc, add4, f4);
-          Value elem = b.create<arith::TruncFOp>(loc, f32, div4);
-          b.create<linalg::YieldOp>(loc, elem);
+          Value add4 = arith::AddFOp::create(b, loc, args[0], f4);
+          Value div4 = arith::DivFOp::create(b, loc, add4, f4);
+          Value elem = arith::TruncFOp::create(b, loc, f32, div4);
+          linalg::YieldOp::create(b, loc, elem);
         });
     Value result = tailProcessOp.getResult(0);
 
@@ -3866,8 +3902,8 @@ public:
 
     RankedTensorType expandTy = RankedTensorType::get({1, 80, 3000}, f32);
 
-    Value resultExpand = rewriter.create<tensor::ExpandShapeOp>(
-        loc, /*resultType=*/expandTy, /*src=*/result,
+    Value resultExpand = tensor::ExpandShapeOp::create(
+        rewriter, loc, /*resultType=*/expandTy, /*src=*/result,
         /*reassociation=*/reassociationIndices);
 
     auto resultMemTp =

--- a/midend/lib/Conversion/GraphRedundancyElimination/SimplifyTosaMatmulScalar.cpp
+++ b/midend/lib/Conversion/GraphRedundancyElimination/SimplifyTosaMatmulScalar.cpp
@@ -27,10 +27,10 @@
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
-#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -101,8 +101,8 @@ struct ReplaceScalarLikeMatmul : public OpRewritePattern<tosa::MatMulOp> {
     auto shiftType = RankedTensorType::get({1}, i8Type);
     auto zeroAttr = IntegerAttr::get(i8Type, 0);
     auto denseAttr = DenseElementsAttr::get(shiftType, zeroAttr);
-    auto shiftOp = rewriter.create<tosa::ConstOp>(op.getLoc(), shiftType,
-                                                   denseAttr);
+    auto shiftOp =
+        tosa::ConstOp::create(rewriter, op.getLoc(), shiftType, denseAttr);
 
     rewriter.replaceOpWithNewOp<tosa::MulOp>(op, outTy, op.getA(), op.getB(),
                                              shiftOp.getResult());

--- a/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
+++ b/midend/lib/Conversion/LinalgToVIR/LinalgToVIRPass.cpp
@@ -79,7 +79,7 @@ buildVIRVectorShape(linalg::LinalgOp op, SmallVectorImpl<int64_t> &shapeOut,
                                                      operandDimPos))) {
         return failure();
       }
-      Value dim = b.create<memref::DimOp>(loc, operand, operandDimPos);
+      Value dim = memref::DimOp::create(b, loc, operand, operandDimPos);
       commonShape.push_back(dim);
     } else {
       commonShape.push_back(b.getIndexAttr(sz));
@@ -158,7 +158,7 @@ static Value transformInputMemrefForProjectedPermutation(
     int64_t shapeVal = memrefShape[i];
     resultShape.push_back(shapeVal);
     if (ShapedType::isDynamic(shapeVal)) {
-      Value dim = rewriter.create<memref::DimOp>(loc, opOperand->get(), i);
+      Value dim = memref::DimOp::create(rewriter, loc, opOperand->get(), i);
       outputShape.push_back(dim);
     } else {
       outputShape.push_back(rewriter.getIndexAttr(shapeVal));
@@ -173,12 +173,12 @@ static Value transformInputMemrefForProjectedPermutation(
     reassociation.push_back({static_cast<int64_t>(numDimsToExpand + i)});
   }
 
-  Value expanded = rewriter.create<memref::ExpandShapeOp>(
-      loc, resultShape, opOperand->get(), reassociation, outputShape);
+  Value expanded = memref::ExpandShapeOp::create(
+      rewriter, loc, resultShape, opOperand->get(), reassociation, outputShape);
 
   // 3) Transpose to align dims in iteration-space order.
-  Value transposed = rewriter.create<memref::TransposeOp>(
-      loc, expanded, AffineMapAttr::get(permutationMap));
+  Value transposed = memref::TransposeOp::create(
+      rewriter, loc, expanded, AffineMapAttr::get(permutationMap));
 
   // 4) Subview to broadcast the dimensions that are not present.
   SmallVector<OpFoldResult> strides;
@@ -193,8 +193,8 @@ static Value transformInputMemrefForProjectedPermutation(
       strides.push_back(rewriter.getIndexAttr(0));
     }
   }
-  Value subview = rewriter.create<memref::SubViewOp>(loc, transposed, offsets,
-                                                     commonShape, strides);
+  Value subview = memref::SubViewOp::create(rewriter, loc, transposed, offsets,
+                                            commonShape, strides);
   return subview;
 }
 
@@ -206,8 +206,8 @@ transformOutputMemrefForProjectedPermutation(OpBuilder &rewriter, Location loc,
                                              AffineMap indexingMap) {
   // For output, just transpose it into the source dimension order.
   auto permutationMap = inversePermutation(reindexIndexingMap(indexingMap));
-  auto transposed = rewriter.create<memref::TransposeOp>(
-      loc, opOperand->get(), AffineMapAttr::get(permutationMap));
+  auto transposed = memref::TransposeOp::create(
+      rewriter, loc, opOperand->get(), AffineMapAttr::get(permutationMap));
   return transposed;
 }
 
@@ -231,7 +231,7 @@ static Operation *createGenericElementwiseVIR(Operation *op,
     // Broadcast scalar to vector type based on its scalar type.
     Type scalarTy = cur.getType();
     auto vecTy = buddy::vir::DynamicVectorType::get(virShape, scalarTy);
-    return rewriter.create<buddy::vir::BroadcastOp>(loc, vecTy, cur);
+    return buddy::vir::BroadcastOp::create(rewriter, loc, vecTy, cur);
   };
 
   // Collect VIR vector operands (broadcast scalars as needed).
@@ -247,8 +247,8 @@ static Operation *createGenericElementwiseVIR(Operation *op,
   if (auto sel = dyn_cast<arith::SelectOp>(op)) {
     Type resElemTy = sel.getType();
     auto resTy = buddy::vir::DynamicVectorType::get(virShape, resElemTy);
-    auto created = rewriter.create<buddy::vir::SelectOp>(
-        loc, resTy, vecOperands[0], vecOperands[1], vecOperands[2]);
+    auto created = buddy::vir::SelectOp::create(
+        rewriter, loc, resTy, vecOperands[0], vecOperands[1], vecOperands[2]);
     return created.getOperation();
   }
 
@@ -257,13 +257,13 @@ static Operation *createGenericElementwiseVIR(Operation *op,
   if (auto extf = dyn_cast<arith::ExtFOp>(op)) {
     auto outTy = buddy::vir::DynamicVectorType::get(virShape, extf.getType());
     auto created =
-        rewriter.create<buddy::vir::ExtFOp>(loc, outTy, vecOperands[0]);
+        buddy::vir::ExtFOp::create(rewriter, loc, outTy, vecOperands[0]);
     return created.getOperation();
   }
   if (auto truncf = dyn_cast<arith::TruncFOp>(op)) {
     auto outTy = buddy::vir::DynamicVectorType::get(virShape, truncf.getType());
     auto created =
-        rewriter.create<buddy::vir::TruncFOp>(loc, outTy, vecOperands[0]);
+        buddy::vir::TruncFOp::create(rewriter, loc, outTy, vecOperands[0]);
     return created.getOperation();
   }
 
@@ -295,8 +295,8 @@ static LogicalResult computeShapeAndVL(linalg::LinalgOp linalgOp,
   }
   Location loc = linalgOp.getLoc();
   if (auto attr = dyn_cast<Attribute>(ofrCommon.back())) {
-    vlVal = rewriter.create<arith::ConstantIndexOp>(
-        loc, cast<IntegerAttr>(attr).getInt());
+    vlVal = arith::ConstantIndexOp::create(rewriter, loc,
+                                           cast<IntegerAttr>(attr).getInt());
   } else if (auto v = dyn_cast<Value>(ofrCommon.back())) {
     vlVal = v;
   } else {
@@ -368,8 +368,8 @@ static LogicalResult lowerReduceToScalarLoop(linalg::ReduceOp reduceOp,
 
   Location loc = reduceOp.getLoc();
   rewriter.setInsertionPoint(reduceOp);
-  Value lower = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-  Value step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  Value lower = arith::ConstantIndexOp::create(rewriter, loc, 0);
+  Value step = arith::ConstantIndexOp::create(rewriter, loc, 1);
 
   auto kindToString = [&](SupportedReduceCombinerKind k) -> StringRef {
     switch (k) {
@@ -388,32 +388,32 @@ static LogicalResult lowerReduceToScalarLoop(linalg::ReduceOp reduceOp,
       return rewriter.notifyMatchFailure(
           reduceOp, "rank-1 -> rank-0 reduction requires dimensions=[0]");
 
-    Value n = rewriter.create<memref::DimOp>(loc, input, 0);
+    Value n = memref::DimOp::create(rewriter, loc, input, 0);
     Type elemTy = inTy.getElementType();
     auto accBufTy = MemRefType::get({}, elemTy);
-    Value accBuf = rewriter.create<memref::AllocaOp>(loc, accBufTy);
-    Value initVal = rewriter.create<memref::LoadOp>(loc, init, ValueRange{});
-    rewriter.create<memref::StoreOp>(loc, initVal, accBuf, ValueRange{});
+    Value accBuf = memref::AllocaOp::create(rewriter, loc, accBufTy);
+    Value initVal = memref::LoadOp::create(rewriter, loc, init, ValueRange{});
+    memref::StoreOp::create(rewriter, loc, initVal, accBuf, ValueRange{});
 
     auto setVl = createSetVLRegion(rewriter, loc, n);
     auto vecTy =
         buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
     Value loaded =
-        rewriter.create<buddy::vir::LoadOp>(loc, vecTy, input, ValueRange{c0})
+        buddy::vir::LoadOp::create(rewriter, loc, vecTy, input, ValueRange{c0})
             .getResult();
-    Value acc = rewriter.create<memref::LoadOp>(loc, accBuf, ValueRange{});
-    Value reduced = rewriter
-                        .create<buddy::vir::ReduceOp>(
-                            loc, elemTy, loaded, acc,
-                            rewriter.getStringAttr(kindToString(*combinerKind)))
+    Value acc = memref::LoadOp::create(rewriter, loc, accBuf, ValueRange{});
+    Value reduced = buddy::vir::ReduceOp::create(
+                        rewriter, loc, elemTy, loaded, acc,
+                        rewriter.getStringAttr(kindToString(*combinerKind)))
                         .getResult();
-    rewriter.create<memref::StoreOp>(loc, reduced, accBuf, ValueRange{});
-    rewriter.create<vector::YieldOp>(loc);
+    memref::StoreOp::create(rewriter, loc, reduced, accBuf, ValueRange{});
+    vector::YieldOp::create(rewriter, loc);
 
     rewriter.setInsertionPointAfter(setVl);
-    Value finalVal = rewriter.create<memref::LoadOp>(loc, accBuf, ValueRange{});
-    rewriter.create<memref::StoreOp>(loc, finalVal, init, ValueRange{});
+    Value finalVal =
+        memref::LoadOp::create(rewriter, loc, accBuf, ValueRange{});
+    memref::StoreOp::create(rewriter, loc, finalVal, init, ValueRange{});
     rewriter.eraseOp(reduceOp);
     return success();
   }
@@ -429,7 +429,7 @@ static LogicalResult lowerReduceToScalarLoop(linalg::ReduceOp reduceOp,
     int64_t inStaticN = inTy.getShape()[1];
     int64_t outStaticM = outTy.getShape()[0];
     Type elemTy = inTy.getElementType();
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
 
     if (dims[0] == 1) {
       if (!ShapedType::isDynamic(inStaticM) &&
@@ -438,46 +438,44 @@ static LogicalResult lowerReduceToScalarLoop(linalg::ReduceOp reduceOp,
             reduceOp, "input/output leading dimension mismatch");
       }
 
-      Value upperM = rewriter.create<memref::DimOp>(loc, input, 0);
-      Value upperN = rewriter.create<memref::DimOp>(loc, input, 1);
-      auto outerLoop = rewriter.create<scf::ForOp>(loc, lower, upperM, step);
+      Value upperM = memref::DimOp::create(rewriter, loc, input, 0);
+      Value upperN = memref::DimOp::create(rewriter, loc, input, 1);
+      auto outerLoop = scf::ForOp::create(rewriter, loc, lower, upperM, step);
 
       {
         OpBuilder::InsertionGuard g(rewriter);
         rewriter.setInsertionPointToStart(outerLoop.getBody());
         Value i = outerLoop.getInductionVar();
         auto accBufTy = MemRefType::get({}, elemTy);
-        Value accBuf = rewriter.create<memref::AllocaOp>(loc, accBufTy);
+        Value accBuf = memref::AllocaOp::create(rewriter, loc, accBufTy);
         Value initVal =
-            rewriter.create<memref::LoadOp>(loc, init, ValueRange{i});
-        rewriter.create<memref::StoreOp>(loc, initVal, accBuf, ValueRange{});
+            memref::LoadOp::create(rewriter, loc, init, ValueRange{i});
+        memref::StoreOp::create(rewriter, loc, initVal, accBuf, ValueRange{});
 
-        auto setVl = rewriter.create<buddy::vir::SetVLOp>(
-            loc, /*results=*/TypeRange{}, /*operands=*/ValueRange{upperN});
+        auto setVl =
+            buddy::vir::SetVLOp::create(rewriter, loc, /*results=*/TypeRange{},
+                                        /*operands=*/ValueRange{upperN});
         Region &region = setVl.getRegion();
         Block &block = region.emplaceBlock();
         rewriter.setInsertionPointToStart(&block);
 
         auto vecTy =
             buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
-        Value row = rewriter
-                        .create<buddy::vir::LoadOp>(loc, vecTy, input,
-                                                    ValueRange{i, c0})
+        Value row = buddy::vir::LoadOp::create(rewriter, loc, vecTy, input,
+                                               ValueRange{i, c0})
                         .getResult();
-        Value acc = rewriter.create<memref::LoadOp>(loc, accBuf, ValueRange{});
-        Value reduced =
-            rewriter
-                .create<buddy::vir::ReduceOp>(
-                    loc, elemTy, row, acc,
-                    rewriter.getStringAttr(kindToString(*combinerKind)))
-                .getResult();
-        rewriter.create<memref::StoreOp>(loc, reduced, accBuf, ValueRange{});
-        rewriter.create<vector::YieldOp>(loc);
+        Value acc = memref::LoadOp::create(rewriter, loc, accBuf, ValueRange{});
+        Value reduced = buddy::vir::ReduceOp::create(
+                            rewriter, loc, elemTy, row, acc,
+                            rewriter.getStringAttr(kindToString(*combinerKind)))
+                            .getResult();
+        memref::StoreOp::create(rewriter, loc, reduced, accBuf, ValueRange{});
+        vector::YieldOp::create(rewriter, loc);
 
         rewriter.setInsertionPointAfter(setVl);
         Value finalVal =
-            rewriter.create<memref::LoadOp>(loc, accBuf, ValueRange{});
-        rewriter.create<memref::StoreOp>(loc, finalVal, init, ValueRange{i});
+            memref::LoadOp::create(rewriter, loc, accBuf, ValueRange{});
+        memref::StoreOp::create(rewriter, loc, finalVal, init, ValueRange{i});
       }
 
       rewriter.eraseOp(reduceOp);
@@ -503,56 +501,54 @@ static LogicalResult lowerReduceToScalarLoop(linalg::ReduceOp reduceOp,
         return rewriter.notifyMatchFailure(
             reduceOp, "input/output trailing dimension mismatch");
 
-      Value upperN = rewriter.create<arith::ConstantIndexOp>(loc, inStaticN);
-      Value upperM = rewriter.create<arith::ConstantIndexOp>(loc, inStaticM);
+      Value upperN = arith::ConstantIndexOp::create(rewriter, loc, inStaticN);
+      Value upperM = arith::ConstantIndexOp::create(rewriter, loc, inStaticM);
       SmallVector<int64_t> permutation = {1, 0};
       auto permutationMap =
           AffineMap::getPermutationMap(permutation, rewriter.getContext());
-      Value transposed = rewriter.create<memref::TransposeOp>(
-          loc, input, AffineMapAttr::get(permutationMap));
+      Value transposed = memref::TransposeOp::create(
+          rewriter, loc, input, AffineMapAttr::get(permutationMap));
       auto scratchTy = MemRefType::get({inStaticN, inStaticM}, elemTy);
-      Value scratch = rewriter.create<memref::AllocOp>(loc, scratchTy);
-      rewriter.create<memref::CopyOp>(loc, transposed, scratch);
-      auto outerLoop = rewriter.create<scf::ForOp>(loc, lower, upperN, step);
+      Value scratch = memref::AllocOp::create(rewriter, loc, scratchTy);
+      memref::CopyOp::create(rewriter, loc, transposed, scratch);
+      auto outerLoop = scf::ForOp::create(rewriter, loc, lower, upperN, step);
 
       {
         OpBuilder::InsertionGuard g(rewriter);
         rewriter.setInsertionPointToStart(outerLoop.getBody());
         Value j = outerLoop.getInductionVar();
         auto accBufTy = MemRefType::get({}, elemTy);
-        Value accBuf = rewriter.create<memref::AllocaOp>(loc, accBufTy);
+        Value accBuf = memref::AllocaOp::create(rewriter, loc, accBufTy);
         Value initVal =
-            rewriter.create<memref::LoadOp>(loc, init, ValueRange{j});
-        rewriter.create<memref::StoreOp>(loc, initVal, accBuf, ValueRange{});
+            memref::LoadOp::create(rewriter, loc, init, ValueRange{j});
+        memref::StoreOp::create(rewriter, loc, initVal, accBuf, ValueRange{});
 
-        auto setVl = rewriter.create<buddy::vir::SetVLOp>(
-            loc, /*results=*/TypeRange{}, /*operands=*/ValueRange{upperM});
+        auto setVl =
+            buddy::vir::SetVLOp::create(rewriter, loc, /*results=*/TypeRange{},
+                                        /*operands=*/ValueRange{upperM});
         Region &region = setVl.getRegion();
         Block &block = region.emplaceBlock();
         rewriter.setInsertionPointToStart(&block);
 
         auto vecTy =
             buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
-        Value col = rewriter
-                        .create<buddy::vir::LoadOp>(loc, vecTy, scratch,
-                                                    ValueRange{j, c0})
+        Value col = buddy::vir::LoadOp::create(rewriter, loc, vecTy, scratch,
+                                               ValueRange{j, c0})
                         .getResult();
-        Value acc = rewriter.create<memref::LoadOp>(loc, accBuf, ValueRange{});
-        Value reduced =
-            rewriter
-                .create<buddy::vir::ReduceOp>(
-                    loc, elemTy, col, acc,
-                    rewriter.getStringAttr(kindToString(*combinerKind)))
-                .getResult();
-        rewriter.create<memref::StoreOp>(loc, reduced, accBuf, ValueRange{});
-        rewriter.create<vector::YieldOp>(loc);
+        Value acc = memref::LoadOp::create(rewriter, loc, accBuf, ValueRange{});
+        Value reduced = buddy::vir::ReduceOp::create(
+                            rewriter, loc, elemTy, col, acc,
+                            rewriter.getStringAttr(kindToString(*combinerKind)))
+                            .getResult();
+        memref::StoreOp::create(rewriter, loc, reduced, accBuf, ValueRange{});
+        vector::YieldOp::create(rewriter, loc);
 
         rewriter.setInsertionPointAfter(setVl);
         Value finalVal =
-            rewriter.create<memref::LoadOp>(loc, accBuf, ValueRange{});
-        rewriter.create<memref::StoreOp>(loc, finalVal, init, ValueRange{j});
+            memref::LoadOp::create(rewriter, loc, accBuf, ValueRange{});
+        memref::StoreOp::create(rewriter, loc, finalVal, init, ValueRange{j});
       }
-      rewriter.create<memref::DeallocOp>(loc, scratch);
+      memref::DeallocOp::create(rewriter, loc, scratch);
 
       rewriter.eraseOp(reduceOp);
       return success();
@@ -590,66 +586,65 @@ static LogicalResult lowerReduceToScalarLoop(linalg::ReduceOp reduceOp,
           reduceOp, "input/output trailing dimensions mismatch");
 
     Type elemTy = inTy.getElementType();
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value upperN = rewriter.create<arith::ConstantIndexOp>(loc, inStaticN);
-    Value upperK = rewriter.create<arith::ConstantIndexOp>(loc, inStaticK);
-    Value upperM = rewriter.create<arith::ConstantIndexOp>(loc, inStaticM);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value upperN = arith::ConstantIndexOp::create(rewriter, loc, inStaticN);
+    Value upperK = arith::ConstantIndexOp::create(rewriter, loc, inStaticK);
+    Value upperM = arith::ConstantIndexOp::create(rewriter, loc, inStaticM);
     SmallVector<int64_t> permutation = {1, 2, 0};
     auto permutationMap =
         AffineMap::getPermutationMap(permutation, rewriter.getContext());
 
-    Value transposed = rewriter.create<memref::TransposeOp>(
-        loc, input, AffineMapAttr::get(permutationMap));
+    Value transposed = memref::TransposeOp::create(
+        rewriter, loc, input, AffineMapAttr::get(permutationMap));
     auto scratchTy = MemRefType::get({inStaticN, inStaticK, inStaticM}, elemTy);
-    Value scratch = rewriter.create<memref::AllocOp>(loc, scratchTy);
-    rewriter.create<memref::CopyOp>(loc, transposed, scratch);
-    auto outerLoop = rewriter.create<scf::ForOp>(loc, lower, upperN, step);
+    Value scratch = memref::AllocOp::create(rewriter, loc, scratchTy);
+    memref::CopyOp::create(rewriter, loc, transposed, scratch);
+    auto outerLoop = scf::ForOp::create(rewriter, loc, lower, upperN, step);
 
     {
       OpBuilder::InsertionGuard g(rewriter);
       rewriter.setInsertionPointToStart(outerLoop.getBody());
       Value j = outerLoop.getInductionVar();
-      auto innerLoop = rewriter.create<scf::ForOp>(loc, lower, upperK, step);
+      auto innerLoop = scf::ForOp::create(rewriter, loc, lower, upperK, step);
 
       {
         OpBuilder::InsertionGuard innerGuard(rewriter);
         rewriter.setInsertionPointToStart(innerLoop.getBody());
         Value k = innerLoop.getInductionVar();
         auto accBufTy = MemRefType::get({}, elemTy);
-        Value accBuf = rewriter.create<memref::AllocaOp>(loc, accBufTy);
+        Value accBuf = memref::AllocaOp::create(rewriter, loc, accBufTy);
         Value initVal =
-            rewriter.create<memref::LoadOp>(loc, init, ValueRange{j, k});
-        rewriter.create<memref::StoreOp>(loc, initVal, accBuf, ValueRange{});
+            memref::LoadOp::create(rewriter, loc, init, ValueRange{j, k});
+        memref::StoreOp::create(rewriter, loc, initVal, accBuf, ValueRange{});
 
-        auto setVl = rewriter.create<buddy::vir::SetVLOp>(
-            loc, /*results=*/TypeRange{}, /*operands=*/ValueRange{upperM});
+        auto setVl =
+            buddy::vir::SetVLOp::create(rewriter, loc, /*results=*/TypeRange{},
+                                        /*operands=*/ValueRange{upperM});
         Region &region = setVl.getRegion();
         Block &block = region.emplaceBlock();
         rewriter.setInsertionPointToStart(&block);
 
         auto vecTy =
             buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
-        Value slice = rewriter
-                          .create<buddy::vir::LoadOp>(loc, vecTy, scratch,
-                                                      ValueRange{j, k, c0})
+        Value slice = buddy::vir::LoadOp::create(rewriter, loc, vecTy, scratch,
+                                                 ValueRange{j, k, c0})
                           .getResult();
-        Value acc = rewriter.create<memref::LoadOp>(loc, accBuf, ValueRange{});
-        Value reduced =
-            rewriter
-                .create<buddy::vir::ReduceOp>(
-                    loc, elemTy, slice, acc,
-                    rewriter.getStringAttr(kindToString(*combinerKind)))
-                .getResult();
-        rewriter.create<memref::StoreOp>(loc, reduced, accBuf, ValueRange{});
-        rewriter.create<vector::YieldOp>(loc);
+        Value acc = memref::LoadOp::create(rewriter, loc, accBuf, ValueRange{});
+        Value reduced = buddy::vir::ReduceOp::create(
+                            rewriter, loc, elemTy, slice, acc,
+                            rewriter.getStringAttr(kindToString(*combinerKind)))
+                            .getResult();
+        memref::StoreOp::create(rewriter, loc, reduced, accBuf, ValueRange{});
+        vector::YieldOp::create(rewriter, loc);
 
         rewriter.setInsertionPointAfter(setVl);
         Value finalVal =
-            rewriter.create<memref::LoadOp>(loc, accBuf, ValueRange{});
-        rewriter.create<memref::StoreOp>(loc, finalVal, init, ValueRange{j, k});
+            memref::LoadOp::create(rewriter, loc, accBuf, ValueRange{});
+        memref::StoreOp::create(rewriter, loc, finalVal, init,
+                                ValueRange{j, k});
       }
     }
-    rewriter.create<memref::DeallocOp>(loc, scratch);
+    memref::DeallocOp::create(rewriter, loc, scratch);
 
     rewriter.eraseOp(reduceOp);
     return success();
@@ -728,19 +723,19 @@ lowerIndexOnlyGenericToScalarLoop(linalg::LinalgOp linalgOp,
   Location loc = genericOp.getLoc();
   rewriter.setInsertionPoint(genericOp);
   Value out = initOpd->get();
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-  Value n = rewriter.create<memref::DimOp>(loc, out, 0);
-  auto loop = rewriter.create<scf::ForOp>(loc, c0, n, c1);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+  Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+  Value n = memref::DimOp::create(rewriter, loc, out, 0);
+  auto loop = scf::ForOp::create(rewriter, loc, c0, n, c1);
   {
     OpBuilder::InsertionGuard g(rewriter);
     rewriter.setInsertionPointToStart(loop.getBody());
     Value iv = loop.getInductionVar();
     Value storeVal = iv;
     if (!outElemTy.isIndex()) {
-      storeVal = rewriter.create<arith::IndexCastOp>(loc, outElemTy, iv);
+      storeVal = arith::IndexCastOp::create(rewriter, loc, outElemTy, iv);
     }
-    rewriter.create<memref::StoreOp>(loc, storeVal, out, ValueRange{iv});
+    memref::StoreOp::create(rewriter, loc, storeVal, out, ValueRange{iv});
   }
   rewriter.eraseOp(genericOp);
   return success();
@@ -805,10 +800,10 @@ lowerSimpleCastGenericToScalarLoop(linalg::LinalgOp linalgOp,
 
   Location loc = genericOp.getLoc();
   rewriter.setInsertionPoint(genericOp);
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-  Value upper = rewriter.create<memref::DimOp>(loc, outOpd->get(), 0);
-  auto loop = rewriter.create<scf::ForOp>(loc, c0, upper, c1);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+  Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+  Value upper = memref::DimOp::create(rewriter, loc, outOpd->get(), 0);
+  auto loop = scf::ForOp::create(rewriter, loc, c0, upper, c1);
   {
     OpBuilder::InsertionGuard g(rewriter);
     rewriter.setInsertionPointToStart(loop.getBody());
@@ -820,7 +815,7 @@ lowerSimpleCastGenericToScalarLoop(linalg::LinalgOp linalgOp,
       if (genericOp.isScalar(opOperand)) {
         mapped = opOperand->get();
       } else {
-        mapped = rewriter.create<memref::LoadOp>(loc, opOperand->get(), iv);
+        mapped = memref::LoadOp::create(rewriter, loc, opOperand->get(), iv);
       }
       bbArgMap[bbArg] = mapped;
     }
@@ -838,8 +833,8 @@ lowerSimpleCastGenericToScalarLoop(linalg::LinalgOp linalgOp,
     state.addTypes(castOp->getResultTypes());
     state.addAttributes(castOp->getAttrs());
     Operation *newCast = rewriter.create(state);
-    rewriter.create<memref::StoreOp>(loc, newCast->getResult(0), outOpd->get(),
-                                     iv);
+    memref::StoreOp::create(rewriter, loc, newCast->getResult(0), outOpd->get(),
+                            iv);
   }
   rewriter.eraseOp(genericOp);
   return success();
@@ -861,8 +856,8 @@ static bool isSupportedGenericBodyOp(Operation &inner) {
 
 static buddy::vir::SetVLOp createSetVLRegion(PatternRewriter &rewriter,
                                              Location loc, Value vlVal) {
-  auto setVl = rewriter.create<buddy::vir::SetVLOp>(
-      loc, /*results=*/TypeRange{}, /*operands=*/ValueRange{vlVal});
+  auto setVl = buddy::vir::SetVLOp::create(
+      rewriter, loc, /*results=*/TypeRange{}, /*operands=*/ValueRange{vlVal});
   Region &region = setVl.getRegion();
   Block &block = region.emplaceBlock();
   rewriter.setInsertionPointToStart(&block);
@@ -896,47 +891,46 @@ static LogicalResult lowerMatmulToVIR(linalg::MatmulOp matmulOp,
                                        "only floating-point matmul supported");
 
   // Vectorize along N (the last dimension of B/C).
-  Value n = rewriter.create<memref::DimOp>(loc, c, 1);
+  Value n = memref::DimOp::create(rewriter, loc, c, 1);
 
   // Create vir.set_vl region to host vector code.
   buddy::vir::SetVLOp setVl = createSetVLRegion(rewriter, loc, n);
 
   // Constants used inside the region.
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
 
   // Determine M/K. Prefer static when available, otherwise take dim from
   // memref.
   Value mVal;
   if (!ShapedType::isDynamic(cTy.getShape()[0])) {
-    mVal = rewriter.create<arith::ConstantIndexOp>(loc, cTy.getShape()[0]);
+    mVal = arith::ConstantIndexOp::create(rewriter, loc, cTy.getShape()[0]);
   } else {
-    mVal = rewriter.create<memref::DimOp>(loc, c, 0);
+    mVal = memref::DimOp::create(rewriter, loc, c, 0);
   }
 
   Value kVal;
   if (!ShapedType::isDynamic(aTy.getShape()[1])) {
-    kVal = rewriter.create<arith::ConstantIndexOp>(loc, aTy.getShape()[1]);
+    kVal = arith::ConstantIndexOp::create(rewriter, loc, aTy.getShape()[1]);
   } else {
-    kVal = rewriter.create<memref::DimOp>(loc, a, 1);
+    kVal = memref::DimOp::create(rewriter, loc, a, 1);
   }
 
   auto vecTy =
       buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
 
-  auto loopM = rewriter.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, rewriter.getDimIdentityMap(), ValueRange{mVal},
-      rewriter.getDimIdentityMap(), /*step=*/1,
+  auto loopM = affine::AffineForOp::create(
+      rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+      ValueRange{mVal}, rewriter.getDimIdentityMap(), /*step=*/1,
       /*iterArgs=*/ValueRange{},
       [&](OpBuilder &bld, Location bodyLoc, Value i, ValueRange) {
         OpBuilder &builder = bld;
         // acc = load(C[i, 0:]) as a vector along N.
-        Value acc = builder
-                        .create<buddy::vir::LoadOp>(bodyLoc, vecTy, c,
-                                                    ValueRange{i, c0})
+        Value acc = buddy::vir::LoadOp::create(builder, bodyLoc, vecTy, c,
+                                               ValueRange{i, c0})
                         .getResult();
 
-        auto loopK = builder.create<affine::AffineForOp>(
-            bodyLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+        auto loopK = affine::AffineForOp::create(
+            builder, bodyLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
             ValueRange{kVal}, rewriter.getDimIdentityMap(), /*step=*/1,
             /*iterArgs=*/ValueRange{acc},
             [&](OpBuilder &kb, Location kLoc, Value k, ValueRange iterArgs) {
@@ -944,34 +938,32 @@ static LogicalResult lowerMatmulToVIR(linalg::MatmulOp matmulOp,
               Value accIn = iterArgs[0];
               // aScalar = A[i, k]
               Value aScalar =
-                  builderK.create<memref::LoadOp>(kLoc, a, ValueRange{i, k});
+                  memref::LoadOp::create(builderK, kLoc, a, ValueRange{i, k});
               // aVec = broadcast(aScalar)
-              Value aVec =
-                  builderK.create<buddy::vir::BroadcastOp>(kLoc, vecTy, aScalar)
-                      .getResult();
+              Value aVec = buddy::vir::BroadcastOp::create(builderK, kLoc,
+                                                           vecTy, aScalar)
+                               .getResult();
               // bVec = load(B[k, 0:]) as a vector along N.
-              Value bVec = builderK
-                               .create<buddy::vir::LoadOp>(kLoc, vecTy, b,
-                                                           ValueRange{k, c0})
+              Value bVec = buddy::vir::LoadOp::create(builderK, kLoc, vecTy, b,
+                                                      ValueRange{k, c0})
                                .getResult();
               // accOut = fma(aVec, bVec, accIn)
-              Value accOut =
-                  builderK
-                      .create<buddy::vir::FMAOp>(kLoc, vecTy, aVec, bVec, accIn)
-                      .getResult();
-              builderK.create<affine::AffineYieldOp>(kLoc, accOut);
+              Value accOut = buddy::vir::FMAOp::create(builderK, kLoc, vecTy,
+                                                       aVec, bVec, accIn)
+                                 .getResult();
+              affine::AffineYieldOp::create(builderK, kLoc, accOut);
             });
         Value finalAcc = loopK.getResult(0);
 
         // store acc back to C[i, 0:].
-        builder.create<buddy::vir::StoreOp>(bodyLoc, finalAcc, c,
-                                            ValueRange{i, c0});
-        builder.create<affine::AffineYieldOp>(bodyLoc);
+        buddy::vir::StoreOp::create(builder, bodyLoc, finalAcc, c,
+                                    ValueRange{i, c0});
+        affine::AffineYieldOp::create(builder, bodyLoc);
       });
   (void)loopM;
 
   // Close the set_vl region.
-  rewriter.create<vector::YieldOp>(loc);
+  vector::YieldOp::create(rewriter, loc);
 
   rewriter.replaceOp(matmulOp, setVl.getResults());
   return success();
@@ -982,8 +974,8 @@ static Value dimOrConstant(OpBuilder &builder, Location loc, Value memref,
   auto ty = cast<MemRefType>(memref.getType());
   int64_t staticDim = ty.getShape()[dim];
   if (!ShapedType::isDynamic(staticDim))
-    return builder.create<arith::ConstantIndexOp>(loc, staticDim);
-  return builder.create<memref::DimOp>(loc, memref, dim);
+    return arith::ConstantIndexOp::create(builder, loc, staticDim);
+  return memref::DimOp::create(builder, loc, memref, dim);
 }
 
 static SmallVector<Value> makeAffineMapResults(OpBuilder &builder, Location loc,
@@ -1011,8 +1003,8 @@ static LogicalResult touchFirstOutputWithVIR(Operation *sourceOp,
     return success();
 
   Location loc = sourceOp->getLoc();
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+  Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
   Value vl = dimOrConstant(rewriter, loc, output, outTy.getRank() - 1);
   buddy::vir::SetVLOp setVl = createSetVLRegion(rewriter, loc, vl);
 
@@ -1022,13 +1014,13 @@ static LogicalResult touchFirstOutputWithVIR(Operation *sourceOp,
       auto vecTy = buddy::vir::DynamicVectorType::get({ShapedType::kDynamic},
                                                       outTy.getElementType());
       Value vec =
-          rewriter.create<buddy::vir::LoadOp>(loc, vecTy, output, indices)
+          buddy::vir::LoadOp::create(rewriter, loc, vecTy, output, indices)
               .getResult();
-      rewriter.create<buddy::vir::StoreOp>(loc, vec, output, indices);
+      buddy::vir::StoreOp::create(rewriter, loc, vec, output, indices);
       return;
     }
     Value upper = dimOrConstant(rewriter, loc, output, depth);
-    auto loop = rewriter.create<scf::ForOp>(loc, c0, upper, c1);
+    auto loop = scf::ForOp::create(rewriter, loc, c0, upper, c1);
     {
       OpBuilder::InsertionGuard g(rewriter);
       rewriter.setInsertionPointToStart(loop.getBody());
@@ -1037,7 +1029,7 @@ static LogicalResult touchFirstOutputWithVIR(Operation *sourceOp,
     }
   };
   emitAtDepth(emitAtDepth, 0);
-  rewriter.create<vector::YieldOp>(loc);
+  vector::YieldOp::create(rewriter, loc);
   rewriter.setInsertionPointAfter(setVl);
   return success();
 }
@@ -1055,14 +1047,14 @@ lowerGenericToScalarLoopsWithVIRMarker(linalg::GenericOp genericOp,
   SmallVector<Value> lbs;
   SmallVector<Value> ubs;
   SmallVector<Value> steps;
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+  Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
   for (int64_t i = 0, e = genericOp.getNumLoops(); i < e; ++i) {
     lbs.push_back(c0);
     steps.push_back(c1);
     int64_t staticSize = genericOp.getStaticLoopRanges()[i];
     if (!ShapedType::isDynamic(staticSize)) {
-      ubs.push_back(rewriter.create<arith::ConstantIndexOp>(loc, staticSize));
+      ubs.push_back(arith::ConstantIndexOp::create(rewriter, loc, staticSize));
       continue;
     }
     Value operand;
@@ -1071,7 +1063,7 @@ lowerGenericToScalarLoopsWithVIRMarker(linalg::GenericOp genericOp,
                                                           operandDimPos)))
       return rewriter.notifyMatchFailure(genericOp,
                                          "cannot derive dynamic loop bound");
-    ubs.push_back(rewriter.create<memref::DimOp>(loc, operand, operandDimPos));
+    ubs.push_back(memref::DimOp::create(rewriter, loc, operand, operandDimPos));
   }
 
   rewriter.setInsertionPoint(genericOp);
@@ -1090,7 +1082,7 @@ lowerGenericToScalarLoopsWithVIRMarker(linalg::GenericOp genericOp,
         SmallVector<Value> indices =
             makeAffineMapResults(rewriter, loc, map, ivs);
         Value loaded =
-            rewriter.create<memref::LoadOp>(loc, opOperand->get(), indices);
+            memref::LoadOp::create(rewriter, loc, opOperand->get(), indices);
         mapper.map(bbArg, loaded);
       }
 
@@ -1112,14 +1104,14 @@ lowerGenericToScalarLoopsWithVIRMarker(linalg::GenericOp genericOp,
         AffineMap map = genericOp.getMatchingIndexingMap(init);
         SmallVector<Value> indices =
             makeAffineMapResults(rewriter, loc, map, ivs);
-        rewriter.create<memref::StoreOp>(loc, mapper.lookup(yielded),
-                                         init->get(), indices);
+        memref::StoreOp::create(rewriter, loc, mapper.lookup(yielded),
+                                init->get(), indices);
       }
       return success();
     }
 
     auto loop =
-        rewriter.create<scf::ForOp>(loc, lbs[depth], ubs[depth], steps[depth]);
+        scf::ForOp::create(rewriter, loc, lbs[depth], ubs[depth], steps[depth]);
     {
       OpBuilder::InsertionGuard g(rewriter);
       rewriter.setInsertionPointToStart(loop.getBody());
@@ -1159,7 +1151,7 @@ lowerRank2MatmulLikeToVIR(Operation *op, PatternRewriter &rewriter, Value a,
 
   Value n = dimOrConstant(rewriter, loc, c, 1);
   buddy::vir::SetVLOp setVl = createSetVLRegion(rewriter, loc, n);
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
   Value mVal = dimOrConstant(rewriter, loc, c, 0);
   Value kVal = dimOrConstant(rewriter, loc, a, transposeA ? 0 : 1);
 
@@ -1168,44 +1160,45 @@ lowerRank2MatmulLikeToVIR(Operation *op, PatternRewriter &rewriter, Value a,
     SmallVector<int64_t> permutation = {1, 0};
     auto permutationMap =
         AffineMap::getPermutationMap(permutation, rewriter.getContext());
-    bForLoad = rewriter.create<memref::TransposeOp>(
-        loc, b, AffineMapAttr::get(permutationMap));
+    bForLoad = memref::TransposeOp::create(rewriter, loc, b,
+                                           AffineMapAttr::get(permutationMap));
   }
 
   auto vecTy =
       buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
-  rewriter.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, rewriter.getDimIdentityMap(), ValueRange{mVal},
-      rewriter.getDimIdentityMap(), /*step=*/1, /*iterArgs=*/ValueRange{},
+  affine::AffineForOp::create(
+      rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+      ValueRange{mVal}, rewriter.getDimIdentityMap(), /*step=*/1,
+      /*iterArgs=*/ValueRange{},
       [&](OpBuilder &bld, Location bodyLoc, Value i, ValueRange) {
-        Value acc =
-            bld.create<buddy::vir::LoadOp>(bodyLoc, vecTy, c, ValueRange{i, c0})
-                .getResult();
-        auto loopK = bld.create<affine::AffineForOp>(
-            bodyLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+        Value acc = buddy::vir::LoadOp::create(bld, bodyLoc, vecTy, c,
+                                               ValueRange{i, c0})
+                        .getResult();
+        auto loopK = affine::AffineForOp::create(
+            bld, bodyLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
             ValueRange{kVal}, rewriter.getDimIdentityMap(), /*step=*/1,
             /*iterArgs=*/ValueRange{acc},
             [&](OpBuilder &kb, Location kLoc, Value k, ValueRange iterArgs) {
               Value aScalar =
                   transposeA
-                      ? kb.create<memref::LoadOp>(kLoc, a, ValueRange{k, i})
-                      : kb.create<memref::LoadOp>(kLoc, a, ValueRange{i, k});
+                      ? memref::LoadOp::create(kb, kLoc, a, ValueRange{k, i})
+                      : memref::LoadOp::create(kb, kLoc, a, ValueRange{i, k});
               Value aVec =
-                  kb.create<buddy::vir::BroadcastOp>(kLoc, vecTy, aScalar)
+                  buddy::vir::BroadcastOp::create(kb, kLoc, vecTy, aScalar)
                       .getResult();
-              Value bVec = kb.create<buddy::vir::LoadOp>(kLoc, vecTy, bForLoad,
-                                                         ValueRange{k, c0})
+              Value bVec = buddy::vir::LoadOp::create(kb, kLoc, vecTy, bForLoad,
+                                                      ValueRange{k, c0})
                                .getResult();
-              Value accOut = kb.create<buddy::vir::FMAOp>(kLoc, vecTy, aVec,
-                                                          bVec, iterArgs[0])
+              Value accOut = buddy::vir::FMAOp::create(kb, kLoc, vecTy, aVec,
+                                                       bVec, iterArgs[0])
                                  .getResult();
-              kb.create<affine::AffineYieldOp>(kLoc, accOut);
+              affine::AffineYieldOp::create(kb, kLoc, accOut);
             });
-        bld.create<buddy::vir::StoreOp>(bodyLoc, loopK.getResult(0), c,
-                                        ValueRange{i, c0});
-        bld.create<affine::AffineYieldOp>(bodyLoc);
+        buddy::vir::StoreOp::create(bld, bodyLoc, loopK.getResult(0), c,
+                                    ValueRange{i, c0});
+        affine::AffineYieldOp::create(bld, bodyLoc);
       });
-  rewriter.create<vector::YieldOp>(loc);
+  vector::YieldOp::create(rewriter, loc);
   rewriter.replaceOp(op, setVl.getResults());
   return success();
 }
@@ -1229,7 +1222,7 @@ lowerBatchMatmulLikeToVIR(Operation *op, PatternRewriter &rewriter, Value a,
 
   Value n = dimOrConstant(rewriter, loc, c, 2);
   buddy::vir::SetVLOp setVl = createSetVLRegion(rewriter, loc, n);
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
   Value batchVal = dimOrConstant(rewriter, loc, c, 0);
   Value mVal = dimOrConstant(rewriter, loc, c, 1);
   Value kVal = dimOrConstant(rewriter, loc, a, transposeA ? 1 : 2);
@@ -1239,54 +1232,56 @@ lowerBatchMatmulLikeToVIR(Operation *op, PatternRewriter &rewriter, Value a,
     SmallVector<int64_t> permutation = {0, 2, 1};
     auto permutationMap =
         AffineMap::getPermutationMap(permutation, rewriter.getContext());
-    bForLoad = rewriter.create<memref::TransposeOp>(
-        loc, b, AffineMapAttr::get(permutationMap));
+    bForLoad = memref::TransposeOp::create(rewriter, loc, b,
+                                           AffineMapAttr::get(permutationMap));
   }
 
   auto vecTy =
       buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
-  rewriter.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, rewriter.getDimIdentityMap(), ValueRange{batchVal},
-      rewriter.getDimIdentityMap(), /*step=*/1, /*iterArgs=*/ValueRange{},
+  affine::AffineForOp::create(
+      rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+      ValueRange{batchVal}, rewriter.getDimIdentityMap(), /*step=*/1,
+      /*iterArgs=*/ValueRange{},
       [&](OpBuilder &bb, Location bLoc, Value batch, ValueRange) {
-        bb.create<affine::AffineForOp>(
-            bLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+        affine::AffineForOp::create(
+            bb, bLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
             ValueRange{mVal}, rewriter.getDimIdentityMap(), /*step=*/1,
             /*iterArgs=*/ValueRange{},
             [&](OpBuilder &mb, Location mLoc, Value i, ValueRange) {
-              Value acc = mb.create<buddy::vir::LoadOp>(
-                                mLoc, vecTy, c, ValueRange{batch, i, c0})
+              Value acc = buddy::vir::LoadOp::create(mb, mLoc, vecTy, c,
+                                                     ValueRange{batch, i, c0})
                               .getResult();
-              auto loopK = mb.create<affine::AffineForOp>(
-                  mLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+              auto loopK = affine::AffineForOp::create(
+                  mb, mLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
                   ValueRange{kVal}, rewriter.getDimIdentityMap(), /*step=*/1,
                   /*iterArgs=*/ValueRange{acc},
                   [&](OpBuilder &kb, Location kLoc, Value k,
                       ValueRange iterArgs) {
-                    Value aScalar = transposeA
-                                        ? kb.create<memref::LoadOp>(
-                                              kLoc, a, ValueRange{batch, k, i})
-                                        : kb.create<memref::LoadOp>(
-                                              kLoc, a, ValueRange{batch, i, k});
-                    Value aVec =
-                        kb.create<buddy::vir::BroadcastOp>(kLoc, vecTy, aScalar)
-                            .getResult();
+                    Value aScalar =
+                        transposeA
+                            ? memref::LoadOp::create(kb, kLoc, a,
+                                                     ValueRange{batch, k, i})
+                            : memref::LoadOp::create(kb, kLoc, a,
+                                                     ValueRange{batch, i, k});
+                    Value aVec = buddy::vir::BroadcastOp::create(kb, kLoc,
+                                                                 vecTy, aScalar)
+                                     .getResult();
                     Value bVec =
-                        kb.create<buddy::vir::LoadOp>(kLoc, vecTy, bForLoad,
-                                                      ValueRange{batch, k, c0})
+                        buddy::vir::LoadOp::create(kb, kLoc, vecTy, bForLoad,
+                                                   ValueRange{batch, k, c0})
                             .getResult();
-                    Value accOut = kb.create<buddy::vir::FMAOp>(
-                                         kLoc, vecTy, aVec, bVec, iterArgs[0])
+                    Value accOut = buddy::vir::FMAOp::create(
+                                       kb, kLoc, vecTy, aVec, bVec, iterArgs[0])
                                        .getResult();
-                    kb.create<affine::AffineYieldOp>(kLoc, accOut);
+                    affine::AffineYieldOp::create(kb, kLoc, accOut);
                   });
-              mb.create<buddy::vir::StoreOp>(mLoc, loopK.getResult(0), c,
-                                             ValueRange{batch, i, c0});
-              mb.create<affine::AffineYieldOp>(mLoc);
+              buddy::vir::StoreOp::create(mb, mLoc, loopK.getResult(0), c,
+                                          ValueRange{batch, i, c0});
+              affine::AffineYieldOp::create(mb, mLoc);
             });
-        bb.create<affine::AffineYieldOp>(bLoc);
+        affine::AffineYieldOp::create(bb, bLoc);
       });
-  rewriter.create<vector::YieldOp>(loc);
+  vector::YieldOp::create(rewriter, loc);
   rewriter.replaceOp(op, setVl.getResults());
   return success();
 }
@@ -1307,29 +1302,31 @@ static LogicalResult lowerVecmatToVIR(linalg::VecmatOp op,
   Value n = dimOrConstant(rewriter, loc, y, 0);
   Value kVal = dimOrConstant(rewriter, loc, x, 0);
   buddy::vir::SetVLOp setVl = createSetVLRegion(rewriter, loc, n);
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
   auto vecTy =
       buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
-  Value acc = rewriter.create<buddy::vir::LoadOp>(loc, vecTy, y, ValueRange{c0})
-                  .getResult();
-  auto loopK = rewriter.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, rewriter.getDimIdentityMap(), ValueRange{kVal},
-      rewriter.getDimIdentityMap(), /*step=*/1, /*iterArgs=*/ValueRange{acc},
+  Value acc =
+      buddy::vir::LoadOp::create(rewriter, loc, vecTy, y, ValueRange{c0})
+          .getResult();
+  auto loopK = affine::AffineForOp::create(
+      rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+      ValueRange{kVal}, rewriter.getDimIdentityMap(), /*step=*/1,
+      /*iterArgs=*/ValueRange{acc},
       [&](OpBuilder &kb, Location kLoc, Value k, ValueRange iterArgs) {
-        Value xScalar = kb.create<memref::LoadOp>(kLoc, x, ValueRange{k});
-        Value xVec = kb.create<buddy::vir::BroadcastOp>(kLoc, vecTy, xScalar)
+        Value xScalar = memref::LoadOp::create(kb, kLoc, x, ValueRange{k});
+        Value xVec = buddy::vir::BroadcastOp::create(kb, kLoc, vecTy, xScalar)
                          .getResult();
         Value bVec =
-            kb.create<buddy::vir::LoadOp>(kLoc, vecTy, b, ValueRange{k, c0})
+            buddy::vir::LoadOp::create(kb, kLoc, vecTy, b, ValueRange{k, c0})
                 .getResult();
         Value accOut =
-            kb.create<buddy::vir::FMAOp>(kLoc, vecTy, xVec, bVec, iterArgs[0])
+            buddy::vir::FMAOp::create(kb, kLoc, vecTy, xVec, bVec, iterArgs[0])
                 .getResult();
-        kb.create<affine::AffineYieldOp>(kLoc, accOut);
+        affine::AffineYieldOp::create(kb, kLoc, accOut);
       });
-  rewriter.create<buddy::vir::StoreOp>(loc, loopK.getResult(0), y,
-                                       ValueRange{c0});
-  rewriter.create<vector::YieldOp>(loc);
+  buddy::vir::StoreOp::create(rewriter, loc, loopK.getResult(0), y,
+                              ValueRange{c0});
+  vector::YieldOp::create(rewriter, loc);
   rewriter.replaceOp(op, setVl.getResults());
   return success();
 }
@@ -1350,34 +1347,36 @@ static LogicalResult lowerMatvecToVIR(linalg::MatvecOp op,
   Value m = dimOrConstant(rewriter, loc, y, 0);
   Value kVal = dimOrConstant(rewriter, loc, x, 0);
   buddy::vir::SetVLOp setVl = createSetVLRegion(rewriter, loc, m);
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
   SmallVector<int64_t> permutation = {1, 0};
   auto permutationMap =
       AffineMap::getPermutationMap(permutation, rewriter.getContext());
-  Value aT = rewriter.create<memref::TransposeOp>(
-      loc, a, AffineMapAttr::get(permutationMap));
+  Value aT = memref::TransposeOp::create(rewriter, loc, a,
+                                         AffineMapAttr::get(permutationMap));
   auto vecTy =
       buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
-  Value acc = rewriter.create<buddy::vir::LoadOp>(loc, vecTy, y, ValueRange{c0})
-                  .getResult();
-  auto loopK = rewriter.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, rewriter.getDimIdentityMap(), ValueRange{kVal},
-      rewriter.getDimIdentityMap(), /*step=*/1, /*iterArgs=*/ValueRange{acc},
+  Value acc =
+      buddy::vir::LoadOp::create(rewriter, loc, vecTy, y, ValueRange{c0})
+          .getResult();
+  auto loopK = affine::AffineForOp::create(
+      rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+      ValueRange{kVal}, rewriter.getDimIdentityMap(), /*step=*/1,
+      /*iterArgs=*/ValueRange{acc},
       [&](OpBuilder &kb, Location kLoc, Value k, ValueRange iterArgs) {
-        Value xScalar = kb.create<memref::LoadOp>(kLoc, x, ValueRange{k});
-        Value xVec = kb.create<buddy::vir::BroadcastOp>(kLoc, vecTy, xScalar)
+        Value xScalar = memref::LoadOp::create(kb, kLoc, x, ValueRange{k});
+        Value xVec = buddy::vir::BroadcastOp::create(kb, kLoc, vecTy, xScalar)
                          .getResult();
         Value aVec =
-            kb.create<buddy::vir::LoadOp>(kLoc, vecTy, aT, ValueRange{k, c0})
+            buddy::vir::LoadOp::create(kb, kLoc, vecTy, aT, ValueRange{k, c0})
                 .getResult();
         Value accOut =
-            kb.create<buddy::vir::FMAOp>(kLoc, vecTy, aVec, xVec, iterArgs[0])
+            buddy::vir::FMAOp::create(kb, kLoc, vecTy, aVec, xVec, iterArgs[0])
                 .getResult();
-        kb.create<affine::AffineYieldOp>(kLoc, accOut);
+        affine::AffineYieldOp::create(kb, kLoc, accOut);
       });
-  rewriter.create<buddy::vir::StoreOp>(loc, loopK.getResult(0), y,
-                                       ValueRange{c0});
-  rewriter.create<vector::YieldOp>(loc);
+  buddy::vir::StoreOp::create(rewriter, loc, loopK.getResult(0), y,
+                              ValueRange{c0});
+  vector::YieldOp::create(rewriter, loc);
   rewriter.replaceOp(op, setVl.getResults());
   return success();
 }
@@ -1397,23 +1396,22 @@ static LogicalResult lowerDotToVIR(linalg::DotOp op,
   Type elemTy = cTy.getElementType();
   Value kVal = dimOrConstant(rewriter, loc, a, 0);
   buddy::vir::SetVLOp setVl = createSetVLRegion(rewriter, loc, kVal);
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
   auto vecTy =
       buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
   Value aVec =
-      rewriter.create<buddy::vir::LoadOp>(loc, vecTy, a, ValueRange{c0})
+      buddy::vir::LoadOp::create(rewriter, loc, vecTy, a, ValueRange{c0})
           .getResult();
   Value bVec =
-      rewriter.create<buddy::vir::LoadOp>(loc, vecTy, b, ValueRange{c0})
+      buddy::vir::LoadOp::create(rewriter, loc, vecTy, b, ValueRange{c0})
           .getResult();
-  Value prod = rewriter.create<arith::MulFOp>(loc, aVec, bVec).getResult();
-  Value acc = rewriter.create<memref::LoadOp>(loc, c, ValueRange{});
-  Value reduced = rewriter
-                      .create<buddy::vir::ReduceOp>(
-                          loc, elemTy, prod, acc, rewriter.getStringAttr("add"))
+  Value prod = arith::MulFOp::create(rewriter, loc, aVec, bVec).getResult();
+  Value acc = memref::LoadOp::create(rewriter, loc, c, ValueRange{});
+  Value reduced = buddy::vir::ReduceOp::create(rewriter, loc, elemTy, prod, acc,
+                                               rewriter.getStringAttr("add"))
                       .getResult();
-  rewriter.create<memref::StoreOp>(loc, reduced, c, ValueRange{});
-  rewriter.create<vector::YieldOp>(loc);
+  memref::StoreOp::create(rewriter, loc, reduced, c, ValueRange{});
+  vector::YieldOp::create(rewriter, loc);
   rewriter.replaceOp(op, setVl.getResults());
   return success();
 }
@@ -1439,48 +1437,49 @@ static LogicalResult lowerBatchMatvecToVIR(linalg::BatchMatvecOp op,
 
   Value m = dimOrConstant(rewriter, loc, y, 1);
   buddy::vir::SetVLOp setVl = createSetVLRegion(rewriter, loc, m);
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
   Value batchVal = dimOrConstant(rewriter, loc, y, 0);
   Value kVal = dimOrConstant(rewriter, loc, x, 1);
 
   SmallVector<int64_t> permutation = {0, 2, 1};
   auto permutationMap =
       AffineMap::getPermutationMap(permutation, rewriter.getContext());
-  Value aT = rewriter.create<memref::TransposeOp>(
-      loc, a, AffineMapAttr::get(permutationMap));
+  Value aT = memref::TransposeOp::create(rewriter, loc, a,
+                                         AffineMapAttr::get(permutationMap));
 
   auto vecTy =
       buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
-  rewriter.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, rewriter.getDimIdentityMap(), ValueRange{batchVal},
-      rewriter.getDimIdentityMap(), /*step=*/1, /*iterArgs=*/ValueRange{},
+  affine::AffineForOp::create(
+      rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+      ValueRange{batchVal}, rewriter.getDimIdentityMap(), /*step=*/1,
+      /*iterArgs=*/ValueRange{},
       [&](OpBuilder &bb, Location bLoc, Value batch, ValueRange) {
-        Value acc =
-            bb.create<buddy::vir::LoadOp>(bLoc, vecTy, y, ValueRange{batch, c0})
-                .getResult();
-        auto loopK = bb.create<affine::AffineForOp>(
-            bLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+        Value acc = buddy::vir::LoadOp::create(bb, bLoc, vecTy, y,
+                                               ValueRange{batch, c0})
+                        .getResult();
+        auto loopK = affine::AffineForOp::create(
+            bb, bLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
             ValueRange{kVal}, rewriter.getDimIdentityMap(), /*step=*/1,
             /*iterArgs=*/ValueRange{acc},
             [&](OpBuilder &kb, Location kLoc, Value k, ValueRange iterArgs) {
               Value xScalar =
-                  kb.create<memref::LoadOp>(kLoc, x, ValueRange{batch, k});
+                  memref::LoadOp::create(kb, kLoc, x, ValueRange{batch, k});
               Value xVec =
-                  kb.create<buddy::vir::BroadcastOp>(kLoc, vecTy, xScalar)
+                  buddy::vir::BroadcastOp::create(kb, kLoc, vecTy, xScalar)
                       .getResult();
-              Value aVec = kb.create<buddy::vir::LoadOp>(
-                                 kLoc, vecTy, aT, ValueRange{batch, k, c0})
+              Value aVec = buddy::vir::LoadOp::create(kb, kLoc, vecTy, aT,
+                                                      ValueRange{batch, k, c0})
                                .getResult();
-              Value accOut = kb.create<buddy::vir::FMAOp>(kLoc, vecTy, aVec,
-                                                          xVec, iterArgs[0])
+              Value accOut = buddy::vir::FMAOp::create(kb, kLoc, vecTy, aVec,
+                                                       xVec, iterArgs[0])
                                  .getResult();
-              kb.create<affine::AffineYieldOp>(kLoc, accOut);
+              affine::AffineYieldOp::create(kb, kLoc, accOut);
             });
-        bb.create<buddy::vir::StoreOp>(bLoc, loopK.getResult(0), y,
-                                       ValueRange{batch, c0});
-        bb.create<affine::AffineYieldOp>(bLoc);
+        buddy::vir::StoreOp::create(bb, bLoc, loopK.getResult(0), y,
+                                    ValueRange{batch, c0});
+        affine::AffineYieldOp::create(bb, bLoc);
       });
-  rewriter.create<vector::YieldOp>(loc);
+  vector::YieldOp::create(rewriter, loc);
   rewriter.replaceOp(op, setVl.getResults());
   return success();
 }
@@ -1506,42 +1505,43 @@ static LogicalResult lowerBatchVecmatToVIR(linalg::BatchVecmatOp op,
 
   Value n = dimOrConstant(rewriter, loc, y, 1);
   buddy::vir::SetVLOp setVl = createSetVLRegion(rewriter, loc, n);
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
   Value batchVal = dimOrConstant(rewriter, loc, y, 0);
   Value kVal = dimOrConstant(rewriter, loc, x, 1);
 
   auto vecTy =
       buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
-  rewriter.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, rewriter.getDimIdentityMap(), ValueRange{batchVal},
-      rewriter.getDimIdentityMap(), /*step=*/1, /*iterArgs=*/ValueRange{},
+  affine::AffineForOp::create(
+      rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+      ValueRange{batchVal}, rewriter.getDimIdentityMap(), /*step=*/1,
+      /*iterArgs=*/ValueRange{},
       [&](OpBuilder &bb, Location bLoc, Value batch, ValueRange) {
-        Value acc =
-            bb.create<buddy::vir::LoadOp>(bLoc, vecTy, y, ValueRange{batch, c0})
-                .getResult();
-        auto loopK = bb.create<affine::AffineForOp>(
-            bLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+        Value acc = buddy::vir::LoadOp::create(bb, bLoc, vecTy, y,
+                                               ValueRange{batch, c0})
+                        .getResult();
+        auto loopK = affine::AffineForOp::create(
+            bb, bLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
             ValueRange{kVal}, rewriter.getDimIdentityMap(), /*step=*/1,
             /*iterArgs=*/ValueRange{acc},
             [&](OpBuilder &kb, Location kLoc, Value k, ValueRange iterArgs) {
               Value xScalar =
-                  kb.create<memref::LoadOp>(kLoc, x, ValueRange{batch, k});
+                  memref::LoadOp::create(kb, kLoc, x, ValueRange{batch, k});
               Value xVec =
-                  kb.create<buddy::vir::BroadcastOp>(kLoc, vecTy, xScalar)
+                  buddy::vir::BroadcastOp::create(kb, kLoc, vecTy, xScalar)
                       .getResult();
-              Value bVec = kb.create<buddy::vir::LoadOp>(
-                                 kLoc, vecTy, b, ValueRange{batch, k, c0})
+              Value bVec = buddy::vir::LoadOp::create(kb, kLoc, vecTy, b,
+                                                      ValueRange{batch, k, c0})
                                .getResult();
-              Value accOut = kb.create<buddy::vir::FMAOp>(kLoc, vecTy, xVec,
-                                                          bVec, iterArgs[0])
+              Value accOut = buddy::vir::FMAOp::create(kb, kLoc, vecTy, xVec,
+                                                       bVec, iterArgs[0])
                                  .getResult();
-              kb.create<affine::AffineYieldOp>(kLoc, accOut);
+              affine::AffineYieldOp::create(kb, kLoc, accOut);
             });
-        bb.create<buddy::vir::StoreOp>(bLoc, loopK.getResult(0), y,
-                                       ValueRange{batch, c0});
-        bb.create<affine::AffineYieldOp>(bLoc);
+        buddy::vir::StoreOp::create(bb, bLoc, loopK.getResult(0), y,
+                                    ValueRange{batch, c0});
+        affine::AffineYieldOp::create(bb, bLoc);
       });
-  rewriter.create<vector::YieldOp>(loc);
+  vector::YieldOp::create(rewriter, loc);
   rewriter.replaceOp(op, setVl.getResults());
   return success();
 }
@@ -1568,52 +1568,54 @@ static LogicalResult lowerBatchReduceMatmulToVIR(linalg::BatchReduceMatmulOp op,
 
   Value n = dimOrConstant(rewriter, loc, c, 1);
   buddy::vir::SetVLOp setVl = createSetVLRegion(rewriter, loc, n);
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
   Value batchVal = dimOrConstant(rewriter, loc, a, 0);
   Value mVal = dimOrConstant(rewriter, loc, c, 0);
   Value kVal = dimOrConstant(rewriter, loc, a, 2);
 
   auto vecTy =
       buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
-  rewriter.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, rewriter.getDimIdentityMap(), ValueRange{mVal},
-      rewriter.getDimIdentityMap(), /*step=*/1, /*iterArgs=*/ValueRange{},
+  affine::AffineForOp::create(
+      rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+      ValueRange{mVal}, rewriter.getDimIdentityMap(), /*step=*/1,
+      /*iterArgs=*/ValueRange{},
       [&](OpBuilder &mb, Location mLoc, Value i, ValueRange) {
         Value acc =
-            mb.create<buddy::vir::LoadOp>(mLoc, vecTy, c, ValueRange{i, c0})
+            buddy::vir::LoadOp::create(mb, mLoc, vecTy, c, ValueRange{i, c0})
                 .getResult();
-        auto loopBatch = mb.create<affine::AffineForOp>(
-            mLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+        auto loopBatch = affine::AffineForOp::create(
+            mb, mLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
             ValueRange{batchVal}, rewriter.getDimIdentityMap(), /*step=*/1,
             /*iterArgs=*/ValueRange{acc},
             [&](OpBuilder &bb, Location bLoc, Value batch,
                 ValueRange batchIterArgs) {
-              auto loopK = bb.create<affine::AffineForOp>(
-                  bLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+              auto loopK = affine::AffineForOp::create(
+                  bb, bLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
                   ValueRange{kVal}, rewriter.getDimIdentityMap(), /*step=*/1,
                   /*iterArgs=*/ValueRange{batchIterArgs[0]},
                   [&](OpBuilder &kb, Location kLoc, Value k,
                       ValueRange iterArgs) {
-                    Value aScalar = kb.create<memref::LoadOp>(
-                        kLoc, a, ValueRange{batch, i, k});
-                    Value aVec =
-                        kb.create<buddy::vir::BroadcastOp>(kLoc, vecTy, aScalar)
-                            .getResult();
-                    Value bVec = kb.create<buddy::vir::LoadOp>(
-                                       kLoc, vecTy, b, ValueRange{batch, k, c0})
+                    Value aScalar = memref::LoadOp::create(
+                        kb, kLoc, a, ValueRange{batch, i, k});
+                    Value aVec = buddy::vir::BroadcastOp::create(kb, kLoc,
+                                                                 vecTy, aScalar)
                                      .getResult();
-                    Value accOut = kb.create<buddy::vir::FMAOp>(
-                                         kLoc, vecTy, aVec, bVec, iterArgs[0])
+                    Value bVec =
+                        buddy::vir::LoadOp::create(kb, kLoc, vecTy, b,
+                                                   ValueRange{batch, k, c0})
+                            .getResult();
+                    Value accOut = buddy::vir::FMAOp::create(
+                                       kb, kLoc, vecTy, aVec, bVec, iterArgs[0])
                                        .getResult();
-                    kb.create<affine::AffineYieldOp>(kLoc, accOut);
+                    affine::AffineYieldOp::create(kb, kLoc, accOut);
                   });
-              bb.create<affine::AffineYieldOp>(bLoc, loopK.getResult(0));
+              affine::AffineYieldOp::create(bb, bLoc, loopK.getResult(0));
             });
-        mb.create<buddy::vir::StoreOp>(mLoc, loopBatch.getResult(0), c,
-                                       ValueRange{i, c0});
-        mb.create<affine::AffineYieldOp>(mLoc);
+        buddy::vir::StoreOp::create(mb, mLoc, loopBatch.getResult(0), c,
+                                    ValueRange{i, c0});
+        affine::AffineYieldOp::create(mb, mLoc);
       });
-  rewriter.create<vector::YieldOp>(loc);
+  vector::YieldOp::create(rewriter, loc);
   rewriter.replaceOp(op, setVl.getResults());
   return success();
 }
@@ -1639,7 +1641,7 @@ static LogicalResult lowerMmt4DToVIR(linalg::Mmt4DOp op,
 
   Value n1 = dimOrConstant(rewriter, loc, c, 3);
   buddy::vir::SetVLOp setVl = createSetVLRegion(rewriter, loc, n1);
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
   Value m0Val = dimOrConstant(rewriter, loc, c, 0);
   Value n0Val = dimOrConstant(rewriter, loc, c, 1);
   Value m1Val = dimOrConstant(rewriter, loc, c, 2);
@@ -1649,72 +1651,72 @@ static LogicalResult lowerMmt4DToVIR(linalg::Mmt4DOp op,
   SmallVector<int64_t> permutation = {0, 1, 3, 2};
   auto permutationMap =
       AffineMap::getPermutationMap(permutation, rewriter.getContext());
-  Value bT = rewriter.create<memref::TransposeOp>(
-      loc, b, AffineMapAttr::get(permutationMap));
+  Value bT = memref::TransposeOp::create(rewriter, loc, b,
+                                         AffineMapAttr::get(permutationMap));
 
   auto vecTy =
       buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
-  rewriter.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, rewriter.getDimIdentityMap(), ValueRange{m0Val},
-      rewriter.getDimIdentityMap(), /*step=*/1, /*iterArgs=*/ValueRange{},
+  affine::AffineForOp::create(
+      rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+      ValueRange{m0Val}, rewriter.getDimIdentityMap(), /*step=*/1,
+      /*iterArgs=*/ValueRange{},
       [&](OpBuilder &m0b, Location m0Loc, Value m0, ValueRange) {
-        m0b.create<affine::AffineForOp>(
-            m0Loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+        affine::AffineForOp::create(
+            m0b, m0Loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
             ValueRange{n0Val}, rewriter.getDimIdentityMap(), /*step=*/1,
             /*iterArgs=*/ValueRange{},
             [&](OpBuilder &n0b, Location n0Loc, Value n0, ValueRange) {
-              n0b.create<affine::AffineForOp>(
-                  n0Loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+              affine::AffineForOp::create(
+                  n0b, n0Loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
                   ValueRange{m1Val}, rewriter.getDimIdentityMap(), /*step=*/1,
                   /*iterArgs=*/ValueRange{},
                   [&](OpBuilder &m1b, Location m1Loc, Value m1, ValueRange) {
                     Value acc =
-                        m1b.create<buddy::vir::LoadOp>(
-                               m1Loc, vecTy, c, ValueRange{m0, n0, m1, c0})
+                        buddy::vir::LoadOp::create(m1b, m1Loc, vecTy, c,
+                                                   ValueRange{m0, n0, m1, c0})
                             .getResult();
-                    auto loopK0 = m1b.create<affine::AffineForOp>(
-                        m1Loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
-                        ValueRange{k0Val}, rewriter.getDimIdentityMap(),
+                    auto loopK0 = affine::AffineForOp::create(
+                        m1b, m1Loc, ValueRange{c0},
+                        rewriter.getDimIdentityMap(), ValueRange{k0Val},
+                        rewriter.getDimIdentityMap(),
                         /*step=*/1, /*iterArgs=*/ValueRange{acc},
                         [&](OpBuilder &k0b, Location k0Loc, Value k0,
                             ValueRange k0IterArgs) {
-                          auto loopK1 = k0b.create<affine::AffineForOp>(
-                              k0Loc, ValueRange{c0},
+                          auto loopK1 = affine::AffineForOp::create(
+                              k0b, k0Loc, ValueRange{c0},
                               rewriter.getDimIdentityMap(), ValueRange{k1Val},
                               rewriter.getDimIdentityMap(), /*step=*/1,
                               /*iterArgs=*/ValueRange{k0IterArgs[0]},
                               [&](OpBuilder &k1b, Location k1Loc, Value k1,
                                   ValueRange iterArgs) {
-                                Value aScalar = k1b.create<memref::LoadOp>(
-                                    k1Loc, a, ValueRange{m0, k0, m1, k1});
-                                Value aVec =
-                                    k1b.create<buddy::vir::BroadcastOp>(
-                                           k1Loc, vecTy, aScalar)
-                                        .getResult();
-                                Value bVec = k1b.create<buddy::vir::LoadOp>(
-                                                    k1Loc, vecTy, bT,
-                                                    ValueRange{n0, k0, k1, c0})
+                                Value aScalar = memref::LoadOp::create(
+                                    k1b, k1Loc, a, ValueRange{m0, k0, m1, k1});
+                                Value aVec = buddy::vir::BroadcastOp::create(
+                                                 k1b, k1Loc, vecTy, aScalar)
                                                  .getResult();
-                                Value accOut = k1b.create<buddy::vir::FMAOp>(
-                                                      k1Loc, vecTy, aVec, bVec,
-                                                      iterArgs[0])
+                                Value bVec = buddy::vir::LoadOp::create(
+                                                 k1b, k1Loc, vecTy, bT,
+                                                 ValueRange{n0, k0, k1, c0})
+                                                 .getResult();
+                                Value accOut = buddy::vir::FMAOp::create(
+                                                   k1b, k1Loc, vecTy, aVec,
+                                                   bVec, iterArgs[0])
                                                    .getResult();
-                                k1b.create<affine::AffineYieldOp>(k1Loc,
-                                                                  accOut);
+                                affine::AffineYieldOp::create(k1b, k1Loc,
+                                                              accOut);
                               });
-                          k0b.create<affine::AffineYieldOp>(
-                              k0Loc, loopK1.getResult(0));
+                          affine::AffineYieldOp::create(k0b, k0Loc,
+                                                        loopK1.getResult(0));
                         });
-                    m1b.create<buddy::vir::StoreOp>(m1Loc, loopK0.getResult(0),
-                                                    c,
-                                                    ValueRange{m0, n0, m1, c0});
-                    m1b.create<affine::AffineYieldOp>(m1Loc);
+                    buddy::vir::StoreOp::create(m1b, m1Loc, loopK0.getResult(0),
+                                                c, ValueRange{m0, n0, m1, c0});
+                    affine::AffineYieldOp::create(m1b, m1Loc);
                   });
-              n0b.create<affine::AffineYieldOp>(n0Loc);
+              affine::AffineYieldOp::create(n0b, n0Loc);
             });
-        m0b.create<affine::AffineYieldOp>(m0Loc);
+        affine::AffineYieldOp::create(m0b, m0Loc);
       });
-  rewriter.create<vector::YieldOp>(loc);
+  vector::YieldOp::create(rewriter, loc);
   rewriter.replaceOp(op, setVl.getResults());
   return success();
 }
@@ -1740,7 +1742,7 @@ static LogicalResult lowerBatchMmt4DToVIR(linalg::BatchMmt4DOp op,
 
   Value n1 = dimOrConstant(rewriter, loc, c, 4);
   buddy::vir::SetVLOp setVl = createSetVLRegion(rewriter, loc, n1);
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
   Value batchVal = dimOrConstant(rewriter, loc, c, 0);
   Value m0Val = dimOrConstant(rewriter, loc, c, 1);
   Value n0Val = dimOrConstant(rewriter, loc, c, 2);
@@ -1751,44 +1753,46 @@ static LogicalResult lowerBatchMmt4DToVIR(linalg::BatchMmt4DOp op,
   SmallVector<int64_t> permutation = {0, 1, 2, 4, 3};
   auto permutationMap =
       AffineMap::getPermutationMap(permutation, rewriter.getContext());
-  Value bT = rewriter.create<memref::TransposeOp>(
-      loc, b, AffineMapAttr::get(permutationMap));
+  Value bT = memref::TransposeOp::create(rewriter, loc, b,
+                                         AffineMapAttr::get(permutationMap));
 
   auto vecTy =
       buddy::vir::DynamicVectorType::get({ShapedType::kDynamic}, elemTy);
-  rewriter.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, rewriter.getDimIdentityMap(), ValueRange{batchVal},
-      rewriter.getDimIdentityMap(), /*step=*/1, /*iterArgs=*/ValueRange{},
+  affine::AffineForOp::create(
+      rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+      ValueRange{batchVal}, rewriter.getDimIdentityMap(), /*step=*/1,
+      /*iterArgs=*/ValueRange{},
       [&](OpBuilder &bb, Location bLoc, Value batch, ValueRange) {
-        bb.create<affine::AffineForOp>(
-            bLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+        affine::AffineForOp::create(
+            bb, bLoc, ValueRange{c0}, rewriter.getDimIdentityMap(),
             ValueRange{m0Val}, rewriter.getDimIdentityMap(), /*step=*/1,
             /*iterArgs=*/ValueRange{},
             [&](OpBuilder &m0b, Location m0Loc, Value m0, ValueRange) {
-              m0b.create<affine::AffineForOp>(
-                  m0Loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+              affine::AffineForOp::create(
+                  m0b, m0Loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
                   ValueRange{n0Val}, rewriter.getDimIdentityMap(), /*step=*/1,
                   /*iterArgs=*/ValueRange{},
                   [&](OpBuilder &n0b, Location n0Loc, Value n0, ValueRange) {
-                    n0b.create<affine::AffineForOp>(
-                        n0Loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
-                        ValueRange{m1Val}, rewriter.getDimIdentityMap(),
+                    affine::AffineForOp::create(
+                        n0b, n0Loc, ValueRange{c0},
+                        rewriter.getDimIdentityMap(), ValueRange{m1Val},
+                        rewriter.getDimIdentityMap(),
                         /*step=*/1, /*iterArgs=*/ValueRange{},
                         [&](OpBuilder &m1b, Location m1Loc, Value m1,
                             ValueRange) {
-                          Value acc = m1b.create<buddy::vir::LoadOp>(
-                                             m1Loc, vecTy, c,
-                                             ValueRange{batch, m0, n0, m1, c0})
+                          Value acc = buddy::vir::LoadOp::create(
+                                          m1b, m1Loc, vecTy, c,
+                                          ValueRange{batch, m0, n0, m1, c0})
                                           .getResult();
-                          auto loopK0 = m1b.create<affine::AffineForOp>(
-                              m1Loc, ValueRange{c0},
+                          auto loopK0 = affine::AffineForOp::create(
+                              m1b, m1Loc, ValueRange{c0},
                               rewriter.getDimIdentityMap(), ValueRange{k0Val},
                               rewriter.getDimIdentityMap(), /*step=*/1,
                               /*iterArgs=*/ValueRange{acc},
                               [&](OpBuilder &k0b, Location k0Loc, Value k0,
                                   ValueRange k0IterArgs) {
-                                auto loopK1 = k0b.create<affine::AffineForOp>(
-                                    k0Loc, ValueRange{c0},
+                                auto loopK1 = affine::AffineForOp::create(
+                                    k0b, k0Loc, ValueRange{c0},
                                     rewriter.getDimIdentityMap(),
                                     ValueRange{k1Val},
                                     rewriter.getDimIdentityMap(), /*step=*/1,
@@ -1796,44 +1800,41 @@ static LogicalResult lowerBatchMmt4DToVIR(linalg::BatchMmt4DOp op,
                                     ValueRange{k0IterArgs[0]},
                                     [&](OpBuilder &k1b, Location k1Loc,
                                         Value k1, ValueRange iterArgs) {
-                                      Value aScalar =
-                                          k1b.create<memref::LoadOp>(
-                                              k1Loc, a,
-                                              ValueRange{batch, m0, k0, m1,
-                                                         k1});
+                                      Value aScalar = memref::LoadOp::create(
+                                          k1b, k1Loc, a,
+                                          ValueRange{batch, m0, k0, m1, k1});
                                       Value aVec =
-                                          k1b.create<buddy::vir::BroadcastOp>(
-                                                 k1Loc, vecTy, aScalar)
+                                          buddy::vir::BroadcastOp::create(
+                                              k1b, k1Loc, vecTy, aScalar)
                                               .getResult();
                                       Value bVec =
-                                          k1b.create<buddy::vir::LoadOp>(
-                                                 k1Loc, vecTy, bT,
-                                                 ValueRange{batch, n0, k0, k1,
-                                                            c0})
+                                          buddy::vir::LoadOp::create(
+                                              k1b, k1Loc, vecTy, bT,
+                                              ValueRange{batch, n0, k0, k1, c0})
                                               .getResult();
                                       Value accOut =
-                                          k1b.create<buddy::vir::FMAOp>(
-                                                 k1Loc, vecTy, aVec, bVec,
-                                                 iterArgs[0])
+                                          buddy::vir::FMAOp::create(
+                                              k1b, k1Loc, vecTy, aVec, bVec,
+                                              iterArgs[0])
                                               .getResult();
-                                      k1b.create<affine::AffineYieldOp>(k1Loc,
-                                                                        accOut);
+                                      affine::AffineYieldOp::create(k1b, k1Loc,
+                                                                    accOut);
                                     });
-                                k0b.create<affine::AffineYieldOp>(
-                                    k0Loc, loopK1.getResult(0));
+                                affine::AffineYieldOp::create(
+                                    k0b, k0Loc, loopK1.getResult(0));
                               });
-                          m1b.create<buddy::vir::StoreOp>(
-                              m1Loc, loopK0.getResult(0), c,
+                          buddy::vir::StoreOp::create(
+                              m1b, m1Loc, loopK0.getResult(0), c,
                               ValueRange{batch, m0, n0, m1, c0});
-                          m1b.create<affine::AffineYieldOp>(m1Loc);
+                          affine::AffineYieldOp::create(m1b, m1Loc);
                         });
-                    n0b.create<affine::AffineYieldOp>(n0Loc);
+                    affine::AffineYieldOp::create(n0b, n0Loc);
                   });
-              m0b.create<affine::AffineYieldOp>(m0Loc);
+              affine::AffineYieldOp::create(m0b, m0Loc);
             });
-        bb.create<affine::AffineYieldOp>(bLoc);
+        affine::AffineYieldOp::create(bb, bLoc);
       });
-  rewriter.create<vector::YieldOp>(loc);
+  vector::YieldOp::create(rewriter, loc);
   rewriter.replaceOp(op, setVl.getResults());
   return success();
 }
@@ -1848,23 +1849,23 @@ static LogicalResult lowerFillRng2DToVIR(linalg::FillRng2DOp op,
     return rewriter.notifyMatchFailure(op, "expected rank-2 f32 output");
 
   Location loc = op.getLoc();
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+  Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
   Value m = dimOrConstant(rewriter, loc, out, 0);
   Value n = dimOrConstant(rewriter, loc, out, 1);
-  Value half = rewriter.create<arith::ConstantFloatOp>(
-      loc, rewriter.getF32Type(), APFloat(0.5f));
-  auto loopM = rewriter.create<scf::ForOp>(loc, c0, m, c1);
+  Value half = arith::ConstantFloatOp::create(
+      rewriter, loc, rewriter.getF32Type(), APFloat(0.5f));
+  auto loopM = scf::ForOp::create(rewriter, loc, c0, m, c1);
   {
     OpBuilder::InsertionGuard g(rewriter);
     rewriter.setInsertionPointToStart(loopM.getBody());
     Value i = loopM.getInductionVar();
-    auto loopN = rewriter.create<scf::ForOp>(loc, c0, n, c1);
+    auto loopN = scf::ForOp::create(rewriter, loc, c0, n, c1);
     {
       OpBuilder::InsertionGuard ng(rewriter);
       rewriter.setInsertionPointToStart(loopN.getBody());
       Value j = loopN.getInductionVar();
-      rewriter.create<memref::StoreOp>(loc, half, out, ValueRange{i, j});
+      memref::StoreOp::create(rewriter, loc, half, out, ValueRange{i, j});
     }
   }
   if (failed(touchFirstOutputWithVIR(op.getOperation(), rewriter, out)))
@@ -1888,50 +1889,50 @@ static LogicalResult lowerSoftmaxToVIR(linalg::SoftmaxOp op,
     return rewriter.notifyMatchFailure(op, "only dimension(2) supported");
 
   Location loc = op.getLoc();
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+  Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
   Value d0 = dimOrConstant(rewriter, loc, out, 0);
   Value d1 = dimOrConstant(rewriter, loc, out, 1);
   Value d2 = dimOrConstant(rewriter, loc, out, 2);
   auto scalarTy = MemRefType::get({}, rewriter.getF32Type());
 
-  auto loop0 = rewriter.create<scf::ForOp>(loc, c0, d0, c1);
+  auto loop0 = scf::ForOp::create(rewriter, loc, c0, d0, c1);
   {
     OpBuilder::InsertionGuard g0(rewriter);
     rewriter.setInsertionPointToStart(loop0.getBody());
     Value i = loop0.getInductionVar();
-    auto loop1 = rewriter.create<scf::ForOp>(loc, c0, d1, c1);
+    auto loop1 = scf::ForOp::create(rewriter, loc, c0, d1, c1);
     {
       OpBuilder::InsertionGuard g1(rewriter);
       rewriter.setInsertionPointToStart(loop1.getBody());
       Value j = loop1.getInductionVar();
-      Value sumBuf = rewriter.create<memref::AllocaOp>(loc, scalarTy);
-      Value zero = rewriter.create<arith::ConstantFloatOp>(
-          loc, rewriter.getF32Type(), APFloat(0.0f));
-      rewriter.create<memref::StoreOp>(loc, zero, sumBuf, ValueRange{});
-      auto expLoop = rewriter.create<scf::ForOp>(loc, c0, d2, c1);
+      Value sumBuf = memref::AllocaOp::create(rewriter, loc, scalarTy);
+      Value zero = arith::ConstantFloatOp::create(
+          rewriter, loc, rewriter.getF32Type(), APFloat(0.0f));
+      memref::StoreOp::create(rewriter, loc, zero, sumBuf, ValueRange{});
+      auto expLoop = scf::ForOp::create(rewriter, loc, c0, d2, c1);
       {
         OpBuilder::InsertionGuard ge(rewriter);
         rewriter.setInsertionPointToStart(expLoop.getBody());
         Value k = expLoop.getInductionVar();
         Value x =
-            rewriter.create<memref::LoadOp>(loc, input, ValueRange{i, j, k});
-        Value e = rewriter.create<math::ExpOp>(loc, x);
-        rewriter.create<memref::StoreOp>(loc, e, out, ValueRange{i, j, k});
-        Value sum = rewriter.create<memref::LoadOp>(loc, sumBuf, ValueRange{});
-        Value next = rewriter.create<arith::AddFOp>(loc, sum, e);
-        rewriter.create<memref::StoreOp>(loc, next, sumBuf, ValueRange{});
+            memref::LoadOp::create(rewriter, loc, input, ValueRange{i, j, k});
+        Value e = math::ExpOp::create(rewriter, loc, x);
+        memref::StoreOp::create(rewriter, loc, e, out, ValueRange{i, j, k});
+        Value sum = memref::LoadOp::create(rewriter, loc, sumBuf, ValueRange{});
+        Value next = arith::AddFOp::create(rewriter, loc, sum, e);
+        memref::StoreOp::create(rewriter, loc, next, sumBuf, ValueRange{});
       }
-      auto normLoop = rewriter.create<scf::ForOp>(loc, c0, d2, c1);
+      auto normLoop = scf::ForOp::create(rewriter, loc, c0, d2, c1);
       {
         OpBuilder::InsertionGuard gn(rewriter);
         rewriter.setInsertionPointToStart(normLoop.getBody());
         Value k = normLoop.getInductionVar();
         Value e =
-            rewriter.create<memref::LoadOp>(loc, out, ValueRange{i, j, k});
-        Value sum = rewriter.create<memref::LoadOp>(loc, sumBuf, ValueRange{});
-        Value norm = rewriter.create<arith::DivFOp>(loc, e, sum);
-        rewriter.create<memref::StoreOp>(loc, norm, out, ValueRange{i, j, k});
+            memref::LoadOp::create(rewriter, loc, out, ValueRange{i, j, k});
+        Value sum = memref::LoadOp::create(rewriter, loc, sumBuf, ValueRange{});
+        Value norm = arith::DivFOp::create(rewriter, loc, e, sum);
+        memref::StoreOp::create(rewriter, loc, norm, out, ValueRange{i, j, k});
       }
     }
   }
@@ -2012,7 +2013,7 @@ static LogicalResult mapInputsToVIRVectors(linalg::LinalgOp linalgOp,
     auto vecTy =
         buddy::vir::DynamicVectorType::get(virShape, memrefTy.getElementType());
     auto loaded =
-        rewriter.create<buddy::vir::LoadOp>(loc, vecTy, base, zeroIdx);
+        buddy::vir::LoadOp::create(rewriter, loc, vecTy, base, zeroIdx);
     valueMap.map(bbArg, loaded.getResult());
   }
   return success();
@@ -2037,8 +2038,8 @@ static LogicalResult convertBodyToVIR(linalg::LinalgOp linalgOp,
     if (auto cst = dyn_cast<arith::ConstantOp>(inner)) {
       // Broadcast constant scalar to a vector matching its scalar type.
       auto vecTy = buddy::vir::DynamicVectorType::get(virShape, cst.getType());
-      auto v =
-          rewriter.create<buddy::vir::BroadcastOp>(loc, vecTy, cst.getResult());
+      auto v = buddy::vir::BroadcastOp::create(rewriter, loc, vecTy,
+                                               cst.getResult());
       vm[cst.getResult()] = v.getResult();
       continue;
     }
@@ -2097,11 +2098,11 @@ static LogicalResult storeYieldValues(linalg::LinalgOp linalgOp,
     if (mapped) {
       if (!isa<buddy::vir::DynamicVectorType>(mapped.getType())) {
         mapped =
-            rewriter.create<buddy::vir::BroadcastOp>(loc, outVecTy, mapped);
+            buddy::vir::BroadcastOp::create(rewriter, loc, outVecTy, mapped);
       }
     } else if (valueMap.contains(yv)) {
       Value scalar = valueMap.lookup(yv);
-      mapped = rewriter.create<buddy::vir::BroadcastOp>(loc, outVecTy, scalar);
+      mapped = buddy::vir::BroadcastOp::create(rewriter, loc, outVecTy, scalar);
     }
     auto indexingMap = linalgOp.getMatchingIndexingMap(initOpd);
     if (!indexingMap.isProjectedPermutation(/*allowZeroInResults=*/true)) {
@@ -2113,7 +2114,7 @@ static LogicalResult storeYieldValues(linalg::LinalgOp linalgOp,
     // Use implicit indices for vir.store. The lowering to vector will interpret
     // empty indices as using the leading-dim IVs (if any) and the VL IV.
     SmallVector<Value> emptyIdx;
-    rewriter.create<buddy::vir::StoreOp>(loc, mapped, base, emptyIdx);
+    buddy::vir::StoreOp::create(rewriter, loc, mapped, base, emptyIdx);
   }
   return success();
 }
@@ -2141,7 +2142,7 @@ static FailureOr<Value> createZeroPaddingValue(OpBuilder &builder, Location loc,
   TypedAttr zeroAttr = builder.getZeroAttr(elementType);
   if (!zeroAttr)
     return failure();
-  return builder.create<arith::ConstantOp>(loc, zeroAttr).getResult();
+  return arith::ConstantOp::create(builder, loc, zeroAttr).getResult();
 }
 
 struct LinalgTransposeToVectorPattern : public RewritePattern {
@@ -2197,7 +2198,7 @@ struct LinalgTransposeToVectorPattern : public RewritePattern {
     }
 
     Location loc = transposeOp.getLoc();
-    Value zeroIndex = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value zeroIndex = arith::ConstantIndexOp::create(rewriter, loc, 0);
     SmallVector<Value> indices(inputType.getRank(), zeroIndex);
     auto vectorType =
         VectorType::get(inputType.getShape(), inputType.getElementType());
@@ -2209,13 +2210,13 @@ struct LinalgTransposeToVectorPattern : public RewritePattern {
     AffineMap identityMap =
         rewriter.getMultiDimIdentityMap(inputType.getRank());
     SmallVector<bool> inBounds(inputType.getRank(), true);
-    Value read = rewriter.create<vector::TransferReadOp>(
-        loc, vectorType, transposeOp.getInput(), indices, *padding, identityMap,
-        inBounds);
-    Value transposed = rewriter.create<vector::TransposeOp>(
-        loc, read, transposeOp.getPermutation());
-    rewriter.create<vector::TransferWriteOp>(
-        loc, transposed, transposeOp.getInit(), indices, identityMap);
+    Value read = vector::TransferReadOp::create(
+        rewriter, loc, vectorType, transposeOp.getInput(), indices, *padding,
+        identityMap, inBounds);
+    Value transposed = vector::TransposeOp::create(
+        rewriter, loc, read, transposeOp.getPermutation());
+    vector::TransferWriteOp::create(
+        rewriter, loc, transposed, transposeOp.getInit(), indices, identityMap);
     rewriter.eraseOp(transposeOp);
     return success();
   }
@@ -2344,7 +2345,7 @@ struct LinalgGenericToVIRPattern : public RewritePattern {
     }
 
     // Close the set_vl region by ending the block (no explicit terminator).
-    rewriter.create<vector::YieldOp>(loc);
+    vector::YieldOp::create(rewriter, loc);
 
     // Erase original op.
     rewriter.eraseOp(linalgOp);

--- a/midend/lib/Conversion/LowerBud/LowerBudPass.cpp
+++ b/midend/lib/Conversion/LowerBud/LowerBudPass.cpp
@@ -47,8 +47,8 @@ public:
     // Get type from the origin operation.
     Type resultType = op.getResult().getType();
     // Create constant operation.
-    Value c0 = rewriter.create<mlir::arith::ConstantOp>(
-        loc, resultType, rewriter.getZeroAttr(resultType));
+    Value c0 = mlir::arith::ConstantOp::create(
+        rewriter, loc, resultType, rewriter.getZeroAttr(resultType));
 
     rewriter.replaceOp(op, c0);
     return success();
@@ -65,17 +65,17 @@ public:
     // Get type from the origin operation.
     Type resultType = op.getResult().getType();
     // Create constant operation.
-    Value c0 = rewriter.create<mlir::arith::ConstantOp>(
-        loc, resultType, rewriter.getZeroAttr(resultType));
+    Value c0 = mlir::arith::ConstantOp::create(
+        rewriter, loc, resultType, rewriter.getZeroAttr(resultType));
     // Create print operation for the scalar value.
-    rewriter.create<vector::PrintOp>(loc, c0);
+    vector::PrintOp::create(rewriter, loc, c0);
     VectorType vectorTy4 =
         VectorType::get({4 /*number of elements in the vector*/}, resultType);
     // Broadcast element of the kernel.
     Value broadcastVector =
-        rewriter.create<vector::BroadcastOp>(loc, vectorTy4, c0);
+        vector::BroadcastOp::create(rewriter, loc, vectorTy4, c0);
     // Create print operation for the vector value.
-    rewriter.create<vector::PrintOp>(loc, broadcastVector);
+    vector::PrintOp::create(rewriter, loc, broadcastVector);
 
     rewriter.eraseOp(op);
     return success();
@@ -100,10 +100,10 @@ public:
     // Lowering to different ops according to the attribute.
     if (arithAttr == buddy::bud::TestEnumAttrOperation::ADD)
       // Create addi operation.
-      result = rewriter.create<arith::AddIOp>(loc, resultType, lhs, rhs);
+      result = arith::AddIOp::create(rewriter, loc, resultType, lhs, rhs);
     if (arithAttr == buddy::bud::TestEnumAttrOperation::SUB)
       // Create subi operation.
-      result = rewriter.create<arith::SubIOp>(loc, resultType, lhs, rhs);
+      result = arith::SubIOp::create(rewriter, loc, resultType, lhs, rhs);
     rewriter.replaceOp(op, result);
     return success();
   }
@@ -123,13 +123,13 @@ public:
     // Get the index attribute and constant value.
     IntegerAttr attrX = rewriter.getIntegerAttr(rewriter.getIndexType(), valX);
     IntegerAttr attrY = rewriter.getIntegerAttr(rewriter.getIndexType(), valY);
-    Value idxX = rewriter.create<arith::ConstantOp>(loc, attrX);
-    Value idxY = rewriter.create<arith::ConstantOp>(loc, attrY);
+    Value idxX = arith::ConstantOp::create(rewriter, loc, attrX);
+    Value idxY = arith::ConstantOp::create(rewriter, loc, attrY);
     SmallVector<Value, 2> memrefIdx = {idxX, idxY};
     // Get base memref.
     Value memref = op.getBase();
     // Create memref load operation.
-    Value result = rewriter.create<memref::LoadOp>(loc, memref, memrefIdx);
+    Value result = memref::LoadOp::create(rewriter, loc, memref, memrefIdx);
     rewriter.replaceOp(op, result);
     return success();
   }

--- a/midend/lib/Conversion/LowerDAP/LowerDAPPass.cpp
+++ b/midend/lib/Conversion/LowerDAP/LowerDAPPass.cpp
@@ -56,61 +56,61 @@ public:
     Value kernel = op->getOperand(1);
     Value output = op->getOperand(2);
 
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
     FloatType f32 = Float32Type::get(ctx);
     Value f0 =
-        rewriter.create<arith::ConstantFloatOp>(loc, f32, APFloat(float(0.0)));
+        arith::ConstantFloatOp::create(rewriter, loc, f32, APFloat(float(0.0)));
 
-    Value kernelSize = rewriter.create<memref::DimOp>(loc, kernel, c0);
-    Value dataLen = rewriter.create<memref::DimOp>(loc, output, c0);
+    Value kernelSize = memref::DimOp::create(rewriter, loc, kernel, c0);
+    Value dataLen = memref::DimOp::create(rewriter, loc, output, c0);
 
     // Populate the FIR pipeline by padding the `input` with [`kernelSize`-1]
     // zeros at the beginning. Compute only the padding section of the input
     // data.
-    Value fillInLen = rewriter.create<arith::SubIOp>(loc, kernelSize, c1);
-    rewriter.create<scf::ForOp>(
-        loc, c0, fillInLen, c1, ValueRange{},
+    Value fillInLen = arith::SubIOp::create(rewriter, loc, kernelSize, c1);
+    scf::ForOp::create(
+        rewriter, loc, c0, fillInLen, c1, ValueRange{},
         [&](OpBuilder &b, Location loc, Value iv_n, ValueRange iargs) {
-          Value upperBound = b.create<arith::AddIOp>(loc, iv_n, c1);
+          Value upperBound = arith::AddIOp::create(b, loc, iv_n, c1);
           Value outFinal =
-              b.create<scf::ForOp>(
-                   loc, c0, upperBound, c1, ValueRange{f0},
-                   [&](OpBuilder &b, Location loc, Value iv_k,
-                       ValueRange iargs) {
-                     Value i = b.create<arith::SubIOp>(loc, iv_n, iv_k);
-                     Value in = b.create<memref::LoadOp>(loc, input, i);
-                     Value k = b.create<memref::LoadOp>(loc, kernel, iv_k);
-                     Value mul = b.create<arith::MulFOp>(loc, in, k);
-                     Value outNext =
-                         b.create<arith::AddFOp>(loc, iargs[0], mul);
-                     b.create<scf::YieldOp>(loc, outNext);
-                   })
+              scf::ForOp::create(
+                  b, loc, c0, upperBound, c1, ValueRange{f0},
+                  [&](OpBuilder &b, Location loc, Value iv_k,
+                      ValueRange iargs) {
+                    Value i = arith::SubIOp::create(b, loc, iv_n, iv_k);
+                    Value in = memref::LoadOp::create(b, loc, input, i);
+                    Value k = memref::LoadOp::create(b, loc, kernel, iv_k);
+                    Value mul = arith::MulFOp::create(b, loc, in, k);
+                    Value outNext =
+                        arith::AddFOp::create(b, loc, iargs[0], mul);
+                    scf::YieldOp::create(b, loc, outNext);
+                  })
                   .getResult(0);
-          b.create<memref::StoreOp>(loc, outFinal, output, ValueRange{iv_n});
-          b.create<scf::YieldOp>(loc);
+          memref::StoreOp::create(b, loc, outFinal, output, ValueRange{iv_n});
+          scf::YieldOp::create(b, loc);
         });
 
     // Compute the input data following the padding section.
-    rewriter.create<scf::ForOp>(
-        loc, fillInLen, dataLen, c1, ValueRange{},
+    scf::ForOp::create(
+        rewriter, loc, fillInLen, dataLen, c1, ValueRange{},
         [&](OpBuilder &b, Location loc, Value iv_n, ValueRange iargs) {
           Value outFinal =
-              b.create<scf::ForOp>(
-                   loc, c0, kernelSize, c1, ValueRange{f0},
-                   [&](OpBuilder &b, Location loc, Value iv_k,
-                       ValueRange iargs) {
-                     Value i = b.create<arith::SubIOp>(loc, iv_n, iv_k);
-                     Value in = b.create<memref::LoadOp>(loc, input, i);
-                     Value k = b.create<memref::LoadOp>(loc, kernel, iv_k);
-                     Value mul = b.create<arith::MulFOp>(loc, in, k);
-                     Value outNext =
-                         b.create<arith::AddFOp>(loc, iargs[0], mul);
-                     b.create<scf::YieldOp>(loc, outNext);
-                   })
+              scf::ForOp::create(
+                  b, loc, c0, kernelSize, c1, ValueRange{f0},
+                  [&](OpBuilder &b, Location loc, Value iv_k,
+                      ValueRange iargs) {
+                    Value i = arith::SubIOp::create(b, loc, iv_n, iv_k);
+                    Value in = memref::LoadOp::create(b, loc, input, i);
+                    Value k = memref::LoadOp::create(b, loc, kernel, iv_k);
+                    Value mul = arith::MulFOp::create(b, loc, in, k);
+                    Value outNext =
+                        arith::AddFOp::create(b, loc, iargs[0], mul);
+                    scf::YieldOp::create(b, loc, outNext);
+                  })
                   .getResult(0);
-          b.create<memref::StoreOp>(loc, outFinal, output, ValueRange{iv_n});
-          b.create<scf::YieldOp>(loc);
+          memref::StoreOp::create(b, loc, outFinal, output, ValueRange{iv_n});
+          scf::YieldOp::create(b, loc);
         });
 
     rewriter.eraseOp(op);
@@ -136,85 +136,87 @@ public:
     Value kernel = op->getOperand(1);
     Value output = op->getOperand(2);
 
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-    Value c2 = rewriter.create<ConstantIndexOp>(loc, 2);
-    Value c4 = rewriter.create<ConstantIndexOp>(loc, 4);
-    Value c5 = rewriter.create<ConstantIndexOp>(loc, 5);
+    Value c0 = ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = ConstantIndexOp::create(rewriter, loc, 1);
+    Value c2 = ConstantIndexOp::create(rewriter, loc, 2);
+    Value c4 = ConstantIndexOp::create(rewriter, loc, 4);
+    Value c5 = ConstantIndexOp::create(rewriter, loc, 5);
 
-    Value b0 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c0});
-    Value b1 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c1});
-    Value b2 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c2});
+    Value b0 = memref::LoadOp::create(rewriter, loc, kernel, ValueRange{c0});
+    Value b1 = memref::LoadOp::create(rewriter, loc, kernel, ValueRange{c1});
+    Value b2 = memref::LoadOp::create(rewriter, loc, kernel, ValueRange{c2});
     // Value a0 of kernel is not used
-    Value a1 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c4});
-    Value a2 = rewriter.create<memref::LoadOp>(loc, kernel, ValueRange{c5});
+    Value a1 = memref::LoadOp::create(rewriter, loc, kernel, ValueRange{c4});
+    Value a2 = memref::LoadOp::create(rewriter, loc, kernel, ValueRange{c5});
 
-    Value N = rewriter.create<memref::DimOp>(loc, input, c0);
+    Value N = memref::DimOp::create(rewriter, loc, input, c0);
 
-    Value strideVal = rewriter.create<ConstantIndexOp>(loc, stride);
+    Value strideVal = ConstantIndexOp::create(rewriter, loc, stride);
 
     FloatType f32 = Float32Type::get(ctx);
 
-    Value z1 = rewriter.create<ConstantFloatOp>(loc, f32, APFloat(float(0)));
-    Value z2 = rewriter.create<ConstantFloatOp>(loc, f32, APFloat(float(0)));
+    Value z1 = ConstantFloatOp::create(rewriter, loc, f32, APFloat(float(0)));
+    Value z2 = ConstantFloatOp::create(rewriter, loc, f32, APFloat(float(0)));
 
     VectorType vectorTy32 = VectorType::get({stride}, f32);
 
-    Value x0 = rewriter.create<memref::LoadOp>(loc, input, ValueRange{c0});
-    Value x = rewriter.create<MulFOp>(loc, b0, x0);
-    rewriter.create<memref::StoreOp>(loc, x, output, ValueRange{c0});
+    Value x0 = memref::LoadOp::create(rewriter, loc, input, ValueRange{c0});
+    Value x = MulFOp::create(rewriter, loc, b0, x0);
+    memref::StoreOp::create(rewriter, loc, x, output, ValueRange{c0});
 
-    Value x1 = rewriter.create<memref::LoadOp>(loc, input, ValueRange{c1});
-    Value x2 = rewriter.create<MulFOp>(loc, b0, x1);
-    Value x3 = rewriter.create<MulFOp>(loc, b1, x0);
-    Value x4 = rewriter.create<AddFOp>(loc, x2, x3);
-    rewriter.create<memref::StoreOp>(loc, x4, output, ValueRange{c1});
+    Value x1 = memref::LoadOp::create(rewriter, loc, input, ValueRange{c1});
+    Value x2 = MulFOp::create(rewriter, loc, b0, x1);
+    Value x3 = MulFOp::create(rewriter, loc, b1, x0);
+    Value x4 = AddFOp::create(rewriter, loc, x2, x3);
+    memref::StoreOp::create(rewriter, loc, x4, output, ValueRange{c1});
 
-    Value Vecb0 = rewriter.create<vector::BroadcastOp>(loc, vectorTy32, b0);
-    Value Vecb1 = rewriter.create<vector::BroadcastOp>(loc, vectorTy32, b1);
-    Value Vecb2 = rewriter.create<vector::BroadcastOp>(loc, vectorTy32, b2);
+    Value Vecb0 = vector::BroadcastOp::create(rewriter, loc, vectorTy32, b0);
+    Value Vecb1 = vector::BroadcastOp::create(rewriter, loc, vectorTy32, b1);
+    Value Vecb2 = vector::BroadcastOp::create(rewriter, loc, vectorTy32, b2);
 
     // A biquad filter expression:
     // y[n] = b0*x[n] + b1*x[n-1] + b2*x[n-2] + a1*y[n-1] + a2*y[n-2];
     // FIR part
-    rewriter.create<scf::ForOp>(
-        loc, c2, N, strideVal, ValueRange{},
+    scf::ForOp::create(
+        rewriter, loc, c2, N, strideVal, ValueRange{},
         [&](OpBuilder &builder, Location loc, Value ivs, ValueRange iargs) {
           Value idx0 = ivs;
-          Value idx1 = builder.create<SubIOp>(loc, idx0, c1);
-          Value idx2 = builder.create<SubIOp>(loc, idx0, c2);
+          Value idx1 = SubIOp::create(builder, loc, idx0, c1);
+          Value idx2 = SubIOp::create(builder, loc, idx0, c2);
 
           Value inputVec0 =
-              builder.create<LoadOp>(loc, vectorTy32, input, ValueRange{idx0});
+              LoadOp::create(builder, loc, vectorTy32, input, ValueRange{idx0});
           Value inputVec1 =
-              builder.create<LoadOp>(loc, vectorTy32, input, ValueRange{idx1});
+              LoadOp::create(builder, loc, vectorTy32, input, ValueRange{idx1});
           Value inputVec2 =
-              builder.create<LoadOp>(loc, vectorTy32, input, ValueRange{idx2});
+              LoadOp::create(builder, loc, vectorTy32, input, ValueRange{idx2});
 
-          Value outputVec =
-              builder.create<LoadOp>(loc, vectorTy32, output, ValueRange{idx0});
+          Value outputVec = LoadOp::create(builder, loc, vectorTy32, output,
+                                           ValueRange{idx0});
           Value resVec0 =
-              builder.create<FMAOp>(loc, inputVec0, Vecb0, outputVec);
-          Value resVec1 = builder.create<FMAOp>(loc, inputVec1, Vecb1, resVec0);
-          Value resVec2 = builder.create<FMAOp>(loc, inputVec2, Vecb2, resVec1);
-          builder.create<StoreOp>(loc, resVec2, output, ValueRange{idx0});
-          builder.create<scf::YieldOp>(loc);
+              FMAOp::create(builder, loc, inputVec0, Vecb0, outputVec);
+          Value resVec1 =
+              FMAOp::create(builder, loc, inputVec1, Vecb1, resVec0);
+          Value resVec2 =
+              FMAOp::create(builder, loc, inputVec2, Vecb2, resVec1);
+          StoreOp::create(builder, loc, resVec2, output, ValueRange{idx0});
+          scf::YieldOp::create(builder, loc);
         });
 
     // IIR part
-    rewriter.create<scf::ForOp>(
-        loc, c0, N, c1, ValueRange{z1, z2},
+    scf::ForOp::create(
+        rewriter, loc, c0, N, c1, ValueRange{z1, z2},
         [&](OpBuilder &builder, Location loc, Value ivs, ValueRange iargs) {
           Value x =
-              builder.create<memref::LoadOp>(loc, output, ValueRange(ivs));
-          Value t1 = builder.create<MulFOp>(loc, a1, iargs[1]);
-          Value t2 = builder.create<MulFOp>(loc, a2, iargs[0]);
-          Value y = builder.create<AddFOp>(loc, t1, t2);
-          Value opt = builder.create<SubFOp>(loc, x, y);
+              memref::LoadOp::create(builder, loc, output, ValueRange(ivs));
+          Value t1 = MulFOp::create(builder, loc, a1, iargs[1]);
+          Value t2 = MulFOp::create(builder, loc, a2, iargs[0]);
+          Value y = AddFOp::create(builder, loc, t1, t2);
+          Value opt = SubFOp::create(builder, loc, x, y);
 
-          builder.create<memref::StoreOp>(loc, opt, output, ValueRange{ivs});
+          memref::StoreOp::create(builder, loc, opt, output, ValueRange{ivs});
 
-          builder.create<scf::YieldOp>(loc, std::vector<Value>{iargs[1], opt});
+          scf::YieldOp::create(builder, loc, std::vector<Value>{iargs[1], opt});
         });
 
     rewriter.eraseOp(op);
@@ -240,63 +242,65 @@ public:
     Value kernel = op->getOperand(1);
     Value output = op->getOperand(2);
 
-    Value c0 = rewriter.create<ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<ConstantIndexOp>(loc, 1);
-    Value c2 = rewriter.create<ConstantIndexOp>(loc, 2);
-    Value c4 = rewriter.create<ConstantIndexOp>(loc, 4);
-    Value c5 = rewriter.create<ConstantIndexOp>(loc, 5);
+    Value c0 = ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = ConstantIndexOp::create(rewriter, loc, 1);
+    Value c2 = ConstantIndexOp::create(rewriter, loc, 2);
+    Value c4 = ConstantIndexOp::create(rewriter, loc, 4);
+    Value c5 = ConstantIndexOp::create(rewriter, loc, 5);
 
-    Value N = rewriter.create<memref::DimOp>(loc, input, c0);
-    Value filterSize = rewriter.create<memref::DimOp>(loc, kernel, c0);
+    Value N = memref::DimOp::create(rewriter, loc, input, c0);
+    Value filterSize = memref::DimOp::create(rewriter, loc, kernel, c0);
 
     FloatType f32 = Float32Type::get(ctx);
 
     // loop over every row in SOS matrix
-    rewriter.create<scf::ForOp>(
-        loc, c0, filterSize, c1, ValueRange{input},
+    scf::ForOp::create(
+        rewriter, loc, c0, filterSize, c1, ValueRange{input},
         [&](OpBuilder &builder, Location loc, Value iv, ValueRange iarg) {
           Value b0 =
-              builder.create<memref::LoadOp>(loc, kernel, ValueRange{iv, c0});
+              memref::LoadOp::create(builder, loc, kernel, ValueRange{iv, c0});
           Value b1 =
-              builder.create<memref::LoadOp>(loc, kernel, ValueRange{iv, c1});
+              memref::LoadOp::create(builder, loc, kernel, ValueRange{iv, c1});
           Value b2 =
-              builder.create<memref::LoadOp>(loc, kernel, ValueRange{iv, c2});
+              memref::LoadOp::create(builder, loc, kernel, ValueRange{iv, c2});
           Value a1 =
-              builder.create<memref::LoadOp>(loc, kernel, ValueRange{iv, c4});
+              memref::LoadOp::create(builder, loc, kernel, ValueRange{iv, c4});
           Value a2 =
-              builder.create<memref::LoadOp>(loc, kernel, ValueRange{iv, c5});
+              memref::LoadOp::create(builder, loc, kernel, ValueRange{iv, c5});
 
           Value z1 =
-              builder.create<ConstantFloatOp>(loc, f32, APFloat(float(0)));
+              ConstantFloatOp::create(builder, loc, f32, APFloat(float(0)));
           Value z2 =
-              builder.create<ConstantFloatOp>(loc, f32, APFloat(float(0)));
+              ConstantFloatOp::create(builder, loc, f32, APFloat(float(0)));
 
           // Loop reordering, compute z1 for next iteration, z2 for the second
           // following iteration.
-          builder.create<scf::ForOp>(
-              loc, c0, N, c1, ValueRange{z1, z2},
+          scf::ForOp::create(
+              builder, loc, c0, N, c1, ValueRange{z1, z2},
               [&](OpBuilder &builder, Location loc, Value iv,
                   ValueRange iargs) {
-                Value inElem = builder.create<memref::LoadOp>(loc, iarg[0], iv);
-                Value t0 = builder.create<arith::MulFOp>(loc, b0, inElem);
+                Value inElem =
+                    memref::LoadOp::create(builder, loc, iarg[0], iv);
+                Value t0 = arith::MulFOp::create(builder, loc, b0, inElem);
                 Value outElem =
-                    builder.create<arith::AddFOp>(loc, t0, iargs[0]);
+                    arith::AddFOp::create(builder, loc, t0, iargs[0]);
 
-                Value t1 = builder.create<arith::MulFOp>(loc, b1, inElem);
-                Value t2 = builder.create<arith::MulFOp>(loc, a1, outElem);
-                Value t3 = builder.create<arith::SubFOp>(loc, t1, t2);
-                Value z1Next = builder.create<arith::AddFOp>(loc, t3, iargs[1]);
+                Value t1 = arith::MulFOp::create(builder, loc, b1, inElem);
+                Value t2 = arith::MulFOp::create(builder, loc, a1, outElem);
+                Value t3 = arith::SubFOp::create(builder, loc, t1, t2);
+                Value z1Next =
+                    arith::AddFOp::create(builder, loc, t3, iargs[1]);
 
-                Value t4 = builder.create<arith::MulFOp>(loc, b2, inElem);
-                Value t5 = builder.create<arith::MulFOp>(loc, a2, outElem);
-                Value z2Next = builder.create<arith::SubFOp>(loc, t4, t5);
+                Value t4 = arith::MulFOp::create(builder, loc, b2, inElem);
+                Value t5 = arith::MulFOp::create(builder, loc, a2, outElem);
+                Value z2Next = arith::SubFOp::create(builder, loc, t4, t5);
 
-                builder.create<memref::StoreOp>(loc, outElem, output, iv);
-                builder.create<scf::YieldOp>(
-                    loc, std::vector<Value>{z1Next, z2Next});
+                memref::StoreOp::create(builder, loc, outElem, output, iv);
+                scf::YieldOp::create(builder, loc,
+                                     std::vector<Value>{z1Next, z2Next});
               });
 
-          builder.create<scf::YieldOp>(loc, output);
+          scf::YieldOp::create(builder, loc, output);
         });
 
     rewriter.eraseOp(op);

--- a/midend/lib/Conversion/LowerDIP/LowerDIPPass.cpp
+++ b/midend/lib/Conversion/LowerDIP/LowerDIPPass.cpp
@@ -68,7 +68,7 @@ public:
     Value centerY = op->getOperand(4);
     Value constantValue = op->getOperand(5);
     dip::BoundaryOption boundaryOptionAttr = op.getBoundaryOption();
-    Value strideVal = rewriter.create<arith::ConstantIndexOp>(loc, stride);
+    Value strideVal = arith::ConstantIndexOp::create(rewriter, loc, stride);
 
     auto inElemTy =
         mlir::cast<mlir::MemRefType>(input.getType()).getElementType();
@@ -112,8 +112,8 @@ public:
     auto ctx = op->getContext();
 
     // Create constant indices.
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
 
     // Register operand values.
     Value inputReal = op->getOperand(0);
@@ -122,15 +122,15 @@ public:
     Value kernelImag = op->getOperand(3);
     Value intermediateReal = op->getOperand(4);
     Value intermediateImag = op->getOperand(5);
-    Value strideVal = rewriter.create<arith::ConstantIndexOp>(loc, stride);
+    Value strideVal = arith::ConstantIndexOp::create(rewriter, loc, stride);
 
     // Create DimOp for padded input image.
-    Value inputRow = rewriter.create<memref::DimOp>(loc, inputReal, c0);
-    Value inputCol = rewriter.create<memref::DimOp>(loc, inputReal, c1);
+    Value inputRow = memref::DimOp::create(rewriter, loc, inputReal, c0);
+    Value inputCol = memref::DimOp::create(rewriter, loc, inputReal, c1);
 
     // Create DimOp for padded original kernel.
-    Value kernelRow = rewriter.create<memref::DimOp>(loc, kernelReal, c0);
-    Value kernelCol = rewriter.create<memref::DimOp>(loc, kernelReal, c1);
+    Value kernelRow = memref::DimOp::create(rewriter, loc, kernelReal, c0);
+    Value kernelCol = memref::DimOp::create(rewriter, loc, kernelReal, c1);
 
     FloatType f32 = Float32Type::get(ctx);
     VectorType vectorTy32 = VectorType::get({stride}, f32);
@@ -190,16 +190,16 @@ public:
     }
 
     // Create constant indices.
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
 
     // Get input image dimensions.
-    Value inputRow = rewriter.create<memref::DimOp>(loc, input, c0);
-    Value inputCol = rewriter.create<memref::DimOp>(loc, input, c1);
+    Value inputRow = memref::DimOp::create(rewriter, loc, input, c0);
+    Value inputCol = memref::DimOp::create(rewriter, loc, input, c1);
 
     // Get output image dimensions.
-    Value outputRow = rewriter.create<memref::DimOp>(loc, output, c0);
-    Value outputCol = rewriter.create<memref::DimOp>(loc, output, c1);
+    Value outputRow = memref::DimOp::create(rewriter, loc, output, c0);
+    Value outputCol = memref::DimOp::create(rewriter, loc, output, c1);
 
     auto rotationMatrix = dip::calculateRotationMatrix(
         rewriter, loc, inputCol, inputRow, outputCol, outputRow, angleVal);
@@ -250,22 +250,22 @@ public:
     }
 
     // Create constant indices.
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    Value c2 = rewriter.create<arith::ConstantIndexOp>(loc, 2);
-    Value c3 = rewriter.create<arith::ConstantIndexOp>(loc, 3);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    Value c2 = arith::ConstantIndexOp::create(rewriter, loc, 2);
+    Value c3 = arith::ConstantIndexOp::create(rewriter, loc, 3);
 
     // Get image dimensions.
     Value inputRow, inputCol, outputRow, outputCol;
     if (imageFormatAttr == dip::ImageFormat::NHWC) {
-      inputRow = rewriter.create<memref::DimOp>(loc, input, c1);
-      inputCol = rewriter.create<memref::DimOp>(loc, input, c2);
-      outputRow = rewriter.create<memref::DimOp>(loc, output, c1);
-      outputCol = rewriter.create<memref::DimOp>(loc, output, c2);
+      inputRow = memref::DimOp::create(rewriter, loc, input, c1);
+      inputCol = memref::DimOp::create(rewriter, loc, input, c2);
+      outputRow = memref::DimOp::create(rewriter, loc, output, c1);
+      outputCol = memref::DimOp::create(rewriter, loc, output, c2);
     } else if (imageFormatAttr == dip::ImageFormat::NCHW) {
-      inputRow = rewriter.create<memref::DimOp>(loc, input, c2);
-      inputCol = rewriter.create<memref::DimOp>(loc, input, c3);
-      outputRow = rewriter.create<memref::DimOp>(loc, output, c2);
-      outputCol = rewriter.create<memref::DimOp>(loc, output, c3);
+      inputRow = memref::DimOp::create(rewriter, loc, input, c2);
+      inputCol = memref::DimOp::create(rewriter, loc, input, c3);
+      outputRow = memref::DimOp::create(rewriter, loc, output, c2);
+      outputCol = memref::DimOp::create(rewriter, loc, output, c3);
     }
 
     auto rotationMatrix = dip::calculateRotationMatrix(
@@ -303,7 +303,7 @@ public:
     Value verticalScalingFactor = op->getOperand(2);
     Value output = op->getOperand(3);
     auto interpolationAttr = op.getInterpolationType();
-    Value strideVal = rewriter.create<arith::ConstantIndexOp>(loc, stride);
+    Value strideVal = arith::ConstantIndexOp::create(rewriter, loc, stride);
 
     auto inElemTy =
         mlir::cast<mlir::MemRefType>(input.getType()).getElementType();
@@ -318,29 +318,29 @@ public:
                                << inElemTy << "is passed";
     }
 
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
     Value c0F32 = indexToF32(rewriter, loc, c0);
 
-    Value inputRow = rewriter.create<memref::DimOp>(loc, input, c0);
-    Value inputCol = rewriter.create<memref::DimOp>(loc, input, c1);
+    Value inputRow = memref::DimOp::create(rewriter, loc, input, c0);
+    Value inputCol = memref::DimOp::create(rewriter, loc, input, c1);
 
-    Value outputRow = rewriter.create<memref::DimOp>(loc, output, c0);
-    Value outputCol = rewriter.create<memref::DimOp>(loc, output, c1);
+    Value outputRow = memref::DimOp::create(rewriter, loc, output, c0);
+    Value outputCol = memref::DimOp::create(rewriter, loc, output, c1);
 
     // Determine lower bound for second call of resize function (this is done
     // for efficient tail processing).
     Value outputColStrideRatio =
-        rewriter.create<arith::DivUIOp>(loc, outputCol, strideVal);
+        arith::DivUIOp::create(rewriter, loc, outputCol, strideVal);
     Value outputColMultiple =
-        rewriter.create<arith::MulIOp>(loc, strideVal, outputColStrideRatio);
+        arith::MulIOp::create(rewriter, loc, strideVal, outputColStrideRatio);
 
     SmallVector<Value, 8> lowerBounds1{c0, c0};
     SmallVector<Value, 8> upperBounds1{outputRow, outputColMultiple};
 
     SmallVector<int64_t, 8> steps{1, stride};
     Value strideTailVal =
-        rewriter.create<arith::SubIOp>(loc, outputCol, outputColMultiple);
+        arith::SubIOp::create(rewriter, loc, outputCol, outputColMultiple);
 
     SmallVector<Value, 8> lowerBounds2{c0, outputColMultiple};
     SmallVector<Value, 8> upperBounds2{outputRow, outputCol};
@@ -348,25 +348,25 @@ public:
     FloatType f32 = Float32Type::get(ctx);
     VectorType vectorTy32 = VectorType::get({stride}, f32);
 
-    Value horizontalScalingFactorVec = rewriter.create<vector::BroadcastOp>(
-        loc, vectorTy32, horizontalScalingFactor);
-    Value verticalScalingFactorVec = rewriter.create<vector::BroadcastOp>(
-        loc, vectorTy32, verticalScalingFactor);
+    Value horizontalScalingFactorVec = vector::BroadcastOp::create(
+        rewriter, loc, vectorTy32, horizontalScalingFactor);
+    Value verticalScalingFactorVec = vector::BroadcastOp::create(
+        rewriter, loc, vectorTy32, verticalScalingFactor);
 
     // Obtain extreme allocatable value(s) in input and output for bounding
     // purpose.
-    Value inputRowLastElem = rewriter.create<arith::SubIOp>(loc, inputRow, c1);
+    Value inputRowLastElem = arith::SubIOp::create(rewriter, loc, inputRow, c1);
     Value inputRowLastElemF32 = indexToF32(rewriter, loc, inputRowLastElem);
 
-    Value inputColLastElem = rewriter.create<arith::SubIOp>(loc, inputCol, c1);
+    Value inputColLastElem = arith::SubIOp::create(rewriter, loc, inputCol, c1);
     Value inputColLastElemF32 = indexToF32(rewriter, loc, inputColLastElem);
 
     Value outputRowLastElem =
-        rewriter.create<arith::SubIOp>(loc, outputRow, c1);
+        arith::SubIOp::create(rewriter, loc, outputRow, c1);
     Value outputRowLastElemF32 = indexToF32(rewriter, loc, outputRowLastElem);
 
     Value outputColLastElem =
-        rewriter.create<arith::SubIOp>(loc, outputCol, c1);
+        arith::SubIOp::create(rewriter, loc, outputCol, c1);
     Value outputColLastElemF32 = indexToF32(rewriter, loc, outputColLastElem);
 
     if (interpolationAttr ==
@@ -429,7 +429,7 @@ public:
     Value verticalScalingFactor = op->getOperand(2);
     Value output = op->getOperand(3);
     auto interpolationAttr = op.getInterpolationType();
-    Value strideVal = rewriter.create<arith::ConstantIndexOp>(loc, stride);
+    Value strideVal = arith::ConstantIndexOp::create(rewriter, loc, stride);
 
     auto inElemTy =
         mlir::cast<mlir::MemRefType>(input.getType()).getElementType();
@@ -445,33 +445,33 @@ public:
     }
 
     // true: NHWC, false: NCHW
-    Value dataCondition = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI1Type(), rewriter.getBoolAttr(true));
+    Value dataCondition = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI1Type(), rewriter.getBoolAttr(true));
 
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    Value c2 = rewriter.create<arith::ConstantIndexOp>(loc, 2);
-    Value c3 = rewriter.create<arith::ConstantIndexOp>(loc, 3);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    Value c2 = arith::ConstantIndexOp::create(rewriter, loc, 2);
+    Value c3 = arith::ConstantIndexOp::create(rewriter, loc, 3);
 
     Value c0F32 = indexToF32(rewriter, loc, c0);
 
     // Value inputBatch = rewriter.create<memref::DimOp>(loc, input, c0);
-    Value inputRow = rewriter.create<memref::DimOp>(loc, input, c1);
-    Value inputCol = rewriter.create<memref::DimOp>(loc, input, c2);
+    Value inputRow = memref::DimOp::create(rewriter, loc, input, c1);
+    Value inputCol = memref::DimOp::create(rewriter, loc, input, c2);
     // TODO: remove inputColor?
     // Value inputColor = rewriter.create<memref::DimOp>(loc, input, c3);
 
-    Value outputBatch = rewriter.create<memref::DimOp>(loc, output, c0);
-    Value outputRow = rewriter.create<memref::DimOp>(loc, output, c1);
-    Value outputCol = rewriter.create<memref::DimOp>(loc, output, c2);
-    Value outputColor = rewriter.create<memref::DimOp>(loc, output, c3);
+    Value outputBatch = memref::DimOp::create(rewriter, loc, output, c0);
+    Value outputRow = memref::DimOp::create(rewriter, loc, output, c1);
+    Value outputCol = memref::DimOp::create(rewriter, loc, output, c2);
+    Value outputColor = memref::DimOp::create(rewriter, loc, output, c3);
 
     // Determine lower bound for second call of resize function (this is done
     // for efficient tail processing).
     Value outputColStrideRatio =
-        rewriter.create<arith::DivUIOp>(loc, outputCol, strideVal);
+        arith::DivUIOp::create(rewriter, loc, outputCol, strideVal);
     Value outputColMultiple =
-        rewriter.create<arith::MulIOp>(loc, strideVal, outputColStrideRatio);
+        arith::MulIOp::create(rewriter, loc, strideVal, outputColStrideRatio);
 
     SmallVector<Value, 8> lowerBounds1{c0, c0, c0, c0};
     SmallVector<Value, 8> upperBounds1{outputBatch, outputColor, outputRow,
@@ -479,7 +479,7 @@ public:
 
     SmallVector<int64_t, 8> steps{1, 1, 1, stride};
     Value strideTailVal =
-        rewriter.create<arith::SubIOp>(loc, outputCol, outputColMultiple);
+        arith::SubIOp::create(rewriter, loc, outputCol, outputColMultiple);
 
     SmallVector<Value, 8> lowerBounds2{c0, c0, c0, outputColMultiple};
     SmallVector<Value, 8> upperBounds2{outputBatch, outputColor, outputRow,
@@ -488,25 +488,25 @@ public:
     FloatType f32 = Float32Type::get(ctx);
     VectorType vectorTy32 = VectorType::get({stride}, f32);
 
-    Value horizontalScalingFactorVec = rewriter.create<vector::BroadcastOp>(
-        loc, vectorTy32, horizontalScalingFactor);
-    Value verticalScalingFactorVec = rewriter.create<vector::BroadcastOp>(
-        loc, vectorTy32, verticalScalingFactor);
+    Value horizontalScalingFactorVec = vector::BroadcastOp::create(
+        rewriter, loc, vectorTy32, horizontalScalingFactor);
+    Value verticalScalingFactorVec = vector::BroadcastOp::create(
+        rewriter, loc, vectorTy32, verticalScalingFactor);
 
     // Obtain extreme allocatable value(s) in input and output for bounding
     // purpose.
-    Value inputRowLastElem = rewriter.create<arith::SubIOp>(loc, inputRow, c1);
+    Value inputRowLastElem = arith::SubIOp::create(rewriter, loc, inputRow, c1);
     Value inputRowLastElemF32 = indexToF32(rewriter, loc, inputRowLastElem);
 
-    Value inputColLastElem = rewriter.create<arith::SubIOp>(loc, inputCol, c1);
+    Value inputColLastElem = arith::SubIOp::create(rewriter, loc, inputCol, c1);
     Value inputColLastElemF32 = indexToF32(rewriter, loc, inputColLastElem);
 
     Value outputRowLastElem =
-        rewriter.create<arith::SubIOp>(loc, outputRow, c1);
+        arith::SubIOp::create(rewriter, loc, outputRow, c1);
     Value outputRowLastElemF32 = indexToF32(rewriter, loc, outputRowLastElem);
 
     Value outputColLastElem =
-        rewriter.create<arith::SubIOp>(loc, outputCol, c1);
+        arith::SubIOp::create(rewriter, loc, outputCol, c1);
     Value outputColLastElemF32 = indexToF32(rewriter, loc, outputColLastElem);
 
     if (interpolationAttr ==
@@ -571,7 +571,7 @@ public:
     Value verticalScalingFactor = op->getOperand(2);
     Value output = op->getOperand(3);
     auto interpolationAttr = op.getInterpolationType();
-    Value strideVal = rewriter.create<arith::ConstantIndexOp>(loc, stride);
+    Value strideVal = arith::ConstantIndexOp::create(rewriter, loc, stride);
 
     auto inElemTy =
         mlir::cast<mlir::MemRefType>(input.getType()).getElementType();
@@ -587,33 +587,33 @@ public:
     }
 
     // true: NHWC, false: NCHW
-    Value dataCondition = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI1Type(), rewriter.getBoolAttr(false));
+    Value dataCondition = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI1Type(), rewriter.getBoolAttr(false));
 
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    Value c2 = rewriter.create<arith::ConstantIndexOp>(loc, 2);
-    Value c3 = rewriter.create<arith::ConstantIndexOp>(loc, 3);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    Value c2 = arith::ConstantIndexOp::create(rewriter, loc, 2);
+    Value c3 = arith::ConstantIndexOp::create(rewriter, loc, 3);
 
     Value c0F32 = indexToF32(rewriter, loc, c0);
 
     // Value inputBatch = rewriter.create<memref::DimOp>(loc, input, c0);
     // TODO: remove inputColor?
     // Value inputColor = rewriter.create<memref::DimOp>(loc, input, c1);
-    Value inputRow = rewriter.create<memref::DimOp>(loc, input, c2);
-    Value inputCol = rewriter.create<memref::DimOp>(loc, input, c3);
+    Value inputRow = memref::DimOp::create(rewriter, loc, input, c2);
+    Value inputCol = memref::DimOp::create(rewriter, loc, input, c3);
 
-    Value outputBatch = rewriter.create<memref::DimOp>(loc, output, c0);
-    Value outputColor = rewriter.create<memref::DimOp>(loc, output, c1);
-    Value outputRow = rewriter.create<memref::DimOp>(loc, output, c2);
-    Value outputCol = rewriter.create<memref::DimOp>(loc, output, c3);
+    Value outputBatch = memref::DimOp::create(rewriter, loc, output, c0);
+    Value outputColor = memref::DimOp::create(rewriter, loc, output, c1);
+    Value outputRow = memref::DimOp::create(rewriter, loc, output, c2);
+    Value outputCol = memref::DimOp::create(rewriter, loc, output, c3);
 
     // Determine lower bound for second call of resize function (this is done
     // for efficient tail processing).
     Value outputColStrideRatio =
-        rewriter.create<arith::DivUIOp>(loc, outputCol, strideVal);
+        arith::DivUIOp::create(rewriter, loc, outputCol, strideVal);
     Value outputColMultiple =
-        rewriter.create<arith::MulIOp>(loc, strideVal, outputColStrideRatio);
+        arith::MulIOp::create(rewriter, loc, strideVal, outputColStrideRatio);
 
     SmallVector<Value, 8> lowerBounds1{c0, c0, c0, c0};
     SmallVector<Value, 8> upperBounds1{outputBatch, outputColor, outputRow,
@@ -621,7 +621,7 @@ public:
 
     SmallVector<int64_t, 8> steps{1, 1, 1, stride};
     Value strideTailVal =
-        rewriter.create<arith::SubIOp>(loc, outputCol, outputColMultiple);
+        arith::SubIOp::create(rewriter, loc, outputCol, outputColMultiple);
 
     SmallVector<Value, 8> lowerBounds2{c0, c0, c0, outputColMultiple};
     SmallVector<Value, 8> upperBounds2{outputBatch, outputColor, outputRow,
@@ -630,25 +630,25 @@ public:
     FloatType f32 = Float32Type::get(ctx);
     VectorType vectorTy32 = VectorType::get({stride}, f32);
 
-    Value horizontalScalingFactorVec = rewriter.create<vector::BroadcastOp>(
-        loc, vectorTy32, horizontalScalingFactor);
-    Value verticalScalingFactorVec = rewriter.create<vector::BroadcastOp>(
-        loc, vectorTy32, verticalScalingFactor);
+    Value horizontalScalingFactorVec = vector::BroadcastOp::create(
+        rewriter, loc, vectorTy32, horizontalScalingFactor);
+    Value verticalScalingFactorVec = vector::BroadcastOp::create(
+        rewriter, loc, vectorTy32, verticalScalingFactor);
 
     // Obtain extreme allocatable value(s) in input and output for bounding
     // purpose.
-    Value inputRowLastElem = rewriter.create<arith::SubIOp>(loc, inputRow, c1);
+    Value inputRowLastElem = arith::SubIOp::create(rewriter, loc, inputRow, c1);
     Value inputRowLastElemF32 = indexToF32(rewriter, loc, inputRowLastElem);
 
-    Value inputColLastElem = rewriter.create<arith::SubIOp>(loc, inputCol, c1);
+    Value inputColLastElem = arith::SubIOp::create(rewriter, loc, inputCol, c1);
     Value inputColLastElemF32 = indexToF32(rewriter, loc, inputColLastElem);
 
     Value outputRowLastElem =
-        rewriter.create<arith::SubIOp>(loc, outputRow, c1);
+        arith::SubIOp::create(rewriter, loc, outputRow, c1);
     Value outputRowLastElemF32 = indexToF32(rewriter, loc, outputRowLastElem);
 
     Value outputColLastElem =
-        rewriter.create<arith::SubIOp>(loc, outputCol, c1);
+        arith::SubIOp::create(rewriter, loc, outputCol, c1);
     Value outputColLastElemF32 = indexToF32(rewriter, loc, outputColLastElem);
 
     if (interpolationAttr ==
@@ -716,7 +716,7 @@ public:
     Value iterations = op->getOperand(6);
     Value constantValue = op->getOperand(7);
     dip::BoundaryOption boundaryOptionAttr = op.getBoundaryOption();
-    Value strideVal = rewriter.create<arith::ConstantIndexOp>(loc, stride);
+    Value strideVal = arith::ConstantIndexOp::create(rewriter, loc, stride);
 
     auto inElemTy =
         mlir::cast<mlir::MemRefType>(input.getType()).getElementType();
@@ -732,28 +732,28 @@ public:
                                << inElemTy << "is passed";
     }
 
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
 
-    rewriter.create<affine::AffineForOp>(
-        loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+    affine::AffineForOp::create(
+        rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
         ValueRange{iterations}, rewriter.getDimIdentityMap(), /*Step=*/1,
         ValueRange{},
         [&](OpBuilder &builder, Location nestedLoc, Value iv,
             ValueRange itrArgs) {
-          Value cond = builder.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::sge, iv, c1);
-          builder.create<scf::IfOp>(
-              loc, cond, [&](OpBuilder &builder, Location loc) {
-                builder.create<memref::CopyOp>(loc, output, input);
-                builder.create<scf::YieldOp>(loc);
+          Value cond = arith::CmpIOp::create(builder, loc,
+                                             arith::CmpIPredicate::sge, iv, c1);
+          scf::IfOp::create(
+              builder, loc, cond, [&](OpBuilder &builder, Location loc) {
+                memref::CopyOp::create(builder, loc, output, input);
+                scf::YieldOp::create(builder, loc);
               });
-          builder.create<memref::CopyOp>(loc, copymemref, output);
+          memref::CopyOp::create(builder, loc, copymemref, output);
           traverseImagewBoundaryExtrapolation(
               rewriter, loc, ctx, input, kernel, output, centerX, centerY,
               constantValue, strideVal, inElemTy, boundaryOptionAttr, stride,
               dip::DIP_OP::EROSION_2D);
-          builder.create<affine::AffineYieldOp>(loc);
+          affine::AffineYieldOp::create(builder, loc);
         });
 
     // Remove the origin erosion operation.
@@ -790,7 +790,7 @@ public:
     Value iterations = op->getOperand(6);
     Value constantValue = op->getOperand(7);
     dip::BoundaryOption boundaryOptionAttr = op.getBoundaryOption();
-    Value strideVal = rewriter.create<arith::ConstantIndexOp>(loc, stride);
+    Value strideVal = arith::ConstantIndexOp::create(rewriter, loc, stride);
 
     auto inElemTy =
         mlir::cast<mlir::MemRefType>(input.getType()).getElementType();
@@ -805,28 +805,28 @@ public:
       return op->emitOpError() << "supports only f32, f64 and integer types. "
                                << inElemTy << "is passed";
     }
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
 
-    rewriter.create<affine::AffineForOp>(
-        loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+    affine::AffineForOp::create(
+        rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
         ValueRange{iterations}, rewriter.getDimIdentityMap(), /*Step=*/1,
         ValueRange{},
         [&](OpBuilder &builder, Location nestedLoc, Value iv,
             ValueRange itrArgs) {
-          Value cond = builder.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::sge, iv, c1);
-          builder.create<scf::IfOp>(
-              loc, cond, [&](OpBuilder &builder, Location loc) {
-                builder.create<memref::CopyOp>(loc, output, input);
-                builder.create<scf::YieldOp>(loc);
+          Value cond = arith::CmpIOp::create(builder, loc,
+                                             arith::CmpIPredicate::sge, iv, c1);
+          scf::IfOp::create(
+              builder, loc, cond, [&](OpBuilder &builder, Location loc) {
+                memref::CopyOp::create(builder, loc, output, input);
+                scf::YieldOp::create(builder, loc);
               });
-          builder.create<memref::CopyOp>(loc, copymemref, output);
+          memref::CopyOp::create(builder, loc, copymemref, output);
           traverseImagewBoundaryExtrapolation(
               rewriter, loc, ctx, input, kernel, output, centerX, centerY,
               constantValue, strideVal, inElemTy, boundaryOptionAttr, stride,
               dip::DIP_OP::DILATION_2D);
-          builder.create<affine::AffineYieldOp>(loc);
+          affine::AffineYieldOp::create(builder, loc);
         });
 
     // Remove the origin dilation operation.
@@ -864,7 +864,7 @@ public:
     Value iterations = op->getOperand(8);
     Value constantValue = op->getOperand(9);
     dip::BoundaryOption boundaryOptionAttr = op.getBoundaryOption();
-    Value strideVal = rewriter.create<arith::ConstantIndexOp>(loc, stride);
+    Value strideVal = arith::ConstantIndexOp::create(rewriter, loc, stride);
 
     auto inElemTy =
         mlir::cast<mlir::MemRefType>(input.getType()).getElementType();
@@ -880,49 +880,49 @@ public:
       return op->emitOpError() << "supports only f32, f64 and integer types. "
                                << inElemTy << "is passed";
     }
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
 
-    rewriter.create<affine::AffineForOp>(
-        loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+    affine::AffineForOp::create(
+        rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
         ValueRange{iterations}, rewriter.getDimIdentityMap(), /*Step=*/1,
         ValueRange{},
         [&](OpBuilder &builder, Location nestedLoc, Value iv,
             ValueRange itrArgs) {
-          Value cond = builder.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::sge, iv, c1);
-          builder.create<scf::IfOp>(
-              loc, cond, [&](OpBuilder &builder, Location loc) {
-                builder.create<memref::CopyOp>(loc, output1, input);
-                builder.create<scf::YieldOp>(loc);
+          Value cond = arith::CmpIOp::create(builder, loc,
+                                             arith::CmpIPredicate::sge, iv, c1);
+          scf::IfOp::create(
+              builder, loc, cond, [&](OpBuilder &builder, Location loc) {
+                memref::CopyOp::create(builder, loc, output1, input);
+                scf::YieldOp::create(builder, loc);
               });
-          builder.create<memref::CopyOp>(loc, copymemref, output1);
+          memref::CopyOp::create(builder, loc, copymemref, output1);
           traverseImagewBoundaryExtrapolation(
               rewriter, loc, ctx, input, kernel, output1, centerX, centerY,
               constantValue, strideVal, inElemTy, boundaryOptionAttr, stride,
               dip::DIP_OP::EROSION_2D);
-          builder.create<affine::AffineYieldOp>(loc);
+          affine::AffineYieldOp::create(builder, loc);
         });
 
-    rewriter.create<affine::AffineForOp>(
-        loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+    affine::AffineForOp::create(
+        rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
         ValueRange{iterations}, rewriter.getDimIdentityMap(), /*Step=*/1,
         ValueRange{},
         [&](OpBuilder &builder, Location nestedLoc, Value iv,
             ValueRange itrArgs) {
-          Value cond = builder.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::sge, iv, c1);
-          builder.create<scf::IfOp>(
-              loc, cond, [&](OpBuilder &builder, Location loc) {
-                builder.create<memref::CopyOp>(loc, output, output1);
-                builder.create<scf::YieldOp>(loc);
+          Value cond = arith::CmpIOp::create(builder, loc,
+                                             arith::CmpIPredicate::sge, iv, c1);
+          scf::IfOp::create(
+              builder, loc, cond, [&](OpBuilder &builder, Location loc) {
+                memref::CopyOp::create(builder, loc, output, output1);
+                scf::YieldOp::create(builder, loc);
               });
-          builder.create<memref::CopyOp>(loc, copymemref1, output);
+          memref::CopyOp::create(builder, loc, copymemref1, output);
           traverseImagewBoundaryExtrapolation(
               rewriter, loc, ctx, output1, kernel, output, centerX, centerY,
               constantValue, strideVal, inElemTy, boundaryOptionAttr, stride,
               dip::DIP_OP::DILATION_2D);
-          builder.create<affine::AffineYieldOp>(loc);
+          affine::AffineYieldOp::create(builder, loc);
         });
 
     // Remove the origin opening operation.
@@ -960,7 +960,7 @@ public:
     Value iterations = op->getOperand(8);
     Value constantValue = op->getOperand(9);
     dip::BoundaryOption boundaryOptionAttr = op.getBoundaryOption();
-    Value strideVal = rewriter.create<arith::ConstantIndexOp>(loc, stride);
+    Value strideVal = arith::ConstantIndexOp::create(rewriter, loc, stride);
 
     auto inElemTy =
         mlir::cast<mlir::MemRefType>(input.getType()).getElementType();
@@ -976,49 +976,49 @@ public:
       return op->emitOpError() << "supports only f32, f64 and integer types. "
                                << inElemTy << "is passed";
     }
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
 
-    rewriter.create<affine::AffineForOp>(
-        loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+    affine::AffineForOp::create(
+        rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
         ValueRange{iterations}, rewriter.getDimIdentityMap(), /*Step=*/1,
         ValueRange{},
         [&](OpBuilder &builder, Location nestedLoc, Value iv,
             ValueRange itrArgs) {
-          Value cond = builder.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::sge, iv, c1);
-          builder.create<scf::IfOp>(
-              loc, cond, [&](OpBuilder &builder, Location loc) {
-                builder.create<memref::CopyOp>(loc, output1, input);
-                builder.create<scf::YieldOp>(loc);
+          Value cond = arith::CmpIOp::create(builder, loc,
+                                             arith::CmpIPredicate::sge, iv, c1);
+          scf::IfOp::create(
+              builder, loc, cond, [&](OpBuilder &builder, Location loc) {
+                memref::CopyOp::create(builder, loc, output1, input);
+                scf::YieldOp::create(builder, loc);
               });
-          builder.create<memref::CopyOp>(loc, copymemref, output1);
+          memref::CopyOp::create(builder, loc, copymemref, output1);
           traverseImagewBoundaryExtrapolation(
               rewriter, loc, ctx, input, kernel, output1, centerX, centerY,
               constantValue, strideVal, inElemTy, boundaryOptionAttr, stride,
               dip::DIP_OP::DILATION_2D);
-          builder.create<affine::AffineYieldOp>(loc);
+          affine::AffineYieldOp::create(builder, loc);
         });
 
-    rewriter.create<affine::AffineForOp>(
-        loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+    affine::AffineForOp::create(
+        rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
         ValueRange{iterations}, rewriter.getDimIdentityMap(), /*Step=*/1,
         ValueRange{},
         [&](OpBuilder &builder, Location nestedLoc, Value iv,
             ValueRange itrArgs) {
-          Value cond = builder.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::sge, iv, c1);
-          builder.create<scf::IfOp>(
-              loc, cond, [&](OpBuilder &builder, Location loc) {
-                builder.create<memref::CopyOp>(loc, output, output1);
-                builder.create<scf::YieldOp>(loc);
+          Value cond = arith::CmpIOp::create(builder, loc,
+                                             arith::CmpIPredicate::sge, iv, c1);
+          scf::IfOp::create(
+              builder, loc, cond, [&](OpBuilder &builder, Location loc) {
+                memref::CopyOp::create(builder, loc, output, output1);
+                scf::YieldOp::create(builder, loc);
               });
-          builder.create<memref::CopyOp>(loc, copymemref1, output);
+          memref::CopyOp::create(builder, loc, copymemref1, output);
           traverseImagewBoundaryExtrapolation(
               rewriter, loc, ctx, output1, kernel, output, centerX, centerY,
               constantValue, strideVal, inElemTy, boundaryOptionAttr, stride,
               dip::DIP_OP::EROSION_2D);
-          builder.create<affine::AffineYieldOp>(loc);
+          affine::AffineYieldOp::create(builder, loc);
         });
 
     // Remove the origin closing operation.
@@ -1045,8 +1045,8 @@ public:
     auto *ctx = op->getContext();
 
     // Create constant indices.
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
 
     // Register operand values.
     Value input = op->getOperand(0);
@@ -1062,7 +1062,7 @@ public:
     Value iterations = op->getOperand(10);
     Value constantValue = op->getOperand(11);
     dip::BoundaryOption boundaryOptionAttr = op.getBoundaryOption();
-    Value strideVal = rewriter.create<arith::ConstantIndexOp>(loc, stride);
+    Value strideVal = arith::ConstantIndexOp::create(rewriter, loc, stride);
 
     auto inElemTy =
         mlir::cast<mlir::MemRefType>(input.getType()).getElementType();
@@ -1080,51 +1080,51 @@ public:
       return op->emitOpError() << "supports only f32, f64 and integer types. "
                                << inElemTy << "is passed";
     }
-    rewriter.create<memref::CopyOp>(loc, input, input1);
-    rewriter.create<affine::AffineForOp>(
-        loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+    memref::CopyOp::create(rewriter, loc, input, input1);
+    affine::AffineForOp::create(
+        rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
         ValueRange{iterations}, rewriter.getDimIdentityMap(), /*Step=*/1,
         ValueRange{},
         [&](OpBuilder &builder, Location nestedLoc, Value iv,
             ValueRange itrArgs) {
-          Value cond = builder.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::sge, iv, c1);
-          builder.create<scf::IfOp>(
-              loc, cond, [&](OpBuilder &builder, Location loc) {
-                builder.create<memref::CopyOp>(loc, output1, input1);
-                builder.create<scf::YieldOp>(loc);
+          Value cond = arith::CmpIOp::create(builder, loc,
+                                             arith::CmpIPredicate::sge, iv, c1);
+          scf::IfOp::create(
+              builder, loc, cond, [&](OpBuilder &builder, Location loc) {
+                memref::CopyOp::create(builder, loc, output1, input1);
+                scf::YieldOp::create(builder, loc);
               });
-          builder.create<memref::CopyOp>(loc, copymemref, output1);
+          memref::CopyOp::create(builder, loc, copymemref, output1);
           traverseImagewBoundaryExtrapolation(
               rewriter, loc, ctx, input1, kernel, output1, centerX, centerY,
               constantValue, strideVal, inElemTy, boundaryOptionAttr, stride,
               dip::DIP_OP::EROSION_2D);
-          builder.create<affine::AffineYieldOp>(loc);
+          affine::AffineYieldOp::create(builder, loc);
         });
 
-    rewriter.create<affine::AffineForOp>(
-        loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+    affine::AffineForOp::create(
+        rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
         ValueRange{iterations}, rewriter.getDimIdentityMap(), /*Step=*/1,
         ValueRange{},
         [&](OpBuilder &builder, Location nestedLoc, Value iv,
             ValueRange itrArgs) {
-          Value cond = builder.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::sge, iv, c1);
-          builder.create<scf::IfOp>(
-              loc, cond, [&](OpBuilder &builder, Location loc) {
-                builder.create<memref::CopyOp>(loc, output2, output1);
-                builder.create<scf::YieldOp>(loc);
+          Value cond = arith::CmpIOp::create(builder, loc,
+                                             arith::CmpIPredicate::sge, iv, c1);
+          scf::IfOp::create(
+              builder, loc, cond, [&](OpBuilder &builder, Location loc) {
+                memref::CopyOp::create(builder, loc, output2, output1);
+                scf::YieldOp::create(builder, loc);
               });
-          builder.create<memref::CopyOp>(loc, copymemref1, output2);
+          memref::CopyOp::create(builder, loc, copymemref1, output2);
           traverseImagewBoundaryExtrapolation(
               rewriter, loc, ctx, output1, kernel, output2, centerX, centerY,
               constantValue, strideVal, inElemTy, boundaryOptionAttr, stride,
               dip::DIP_OP::DILATION_2D);
-          builder.create<affine::AffineYieldOp>(loc);
+          affine::AffineYieldOp::create(builder, loc);
         });
 
-    Value outputRow = rewriter.create<memref::DimOp>(loc, output, c0);
-    Value outputCol = rewriter.create<memref::DimOp>(loc, output, c1);
+    Value outputRow = memref::DimOp::create(rewriter, loc, output, c0);
+    Value outputCol = memref::DimOp::create(rewriter, loc, output, c1);
 
     SmallVector<Value, 8> lowerbounds4(2, c0);
     SmallVector<Value, 8> upperbounds4{outputRow, outputCol};
@@ -1134,48 +1134,50 @@ public:
     VectorType vectorMaskTy = VectorType::get({stride}, i1);
     Value zeroPaddingElem = insertZeroConstantOp(ctx, rewriter, loc, inElemTy);
     Value zeroPaddingVec =
-        rewriter.create<vector::BroadcastOp>(loc, vectorTy32, zeroPaddingElem);
+        vector::BroadcastOp::create(rewriter, loc, vectorTy32, zeroPaddingElem);
 
     if (inElemTy.isF32() || inElemTy.isF64()) {
       affine::buildAffineLoopNest(
           rewriter, loc, lowerbounds4, upperbounds4, steps4,
           [&](OpBuilder &builder, Location loc, ValueRange ivs4) {
             Value pseudoCol =
-                builder.create<arith::AddIOp>(loc, ivs4[1], strideVal);
+                arith::AddIOp::create(builder, loc, ivs4[1], strideVal);
             Value pseudoCol1 =
-                builder.create<arith::SubIOp>(loc, pseudoCol, c1);
-            Value cond = builder.create<arith::CmpIOp>(
-                loc, arith::CmpIPredicate::sgt, pseudoCol1, outputCol);
-            builder.create<scf::IfOp>(
-                loc, cond,
+                arith::SubIOp::create(builder, loc, pseudoCol, c1);
+            Value cond = arith::CmpIOp::create(
+                builder, loc, arith::CmpIPredicate::sgt, pseudoCol1, outputCol);
+            scf::IfOp::create(
+                builder, loc, cond,
                 [&](OpBuilder &builder, Location loc) {
-                  Value res =
-                      builder.create<arith::SubIOp>(loc, pseudoCol1, outputCol);
+                  Value res = arith::SubIOp::create(builder, loc, pseudoCol1,
+                                                    outputCol);
                   Value maskVal =
-                      builder.create<arith::SubIOp>(loc, strideVal, res);
-                  Value maskVec = builder.create<vector::CreateMaskOp>(
-                      loc, vectorMaskTy, maskVal);
-                  Value ou1 = builder.create<vector::MaskedLoadOp>(
-                      loc, vectorTy32, output2, ValueRange{ivs4[0], ivs4[1]},
-                      maskVec, zeroPaddingVec);
-                  Value ou2 = builder.create<vector::MaskedLoadOp>(
-                      loc, vectorTy32, input, ValueRange{ivs4[0], ivs4[1]},
-                      maskVec, zeroPaddingVec);
-                  Value resVec = builder.create<arith::SubFOp>(loc, ou2, ou1);
-                  builder.create<vector::MaskedStoreOp>(
-                      loc, output, ValueRange{ivs4[0], ivs4[1]}, maskVec,
-                      resVec);
-                  builder.create<scf::YieldOp>(loc);
+                      arith::SubIOp::create(builder, loc, strideVal, res);
+                  Value maskVec = vector::CreateMaskOp::create(
+                      builder, loc, vectorMaskTy, maskVal);
+                  Value ou1 = vector::MaskedLoadOp::create(
+                      builder, loc, vectorTy32, output2,
+                      ValueRange{ivs4[0], ivs4[1]}, maskVec, zeroPaddingVec);
+                  Value ou2 = vector::MaskedLoadOp::create(
+                      builder, loc, vectorTy32, input,
+                      ValueRange{ivs4[0], ivs4[1]}, maskVec, zeroPaddingVec);
+                  Value resVec = arith::SubFOp::create(builder, loc, ou2, ou1);
+                  vector::MaskedStoreOp::create(builder, loc, output,
+                                                ValueRange{ivs4[0], ivs4[1]},
+                                                maskVec, resVec);
+                  scf::YieldOp::create(builder, loc);
                 },
                 [&](OpBuilder &builder, Location loc) {
-                  Value ou1 = builder.create<vector::LoadOp>(
-                      loc, vectorTy32, output2, ValueRange{ivs4[0], ivs4[1]});
-                  Value ou2 = builder.create<vector::LoadOp>(
-                      loc, vectorTy32, input, ValueRange{ivs4[0], ivs4[1]});
-                  Value resVec = builder.create<arith::SubFOp>(loc, ou2, ou1);
-                  builder.create<vector::StoreOp>(loc, resVec, output,
-                                                  ValueRange{ivs4[0], ivs4[1]});
-                  builder.create<scf::YieldOp>(loc);
+                  Value ou1 =
+                      vector::LoadOp::create(builder, loc, vectorTy32, output2,
+                                             ValueRange{ivs4[0], ivs4[1]});
+                  Value ou2 =
+                      vector::LoadOp::create(builder, loc, vectorTy32, input,
+                                             ValueRange{ivs4[0], ivs4[1]});
+                  Value resVec = arith::SubFOp::create(builder, loc, ou2, ou1);
+                  vector::StoreOp::create(builder, loc, resVec, output,
+                                          ValueRange{ivs4[0], ivs4[1]});
+                  scf::YieldOp::create(builder, loc);
                 });
           }
 
@@ -1185,41 +1187,43 @@ public:
           rewriter, loc, lowerbounds4, upperbounds4, steps4,
           [&](OpBuilder &builder, Location loc, ValueRange ivs4) {
             Value pseudoCol =
-                builder.create<arith::AddIOp>(loc, ivs4[1], strideVal);
+                arith::AddIOp::create(builder, loc, ivs4[1], strideVal);
             Value pseudoCol1 =
-                builder.create<arith::SubIOp>(loc, pseudoCol, c1);
-            Value cond = builder.create<arith::CmpIOp>(
-                loc, arith::CmpIPredicate::sgt, pseudoCol1, outputCol);
-            builder.create<scf::IfOp>(
-                loc, cond,
+                arith::SubIOp::create(builder, loc, pseudoCol, c1);
+            Value cond = arith::CmpIOp::create(
+                builder, loc, arith::CmpIPredicate::sgt, pseudoCol1, outputCol);
+            scf::IfOp::create(
+                builder, loc, cond,
                 [&](OpBuilder &builder, Location loc) {
-                  Value res =
-                      builder.create<arith::SubIOp>(loc, pseudoCol1, outputCol);
+                  Value res = arith::SubIOp::create(builder, loc, pseudoCol1,
+                                                    outputCol);
                   Value maskVal =
-                      builder.create<arith::SubIOp>(loc, strideVal, res);
-                  Value maskVec = builder.create<vector::CreateMaskOp>(
-                      loc, vectorMaskTy, maskVal);
-                  Value ou1 = builder.create<vector::MaskedLoadOp>(
-                      loc, vectorTy32, output1, ValueRange{ivs4[0], ivs4[1]},
-                      maskVec, zeroPaddingVec);
-                  Value ou2 = builder.create<vector::MaskedLoadOp>(
-                      loc, vectorTy32, output2, ValueRange{ivs4[0], ivs4[1]},
-                      maskVec, zeroPaddingVec);
-                  Value resVec = builder.create<arith::SubIOp>(loc, ou1, ou2);
-                  builder.create<vector::MaskedStoreOp>(
-                      loc, output, ValueRange{ivs4[0], ivs4[1]}, maskVec,
-                      resVec);
-                  builder.create<scf::YieldOp>(loc);
+                      arith::SubIOp::create(builder, loc, strideVal, res);
+                  Value maskVec = vector::CreateMaskOp::create(
+                      builder, loc, vectorMaskTy, maskVal);
+                  Value ou1 = vector::MaskedLoadOp::create(
+                      builder, loc, vectorTy32, output1,
+                      ValueRange{ivs4[0], ivs4[1]}, maskVec, zeroPaddingVec);
+                  Value ou2 = vector::MaskedLoadOp::create(
+                      builder, loc, vectorTy32, output2,
+                      ValueRange{ivs4[0], ivs4[1]}, maskVec, zeroPaddingVec);
+                  Value resVec = arith::SubIOp::create(builder, loc, ou1, ou2);
+                  vector::MaskedStoreOp::create(builder, loc, output,
+                                                ValueRange{ivs4[0], ivs4[1]},
+                                                maskVec, resVec);
+                  scf::YieldOp::create(builder, loc);
                 },
                 [&](OpBuilder &builder, Location loc) {
-                  Value ou1 = builder.create<vector::LoadOp>(
-                      loc, vectorTy32, output1, ValueRange{ivs4[0], ivs4[1]});
-                  Value ou2 = builder.create<vector::LoadOp>(
-                      loc, vectorTy32, output2, ValueRange{ivs4[0], ivs4[1]});
-                  Value resVec = builder.create<arith::SubIOp>(loc, ou1, ou2);
-                  builder.create<vector::StoreOp>(loc, resVec, output,
-                                                  ValueRange{ivs4[0], ivs4[1]});
-                  builder.create<scf::YieldOp>(loc);
+                  Value ou1 =
+                      vector::LoadOp::create(builder, loc, vectorTy32, output1,
+                                             ValueRange{ivs4[0], ivs4[1]});
+                  Value ou2 =
+                      vector::LoadOp::create(builder, loc, vectorTy32, output2,
+                                             ValueRange{ivs4[0], ivs4[1]});
+                  Value resVec = arith::SubIOp::create(builder, loc, ou1, ou2);
+                  vector::StoreOp::create(builder, loc, resVec, output,
+                                          ValueRange{ivs4[0], ivs4[1]});
+                  scf::YieldOp::create(builder, loc);
                 });
           }
 
@@ -1250,8 +1254,8 @@ public:
     auto *ctx = op->getContext();
 
     // Create constant indices.
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
 
     // Register operand values.
     Value input = op->getOperand(0);
@@ -1267,7 +1271,7 @@ public:
     Value iterations = op->getOperand(10);
     Value constantValue = op->getOperand(11);
     dip::BoundaryOption boundaryOptionAttr = op.getBoundaryOption();
-    Value strideVal = rewriter.create<arith::ConstantIndexOp>(loc, stride);
+    Value strideVal = arith::ConstantIndexOp::create(rewriter, loc, stride);
 
     auto inElemTy =
         mlir::cast<mlir::MemRefType>(input.getType()).getElementType();
@@ -1285,51 +1289,51 @@ public:
       return op->emitOpError() << "supports only f32, f64 and integer types. "
                                << inElemTy << "is passed";
     }
-    rewriter.create<memref::CopyOp>(loc, input, input1);
-    rewriter.create<affine::AffineForOp>(
-        loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+    memref::CopyOp::create(rewriter, loc, input, input1);
+    affine::AffineForOp::create(
+        rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
         ValueRange{iterations}, rewriter.getDimIdentityMap(), /*Step=*/1,
         ValueRange{},
         [&](OpBuilder &builder, Location nestedLoc, Value iv,
             ValueRange itrArgs) {
-          Value cond = builder.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::sge, iv, c1);
-          builder.create<scf::IfOp>(
-              loc, cond, [&](OpBuilder &builder, Location loc) {
-                builder.create<memref::CopyOp>(loc, output1, input1);
-                builder.create<scf::YieldOp>(loc);
+          Value cond = arith::CmpIOp::create(builder, loc,
+                                             arith::CmpIPredicate::sge, iv, c1);
+          scf::IfOp::create(
+              builder, loc, cond, [&](OpBuilder &builder, Location loc) {
+                memref::CopyOp::create(builder, loc, output1, input1);
+                scf::YieldOp::create(builder, loc);
               });
-          builder.create<memref::CopyOp>(loc, copymemref, output1);
+          memref::CopyOp::create(builder, loc, copymemref, output1);
           traverseImagewBoundaryExtrapolation(
               rewriter, loc, ctx, input1, kernel, output1, centerX, centerY,
               constantValue, strideVal, inElemTy, boundaryOptionAttr, stride,
               dip::DIP_OP::DILATION_2D);
-          builder.create<affine::AffineYieldOp>(loc);
+          affine::AffineYieldOp::create(builder, loc);
         });
 
-    rewriter.create<affine::AffineForOp>(
-        loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+    affine::AffineForOp::create(
+        rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
         ValueRange{iterations}, rewriter.getDimIdentityMap(), /*Step=*/1,
         ValueRange{},
         [&](OpBuilder &builder, Location nestedLoc, Value iv,
             ValueRange itrArgs) {
-          Value cond = builder.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::sge, iv, c1);
-          builder.create<scf::IfOp>(
-              loc, cond, [&](OpBuilder &builder, Location loc) {
-                builder.create<memref::CopyOp>(loc, output2, output1);
-                builder.create<scf::YieldOp>(loc);
+          Value cond = arith::CmpIOp::create(builder, loc,
+                                             arith::CmpIPredicate::sge, iv, c1);
+          scf::IfOp::create(
+              builder, loc, cond, [&](OpBuilder &builder, Location loc) {
+                memref::CopyOp::create(builder, loc, output2, output1);
+                scf::YieldOp::create(builder, loc);
               });
-          builder.create<memref::CopyOp>(loc, copymemref1, output2);
+          memref::CopyOp::create(builder, loc, copymemref1, output2);
           traverseImagewBoundaryExtrapolation(
               rewriter, loc, ctx, output1, kernel, output2, centerX, centerY,
               constantValue, strideVal, inElemTy, boundaryOptionAttr, stride,
               dip::DIP_OP::EROSION_2D);
-          builder.create<affine::AffineYieldOp>(loc);
+          affine::AffineYieldOp::create(builder, loc);
         });
 
-    Value outputRow = rewriter.create<memref::DimOp>(loc, output, c0);
-    Value outputCol = rewriter.create<memref::DimOp>(loc, output, c1);
+    Value outputRow = memref::DimOp::create(rewriter, loc, output, c0);
+    Value outputCol = memref::DimOp::create(rewriter, loc, output, c1);
 
     SmallVector<Value, 8> lowerbounds4(2, c0);
     SmallVector<Value, 8> upperbounds4{outputRow, outputCol};
@@ -1340,48 +1344,50 @@ public:
     VectorType vectorMaskTy = VectorType::get({stride}, i1);
     Value zeroPaddingElem = insertZeroConstantOp(ctx, rewriter, loc, inElemTy);
     Value zeroPaddingVec =
-        rewriter.create<vector::BroadcastOp>(loc, vectorTy32, zeroPaddingElem);
+        vector::BroadcastOp::create(rewriter, loc, vectorTy32, zeroPaddingElem);
 
     if (inElemTy.isF32() || inElemTy.isF64()) {
       affine::buildAffineLoopNest(
           rewriter, loc, lowerbounds4, upperbounds4, steps4,
           [&](OpBuilder &builder, Location loc, ValueRange ivs4) {
             Value pseudoCol =
-                builder.create<arith::AddIOp>(loc, ivs4[1], strideVal);
+                arith::AddIOp::create(builder, loc, ivs4[1], strideVal);
             Value pseudoCol1 =
-                builder.create<arith::SubIOp>(loc, pseudoCol, c1);
-            Value cond = builder.create<arith::CmpIOp>(
-                loc, arith::CmpIPredicate::sgt, pseudoCol1, outputCol);
-            builder.create<scf::IfOp>(
-                loc, cond,
+                arith::SubIOp::create(builder, loc, pseudoCol, c1);
+            Value cond = arith::CmpIOp::create(
+                builder, loc, arith::CmpIPredicate::sgt, pseudoCol1, outputCol);
+            scf::IfOp::create(
+                builder, loc, cond,
                 [&](OpBuilder &builder, Location loc) {
-                  Value res =
-                      builder.create<arith::SubIOp>(loc, pseudoCol1, outputCol);
+                  Value res = arith::SubIOp::create(builder, loc, pseudoCol1,
+                                                    outputCol);
                   Value maskVal =
-                      builder.create<arith::SubIOp>(loc, strideVal, res);
-                  Value maskVec = builder.create<vector::CreateMaskOp>(
-                      loc, vectorMaskTy, maskVal);
-                  Value ou = builder.create<vector::MaskedLoadOp>(
-                      loc, vectorTy32, output2, ValueRange{ivs4[0], ivs4[1]},
-                      maskVec, zeroPaddingVec);
-                  Value in = builder.create<vector::MaskedLoadOp>(
-                      loc, vectorTy32, input, ValueRange{ivs4[0], ivs4[1]},
-                      maskVec, zeroPaddingVec);
-                  Value resVec = builder.create<arith::SubFOp>(loc, ou, in);
-                  builder.create<vector::MaskedStoreOp>(
-                      loc, output, ValueRange{ivs4[0], ivs4[1]}, maskVec,
-                      resVec);
-                  builder.create<scf::YieldOp>(loc);
+                      arith::SubIOp::create(builder, loc, strideVal, res);
+                  Value maskVec = vector::CreateMaskOp::create(
+                      builder, loc, vectorMaskTy, maskVal);
+                  Value ou = vector::MaskedLoadOp::create(
+                      builder, loc, vectorTy32, output2,
+                      ValueRange{ivs4[0], ivs4[1]}, maskVec, zeroPaddingVec);
+                  Value in = vector::MaskedLoadOp::create(
+                      builder, loc, vectorTy32, input,
+                      ValueRange{ivs4[0], ivs4[1]}, maskVec, zeroPaddingVec);
+                  Value resVec = arith::SubFOp::create(builder, loc, ou, in);
+                  vector::MaskedStoreOp::create(builder, loc, output,
+                                                ValueRange{ivs4[0], ivs4[1]},
+                                                maskVec, resVec);
+                  scf::YieldOp::create(builder, loc);
                 },
                 [&](OpBuilder &builder, Location loc) {
-                  Value ou = builder.create<vector::LoadOp>(
-                      loc, vectorTy32, output2, ValueRange{ivs4[0], ivs4[1]});
-                  Value in = builder.create<vector::LoadOp>(
-                      loc, vectorTy32, input, ValueRange{ivs4[0], ivs4[1]});
-                  Value resVec = builder.create<arith::SubFOp>(loc, ou, in);
-                  builder.create<vector::StoreOp>(loc, resVec, output,
-                                                  ValueRange{ivs4[0], ivs4[1]});
-                  builder.create<scf::YieldOp>(loc);
+                  Value ou =
+                      vector::LoadOp::create(builder, loc, vectorTy32, output2,
+                                             ValueRange{ivs4[0], ivs4[1]});
+                  Value in =
+                      vector::LoadOp::create(builder, loc, vectorTy32, input,
+                                             ValueRange{ivs4[0], ivs4[1]});
+                  Value resVec = arith::SubFOp::create(builder, loc, ou, in);
+                  vector::StoreOp::create(builder, loc, resVec, output,
+                                          ValueRange{ivs4[0], ivs4[1]});
+                  scf::YieldOp::create(builder, loc);
                 });
           }
 
@@ -1391,41 +1397,43 @@ public:
           rewriter, loc, lowerbounds4, upperbounds4, steps4,
           [&](OpBuilder &builder, Location loc, ValueRange ivs4) {
             Value pseudoCol =
-                builder.create<arith::AddIOp>(loc, ivs4[1], strideVal);
+                arith::AddIOp::create(builder, loc, ivs4[1], strideVal);
             Value pseudoCol1 =
-                builder.create<arith::SubIOp>(loc, pseudoCol, c1);
-            Value cond = builder.create<arith::CmpIOp>(
-                loc, arith::CmpIPredicate::sgt, pseudoCol1, outputCol);
-            builder.create<scf::IfOp>(
-                loc, cond,
+                arith::SubIOp::create(builder, loc, pseudoCol, c1);
+            Value cond = arith::CmpIOp::create(
+                builder, loc, arith::CmpIPredicate::sgt, pseudoCol1, outputCol);
+            scf::IfOp::create(
+                builder, loc, cond,
                 [&](OpBuilder &builder, Location loc) {
-                  Value res =
-                      builder.create<arith::SubIOp>(loc, pseudoCol1, outputCol);
+                  Value res = arith::SubIOp::create(builder, loc, pseudoCol1,
+                                                    outputCol);
                   Value maskVal =
-                      builder.create<arith::SubIOp>(loc, strideVal, res);
-                  Value maskVec = builder.create<vector::CreateMaskOp>(
-                      loc, vectorMaskTy, maskVal);
-                  Value ou = builder.create<vector::MaskedLoadOp>(
-                      loc, vectorTy32, output2, ValueRange{ivs4[0], ivs4[1]},
-                      maskVec, zeroPaddingVec);
-                  Value in = builder.create<vector::MaskedLoadOp>(
-                      loc, vectorTy32, input, ValueRange{ivs4[0], ivs4[1]},
-                      maskVec, zeroPaddingVec);
-                  Value resVec = builder.create<arith::SubIOp>(loc, ou, in);
-                  builder.create<vector::MaskedStoreOp>(
-                      loc, output, ValueRange{ivs4[0], ivs4[1]}, maskVec,
-                      resVec);
-                  builder.create<scf::YieldOp>(loc);
+                      arith::SubIOp::create(builder, loc, strideVal, res);
+                  Value maskVec = vector::CreateMaskOp::create(
+                      builder, loc, vectorMaskTy, maskVal);
+                  Value ou = vector::MaskedLoadOp::create(
+                      builder, loc, vectorTy32, output2,
+                      ValueRange{ivs4[0], ivs4[1]}, maskVec, zeroPaddingVec);
+                  Value in = vector::MaskedLoadOp::create(
+                      builder, loc, vectorTy32, input,
+                      ValueRange{ivs4[0], ivs4[1]}, maskVec, zeroPaddingVec);
+                  Value resVec = arith::SubIOp::create(builder, loc, ou, in);
+                  vector::MaskedStoreOp::create(builder, loc, output,
+                                                ValueRange{ivs4[0], ivs4[1]},
+                                                maskVec, resVec);
+                  scf::YieldOp::create(builder, loc);
                 },
                 [&](OpBuilder &builder, Location loc) {
-                  Value ou = builder.create<vector::LoadOp>(
-                      loc, vectorTy32, output2, ValueRange{ivs4[0], ivs4[1]});
-                  Value in = builder.create<vector::LoadOp>(
-                      loc, vectorTy32, input, ValueRange{ivs4[0], ivs4[1]});
-                  Value resVec = builder.create<arith::SubIOp>(loc, ou, in);
-                  builder.create<vector::StoreOp>(loc, resVec, output,
-                                                  ValueRange{ivs4[0], ivs4[1]});
-                  builder.create<scf::YieldOp>(loc);
+                  Value ou =
+                      vector::LoadOp::create(builder, loc, vectorTy32, output2,
+                                             ValueRange{ivs4[0], ivs4[1]});
+                  Value in =
+                      vector::LoadOp::create(builder, loc, vectorTy32, input,
+                                             ValueRange{ivs4[0], ivs4[1]});
+                  Value resVec = arith::SubIOp::create(builder, loc, ou, in);
+                  vector::StoreOp::create(builder, loc, resVec, output,
+                                          ValueRange{ivs4[0], ivs4[1]});
+                  scf::YieldOp::create(builder, loc);
                 });
           });
     }
@@ -1466,7 +1474,7 @@ public:
     Value iterations = op->getOperand(10);
     Value constantValue = op->getOperand(11);
     dip::BoundaryOption boundaryOptionAttr = op.getBoundaryOption();
-    Value strideVal = rewriter.create<arith::ConstantIndexOp>(loc, stride);
+    Value strideVal = arith::ConstantIndexOp::create(rewriter, loc, stride);
 
     auto inElemTy =
         mlir::cast<mlir::MemRefType>(input.getType()).getElementType();
@@ -1484,54 +1492,54 @@ public:
       return op->emitOpError() << "supports only f32, f64 and integer types. "
                                << inElemTy << "is passed";
     }
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    rewriter.create<memref::CopyOp>(loc, input, input1);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    memref::CopyOp::create(rewriter, loc, input, input1);
 
-    rewriter.create<affine::AffineForOp>(
-        loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+    affine::AffineForOp::create(
+        rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
         ValueRange{iterations}, rewriter.getDimIdentityMap(), /*Step=*/1,
         ValueRange{},
         [&](OpBuilder &builder, Location nestedLoc, Value iv,
             ValueRange itrArgs) {
-          Value cond = builder.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::sge, iv, c1);
-          builder.create<scf::IfOp>(
-              loc, cond, [&](OpBuilder &builder, Location loc) {
-                builder.create<memref::CopyOp>(loc, output1, input);
-                builder.create<scf::YieldOp>(loc);
+          Value cond = arith::CmpIOp::create(builder, loc,
+                                             arith::CmpIPredicate::sge, iv, c1);
+          scf::IfOp::create(
+              builder, loc, cond, [&](OpBuilder &builder, Location loc) {
+                memref::CopyOp::create(builder, loc, output1, input);
+                scf::YieldOp::create(builder, loc);
               });
-          builder.create<memref::CopyOp>(loc, copymemref, output1);
+          memref::CopyOp::create(builder, loc, copymemref, output1);
           traverseImagewBoundaryExtrapolation(
               rewriter, loc, ctx, input, kernel, output1, centerX, centerY,
               constantValue, strideVal, inElemTy, boundaryOptionAttr, stride,
               dip::DIP_OP::DILATION_2D);
-          builder.create<affine::AffineYieldOp>(loc);
+          affine::AffineYieldOp::create(builder, loc);
         });
 
-    rewriter.create<affine::AffineForOp>(
-        loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+    affine::AffineForOp::create(
+        rewriter, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
         ValueRange{iterations}, rewriter.getDimIdentityMap(), /*Step=*/1,
         ValueRange{},
         [&](OpBuilder &builder, Location nestedLoc, Value iv,
             ValueRange itrArgs) {
-          Value cond = builder.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::sge, iv, c1);
-          builder.create<scf::IfOp>(
-              loc, cond, [&](OpBuilder &builder, Location loc) {
-                builder.create<memref::CopyOp>(loc, output2, input1);
-                builder.create<scf::YieldOp>(loc);
+          Value cond = arith::CmpIOp::create(builder, loc,
+                                             arith::CmpIPredicate::sge, iv, c1);
+          scf::IfOp::create(
+              builder, loc, cond, [&](OpBuilder &builder, Location loc) {
+                memref::CopyOp::create(builder, loc, output2, input1);
+                scf::YieldOp::create(builder, loc);
               });
-          builder.create<memref::CopyOp>(loc, copymemref1, output2);
+          memref::CopyOp::create(builder, loc, copymemref1, output2);
           traverseImagewBoundaryExtrapolation(
               rewriter, loc, ctx, input1, kernel, output2, centerX, centerY,
               constantValue, strideVal, inElemTy, boundaryOptionAttr, stride,
               dip::DIP_OP::EROSION_2D);
-          builder.create<affine::AffineYieldOp>(loc);
+          affine::AffineYieldOp::create(builder, loc);
         });
 
-    Value outputRow = rewriter.create<memref::DimOp>(loc, output, c0);
-    Value outputCol = rewriter.create<memref::DimOp>(loc, output, c1);
+    Value outputRow = memref::DimOp::create(rewriter, loc, output, c0);
+    Value outputCol = memref::DimOp::create(rewriter, loc, output, c1);
 
     SmallVector<Value, 8> lowerbounds4(2, c0);
     SmallVector<Value, 8> upperbounds4{outputRow, outputCol};
@@ -1542,48 +1550,50 @@ public:
     VectorType vectorMaskTy = VectorType::get({stride}, i1);
     Value zeroPaddingElem = insertZeroConstantOp(ctx, rewriter, loc, inElemTy);
     Value zeroPaddingVec =
-        rewriter.create<vector::BroadcastOp>(loc, vectorTy32, zeroPaddingElem);
+        vector::BroadcastOp::create(rewriter, loc, vectorTy32, zeroPaddingElem);
 
     if (inElemTy.isF32() || inElemTy.isF64()) {
       affine::buildAffineLoopNest(
           rewriter, loc, lowerbounds4, upperbounds4, steps4,
           [&](OpBuilder &builder, Location loc, ValueRange ivs4) {
             Value pseudoCol =
-                builder.create<arith::AddIOp>(loc, ivs4[1], strideVal);
+                arith::AddIOp::create(builder, loc, ivs4[1], strideVal);
             Value pseudoCol1 =
-                builder.create<arith::SubIOp>(loc, pseudoCol, c1);
-            Value cond = builder.create<arith::CmpIOp>(
-                loc, arith::CmpIPredicate::sgt, pseudoCol1, outputCol);
-            builder.create<scf::IfOp>(
-                loc, cond,
+                arith::SubIOp::create(builder, loc, pseudoCol, c1);
+            Value cond = arith::CmpIOp::create(
+                builder, loc, arith::CmpIPredicate::sgt, pseudoCol1, outputCol);
+            scf::IfOp::create(
+                builder, loc, cond,
                 [&](OpBuilder &builder, Location loc) {
-                  Value res =
-                      builder.create<arith::SubIOp>(loc, pseudoCol1, outputCol);
+                  Value res = arith::SubIOp::create(builder, loc, pseudoCol1,
+                                                    outputCol);
                   Value maskVal =
-                      builder.create<arith::SubIOp>(loc, strideVal, res);
-                  Value maskVec = builder.create<vector::CreateMaskOp>(
-                      loc, vectorMaskTy, maskVal);
-                  Value ou1 = builder.create<vector::MaskedLoadOp>(
-                      loc, vectorTy32, output1, ValueRange{ivs4[0], ivs4[1]},
-                      maskVec, zeroPaddingVec);
-                  Value ou2 = builder.create<vector::MaskedLoadOp>(
-                      loc, vectorTy32, output2, ValueRange{ivs4[0], ivs4[1]},
-                      maskVec, zeroPaddingVec);
-                  Value resVec = builder.create<arith::SubFOp>(loc, ou1, ou2);
-                  builder.create<vector::MaskedStoreOp>(
-                      loc, output, ValueRange{ivs4[0], ivs4[1]}, maskVec,
-                      resVec);
-                  builder.create<scf::YieldOp>(loc);
+                      arith::SubIOp::create(builder, loc, strideVal, res);
+                  Value maskVec = vector::CreateMaskOp::create(
+                      builder, loc, vectorMaskTy, maskVal);
+                  Value ou1 = vector::MaskedLoadOp::create(
+                      builder, loc, vectorTy32, output1,
+                      ValueRange{ivs4[0], ivs4[1]}, maskVec, zeroPaddingVec);
+                  Value ou2 = vector::MaskedLoadOp::create(
+                      builder, loc, vectorTy32, output2,
+                      ValueRange{ivs4[0], ivs4[1]}, maskVec, zeroPaddingVec);
+                  Value resVec = arith::SubFOp::create(builder, loc, ou1, ou2);
+                  vector::MaskedStoreOp::create(builder, loc, output,
+                                                ValueRange{ivs4[0], ivs4[1]},
+                                                maskVec, resVec);
+                  scf::YieldOp::create(builder, loc);
                 },
                 [&](OpBuilder &builder, Location loc) {
-                  Value ou1 = builder.create<vector::LoadOp>(
-                      loc, vectorTy32, output1, ValueRange{ivs4[0], ivs4[1]});
-                  Value ou2 = builder.create<vector::LoadOp>(
-                      loc, vectorTy32, output2, ValueRange{ivs4[0], ivs4[1]});
-                  Value resVec = builder.create<arith::SubFOp>(loc, ou1, ou2);
-                  builder.create<vector::StoreOp>(loc, resVec, output,
-                                                  ValueRange{ivs4[0], ivs4[1]});
-                  builder.create<scf::YieldOp>(loc);
+                  Value ou1 =
+                      vector::LoadOp::create(builder, loc, vectorTy32, output1,
+                                             ValueRange{ivs4[0], ivs4[1]});
+                  Value ou2 =
+                      vector::LoadOp::create(builder, loc, vectorTy32, output2,
+                                             ValueRange{ivs4[0], ivs4[1]});
+                  Value resVec = arith::SubFOp::create(builder, loc, ou1, ou2);
+                  vector::StoreOp::create(builder, loc, resVec, output,
+                                          ValueRange{ivs4[0], ivs4[1]});
+                  scf::YieldOp::create(builder, loc);
                 });
           }
 
@@ -1593,39 +1603,41 @@ public:
           rewriter, loc, lowerbounds4, upperbounds4, steps4,
           [&](OpBuilder &builder, Location loc, ValueRange ivs4) {
             Value pseudoCol =
-                builder.create<arith::AddIOp>(loc, ivs4[1], strideVal);
+                arith::AddIOp::create(builder, loc, ivs4[1], strideVal);
             Value pseudoCol1 =
-                builder.create<arith::SubIOp>(loc, pseudoCol, c1);
-            Value cond = builder.create<arith::CmpIOp>(
-                loc, arith::CmpIPredicate::sgt, pseudoCol1, outputCol);
-            builder.create<scf::IfOp>(
-                loc, cond,
+                arith::SubIOp::create(builder, loc, pseudoCol, c1);
+            Value cond = arith::CmpIOp::create(
+                builder, loc, arith::CmpIPredicate::sgt, pseudoCol1, outputCol);
+            scf::IfOp::create(
+                builder, loc, cond,
                 [&](OpBuilder &builder, Location loc) {
-                  Value res =
-                      builder.create<arith::SubIOp>(loc, pseudoCol1, outputCol);
+                  Value res = arith::SubIOp::create(builder, loc, pseudoCol1,
+                                                    outputCol);
                   Value maskVal =
-                      builder.create<arith::SubIOp>(loc, strideVal, res);
-                  Value maskVec = builder.create<vector::CreateMaskOp>(
-                      loc, vectorMaskTy, maskVal);
-                  Value ou1 = builder.create<vector::MaskedLoadOp>(
-                      loc, vectorTy32, output1, ValueRange{ivs4[0], ivs4[1]},
-                      maskVec, zeroPaddingVec);
-                  Value ou2 = builder.create<vector::MaskedLoadOp>(
-                      loc, vectorTy32, output2, ValueRange{ivs4[0], ivs4[1]},
-                      maskVec, zeroPaddingVec);
-                  Value resVec = builder.create<arith::SubFOp>(loc, ou1, ou2);
-                  builder.create<vector::MaskedStoreOp>(
-                      loc, output, ValueRange{ivs4[0], ivs4[1]}, maskVec,
-                      resVec);
+                      arith::SubIOp::create(builder, loc, strideVal, res);
+                  Value maskVec = vector::CreateMaskOp::create(
+                      builder, loc, vectorMaskTy, maskVal);
+                  Value ou1 = vector::MaskedLoadOp::create(
+                      builder, loc, vectorTy32, output1,
+                      ValueRange{ivs4[0], ivs4[1]}, maskVec, zeroPaddingVec);
+                  Value ou2 = vector::MaskedLoadOp::create(
+                      builder, loc, vectorTy32, output2,
+                      ValueRange{ivs4[0], ivs4[1]}, maskVec, zeroPaddingVec);
+                  Value resVec = arith::SubFOp::create(builder, loc, ou1, ou2);
+                  vector::MaskedStoreOp::create(builder, loc, output,
+                                                ValueRange{ivs4[0], ivs4[1]},
+                                                maskVec, resVec);
                 },
                 [&](OpBuilder &builder, Location loc) {
-                  Value ou1 = builder.create<vector::LoadOp>(
-                      loc, vectorTy32, output1, ValueRange{ivs4[0], ivs4[1]});
-                  Value ou2 = builder.create<vector::LoadOp>(
-                      loc, vectorTy32, output2, ValueRange{ivs4[0], ivs4[1]});
-                  Value resVec = builder.create<arith::SubFOp>(loc, ou1, ou2);
-                  builder.create<vector::StoreOp>(loc, resVec, output,
-                                                  ValueRange{ivs4[0], ivs4[1]});
+                  Value ou1 =
+                      vector::LoadOp::create(builder, loc, vectorTy32, output1,
+                                             ValueRange{ivs4[0], ivs4[1]});
+                  Value ou2 =
+                      vector::LoadOp::create(builder, loc, vectorTy32, output2,
+                                             ValueRange{ivs4[0], ivs4[1]});
+                  Value resVec = arith::SubFOp::create(builder, loc, ou1, ou2);
+                  vector::StoreOp::create(builder, loc, resVec, output,
+                                          ValueRange{ivs4[0], ivs4[1]});
                 });
           });
     }

--- a/midend/lib/Conversion/LowerGemmini/LowerGemminiPass.cpp
+++ b/midend/lib/Conversion/LowerGemmini/LowerGemminiPass.cpp
@@ -73,12 +73,12 @@ public:
         loc, rewriter, "nl", StringRef("\n\0", 2), parentModule);
     SmallVector<Value, 4> loopIvs;
     for (unsigned i = 0, e = memRefShape.size(); i != e; ++i) {
-      auto lowerBound = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+      auto lowerBound = arith::ConstantIndexOp::create(rewriter, loc, 0);
       auto upperBound =
-          rewriter.create<arith::ConstantIndexOp>(loc, memRefShape[i]);
-      auto step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+          arith::ConstantIndexOp::create(rewriter, loc, memRefShape[i]);
+      auto step = arith::ConstantIndexOp::create(rewriter, loc, 1);
       auto loop =
-          rewriter.create<scf::ForOp>(loc, lowerBound, upperBound, step);
+          scf::ForOp::create(rewriter, loc, lowerBound, upperBound, step);
       for (Operation &nested : *loop.getBody())
         rewriter.eraseOp(&nested);
       loopIvs.push_back(loop.getInductionVar());
@@ -86,24 +86,23 @@ public:
       rewriter.setInsertionPointToEnd(loop.getBody());
 
       if (i != e - 1)
-        rewriter.create<LLVM::CallOp>(loc, getPrintfType(context), printfRef,
-                                      newLineCst);
-      rewriter.create<scf::YieldOp>(loc);
+        LLVM::CallOp::create(rewriter, loc, getPrintfType(context), printfRef,
+                             newLineCst);
+      scf::YieldOp::create(rewriter, loc);
       rewriter.setInsertionPointToStart(loop.getBody());
     }
 
     auto printOp = cast<gemmini::PrintOp>(op);
     Value elementLoad =
-        rewriter.create<memref::LoadOp>(loc, printOp.getInput(), loopIvs);
+        memref::LoadOp::create(rewriter, loc, printOp.getInput(), loopIvs);
     if (elementLoad.getType() == rewriter.getF32Type())
-      elementLoad = rewriter.create<mlir::LLVM::FPExtOp>(
-          loc, rewriter.getF64Type(), elementLoad);
+      elementLoad = mlir::LLVM::FPExtOp::create(
+          rewriter, loc, rewriter.getF64Type(), elementLoad);
     else if (elementLoad.getType() == rewriter.getI8Type())
-      elementLoad = rewriter.create<mlir::LLVM::SExtOp>(
-          loc, rewriter.getI32Type(), elementLoad);
-    rewriter.create<LLVM::CallOp>(
-        loc, getPrintfType(context), printfRef,
-        ArrayRef<Value>({formatSpecifierCst, elementLoad}));
+      elementLoad = mlir::LLVM::SExtOp::create(
+          rewriter, loc, rewriter.getI32Type(), elementLoad);
+    LLVM::CallOp::create(rewriter, loc, getPrintfType(context), printfRef,
+                         ArrayRef<Value>({formatSpecifierCst, elementLoad}));
 
     rewriter.eraseOp(op);
     return success();
@@ -124,8 +123,8 @@ private:
 
     PatternRewriter::InsertionGuard insertGuard(rewriter);
     rewriter.setInsertionPointToStart(module.getBody());
-    rewriter.create<LLVM::LLVMFuncOp>(module.getLoc(), "printf",
-                                      getPrintfType(context));
+    LLVM::LLVMFuncOp::create(rewriter, module.getLoc(), "printf",
+                             getPrintfType(context));
     return SymbolRefAttr::get(context, "printf");
   }
 
@@ -138,17 +137,17 @@ private:
       builder.setInsertionPointToStart(module.getBody());
       auto type = LLVM::LLVMArrayType::get(
           IntegerType::get(builder.getContext(), 8), value.size());
-      global = builder.create<LLVM::GlobalOp>(loc, type, true,
-                                              LLVM::Linkage::Internal, name,
-                                              builder.getStringAttr(value), 0);
+      global = LLVM::GlobalOp::create(builder, loc, type, true,
+                                      LLVM::Linkage::Internal, name,
+                                      builder.getStringAttr(value), 0);
     }
 
-    Value globalPtr = builder.create<LLVM::AddressOfOp>(loc, global);
-    Value cst0 = builder.create<LLVM::ConstantOp>(loc, builder.getI64Type(),
-                                                  builder.getIndexAttr(0));
-    return builder.create<LLVM::GEPOp>(
-        loc, LLVM::LLVMPointerType::get(builder.getContext()), global.getType(),
-        globalPtr, ArrayRef<Value>({cst0, cst0}));
+    Value globalPtr = LLVM::AddressOfOp::create(builder, loc, global);
+    Value cst0 = LLVM::ConstantOp::create(builder, loc, builder.getI64Type(),
+                                          builder.getIndexAttr(0));
+    return LLVM::GEPOp::create(
+        builder, loc, LLVM::LLVMPointerType::get(builder.getContext()),
+        global.getType(), globalPtr, ArrayRef<Value>({cst0, cst0}));
   }
 };
 

--- a/midend/lib/Conversion/LowerLinalgToGemmini/LowerLinalgToGemmini.cpp
+++ b/midend/lib/Conversion/LowerLinalgToGemmini/LowerLinalgToGemmini.cpp
@@ -74,10 +74,10 @@ public:
     }
     llvm::APFloat scale1((float)1.0);
     llvm::APFloat scale0((float)0.0);
-    Value bias = rewriter.create<memref::AllocOp>(loc, biasType);
-    Value fillOpInputValue =
-        rewriter.create<arith::ConstantOp>(loc, fillOpInsType, fillOpInputAttr);
-    rewriter.create<linalg::FillOp>(loc, fillOpInputValue, bias);
+    Value bias = memref::AllocOp::create(rewriter, loc, biasType);
+    Value fillOpInputValue = arith::ConstantOp::create(
+        rewriter, loc, fillOpInsType, fillOpInputAttr);
+    linalg::FillOp::create(rewriter, loc, fillOpInputValue, bias);
     // Collapse 3D (1xMxK, 1xKxN, 1xMxN) -> 2D (MxK, KxN, MxN)
     Value aVal = input0;
     Value bVal = input1;
@@ -85,17 +85,17 @@ public:
     Value biasVal = bias;
     if (needCollapse) {
       SmallVector<SmallVector<int64_t, 2>, 2> reassoc = {{0, 1}, {2}};
-      aVal = rewriter.create<memref::CollapseShapeOp>(loc, input0, reassoc);
-      bVal = rewriter.create<memref::CollapseShapeOp>(loc, input1, reassoc);
-      oVal = rewriter.create<memref::CollapseShapeOp>(loc, output0, reassoc);
-      biasVal = rewriter.create<memref::CollapseShapeOp>(loc, bias, reassoc);
+      aVal = memref::CollapseShapeOp::create(rewriter, loc, input0, reassoc);
+      bVal = memref::CollapseShapeOp::create(rewriter, loc, input1, reassoc);
+      oVal = memref::CollapseShapeOp::create(rewriter, loc, output0, reassoc);
+      biasVal = memref::CollapseShapeOp::create(rewriter, loc, bias, reassoc);
     }
 
     rewriter.replaceOpWithNewOp<gemmini::TileMatMulOp>(
         matMulOp, aVal, bVal, oVal, biasVal, /*aScaleFactor = */ scale1,
         /*bScaleFactor = */ scale1, /*dScaleFactor = */ scale1, /*act = */ 0,
         /*accScale = */ scale1, /*bertScale = */ scale0);
-    rewriter.create<memref::DeallocOp>(loc, bias);
+    memref::DeallocOp::create(rewriter, loc, bias);
     return success();
   }
 
@@ -139,95 +139,96 @@ public:
     SmallVector<int64_t> kernelMatShape = {
         kernelShape[1] * kernelShape[2] * kernelShape[3], kernelShape[0]};
     MemRefType kernelMatType = MemRefType::get(kernelMatShape, kernelElemType);
-    Value kernelMat = rewriter.create<memref::AllocOp>(loc, kernelMatType);
+    Value kernelMat = memref::AllocOp::create(rewriter, loc, kernelMatType);
     SmallVector<int64_t> outputMatShape = {
         outputShape[0] * outputShape[1] * outputShape[2], outputShape[3]};
     MemRefType outputMatType = MemRefType::get(outputMatShape, outputElemType);
-    Value outputMat = rewriter.create<memref::AllocOp>(loc, outputMatType);
+    Value outputMat = memref::AllocOp::create(rewriter, loc, outputMatType);
     MemRefType biasType =
         MemRefType::get(outputShape[3], rewriter.getI32Type());
     if (accType == "f32")
       biasType = MemRefType::get(outputShape[3], rewriter.getF32Type());
-    Value bias = rewriter.create<memref::AllocOp>(loc, biasType);
+    Value bias = memref::AllocOp::create(rewriter, loc, biasType);
     TypedAttr attr = rewriter.getI32IntegerAttr(0);
     if (accType == "f32")
       attr = rewriter.getF32FloatAttr(0);
-    Value constant0 = rewriter.create<arith::ConstantOp>(loc, attr);
+    Value constant0 = arith::ConstantOp::create(rewriter, loc, attr);
     SmallVector<Value, 1> inputs = {constant0};
     SmallVector<Value, 1> outputs = {bias};
-    rewriter.create<linalg::FillOp>(loc, inputs, outputs);
+    linalg::FillOp::create(rewriter, loc, inputs, outputs);
     Operation *loopOp = nullptr;
     SmallVector<Value, 4> loopIvs;
     for (size_t i = 0; i != kernelShape.size(); i++) {
-      Value lowerBound = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+      Value lowerBound = arith::ConstantIndexOp::create(rewriter, loc, 0);
       Value upperBound =
-          rewriter.create<arith::ConstantIndexOp>(loc, kernelShape[i]);
-      Value step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+          arith::ConstantIndexOp::create(rewriter, loc, kernelShape[i]);
+      Value step = arith::ConstantIndexOp::create(rewriter, loc, 1);
       auto loop =
-          rewriter.create<scf::ForOp>(loc, lowerBound, upperBound, step);
+          scf::ForOp::create(rewriter, loc, lowerBound, upperBound, step);
       loopIvs.push_back(loop.getInductionVar());
       if (i == 0)
         loopOp = loop.getOperation();
       rewriter.setInsertionPointToStart(loop.getBody());
     }
     Value kernelWidth =
-        rewriter.create<arith::ConstantIndexOp>(loc, kernelShape[2]);
+        arith::ConstantIndexOp::create(rewriter, loc, kernelShape[2]);
     Value inChannels =
-        rewriter.create<arith::ConstantIndexOp>(loc, kernelShape[3]);
+        arith::ConstantIndexOp::create(rewriter, loc, kernelShape[3]);
     // Conv kernel mapping (f,h,w,c) -> (h*w*c, f)
     // Calculate: h * (W*C) + w * C + c
-    Value tmp0 = rewriter.create<arith::MulIOp>(loc, loopIvs[1], kernelWidth);
-    tmp0 = rewriter.create<arith::MulIOp>(loc, tmp0, inChannels);
-    Value tmp1 = rewriter.create<arith::MulIOp>(loc, loopIvs[2], inChannels);
-    tmp0 = rewriter.create<arith::AddIOp>(loc, tmp0, tmp1);
-    tmp0 = rewriter.create<arith::AddIOp>(loc, tmp0, loopIvs[3]);
-    Value element = rewriter.create<memref::LoadOp>(loc, kernel, loopIvs);
+    Value tmp0 = arith::MulIOp::create(rewriter, loc, loopIvs[1], kernelWidth);
+    tmp0 = arith::MulIOp::create(rewriter, loc, tmp0, inChannels);
+    Value tmp1 = arith::MulIOp::create(rewriter, loc, loopIvs[2], inChannels);
+    tmp0 = arith::AddIOp::create(rewriter, loc, tmp0, tmp1);
+    tmp0 = arith::AddIOp::create(rewriter, loc, tmp0, loopIvs[3]);
+    Value element = memref::LoadOp::create(rewriter, loc, kernel, loopIvs);
     SmallVector<Value, 2> indices = {tmp0, loopIvs[0]};
-    rewriter.create<memref::StoreOp>(loc, element, kernelMat, indices);
+    memref::StoreOp::create(rewriter, loc, element, kernelMat, indices);
     rewriter.setInsertionPointAfter(loopOp);
     attr = rewriter.getI64IntegerAttr(outputShape[1]);
-    Value outRowDim = rewriter.create<arith::ConstantOp>(loc, attr);
+    Value outRowDim = arith::ConstantOp::create(rewriter, loc, attr);
     attr = rewriter.getI64IntegerAttr(outputShape[2]);
-    Value outColDim = rewriter.create<arith::ConstantOp>(loc, attr);
-    Value kernelDim = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64Type(), rewriter.getI64IntegerAttr(kernelShape[1]));
-    rewriter.create<gemmini::TileConvOp>(
-        loc, input, kernelMat, bias, outputMat, outRowDim, outColDim, kernelDim,
-        llvm::APFloat(float(1.0)), strides, /*inputDilation=*/1,
+    Value outColDim = arith::ConstantOp::create(rewriter, loc, attr);
+    Value kernelDim =
+        arith::ConstantOp::create(rewriter, loc, rewriter.getI64Type(),
+                                  rewriter.getI64IntegerAttr(kernelShape[1]));
+    gemmini::TileConvOp::create(
+        rewriter, loc, input, kernelMat, bias, outputMat, outRowDim, outColDim,
+        kernelDim, llvm::APFloat(float(1.0)), strides, /*inputDilation=*/1,
         /*kernelDilation=*/dilations);
     // After the conv operation is completed, the data in outputMat needs to be
     // transferred into output (2-D to 4-D).
     loopIvs.clear();
     indices.clear();
     for (size_t i = 0; i < outputShape.size(); i++) {
-      Value lowerBound = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+      Value lowerBound = arith::ConstantIndexOp::create(rewriter, loc, 0);
       Value upperBound =
-          rewriter.create<arith::ConstantIndexOp>(loc, outputShape[i]);
-      Value step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+          arith::ConstantIndexOp::create(rewriter, loc, outputShape[i]);
+      Value step = arith::ConstantIndexOp::create(rewriter, loc, 1);
       auto loop =
-          rewriter.create<scf::ForOp>(loc, lowerBound, upperBound, step);
+          scf::ForOp::create(rewriter, loc, lowerBound, upperBound, step);
       loopIvs.push_back(loop.getInductionVar());
       if (i == 0)
         loopOp = loop.getOperation();
       rewriter.setInsertionPointToStart(loop.getBody());
     }
     // Map output from 2D (N*H*W, C) back to NHWC (n,h,w,c)
-    Value outH = rewriter.create<arith::ConstantIndexOp>(loc, outputShape[1]);
-    Value outW = rewriter.create<arith::ConstantIndexOp>(loc, outputShape[2]);
+    Value outH = arith::ConstantIndexOp::create(rewriter, loc, outputShape[1]);
+    Value outW = arith::ConstantIndexOp::create(rewriter, loc, outputShape[2]);
     // Calculate the row index in the 2D matrix: n * (H*W) + h * W + w
-    tmp0 = rewriter.create<arith::MulIOp>(loc, loopIvs[0], outH);
-    tmp0 = rewriter.create<arith::MulIOp>(loc, tmp0, outW);
-    tmp1 = rewriter.create<arith::MulIOp>(loc, loopIvs[1], outW);
-    tmp0 = rewriter.create<arith::AddIOp>(loc, tmp0, tmp1);
-    tmp0 = rewriter.create<arith::AddIOp>(loc, tmp0, loopIvs[2]);
+    tmp0 = arith::MulIOp::create(rewriter, loc, loopIvs[0], outH);
+    tmp0 = arith::MulIOp::create(rewriter, loc, tmp0, outW);
+    tmp1 = arith::MulIOp::create(rewriter, loc, loopIvs[1], outW);
+    tmp0 = arith::AddIOp::create(rewriter, loc, tmp0, tmp1);
+    tmp0 = arith::AddIOp::create(rewriter, loc, tmp0, loopIvs[2]);
     // The index in the 2D matrix is [n*H*W + h*W + w, c]
     indices.assign({tmp0, loopIvs[3]});
-    tmp0 = rewriter.create<memref::LoadOp>(loc, outputMat, indices);
-    rewriter.create<memref::StoreOp>(loc, tmp0, output, loopIvs);
+    tmp0 = memref::LoadOp::create(rewriter, loc, outputMat, indices);
+    memref::StoreOp::create(rewriter, loc, tmp0, output, loopIvs);
     rewriter.setInsertionPointAfter(loopOp);
-    rewriter.create<memref::DeallocOp>(loc, kernelMat);
-    rewriter.create<memref::DeallocOp>(loc, outputMat);
-    rewriter.create<memref::DeallocOp>(loc, bias);
+    memref::DeallocOp::create(rewriter, loc, kernelMat);
+    memref::DeallocOp::create(rewriter, loc, outputMat);
+    memref::DeallocOp::create(rewriter, loc, bias);
     rewriter.eraseOp(convOp);
     return success();
   }
@@ -274,8 +275,8 @@ public:
     MemRefType inputMatType = MemRefType::get(inputMatShape, inputElemType);
     MemRefType weightsMatType =
         MemRefType::get(weightsMatShape, weightsElemType);
-    Value inputMat = rewriter.create<memref::AllocOp>(loc, inputMatType);
-    Value weightsMat = rewriter.create<memref::AllocOp>(loc, weightsMatType);
+    Value inputMat = memref::AllocOp::create(rewriter, loc, inputMatType);
+    Value weightsMat = memref::AllocOp::create(rewriter, loc, weightsMatType);
     MemRefType biasType =
         MemRefType::get(weightsShape[0], rewriter.getI32Type());
     if (accType == "f32")
@@ -283,25 +284,25 @@ public:
     SmallVector<int64_t, 2> outputMatShape = {
         inputShape[0] * outputShape[2] * outputShape[3], outputShape[1]};
     MemRefType outputMatType = MemRefType::get(outputMatShape, outputElemType);
-    Value bias = rewriter.create<memref::AllocOp>(loc, biasType);
-    Value outputMat = rewriter.create<memref::AllocOp>(loc, outputMatType);
+    Value bias = memref::AllocOp::create(rewriter, loc, biasType);
+    Value outputMat = memref::AllocOp::create(rewriter, loc, outputMatType);
     TypedAttr outDimAttr = rewriter.getI64IntegerAttr(outputShape[2]);
-    Value outDim = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64Type(), outDimAttr);
+    Value outDim = arith::ConstantOp::create(rewriter, loc,
+                                             rewriter.getI64Type(), outDimAttr);
     Value kernelDim =
-        rewriter.create<arith::ConstantIndexOp>(loc, weightsShape[2]);
+        arith::ConstantIndexOp::create(rewriter, loc, weightsShape[2]);
     Value inChannels =
-        rewriter.create<arith::ConstantIndexOp>(loc, inputShape[1]);
+        arith::ConstantIndexOp::create(rewriter, loc, inputShape[1]);
     SmallVector<Value, 4> loopIvs0;
     SmallVector<Value, 4> loopIvs1;
     Operation *loopOp = nullptr;
     for (unsigned i = 0, e = inputShape.size(); i != e; i++) {
-      Value lowerBound = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+      Value lowerBound = arith::ConstantIndexOp::create(rewriter, loc, 0);
       Value upperBound =
-          rewriter.create<arith::ConstantIndexOp>(loc, inputShape[i]);
-      Value step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+          arith::ConstantIndexOp::create(rewriter, loc, inputShape[i]);
+      Value step = arith::ConstantIndexOp::create(rewriter, loc, 1);
       auto loop =
-          rewriter.create<scf::ForOp>(loc, lowerBound, upperBound, step);
+          scf::ForOp::create(rewriter, loc, lowerBound, upperBound, step);
       loopIvs0.push_back(loop.getInductionVar());
       rewriter.setInsertionPointToStart(loop.getBody());
       if (i == 0)
@@ -311,71 +312,72 @@ public:
     loopIvs1.push_back(loopIvs0[2]);
     loopIvs1.push_back(loopIvs0[3]);
     loopIvs1.push_back(loopIvs0[1]);
-    Value element = rewriter.create<memref::LoadOp>(loc, input0, loopIvs0);
-    rewriter.create<memref::StoreOp>(loc, element, inputMat, loopIvs1);
+    Value element = memref::LoadOp::create(rewriter, loc, input0, loopIvs0);
+    memref::StoreOp::create(rewriter, loc, element, inputMat, loopIvs1);
     rewriter.setInsertionPointAfter(loopOp);
     loopIvs0.clear();
     loopIvs1.clear();
     for (unsigned i = 0, e = weightsShape.size(); i != e; i++) {
-      Value lowerBound = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+      Value lowerBound = arith::ConstantIndexOp::create(rewriter, loc, 0);
       Value upperBound =
-          rewriter.create<arith::ConstantIndexOp>(loc, weightsShape[i]);
-      Value step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+          arith::ConstantIndexOp::create(rewriter, loc, weightsShape[i]);
+      Value step = arith::ConstantIndexOp::create(rewriter, loc, 1);
       auto loop =
-          rewriter.create<scf::ForOp>(loc, lowerBound, upperBound, step);
+          scf::ForOp::create(rewriter, loc, lowerBound, upperBound, step);
       loopIvs0.push_back(loop.getInductionVar());
       rewriter.setInsertionPointToStart(loop.getBody());
       if (i == 0)
         loopOp = loop.getOperation();
     }
     Value tmp0 =
-        rewriter.create<arith::MulIOp>(loc, /*krow*/ loopIvs0[2], kernelDim);
-    tmp0 = rewriter.create<arith::MulIOp>(loc, tmp0, inChannels);
+        arith::MulIOp::create(rewriter, loc, /*krow*/ loopIvs0[2], kernelDim);
+    tmp0 = arith::MulIOp::create(rewriter, loc, tmp0, inChannels);
     Value tmp1 =
-        rewriter.create<arith::MulIOp>(loc, /*kcol*/ loopIvs0[3], inChannels);
-    tmp0 = rewriter.create<arith::AddIOp>(loc, tmp0, tmp1);
-    tmp0 = rewriter.create<arith::AddIOp>(loc, tmp0, /*inchannel*/ loopIvs0[1]);
-    tmp1 = rewriter.create<memref::LoadOp>(loc, input1, loopIvs0);
+        arith::MulIOp::create(rewriter, loc, /*kcol*/ loopIvs0[3], inChannels);
+    tmp0 = arith::AddIOp::create(rewriter, loc, tmp0, tmp1);
+    tmp0 =
+        arith::AddIOp::create(rewriter, loc, tmp0, /*inchannel*/ loopIvs0[1]);
+    tmp1 = memref::LoadOp::create(rewriter, loc, input1, loopIvs0);
     SmallVector<Value, 2> valueRange = {tmp0, loopIvs0[0]};
-    rewriter.create<memref::StoreOp>(loc, tmp1, weightsMat, valueRange);
+    memref::StoreOp::create(rewriter, loc, tmp1, weightsMat, valueRange);
     rewriter.setInsertionPointAfter(loopOp);
-    kernelDim = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64Type(),
-        rewriter.getI64IntegerAttr(weightsShape[2]));
-    rewriter.create<gemmini::TileConvOp>(
-        loc, inputMat, weightsMat, bias, outputMat, outDim, outDim, kernelDim,
-        llvm::APFloat(float(1.0)), strides, /*inputDilation=*/1,
+    kernelDim =
+        arith::ConstantOp::create(rewriter, loc, rewriter.getI64Type(),
+                                  rewriter.getI64IntegerAttr(weightsShape[2]));
+    gemmini::TileConvOp::create(
+        rewriter, loc, inputMat, weightsMat, bias, outputMat, outDim, outDim,
+        kernelDim, llvm::APFloat(float(1.0)), strides, /*inputDilation=*/1,
         /*kernelDilation=*/dilations);
     rewriter.eraseOp(convOp);
     loopIvs0.clear();
     loopIvs1.clear();
     for (unsigned i = 0, e = outputShape.size(); i != e; i++) {
-      Value lowerBound = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+      Value lowerBound = arith::ConstantIndexOp::create(rewriter, loc, 0);
       Value upperBound =
-          rewriter.create<arith::ConstantIndexOp>(loc, outputShape[i]);
-      Value step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+          arith::ConstantIndexOp::create(rewriter, loc, outputShape[i]);
+      Value step = arith::ConstantIndexOp::create(rewriter, loc, 1);
       auto loop =
-          rewriter.create<scf::ForOp>(loc, lowerBound, upperBound, step);
+          scf::ForOp::create(rewriter, loc, lowerBound, upperBound, step);
       loopIvs0.push_back(loop.getInductionVar());
       rewriter.setInsertionPointToStart(loop.getBody());
       if (i == 0)
         loopOp = loop.getOperation();
     }
-    outDim = rewriter.create<arith::ConstantIndexOp>(loc, outputShape[2]);
-    tmp0 = rewriter.create<arith::MulIOp>(loc, loopIvs0[0], outDim);
-    tmp0 = rewriter.create<arith::MulIOp>(loc, tmp0, outDim);
-    tmp1 = rewriter.create<arith::MulIOp>(loc, loopIvs0[2], outDim);
-    tmp0 = rewriter.create<arith::AddIOp>(loc, tmp0, tmp1);
-    tmp0 = rewriter.create<arith::AddIOp>(loc, tmp0, loopIvs0[3]);
+    outDim = arith::ConstantIndexOp::create(rewriter, loc, outputShape[2]);
+    tmp0 = arith::MulIOp::create(rewriter, loc, loopIvs0[0], outDim);
+    tmp0 = arith::MulIOp::create(rewriter, loc, tmp0, outDim);
+    tmp1 = arith::MulIOp::create(rewriter, loc, loopIvs0[2], outDim);
+    tmp0 = arith::AddIOp::create(rewriter, loc, tmp0, tmp1);
+    tmp0 = arith::AddIOp::create(rewriter, loc, tmp0, loopIvs0[3]);
     loopIvs1.push_back(tmp0);
     loopIvs1.push_back(loopIvs0[1]);
-    tmp1 = rewriter.create<memref::LoadOp>(loc, outputMat, loopIvs1);
-    rewriter.create<memref::StoreOp>(loc, tmp1, output, loopIvs0);
+    tmp1 = memref::LoadOp::create(rewriter, loc, outputMat, loopIvs1);
+    memref::StoreOp::create(rewriter, loc, tmp1, output, loopIvs0);
     rewriter.setInsertionPointAfter(loopOp);
-    rewriter.create<memref::DeallocOp>(loc, inputMat);
-    rewriter.create<memref::DeallocOp>(loc, weightsMat);
-    rewriter.create<memref::DeallocOp>(loc, outputMat);
-    rewriter.create<memref::DeallocOp>(loc, bias);
+    memref::DeallocOp::create(rewriter, loc, inputMat);
+    memref::DeallocOp::create(rewriter, loc, weightsMat);
+    memref::DeallocOp::create(rewriter, loc, outputMat);
+    memref::DeallocOp::create(rewriter, loc, bias);
     return success();
   }
 
@@ -421,58 +423,58 @@ public:
     SmallVector<int64_t> memRefShape = {
         kernelShape[0] * kernelShape[1] * kernelShape[2], kernelShape[3]};
     MemRefType kernelMatType = MemRefType::get(memRefShape, kernelElemType);
-    Value kernelMat = rewriter.create<memref::AllocOp>(loc, kernelMatType);
+    Value kernelMat = memref::AllocOp::create(rewriter, loc, kernelMatType);
     memRefShape.assign(
         {outputShape[0] * outputShape[1] * outputShape[2], outputShape[3]});
     MemRefType outputMatType = MemRefType::get(memRefShape, outputElemType);
-    Value outputMat = rewriter.create<memref::AllocOp>(loc, outputMatType);
+    Value outputMat = memref::AllocOp::create(rewriter, loc, outputMatType);
     memRefShape.assign({outputShape[3]});
     MemRefType biasType = MemRefType::get(memRefShape, rewriter.getI32Type());
     if (accType == "f32")
       biasType = MemRefType::get(memRefShape, rewriter.getF32Type());
-    Value bias = rewriter.create<memref::AllocOp>(loc, biasType);
+    Value bias = memref::AllocOp::create(rewriter, loc, biasType);
     TypedAttr attr = rewriter.getI32IntegerAttr(0);
     if (accType == "f32")
       attr = rewriter.getF32FloatAttr(0);
-    Value constant0 = rewriter.create<arith::ConstantOp>(loc, attr);
+    Value constant0 = arith::ConstantOp::create(rewriter, loc, attr);
     SmallVector<Value, 1> inputs = {constant0};
     SmallVector<Value, 1> outputs = {bias};
-    rewriter.create<linalg::FillOp>(loc, inputs, outputs);
+    linalg::FillOp::create(rewriter, loc, inputs, outputs);
     // Transferring kernel data to kernelMat.
-    Value lowerBound = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value lowerBound = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value step = arith::ConstantIndexOp::create(rewriter, loc, 1);
     Operation *loopOp = nullptr;
     SmallVector<Value, 4> loopIvs;
     for (size_t i = 0; i != kernelShape.size(); i++) {
       Value upperBound =
-          rewriter.create<arith::ConstantIndexOp>(loc, kernelShape[i]);
+          arith::ConstantIndexOp::create(rewriter, loc, kernelShape[i]);
       auto loop =
-          rewriter.create<scf::ForOp>(loc, lowerBound, upperBound, step);
+          scf::ForOp::create(rewriter, loc, lowerBound, upperBound, step);
       loopIvs.push_back(loop.getInductionVar());
       if (i == 0)
         loopOp = loop.getOperation();
       rewriter.setInsertionPointToStart(loop.getBody());
     }
     Value kernelDim =
-        rewriter.create<arith::ConstantIndexOp>(loc, kernelShape[1]);
+        arith::ConstantIndexOp::create(rewriter, loc, kernelShape[1]);
     Value inChannels =
-        rewriter.create<arith::ConstantIndexOp>(loc, kernelShape[2]);
-    Value tmp0 = rewriter.create<arith::MulIOp>(loc, loopIvs[0], kernelDim);
-    tmp0 = rewriter.create<arith::MulIOp>(loc, tmp0, inChannels);
-    Value tmp1 = rewriter.create<arith::MulIOp>(loc, loopIvs[1], inChannels);
-    tmp0 = rewriter.create<arith::AddIOp>(loc, tmp0, tmp1);
-    tmp0 = rewriter.create<arith::AddIOp>(loc, tmp0, loopIvs[2]);
-    tmp1 = rewriter.create<memref::LoadOp>(loc, kernel, loopIvs);
+        arith::ConstantIndexOp::create(rewriter, loc, kernelShape[2]);
+    Value tmp0 = arith::MulIOp::create(rewriter, loc, loopIvs[0], kernelDim);
+    tmp0 = arith::MulIOp::create(rewriter, loc, tmp0, inChannels);
+    Value tmp1 = arith::MulIOp::create(rewriter, loc, loopIvs[1], inChannels);
+    tmp0 = arith::AddIOp::create(rewriter, loc, tmp0, tmp1);
+    tmp0 = arith::AddIOp::create(rewriter, loc, tmp0, loopIvs[2]);
+    tmp1 = memref::LoadOp::create(rewriter, loc, kernel, loopIvs);
     SmallVector<Value, 2> indices = {tmp0, loopIvs[3]};
-    rewriter.create<memref::StoreOp>(loc, tmp1, kernelMat, indices);
+    memref::StoreOp::create(rewriter, loc, tmp1, kernelMat, indices);
     rewriter.setInsertionPointAfter(loopOp);
     attr = rewriter.getI64IntegerAttr(outputShape[1]);
-    Value outDim = rewriter.create<arith::ConstantOp>(loc, attr);
+    Value outDim = arith::ConstantOp::create(rewriter, loc, attr);
     attr = rewriter.getI64IntegerAttr(kernelShape[1]);
-    kernelDim = rewriter.create<arith::ConstantOp>(loc, attr);
-    rewriter.create<gemmini::TileConvOp>(
-        loc, input, kernelMat, bias, outputMat, outDim, outDim, kernelDim,
-        llvm::APFloat(float(1.0)), strides, /*inputDilation=*/1,
+    kernelDim = arith::ConstantOp::create(rewriter, loc, attr);
+    gemmini::TileConvOp::create(
+        rewriter, loc, input, kernelMat, bias, outputMat, outDim, outDim,
+        kernelDim, llvm::APFloat(float(1.0)), strides, /*inputDilation=*/1,
         /*kernelDilation=*/dilations);
     // after the conv operation is completed, the data in outputmat needs to be
     // transferred into output.
@@ -480,9 +482,9 @@ public:
     indices.clear();
     for (size_t i = 0; i < outputShape.size(); i++) {
       Value upperBound =
-          rewriter.create<arith::ConstantIndexOp>(loc, outputShape[i]);
+          arith::ConstantIndexOp::create(rewriter, loc, outputShape[i]);
       auto loop =
-          rewriter.create<scf::ForOp>(loc, lowerBound, upperBound, step);
+          scf::ForOp::create(rewriter, loc, lowerBound, upperBound, step);
       loopIvs.push_back(loop.getInductionVar());
       if (i == 0)
         loopOp = loop.getOperation();
@@ -491,19 +493,19 @@ public:
 
     // Because outputRow is equal to outputCol,here you only need to use
     // outputRow.
-    Value row = rewriter.create<arith::ConstantIndexOp>(loc, outputShape[1]);
-    tmp0 = rewriter.create<arith::MulIOp>(loc, loopIvs[0], row);
-    tmp0 = rewriter.create<arith::MulIOp>(loc, tmp0, row);
-    tmp1 = rewriter.create<arith::MulIOp>(loc, row, loopIvs[1]);
-    tmp0 = rewriter.create<arith::AddIOp>(loc, tmp0, tmp1);
-    tmp0 = rewriter.create<arith::AddIOp>(loc, tmp0, loopIvs[2]);
+    Value row = arith::ConstantIndexOp::create(rewriter, loc, outputShape[1]);
+    tmp0 = arith::MulIOp::create(rewriter, loc, loopIvs[0], row);
+    tmp0 = arith::MulIOp::create(rewriter, loc, tmp0, row);
+    tmp1 = arith::MulIOp::create(rewriter, loc, row, loopIvs[1]);
+    tmp0 = arith::AddIOp::create(rewriter, loc, tmp0, tmp1);
+    tmp0 = arith::AddIOp::create(rewriter, loc, tmp0, loopIvs[2]);
     indices.assign({tmp0, loopIvs[3]});
-    tmp0 = rewriter.create<memref::LoadOp>(loc, outputMat, indices);
-    rewriter.create<memref::StoreOp>(loc, tmp0, output, loopIvs);
+    tmp0 = memref::LoadOp::create(rewriter, loc, outputMat, indices);
+    memref::StoreOp::create(rewriter, loc, tmp0, output, loopIvs);
     rewriter.setInsertionPointAfter(loopOp);
-    rewriter.create<memref::DeallocOp>(loc, kernelMat);
-    rewriter.create<memref::DeallocOp>(loc, outputMat);
-    rewriter.create<memref::DeallocOp>(loc, bias);
+    memref::DeallocOp::create(rewriter, loc, kernelMat);
+    memref::DeallocOp::create(rewriter, loc, outputMat);
+    memref::DeallocOp::create(rewriter, loc, bias);
     rewriter.eraseOp(convOp);
     return success();
   }
@@ -535,36 +537,37 @@ public:
       SmallVector<int64_t> staticOffsets = {i, 0, 0};
       SmallVector<int64_t> staticSizes = {1, input0Shape[1], input0Shape[2]};
       SmallVector<int64_t> staticStrides = {1, 1, 1};
-      Value subInput0 = rewriter.create<memref::SubViewOp>(
-          loc, input0, staticOffsets, staticSizes, staticStrides);
+      Value subInput0 = memref::SubViewOp::create(
+          rewriter, loc, input0, staticOffsets, staticSizes, staticStrides);
       // If rank is 3 with leading 1, collapse to 2D [M,K]
       if (dyn_cast<MemRefType>(subInput0.getType()).getRank() == 3 &&
           dyn_cast<MemRefType>(subInput0.getType()).getShape()[0] == 1) {
         SmallVector<SmallVector<int64_t, 2>, 2> reassoc = {{0, 1}, {2}};
         subInput0 =
-            rewriter.create<memref::CollapseShapeOp>(loc, subInput0, reassoc);
+            memref::CollapseShapeOp::create(rewriter, loc, subInput0, reassoc);
       }
       staticSizes.assign({1, input1Shape[1], input1Shape[2]});
-      Value subInput1 = rewriter.create<memref::SubViewOp>(
-          loc, input1, staticOffsets, staticSizes, staticStrides);
+      Value subInput1 = memref::SubViewOp::create(
+          rewriter, loc, input1, staticOffsets, staticSizes, staticStrides);
       if (dyn_cast<MemRefType>(subInput1.getType()).getRank() == 3 &&
           dyn_cast<MemRefType>(subInput1.getType()).getShape()[0] == 1) {
         SmallVector<SmallVector<int64_t, 2>, 2> reassoc = {{0, 1}, {2}};
         subInput1 =
-            rewriter.create<memref::CollapseShapeOp>(loc, subInput1, reassoc);
+            memref::CollapseShapeOp::create(rewriter, loc, subInput1, reassoc);
       }
       staticSizes.assign({1, outputShape[1], outputShape[2]});
-      Value subOutput = rewriter.create<memref::SubViewOp>(
-          loc, output, staticOffsets, staticSizes, staticStrides);
+      Value subOutput = memref::SubViewOp::create(
+          rewriter, loc, output, staticOffsets, staticSizes, staticStrides);
       if (dyn_cast<MemRefType>(subOutput.getType()).getRank() == 3 &&
           dyn_cast<MemRefType>(subOutput.getType()).getShape()[0] == 1) {
         SmallVector<SmallVector<int64_t, 2>, 2> reassoc = {{0, 1}, {2}};
         subOutput =
-            rewriter.create<memref::CollapseShapeOp>(loc, subOutput, reassoc);
+            memref::CollapseShapeOp::create(rewriter, loc, subOutput, reassoc);
       }
       SmallVector<Value> inputs = {subInput0, subInput1};
       SmallVector<Value> output = {subOutput};
-      rewriter.create<linalg::MatmulOp>(batchMatMulOp.getLoc(), inputs, output);
+      linalg::MatmulOp::create(rewriter, batchMatMulOp.getLoc(), inputs,
+                               output);
     }
     rewriter.eraseOp(batchMatMulOp.getOperation());
     return success();
@@ -601,34 +604,34 @@ public:
       SmallVector<int64_t> staticOffsets = {i, 0, 0};
       SmallVector<int64_t> staticSizes = {1, input0Shape[1], input0Shape[2]};
       SmallVector<int64_t> staticStrides = {1, 1, 1};
-      Value subInput0 = rewriter.create<memref::SubViewOp>(
-          loc, input0, staticOffsets, staticSizes, staticStrides);
+      Value subInput0 = memref::SubViewOp::create(
+          rewriter, loc, input0, staticOffsets, staticSizes, staticStrides);
       // If rank is 3 with leading 1, collapse to 2D [M,K]
       if (dyn_cast<MemRefType>(subInput0.getType()).getRank() == 3 &&
           dyn_cast<MemRefType>(subInput0.getType()).getShape()[0] == 1) {
         SmallVector<SmallVector<int64_t, 2>, 2> reassoc = {{0, 1}, {2}};
         subInput0 =
-            rewriter.create<memref::CollapseShapeOp>(loc, subInput0, reassoc);
+            memref::CollapseShapeOp::create(rewriter, loc, subInput0, reassoc);
       }
       // For BatchMatmulTransposeBOp, input1 has shape [batch, N, K]
       // where batch dimension index is 0, N is at index 1, K is at index 2
       staticSizes.assign({1, input1Shape[1], input1Shape[2]});
-      Value subInput1 = rewriter.create<memref::SubViewOp>(
-          loc, input1, staticOffsets, staticSizes, staticStrides);
+      Value subInput1 = memref::SubViewOp::create(
+          rewriter, loc, input1, staticOffsets, staticSizes, staticStrides);
       if (dyn_cast<MemRefType>(subInput1.getType()).getRank() == 3 &&
           dyn_cast<MemRefType>(subInput1.getType()).getShape()[0] == 1) {
         SmallVector<SmallVector<int64_t, 2>, 2> reassoc = {{0, 1}, {2}};
         subInput1 =
-            rewriter.create<memref::CollapseShapeOp>(loc, subInput1, reassoc);
+            memref::CollapseShapeOp::create(rewriter, loc, subInput1, reassoc);
       }
       staticSizes.assign({1, outputShape[1], outputShape[2]});
-      Value subOutput = rewriter.create<memref::SubViewOp>(
-          loc, output, staticOffsets, staticSizes, staticStrides);
+      Value subOutput = memref::SubViewOp::create(
+          rewriter, loc, output, staticOffsets, staticSizes, staticStrides);
       if (dyn_cast<MemRefType>(subOutput.getType()).getRank() == 3 &&
           dyn_cast<MemRefType>(subOutput.getType()).getShape()[0] == 1) {
         SmallVector<SmallVector<int64_t, 2>, 2> reassoc = {{0, 1}, {2}};
         subOutput =
-            rewriter.create<memref::CollapseShapeOp>(loc, subOutput, reassoc);
+            memref::CollapseShapeOp::create(rewriter, loc, subOutput, reassoc);
       }
 
       // Create bias memref
@@ -645,14 +648,14 @@ public:
       }
       llvm::APFloat scale1((float)1.0);
       llvm::APFloat scale0((float)0.0);
-      Value bias = rewriter.create<memref::AllocOp>(loc, biasType);
-      Value fillOpInputValue = rewriter.create<arith::ConstantOp>(
-          loc, fillOpInsType, fillOpInputAttr);
-      rewriter.create<linalg::FillOp>(loc, fillOpInputValue, bias);
+      Value bias = memref::AllocOp::create(rewriter, loc, biasType);
+      Value fillOpInputValue = arith::ConstantOp::create(
+          rewriter, loc, fillOpInsType, fillOpInputAttr);
+      linalg::FillOp::create(rewriter, loc, fillOpInputValue, bias);
 
       // Create TileMatMulOp with bTranspose=true
-      rewriter.create<gemmini::TileMatMulOp>(
-          loc, subInput0, subInput1, subOutput, bias,
+      gemmini::TileMatMulOp::create(
+          rewriter, loc, subInput0, subInput1, subOutput, bias,
           /*aScaleFactor = */ scale1,
           /*bScaleFactor = */ scale1, /*dScaleFactor = */ scale1,
           /*act = */ 0, /*accScale = */ scale1, /*bertScale = */ scale0,
@@ -660,7 +663,7 @@ public:
           /*bTranspose = */ true, /*fullC = */ false, /*lowD = */ false,
           /*weightA = */ 0, /*dataflow = */ 1);
 
-      rewriter.create<memref::DeallocOp>(loc, bias);
+      memref::DeallocOp::create(rewriter, loc, bias);
     }
     rewriter.eraseOp(batchMatMulTransBOp.getOperation());
     return success();

--- a/midend/lib/Conversion/LowerLinalgToIME/LowerLinalgToIME.cpp
+++ b/midend/lib/Conversion/LowerLinalgToIME/LowerLinalgToIME.cpp
@@ -144,187 +144,187 @@ public:
     int64_t numTilesN = (N + tileN - 1) / tileN;
 
     // Create constants
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    Value tileMVal = rewriter.create<arith::ConstantIndexOp>(loc, tileM);
-    Value tileKVal = rewriter.create<arith::ConstantIndexOp>(loc, tileK);
-    Value tileNVal = rewriter.create<arith::ConstantIndexOp>(loc, tileN);
-    Value boundM = rewriter.create<arith::ConstantIndexOp>(loc, M);
-    Value boundK = rewriter.create<arith::ConstantIndexOp>(loc, K);
-    Value boundN = rewriter.create<arith::ConstantIndexOp>(loc, N);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    Value tileMVal = arith::ConstantIndexOp::create(rewriter, loc, tileM);
+    Value tileKVal = arith::ConstantIndexOp::create(rewriter, loc, tileK);
+    Value tileNVal = arith::ConstantIndexOp::create(rewriter, loc, tileN);
+    Value boundM = arith::ConstantIndexOp::create(rewriter, loc, M);
+    Value boundK = arith::ConstantIndexOp::create(rewriter, loc, K);
+    Value boundN = arith::ConstantIndexOp::create(rewriter, loc, N);
     Value numTilesMVal =
-        rewriter.create<arith::ConstantIndexOp>(loc, numTilesM);
+        arith::ConstantIndexOp::create(rewriter, loc, numTilesM);
     Value numTilesKVal =
-        rewriter.create<arith::ConstantIndexOp>(loc, numTilesK);
+        arith::ConstantIndexOp::create(rewriter, loc, numTilesK);
     Value numTilesNVal =
-        rewriter.create<arith::ConstantIndexOp>(loc, numTilesN);
+        arith::ConstantIndexOp::create(rewriter, loc, numTilesN);
 
     // Create zero constants for padding
-    Value zeroElem = rewriter.create<arith::ConstantOp>(
-        loc, AElemType, rewriter.getZeroAttr(AElemType));
+    Value zeroElem = arith::ConstantOp::create(rewriter, loc, AElemType,
+                                               rewriter.getZeroAttr(AElemType));
     // Zero constant for C tile (type depends on element type: f16 or i32)
-    Value zeroC = rewriter.create<arith::ConstantOp>(
-        loc, CElemType, rewriter.getZeroAttr(CElemType));
+    Value zeroC = arith::ConstantOp::create(rewriter, loc, CElemType,
+                                            rewriter.getZeroAttr(CElemType));
 
     auto ATileType = MemRefType::get({tileM, tileK}, AElemType);
     auto BTileType = MemRefType::get({tileN, tileK},
                                      AElemType); // [N, K] for column-major pack
     auto CTileType = MemRefType::get({tileM, tileN}, CElemType);
 
-    Value ATile = rewriter.create<memref::AllocaOp>(loc, ATileType);
-    Value BTile = rewriter.create<memref::AllocaOp>(loc, BTileType);
-    Value CTile = rewriter.create<memref::AllocaOp>(loc, CTileType);
+    Value ATile = memref::AllocaOp::create(rewriter, loc, ATileType);
+    Value BTile = memref::AllocaOp::create(rewriter, loc, BTileType);
+    Value CTile = memref::AllocaOp::create(rewriter, loc, CTileType);
 
     // Loop over M tiles
-    auto loopTileM = rewriter.create<scf::ForOp>(loc, c0, numTilesMVal, c1);
+    auto loopTileM = scf::ForOp::create(rewriter, loc, c0, numTilesMVal, c1);
     rewriter.setInsertionPointToStart(loopTileM.getBody());
     Value tileIdxM = loopTileM.getInductionVar();
-    Value baseM = rewriter.create<arith::MulIOp>(loc, tileIdxM, tileMVal);
+    Value baseM = arith::MulIOp::create(rewriter, loc, tileIdxM, tileMVal);
 
     // Loop over N tiles
-    auto loopTileN = rewriter.create<scf::ForOp>(loc, c0, numTilesNVal, c1);
+    auto loopTileN = scf::ForOp::create(rewriter, loc, c0, numTilesNVal, c1);
     rewriter.setInsertionPointToStart(loopTileN.getBody());
     Value tileIdxN = loopTileN.getInductionVar();
-    Value baseN = rewriter.create<arith::MulIOp>(loc, tileIdxN, tileNVal);
+    Value baseN = arith::MulIOp::create(rewriter, loc, tileIdxN, tileNVal);
 
     // Initialize CTile to zeros (or copy from C for initial values)
-    auto initCLoop1 = rewriter.create<scf::ForOp>(loc, c0, tileMVal, c1);
+    auto initCLoop1 = scf::ForOp::create(rewriter, loc, c0, tileMVal, c1);
     rewriter.setInsertionPointToStart(initCLoop1.getBody());
     Value initCi = initCLoop1.getInductionVar();
-    auto initCLoop2 = rewriter.create<scf::ForOp>(loc, c0, tileNVal, c1);
+    auto initCLoop2 = scf::ForOp::create(rewriter, loc, c0, tileNVal, c1);
     rewriter.setInsertionPointToStart(initCLoop2.getBody());
     Value initCj = initCLoop2.getInductionVar();
 
     // Calculate global indices
-    Value globalCi = rewriter.create<arith::AddIOp>(loc, baseM, initCi);
-    Value globalCj = rewriter.create<arith::AddIOp>(loc, baseN, initCj);
+    Value globalCi = arith::AddIOp::create(rewriter, loc, baseM, initCi);
+    Value globalCj = arith::AddIOp::create(rewriter, loc, baseN, initCj);
 
     // Check if within bounds
-    Value inBoundM = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::ult, globalCi, boundM);
-    Value inBoundN = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::ult, globalCj, boundN);
-    Value inBound = rewriter.create<arith::AndIOp>(loc, inBoundM, inBoundN);
+    Value inBoundM = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::ult, globalCi, boundM);
+    Value inBoundN = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::ult, globalCj, boundN);
+    Value inBound = arith::AndIOp::create(rewriter, loc, inBoundM, inBoundN);
 
     // Load from C if in bounds, else use zero
-    auto selectC = rewriter.create<scf::IfOp>(loc, CElemType, inBound,
-                                              /*withElseRegion=*/true);
+    auto selectC = scf::IfOp::create(rewriter, loc, CElemType, inBound,
+                                     /*withElseRegion=*/true);
     rewriter.setInsertionPointToStart(&selectC.getThenRegion().front());
-    Value cLoadVal =
-        rewriter.create<memref::LoadOp>(loc, C, ValueRange{globalCi, globalCj});
-    rewriter.create<scf::YieldOp>(loc, cLoadVal);
+    Value cLoadVal = memref::LoadOp::create(rewriter, loc, C,
+                                            ValueRange{globalCi, globalCj});
+    scf::YieldOp::create(rewriter, loc, cLoadVal);
     rewriter.setInsertionPointToStart(&selectC.getElseRegion().front());
-    rewriter.create<scf::YieldOp>(loc, zeroC);
+    scf::YieldOp::create(rewriter, loc, zeroC);
     rewriter.setInsertionPointAfter(selectC);
 
-    rewriter.create<memref::StoreOp>(loc, selectC.getResult(0), CTile,
-                                     ValueRange{initCi, initCj});
+    memref::StoreOp::create(rewriter, loc, selectC.getResult(0), CTile,
+                            ValueRange{initCi, initCj});
     rewriter.setInsertionPointAfter(initCLoop1);
 
     // Loop over K tiles
-    auto loopTileK = rewriter.create<scf::ForOp>(loc, c0, numTilesKVal, c1);
+    auto loopTileK = scf::ForOp::create(rewriter, loc, c0, numTilesKVal, c1);
     rewriter.setInsertionPointToStart(loopTileK.getBody());
     Value tileIdxK = loopTileK.getInductionVar();
-    Value baseK = rewriter.create<arith::MulIOp>(loc, tileIdxK, tileKVal);
+    Value baseK = arith::MulIOp::create(rewriter, loc, tileIdxK, tileKVal);
 
     // Copy A tile with boundary handling
-    auto copyALoop1 = rewriter.create<scf::ForOp>(loc, c0, tileMVal, c1);
+    auto copyALoop1 = scf::ForOp::create(rewriter, loc, c0, tileMVal, c1);
     rewriter.setInsertionPointToStart(copyALoop1.getBody());
     Value copyAi = copyALoop1.getInductionVar();
-    auto copyALoop2 = rewriter.create<scf::ForOp>(loc, c0, tileKVal, c1);
+    auto copyALoop2 = scf::ForOp::create(rewriter, loc, c0, tileKVal, c1);
     rewriter.setInsertionPointToStart(copyALoop2.getBody());
     Value copyAk = copyALoop2.getInductionVar();
 
-    Value globalAi = rewriter.create<arith::AddIOp>(loc, baseM, copyAi);
-    Value globalAk = rewriter.create<arith::AddIOp>(loc, baseK, copyAk);
-    Value inBoundAM = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::ult, globalAi, boundM);
-    Value inBoundAK = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::ult, globalAk, boundK);
-    Value inBoundA = rewriter.create<arith::AndIOp>(loc, inBoundAM, inBoundAK);
+    Value globalAi = arith::AddIOp::create(rewriter, loc, baseM, copyAi);
+    Value globalAk = arith::AddIOp::create(rewriter, loc, baseK, copyAk);
+    Value inBoundAM = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::ult, globalAi, boundM);
+    Value inBoundAK = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::ult, globalAk, boundK);
+    Value inBoundA = arith::AndIOp::create(rewriter, loc, inBoundAM, inBoundAK);
 
-    auto selectA = rewriter.create<scf::IfOp>(loc, AElemType, inBoundA,
-                                              /*withElseRegion=*/true);
+    auto selectA = scf::IfOp::create(rewriter, loc, AElemType, inBoundA,
+                                     /*withElseRegion=*/true);
     rewriter.setInsertionPointToStart(&selectA.getThenRegion().front());
-    Value aLoadVal =
-        rewriter.create<memref::LoadOp>(loc, A, ValueRange{globalAi, globalAk});
-    rewriter.create<scf::YieldOp>(loc, aLoadVal);
+    Value aLoadVal = memref::LoadOp::create(rewriter, loc, A,
+                                            ValueRange{globalAi, globalAk});
+    scf::YieldOp::create(rewriter, loc, aLoadVal);
     rewriter.setInsertionPointToStart(&selectA.getElseRegion().front());
-    rewriter.create<scf::YieldOp>(loc, zeroElem);
+    scf::YieldOp::create(rewriter, loc, zeroElem);
     rewriter.setInsertionPointAfter(selectA);
 
-    rewriter.create<memref::StoreOp>(loc, selectA.getResult(0), ATile,
-                                     ValueRange{copyAi, copyAk});
+    memref::StoreOp::create(rewriter, loc, selectA.getResult(0), ATile,
+                            ValueRange{copyAi, copyAk});
     rewriter.setInsertionPointAfter(copyALoop1);
 
     // Copy B tile with boundary handling
     // Note: B is stored in column-major pack format for IME
     // B[k][n] in original matrix -> BTile[n][k] in packed format
-    auto copyBLoop1 = rewriter.create<scf::ForOp>(loc, c0, tileNVal, c1);
+    auto copyBLoop1 = scf::ForOp::create(rewriter, loc, c0, tileNVal, c1);
     rewriter.setInsertionPointToStart(copyBLoop1.getBody());
     Value copyBn = copyBLoop1.getInductionVar();
-    auto copyBLoop2 = rewriter.create<scf::ForOp>(loc, c0, tileKVal, c1);
+    auto copyBLoop2 = scf::ForOp::create(rewriter, loc, c0, tileKVal, c1);
     rewriter.setInsertionPointToStart(copyBLoop2.getBody());
     Value copyBk = copyBLoop2.getInductionVar();
 
-    Value globalBk = rewriter.create<arith::AddIOp>(loc, baseK, copyBk);
-    Value globalBn = rewriter.create<arith::AddIOp>(loc, baseN, copyBn);
-    Value inBoundBK = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::ult, globalBk, boundK);
-    Value inBoundBN = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::ult, globalBn, boundN);
-    Value inBoundB = rewriter.create<arith::AndIOp>(loc, inBoundBK, inBoundBN);
+    Value globalBk = arith::AddIOp::create(rewriter, loc, baseK, copyBk);
+    Value globalBn = arith::AddIOp::create(rewriter, loc, baseN, copyBn);
+    Value inBoundBK = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::ult, globalBk, boundK);
+    Value inBoundBN = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::ult, globalBn, boundN);
+    Value inBoundB = arith::AndIOp::create(rewriter, loc, inBoundBK, inBoundBN);
 
-    auto selectB = rewriter.create<scf::IfOp>(loc, AElemType, inBoundB,
-                                              /*withElseRegion=*/true);
+    auto selectB = scf::IfOp::create(rewriter, loc, AElemType, inBoundB,
+                                     /*withElseRegion=*/true);
     rewriter.setInsertionPointToStart(&selectB.getThenRegion().front());
     // Load from B[k][n] in row-major
-    Value bLoadVal =
-        rewriter.create<memref::LoadOp>(loc, B, ValueRange{globalBk, globalBn});
-    rewriter.create<scf::YieldOp>(loc, bLoadVal);
+    Value bLoadVal = memref::LoadOp::create(rewriter, loc, B,
+                                            ValueRange{globalBk, globalBn});
+    scf::YieldOp::create(rewriter, loc, bLoadVal);
     rewriter.setInsertionPointToStart(&selectB.getElseRegion().front());
-    rewriter.create<scf::YieldOp>(loc, zeroElem);
+    scf::YieldOp::create(rewriter, loc, zeroElem);
     rewriter.setInsertionPointAfter(selectB);
 
     // Store to BTile[n][k] in column-major pack format
-    rewriter.create<memref::StoreOp>(loc, selectB.getResult(0), BTile,
-                                     ValueRange{copyBn, copyBk});
+    memref::StoreOp::create(rewriter, loc, selectB.getResult(0), BTile,
+                            ValueRange{copyBn, copyBk});
     rewriter.setInsertionPointAfter(copyBLoop1);
 
     // IME vmadot/vfmadot on contiguous tile buffers
     if (AElemType.isF16()) {
-      rewriter.create<VfmadotOp>(loc, CTile, ATile, BTile);
+      VfmadotOp::create(rewriter, loc, CTile, ATile, BTile);
     } else {
-      rewriter.create<VmadotOp>(loc, CTile, ATile, BTile);
+      VmadotOp::create(rewriter, loc, CTile, ATile, BTile);
     }
 
     // End of K tile loop
     rewriter.setInsertionPointAfter(loopTileK);
 
     // Copy CTile back to C (only valid elements)
-    auto storeCLoop1 = rewriter.create<scf::ForOp>(loc, c0, tileMVal, c1);
+    auto storeCLoop1 = scf::ForOp::create(rewriter, loc, c0, tileMVal, c1);
     rewriter.setInsertionPointToStart(storeCLoop1.getBody());
     Value storeCi = storeCLoop1.getInductionVar();
-    auto storeCLoop2 = rewriter.create<scf::ForOp>(loc, c0, tileNVal, c1);
+    auto storeCLoop2 = scf::ForOp::create(rewriter, loc, c0, tileNVal, c1);
     rewriter.setInsertionPointToStart(storeCLoop2.getBody());
     Value storeCj = storeCLoop2.getInductionVar();
 
-    Value globalStoreCi = rewriter.create<arith::AddIOp>(loc, baseM, storeCi);
-    Value globalStoreCj = rewriter.create<arith::AddIOp>(loc, baseN, storeCj);
-    Value inBoundStoreM = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::ult, globalStoreCi, boundM);
-    Value inBoundStoreN = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::ult, globalStoreCj, boundN);
+    Value globalStoreCi = arith::AddIOp::create(rewriter, loc, baseM, storeCi);
+    Value globalStoreCj = arith::AddIOp::create(rewriter, loc, baseN, storeCj);
+    Value inBoundStoreM = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::ult, globalStoreCi, boundM);
+    Value inBoundStoreN = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::ult, globalStoreCj, boundN);
     Value inBoundStore =
-        rewriter.create<arith::AndIOp>(loc, inBoundStoreM, inBoundStoreN);
+        arith::AndIOp::create(rewriter, loc, inBoundStoreM, inBoundStoreN);
 
-    auto storeIf =
-        rewriter.create<scf::IfOp>(loc, inBoundStore, /*withElseRegion=*/false);
+    auto storeIf = scf::IfOp::create(rewriter, loc, inBoundStore,
+                                     /*withElseRegion=*/false);
     rewriter.setInsertionPointToStart(&storeIf.getThenRegion().front());
-    Value cResult = rewriter.create<memref::LoadOp>(
-        loc, CTile, ValueRange{storeCi, storeCj});
-    rewriter.create<memref::StoreOp>(loc, cResult, C,
-                                     ValueRange{globalStoreCi, globalStoreCj});
+    Value cResult = memref::LoadOp::create(rewriter, loc, CTile,
+                                           ValueRange{storeCi, storeCj});
+    memref::StoreOp::create(rewriter, loc, cResult, C,
+                            ValueRange{globalStoreCi, globalStoreCj});
 
     rewriter.setInsertionPointAfter(storeCLoop1);
 
@@ -421,31 +421,31 @@ public:
     bool isDynamic = ShapedType::isDynamic(M) || ShapedType::isDynamic(K) ||
                      ShapedType::isDynamic(N);
 
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value stepM = rewriter.create<arith::ConstantIndexOp>(loc, tileM);
-    Value stepK = rewriter.create<arith::ConstantIndexOp>(loc, tileK);
-    Value stepN = rewriter.create<arith::ConstantIndexOp>(loc, tileN);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value stepM = arith::ConstantIndexOp::create(rewriter, loc, tileM);
+    Value stepK = arith::ConstantIndexOp::create(rewriter, loc, tileK);
+    Value stepN = arith::ConstantIndexOp::create(rewriter, loc, tileN);
 
     Value boundM, boundK, boundN;
     if (isDynamic) {
-      boundM = rewriter.create<memref::DimOp>(loc, A, 0);
-      boundK = rewriter.create<memref::DimOp>(loc, A, 1);
-      boundN = rewriter.create<memref::DimOp>(loc, B, 1);
+      boundM = memref::DimOp::create(rewriter, loc, A, 0);
+      boundK = memref::DimOp::create(rewriter, loc, A, 1);
+      boundN = memref::DimOp::create(rewriter, loc, B, 1);
     } else {
-      boundM = rewriter.create<arith::ConstantIndexOp>(loc, M);
-      boundK = rewriter.create<arith::ConstantIndexOp>(loc, K);
-      boundN = rewriter.create<arith::ConstantIndexOp>(loc, N);
+      boundM = arith::ConstantIndexOp::create(rewriter, loc, M);
+      boundK = arith::ConstantIndexOp::create(rewriter, loc, K);
+      boundN = arith::ConstantIndexOp::create(rewriter, loc, N);
     }
 
-    auto loopI = rewriter.create<scf::ForOp>(loc, c0, boundM, stepM);
+    auto loopI = scf::ForOp::create(rewriter, loc, c0, boundM, stepM);
     rewriter.setInsertionPointToStart(loopI.getBody());
     Value ivI = loopI.getInductionVar();
 
-    auto loopJ = rewriter.create<scf::ForOp>(loc, c0, boundN, stepN);
+    auto loopJ = scf::ForOp::create(rewriter, loc, c0, boundN, stepN);
     rewriter.setInsertionPointToStart(loopJ.getBody());
     Value ivJ = loopJ.getInductionVar();
 
-    auto loopK = rewriter.create<scf::ForOp>(loc, c0, boundK, stepK);
+    auto loopK = scf::ForOp::create(rewriter, loc, c0, boundK, stepK);
     rewriter.setInsertionPointToStart(loopK.getBody());
     Value ivK = loopK.getInductionVar();
 
@@ -456,24 +456,24 @@ public:
                                          rewriter.getIndexAttr(1)};
 
     Value ATile =
-        rewriter.create<memref::SubViewOp>(loc, A, aOffsets, aSizes, strides);
+        memref::SubViewOp::create(rewriter, loc, A, aOffsets, aSizes, strides);
 
     SmallVector<OpFoldResult> bOffsets = {ivK, ivJ};
     SmallVector<OpFoldResult> bSizes = {rewriter.getIndexAttr(tileK),
                                         rewriter.getIndexAttr(tileN)};
     Value BTile =
-        rewriter.create<memref::SubViewOp>(loc, B, bOffsets, bSizes, strides);
+        memref::SubViewOp::create(rewriter, loc, B, bOffsets, bSizes, strides);
 
     SmallVector<OpFoldResult> cOffsets = {ivI, ivJ};
     SmallVector<OpFoldResult> cSizes = {rewriter.getIndexAttr(tileM),
                                         rewriter.getIndexAttr(tileN)};
     Value CTile =
-        rewriter.create<memref::SubViewOp>(loc, C, cOffsets, cSizes, strides);
+        memref::SubViewOp::create(rewriter, loc, C, cOffsets, cSizes, strides);
 
     if (isFloatGeneric) {
-      rewriter.create<VfmadotOp>(loc, CTile, ATile, BTile);
+      VfmadotOp::create(rewriter, loc, CTile, ATile, BTile);
     } else {
-      rewriter.create<VmadotOp>(loc, CTile, ATile, BTile);
+      VmadotOp::create(rewriter, loc, CTile, ATile, BTile);
     }
 
     rewriter.setInsertionPointAfter(loopI);
@@ -560,188 +560,188 @@ public:
     int64_t numTilesN = (N + tileN - 1) / tileN;
 
     // Constants
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    Value tileMVal = rewriter.create<arith::ConstantIndexOp>(loc, tileM);
-    Value tileKVal = rewriter.create<arith::ConstantIndexOp>(loc, tileK);
-    Value tileNVal = rewriter.create<arith::ConstantIndexOp>(loc, tileN);
-    Value boundM = rewriter.create<arith::ConstantIndexOp>(loc, M);
-    Value boundK = rewriter.create<arith::ConstantIndexOp>(loc, K);
-    Value boundN = rewriter.create<arith::ConstantIndexOp>(loc, N);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    Value tileMVal = arith::ConstantIndexOp::create(rewriter, loc, tileM);
+    Value tileKVal = arith::ConstantIndexOp::create(rewriter, loc, tileK);
+    Value tileNVal = arith::ConstantIndexOp::create(rewriter, loc, tileN);
+    Value boundM = arith::ConstantIndexOp::create(rewriter, loc, M);
+    Value boundK = arith::ConstantIndexOp::create(rewriter, loc, K);
+    Value boundN = arith::ConstantIndexOp::create(rewriter, loc, N);
     Value numTilesMVal =
-        rewriter.create<arith::ConstantIndexOp>(loc, numTilesM);
+        arith::ConstantIndexOp::create(rewriter, loc, numTilesM);
     Value numTilesKVal =
-        rewriter.create<arith::ConstantIndexOp>(loc, numTilesK);
+        arith::ConstantIndexOp::create(rewriter, loc, numTilesK);
     Value numTilesNVal =
-        rewriter.create<arith::ConstantIndexOp>(loc, numTilesN);
-    Value batchBound = rewriter.create<arith::ConstantIndexOp>(loc, Batch);
+        arith::ConstantIndexOp::create(rewriter, loc, numTilesN);
+    Value batchBound = arith::ConstantIndexOp::create(rewriter, loc, Batch);
 
-    Value zeroElem = rewriter.create<arith::ConstantOp>(
-        loc, AElemType, rewriter.getZeroAttr(AElemType));
-    Value zeroC = rewriter.create<arith::ConstantOp>(
-        loc, CElemType, rewriter.getZeroAttr(CElemType));
+    Value zeroElem = arith::ConstantOp::create(rewriter, loc, AElemType,
+                                               rewriter.getZeroAttr(AElemType));
+    Value zeroC = arith::ConstantOp::create(rewriter, loc, CElemType,
+                                            rewriter.getZeroAttr(CElemType));
 
     auto ATileType = MemRefType::get({tileM, tileK}, AElemType);
     // B is [N,K] per batch — already column-major pack for IME
     auto BTileType = MemRefType::get({tileN, tileK}, AElemType);
     auto CTileType = MemRefType::get({tileM, tileN}, CElemType);
 
-    Value ATile = rewriter.create<memref::AllocaOp>(loc, ATileType);
-    Value BTile = rewriter.create<memref::AllocaOp>(loc, BTileType);
-    Value CTile = rewriter.create<memref::AllocaOp>(loc, CTileType);
+    Value ATile = memref::AllocaOp::create(rewriter, loc, ATileType);
+    Value BTile = memref::AllocaOp::create(rewriter, loc, BTileType);
+    Value CTile = memref::AllocaOp::create(rewriter, loc, CTileType);
 
     // Batch loop
-    auto loopBatch = rewriter.create<scf::ForOp>(loc, c0, batchBound, c1);
+    auto loopBatch = scf::ForOp::create(rewriter, loc, c0, batchBound, c1);
     rewriter.setInsertionPointToStart(loopBatch.getBody());
     Value batchIdx = loopBatch.getInductionVar();
 
     // Loop over M tiles
-    auto loopTileM = rewriter.create<scf::ForOp>(loc, c0, numTilesMVal, c1);
+    auto loopTileM = scf::ForOp::create(rewriter, loc, c0, numTilesMVal, c1);
     rewriter.setInsertionPointToStart(loopTileM.getBody());
     Value tileIdxM = loopTileM.getInductionVar();
-    Value baseM = rewriter.create<arith::MulIOp>(loc, tileIdxM, tileMVal);
+    Value baseM = arith::MulIOp::create(rewriter, loc, tileIdxM, tileMVal);
 
     // Loop over N tiles
-    auto loopTileN = rewriter.create<scf::ForOp>(loc, c0, numTilesNVal, c1);
+    auto loopTileN = scf::ForOp::create(rewriter, loc, c0, numTilesNVal, c1);
     rewriter.setInsertionPointToStart(loopTileN.getBody());
     Value tileIdxN = loopTileN.getInductionVar();
-    Value baseN = rewriter.create<arith::MulIOp>(loc, tileIdxN, tileNVal);
+    Value baseN = arith::MulIOp::create(rewriter, loc, tileIdxN, tileNVal);
 
     // Initialize CTile from C[batch, m, n]
-    auto initCLoop1 = rewriter.create<scf::ForOp>(loc, c0, tileMVal, c1);
+    auto initCLoop1 = scf::ForOp::create(rewriter, loc, c0, tileMVal, c1);
     rewriter.setInsertionPointToStart(initCLoop1.getBody());
     Value initCi = initCLoop1.getInductionVar();
-    auto initCLoop2 = rewriter.create<scf::ForOp>(loc, c0, tileNVal, c1);
+    auto initCLoop2 = scf::ForOp::create(rewriter, loc, c0, tileNVal, c1);
     rewriter.setInsertionPointToStart(initCLoop2.getBody());
     Value initCj = initCLoop2.getInductionVar();
 
-    Value globalCi = rewriter.create<arith::AddIOp>(loc, baseM, initCi);
-    Value globalCj = rewriter.create<arith::AddIOp>(loc, baseN, initCj);
+    Value globalCi = arith::AddIOp::create(rewriter, loc, baseM, initCi);
+    Value globalCj = arith::AddIOp::create(rewriter, loc, baseN, initCj);
 
-    Value inBoundM = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::ult, globalCi, boundM);
-    Value inBoundN = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::ult, globalCj, boundN);
-    Value inBound = rewriter.create<arith::AndIOp>(loc, inBoundM, inBoundN);
+    Value inBoundM = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::ult, globalCi, boundM);
+    Value inBoundN = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::ult, globalCj, boundN);
+    Value inBound = arith::AndIOp::create(rewriter, loc, inBoundM, inBoundN);
 
-    auto selectC = rewriter.create<scf::IfOp>(loc, CElemType, inBound,
-                                              /*withElseRegion=*/true);
+    auto selectC = scf::IfOp::create(rewriter, loc, CElemType, inBound,
+                                     /*withElseRegion=*/true);
     rewriter.setInsertionPointToStart(&selectC.getThenRegion().front());
-    Value cLoadVal = rewriter.create<memref::LoadOp>(
-        loc, C, ValueRange{batchIdx, globalCi, globalCj});
-    rewriter.create<scf::YieldOp>(loc, cLoadVal);
+    Value cLoadVal = memref::LoadOp::create(
+        rewriter, loc, C, ValueRange{batchIdx, globalCi, globalCj});
+    scf::YieldOp::create(rewriter, loc, cLoadVal);
     rewriter.setInsertionPointToStart(&selectC.getElseRegion().front());
-    rewriter.create<scf::YieldOp>(loc, zeroC);
+    scf::YieldOp::create(rewriter, loc, zeroC);
     rewriter.setInsertionPointAfter(selectC);
 
-    rewriter.create<memref::StoreOp>(loc, selectC.getResult(0), CTile,
-                                     ValueRange{initCi, initCj});
+    memref::StoreOp::create(rewriter, loc, selectC.getResult(0), CTile,
+                            ValueRange{initCi, initCj});
     rewriter.setInsertionPointAfter(initCLoop1);
 
     // K tile loop
-    auto loopTileK = rewriter.create<scf::ForOp>(loc, c0, numTilesKVal, c1);
+    auto loopTileK = scf::ForOp::create(rewriter, loc, c0, numTilesKVal, c1);
     rewriter.setInsertionPointToStart(loopTileK.getBody());
     Value tileIdxK = loopTileK.getInductionVar();
-    Value baseK = rewriter.create<arith::MulIOp>(loc, tileIdxK, tileKVal);
+    Value baseK = arith::MulIOp::create(rewriter, loc, tileIdxK, tileKVal);
 
     // Copy A tile: A[batch, m, k] → ATile[tileM, tileK]
-    auto copyALoop1 = rewriter.create<scf::ForOp>(loc, c0, tileMVal, c1);
+    auto copyALoop1 = scf::ForOp::create(rewriter, loc, c0, tileMVal, c1);
     rewriter.setInsertionPointToStart(copyALoop1.getBody());
     Value copyAi = copyALoop1.getInductionVar();
-    auto copyALoop2 = rewriter.create<scf::ForOp>(loc, c0, tileKVal, c1);
+    auto copyALoop2 = scf::ForOp::create(rewriter, loc, c0, tileKVal, c1);
     rewriter.setInsertionPointToStart(copyALoop2.getBody());
     Value copyAk = copyALoop2.getInductionVar();
 
-    Value globalAi = rewriter.create<arith::AddIOp>(loc, baseM, copyAi);
-    Value globalAk = rewriter.create<arith::AddIOp>(loc, baseK, copyAk);
-    Value inBoundAM = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::ult, globalAi, boundM);
-    Value inBoundAK = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::ult, globalAk, boundK);
-    Value inBoundA = rewriter.create<arith::AndIOp>(loc, inBoundAM, inBoundAK);
+    Value globalAi = arith::AddIOp::create(rewriter, loc, baseM, copyAi);
+    Value globalAk = arith::AddIOp::create(rewriter, loc, baseK, copyAk);
+    Value inBoundAM = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::ult, globalAi, boundM);
+    Value inBoundAK = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::ult, globalAk, boundK);
+    Value inBoundA = arith::AndIOp::create(rewriter, loc, inBoundAM, inBoundAK);
 
-    auto selectA = rewriter.create<scf::IfOp>(loc, AElemType, inBoundA,
-                                              /*withElseRegion=*/true);
+    auto selectA = scf::IfOp::create(rewriter, loc, AElemType, inBoundA,
+                                     /*withElseRegion=*/true);
     rewriter.setInsertionPointToStart(&selectA.getThenRegion().front());
-    Value aLoadVal = rewriter.create<memref::LoadOp>(
-        loc, A, ValueRange{batchIdx, globalAi, globalAk});
-    rewriter.create<scf::YieldOp>(loc, aLoadVal);
+    Value aLoadVal = memref::LoadOp::create(
+        rewriter, loc, A, ValueRange{batchIdx, globalAi, globalAk});
+    scf::YieldOp::create(rewriter, loc, aLoadVal);
     rewriter.setInsertionPointToStart(&selectA.getElseRegion().front());
-    rewriter.create<scf::YieldOp>(loc, zeroElem);
+    scf::YieldOp::create(rewriter, loc, zeroElem);
     rewriter.setInsertionPointAfter(selectA);
 
-    rewriter.create<memref::StoreOp>(loc, selectA.getResult(0), ATile,
-                                     ValueRange{copyAi, copyAk});
+    memref::StoreOp::create(rewriter, loc, selectA.getResult(0), ATile,
+                            ValueRange{copyAi, copyAk});
     rewriter.setInsertionPointAfter(copyALoop1);
 
     // Copy B tile: B[batch, n, k] → BTile[tileN, tileK]
     // B is already [N,K] per batch — same as IME's expected format!
     // No transpose/repack needed.
-    auto copyBLoop1 = rewriter.create<scf::ForOp>(loc, c0, tileNVal, c1);
+    auto copyBLoop1 = scf::ForOp::create(rewriter, loc, c0, tileNVal, c1);
     rewriter.setInsertionPointToStart(copyBLoop1.getBody());
     Value copyBn = copyBLoop1.getInductionVar();
-    auto copyBLoop2 = rewriter.create<scf::ForOp>(loc, c0, tileKVal, c1);
+    auto copyBLoop2 = scf::ForOp::create(rewriter, loc, c0, tileKVal, c1);
     rewriter.setInsertionPointToStart(copyBLoop2.getBody());
     Value copyBk = copyBLoop2.getInductionVar();
 
-    Value globalBn = rewriter.create<arith::AddIOp>(loc, baseN, copyBn);
-    Value globalBk = rewriter.create<arith::AddIOp>(loc, baseK, copyBk);
-    Value inBoundBN = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::ult, globalBn, boundN);
-    Value inBoundBK = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::ult, globalBk, boundK);
-    Value inBoundB = rewriter.create<arith::AndIOp>(loc, inBoundBN, inBoundBK);
+    Value globalBn = arith::AddIOp::create(rewriter, loc, baseN, copyBn);
+    Value globalBk = arith::AddIOp::create(rewriter, loc, baseK, copyBk);
+    Value inBoundBN = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::ult, globalBn, boundN);
+    Value inBoundBK = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::ult, globalBk, boundK);
+    Value inBoundB = arith::AndIOp::create(rewriter, loc, inBoundBN, inBoundBK);
 
-    auto selectB = rewriter.create<scf::IfOp>(loc, AElemType, inBoundB,
-                                              /*withElseRegion=*/true);
+    auto selectB = scf::IfOp::create(rewriter, loc, AElemType, inBoundB,
+                                     /*withElseRegion=*/true);
     rewriter.setInsertionPointToStart(&selectB.getThenRegion().front());
     // B[batch, n, k] — already column-major
-    Value bLoadVal = rewriter.create<memref::LoadOp>(
-        loc, B, ValueRange{batchIdx, globalBn, globalBk});
-    rewriter.create<scf::YieldOp>(loc, bLoadVal);
+    Value bLoadVal = memref::LoadOp::create(
+        rewriter, loc, B, ValueRange{batchIdx, globalBn, globalBk});
+    scf::YieldOp::create(rewriter, loc, bLoadVal);
     rewriter.setInsertionPointToStart(&selectB.getElseRegion().front());
-    rewriter.create<scf::YieldOp>(loc, zeroElem);
+    scf::YieldOp::create(rewriter, loc, zeroElem);
     rewriter.setInsertionPointAfter(selectB);
 
     // BTile[n,k] — direct copy, no repack
-    rewriter.create<memref::StoreOp>(loc, selectB.getResult(0), BTile,
-                                     ValueRange{copyBn, copyBk});
+    memref::StoreOp::create(rewriter, loc, selectB.getResult(0), BTile,
+                            ValueRange{copyBn, copyBk});
     rewriter.setInsertionPointAfter(copyBLoop1);
 
     // IME compute
     if (isFloat) {
-      rewriter.create<VfmadotOp>(loc, CTile, ATile, BTile);
+      VfmadotOp::create(rewriter, loc, CTile, ATile, BTile);
     } else {
-      rewriter.create<VmadotOp>(loc, CTile, ATile, BTile);
+      VmadotOp::create(rewriter, loc, CTile, ATile, BTile);
     }
 
     // End K tile loop
     rewriter.setInsertionPointAfter(loopTileK);
 
     // Store CTile back to C[batch, m, n]
-    auto storeCLoop1 = rewriter.create<scf::ForOp>(loc, c0, tileMVal, c1);
+    auto storeCLoop1 = scf::ForOp::create(rewriter, loc, c0, tileMVal, c1);
     rewriter.setInsertionPointToStart(storeCLoop1.getBody());
     Value storeCi = storeCLoop1.getInductionVar();
-    auto storeCLoop2 = rewriter.create<scf::ForOp>(loc, c0, tileNVal, c1);
+    auto storeCLoop2 = scf::ForOp::create(rewriter, loc, c0, tileNVal, c1);
     rewriter.setInsertionPointToStart(storeCLoop2.getBody());
     Value storeCj = storeCLoop2.getInductionVar();
 
-    Value globalStoreCi = rewriter.create<arith::AddIOp>(loc, baseM, storeCi);
-    Value globalStoreCj = rewriter.create<arith::AddIOp>(loc, baseN, storeCj);
-    Value inBoundStoreM = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::ult, globalStoreCi, boundM);
-    Value inBoundStoreN = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::ult, globalStoreCj, boundN);
+    Value globalStoreCi = arith::AddIOp::create(rewriter, loc, baseM, storeCi);
+    Value globalStoreCj = arith::AddIOp::create(rewriter, loc, baseN, storeCj);
+    Value inBoundStoreM = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::ult, globalStoreCi, boundM);
+    Value inBoundStoreN = arith::CmpIOp::create(
+        rewriter, loc, arith::CmpIPredicate::ult, globalStoreCj, boundN);
     Value inBoundStore =
-        rewriter.create<arith::AndIOp>(loc, inBoundStoreM, inBoundStoreN);
+        arith::AndIOp::create(rewriter, loc, inBoundStoreM, inBoundStoreN);
 
-    auto storeIf = rewriter.create<scf::IfOp>(loc, inBoundStore,
-                                              /*withElseRegion=*/false);
+    auto storeIf = scf::IfOp::create(rewriter, loc, inBoundStore,
+                                     /*withElseRegion=*/false);
     rewriter.setInsertionPointToStart(&storeIf.getThenRegion().front());
-    Value cResult = rewriter.create<memref::LoadOp>(
-        loc, CTile, ValueRange{storeCi, storeCj});
-    rewriter.create<memref::StoreOp>(
-        loc, cResult, C, ValueRange{batchIdx, globalStoreCi, globalStoreCj});
+    Value cResult = memref::LoadOp::create(rewriter, loc, CTile,
+                                           ValueRange{storeCi, storeCj});
+    memref::StoreOp::create(rewriter, loc, cResult, C,
+                            ValueRange{batchIdx, globalStoreCi, globalStoreCj});
 
     rewriter.setInsertionPointAfter(storeCLoop1);
 
@@ -814,152 +814,155 @@ public:
     const int64_t TILE_K = 8;
     const int64_t TILE_N = 4;
 
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
 
-    Value boundN = rewriter.create<arith::ConstantIndexOp>(loc, N);
-    Value boundOH = rewriter.create<arith::ConstantIndexOp>(loc, OH);
-    Value boundOW = rewriter.create<arith::ConstantIndexOp>(loc, OW);
-    Value boundOC = rewriter.create<arith::ConstantIndexOp>(loc, OC);
-    Value boundFH = rewriter.create<arith::ConstantIndexOp>(loc, FH);
-    Value boundFW = rewriter.create<arith::ConstantIndexOp>(loc, FW);
-    Value boundIC = rewriter.create<arith::ConstantIndexOp>(loc, IC);
+    Value boundN = arith::ConstantIndexOp::create(rewriter, loc, N);
+    Value boundOH = arith::ConstantIndexOp::create(rewriter, loc, OH);
+    Value boundOW = arith::ConstantIndexOp::create(rewriter, loc, OW);
+    Value boundOC = arith::ConstantIndexOp::create(rewriter, loc, OC);
+    Value boundFH = arith::ConstantIndexOp::create(rewriter, loc, FH);
+    Value boundFW = arith::ConstantIndexOp::create(rewriter, loc, FW);
+    Value boundIC = arith::ConstantIndexOp::create(rewriter, loc, IC);
 
-    Value stepM = rewriter.create<arith::ConstantIndexOp>(loc, TILE_M);
-    Value stepK = rewriter.create<arith::ConstantIndexOp>(loc, TILE_K);
-    Value stepN = rewriter.create<arith::ConstantIndexOp>(loc, TILE_N);
+    Value stepM = arith::ConstantIndexOp::create(rewriter, loc, TILE_M);
+    Value stepK = arith::ConstantIndexOp::create(rewriter, loc, TILE_K);
+    Value stepN = arith::ConstantIndexOp::create(rewriter, loc, TILE_N);
 
-    Value strideHVal = rewriter.create<arith::ConstantIndexOp>(loc, strideH);
-    Value strideWVal = rewriter.create<arith::ConstantIndexOp>(loc, strideW);
+    Value strideHVal = arith::ConstantIndexOp::create(rewriter, loc, strideH);
+    Value strideWVal = arith::ConstantIndexOp::create(rewriter, loc, strideW);
 
     auto inputTileType = MemRefType::get({TILE_2M, TILE_K}, inputElemType);
     auto filterTileType = MemRefType::get({TILE_K, TILE_N}, inputElemType);
     auto outputTileType =
         MemRefType::get({TILE_M, TILE_N}, rewriter.getI32Type());
 
-    auto loopN = rewriter.create<scf::ForOp>(loc, c0, boundN, c1);
+    auto loopN = scf::ForOp::create(rewriter, loc, c0, boundN, c1);
     rewriter.setInsertionPointToStart(loopN.getBody());
     Value ivN = loopN.getInductionVar();
 
-    auto loopOH = rewriter.create<scf::ForOp>(loc, c0, boundOH, stepM);
+    auto loopOH = scf::ForOp::create(rewriter, loc, c0, boundOH, stepM);
     rewriter.setInsertionPointToStart(loopOH.getBody());
     Value ivOH = loopOH.getInductionVar();
 
-    auto loopOC = rewriter.create<scf::ForOp>(loc, c0, boundOC, stepN);
+    auto loopOC = scf::ForOp::create(rewriter, loc, c0, boundOC, stepN);
     rewriter.setInsertionPointToStart(loopOC.getBody());
     Value ivOC = loopOC.getInductionVar();
 
-    auto loopOW = rewriter.create<scf::ForOp>(loc, c0, boundOW, c1);
+    auto loopOW = scf::ForOp::create(rewriter, loc, c0, boundOW, c1);
     rewriter.setInsertionPointToStart(loopOW.getBody());
     Value ivOW = loopOW.getInductionVar();
 
-    auto loopFH = rewriter.create<scf::ForOp>(loc, c0, boundFH, c1);
+    auto loopFH = scf::ForOp::create(rewriter, loc, c0, boundFH, c1);
     rewriter.setInsertionPointToStart(loopFH.getBody());
     Value ivFH = loopFH.getInductionVar();
 
-    auto loopFW = rewriter.create<scf::ForOp>(loc, c0, boundFW, c1);
+    auto loopFW = scf::ForOp::create(rewriter, loc, c0, boundFW, c1);
     rewriter.setInsertionPointToStart(loopFW.getBody());
     Value ivFW = loopFW.getInductionVar();
 
-    auto loopIC = rewriter.create<scf::ForOp>(loc, c0, boundIC, stepK);
+    auto loopIC = scf::ForOp::create(rewriter, loc, c0, boundIC, stepK);
     rewriter.setInsertionPointToStart(loopIC.getBody());
     Value ivIC = loopIC.getInductionVar();
 
-    Value inputTile = rewriter.create<memref::AllocaOp>(loc, inputTileType);
-    Value filterTile = rewriter.create<memref::AllocaOp>(loc, filterTileType);
-    Value outputTile = rewriter.create<memref::AllocaOp>(loc, outputTileType);
+    Value inputTile = memref::AllocaOp::create(rewriter, loc, inputTileType);
+    Value filterTile = memref::AllocaOp::create(rewriter, loc, filterTileType);
+    Value outputTile = memref::AllocaOp::create(rewriter, loc, outputTileType);
 
-    Value ihBase = rewriter.create<arith::MulIOp>(loc, ivOH, strideHVal);
-    ihBase = rewriter.create<arith::AddIOp>(loc, ihBase, ivFH);
-    Value iw = rewriter.create<arith::MulIOp>(loc, ivOW, strideWVal);
-    iw = rewriter.create<arith::AddIOp>(loc, iw, ivFW);
+    Value ihBase = arith::MulIOp::create(rewriter, loc, ivOH, strideHVal);
+    ihBase = arith::AddIOp::create(rewriter, loc, ihBase, ivFH);
+    Value iw = arith::MulIOp::create(rewriter, loc, ivOW, strideWVal);
+    iw = arith::AddIOp::create(rewriter, loc, iw, ivFW);
 
-    Value tileMBound = rewriter.create<arith::ConstantIndexOp>(loc, TILE_M);
-    Value tile2MBound = rewriter.create<arith::ConstantIndexOp>(loc, TILE_2M);
-    Value tileKBound = rewriter.create<arith::ConstantIndexOp>(loc, TILE_K);
-    Value tileNBound = rewriter.create<arith::ConstantIndexOp>(loc, TILE_N);
+    Value tileMBound = arith::ConstantIndexOp::create(rewriter, loc, TILE_M);
+    Value tile2MBound = arith::ConstantIndexOp::create(rewriter, loc, TILE_2M);
+    Value tileKBound = arith::ConstantIndexOp::create(rewriter, loc, TILE_K);
+    Value tileNBound = arith::ConstantIndexOp::create(rewriter, loc, TILE_N);
 
-    auto fillInputLoop = rewriter.create<scf::ForOp>(loc, c0, tile2MBound, c1);
+    auto fillInputLoop = scf::ForOp::create(rewriter, loc, c0, tile2MBound, c1);
     rewriter.setInsertionPointToStart(fillInputLoop.getBody());
     Value fillM = fillInputLoop.getInductionVar();
 
     auto fillInputInnerLoop =
-        rewriter.create<scf::ForOp>(loc, c0, tileKBound, c1);
+        scf::ForOp::create(rewriter, loc, c0, tileKBound, c1);
     rewriter.setInsertionPointToStart(fillInputInnerLoop.getBody());
     Value fillK = fillInputInnerLoop.getInductionVar();
 
-    Value mTimesStride = rewriter.create<arith::MulIOp>(loc, fillM, strideHVal);
-    Value inputIH = rewriter.create<arith::AddIOp>(loc, ihBase, mTimesStride);
-    Value inputIC = rewriter.create<arith::AddIOp>(loc, ivIC, fillK);
-    Value inputVal = rewriter.create<memref::LoadOp>(
-        loc, input, ValueRange{ivN, inputIH, iw, inputIC});
-    rewriter.create<memref::StoreOp>(loc, inputVal, inputTile,
-                                     ValueRange{fillM, fillK});
+    Value mTimesStride =
+        arith::MulIOp::create(rewriter, loc, fillM, strideHVal);
+    Value inputIH = arith::AddIOp::create(rewriter, loc, ihBase, mTimesStride);
+    Value inputIC = arith::AddIOp::create(rewriter, loc, ivIC, fillK);
+    Value inputVal = memref::LoadOp::create(
+        rewriter, loc, input, ValueRange{ivN, inputIH, iw, inputIC});
+    memref::StoreOp::create(rewriter, loc, inputVal, inputTile,
+                            ValueRange{fillM, fillK});
 
     rewriter.setInsertionPointAfter(fillInputLoop);
 
-    auto fillFilterLoop = rewriter.create<scf::ForOp>(loc, c0, tileKBound, c1);
+    auto fillFilterLoop = scf::ForOp::create(rewriter, loc, c0, tileKBound, c1);
     rewriter.setInsertionPointToStart(fillFilterLoop.getBody());
     Value fillFK = fillFilterLoop.getInductionVar();
 
     auto fillFilterInnerLoop =
-        rewriter.create<scf::ForOp>(loc, c0, tileNBound, c1);
+        scf::ForOp::create(rewriter, loc, c0, tileNBound, c1);
     rewriter.setInsertionPointToStart(fillFilterInnerLoop.getBody());
     Value fillFN = fillFilterInnerLoop.getInductionVar();
 
-    Value filterIC = rewriter.create<arith::AddIOp>(loc, ivIC, fillFK);
-    Value filterOC = rewriter.create<arith::AddIOp>(loc, ivOC, fillFN);
-    Value filterVal = rewriter.create<memref::LoadOp>(
-        loc, filter, ValueRange{ivFH, ivFW, filterIC, filterOC});
-    rewriter.create<memref::StoreOp>(loc, filterVal, filterTile,
-                                     ValueRange{fillFK, fillFN});
+    Value filterIC = arith::AddIOp::create(rewriter, loc, ivIC, fillFK);
+    Value filterOC = arith::AddIOp::create(rewriter, loc, ivOC, fillFN);
+    Value filterVal = memref::LoadOp::create(
+        rewriter, loc, filter, ValueRange{ivFH, ivFW, filterIC, filterOC});
+    memref::StoreOp::create(rewriter, loc, filterVal, filterTile,
+                            ValueRange{fillFK, fillFN});
 
     rewriter.setInsertionPointAfter(fillFilterLoop);
 
-    auto loadOutputLoop = rewriter.create<scf::ForOp>(loc, c0, tileMBound, c1);
+    auto loadOutputLoop = scf::ForOp::create(rewriter, loc, c0, tileMBound, c1);
     rewriter.setInsertionPointToStart(loadOutputLoop.getBody());
     Value loadM = loadOutputLoop.getInductionVar();
 
     auto loadOutputInnerLoop =
-        rewriter.create<scf::ForOp>(loc, c0, tileNBound, c1);
+        scf::ForOp::create(rewriter, loc, c0, tileNBound, c1);
     rewriter.setInsertionPointToStart(loadOutputInnerLoop.getBody());
     Value loadN = loadOutputInnerLoop.getInductionVar();
 
-    Value outOH = rewriter.create<arith::AddIOp>(loc, ivOH, loadM);
-    Value outOC = rewriter.create<arith::AddIOp>(loc, ivOC, loadN);
-    Value outVal = rewriter.create<memref::LoadOp>(
-        loc, output, ValueRange{ivN, outOH, ivOW, outOC});
-    rewriter.create<memref::StoreOp>(loc, outVal, outputTile,
-                                     ValueRange{loadM, loadN});
+    Value outOH = arith::AddIOp::create(rewriter, loc, ivOH, loadM);
+    Value outOC = arith::AddIOp::create(rewriter, loc, ivOC, loadN);
+    Value outVal = memref::LoadOp::create(rewriter, loc, output,
+                                          ValueRange{ivN, outOH, ivOW, outOC});
+    memref::StoreOp::create(rewriter, loc, outVal, outputTile,
+                            ValueRange{loadM, loadN});
 
     rewriter.setInsertionPointAfter(loadOutputLoop);
 
     if (strideH == 1) {
-      rewriter.create<Vmadot1Op>(loc, outputTile, inputTile, filterTile);
+      Vmadot1Op::create(rewriter, loc, outputTile, inputTile, filterTile);
     } else if (strideH == 2) {
-      rewriter.create<Vmadot2Op>(loc, outputTile, inputTile, filterTile);
+      Vmadot2Op::create(rewriter, loc, outputTile, inputTile, filterTile);
     } else if (strideH == 3) {
-      rewriter.create<Vmadot3Op>(loc, outputTile, inputTile, filterTile);
+      Vmadot3Op::create(rewriter, loc, outputTile, inputTile, filterTile);
     } else {
-      Value slide = rewriter.create<arith::ConstantIntOp>(loc, 0, 64);
-      rewriter.create<VmadotnOp>(loc, outputTile, inputTile, filterTile, slide);
+      Value slide = arith::ConstantIntOp::create(rewriter, loc, 0, 64);
+      VmadotnOp::create(rewriter, loc, outputTile, inputTile, filterTile,
+                        slide);
     }
 
-    auto storeOutputLoop = rewriter.create<scf::ForOp>(loc, c0, tileMBound, c1);
+    auto storeOutputLoop =
+        scf::ForOp::create(rewriter, loc, c0, tileMBound, c1);
     rewriter.setInsertionPointToStart(storeOutputLoop.getBody());
     Value storeM = storeOutputLoop.getInductionVar();
 
     auto storeOutputInnerLoop =
-        rewriter.create<scf::ForOp>(loc, c0, tileNBound, c1);
+        scf::ForOp::create(rewriter, loc, c0, tileNBound, c1);
     rewriter.setInsertionPointToStart(storeOutputInnerLoop.getBody());
     Value storeN = storeOutputInnerLoop.getInductionVar();
 
-    Value storeOH = rewriter.create<arith::AddIOp>(loc, ivOH, storeM);
-    Value storeOC = rewriter.create<arith::AddIOp>(loc, ivOC, storeN);
-    Value storeVal = rewriter.create<memref::LoadOp>(
-        loc, outputTile, ValueRange{storeM, storeN});
-    rewriter.create<memref::StoreOp>(loc, storeVal, output,
-                                     ValueRange{ivN, storeOH, ivOW, storeOC});
+    Value storeOH = arith::AddIOp::create(rewriter, loc, ivOH, storeM);
+    Value storeOC = arith::AddIOp::create(rewriter, loc, ivOC, storeN);
+    Value storeVal = memref::LoadOp::create(rewriter, loc, outputTile,
+                                            ValueRange{storeM, storeN});
+    memref::StoreOp::create(rewriter, loc, storeVal, output,
+                            ValueRange{ivN, storeOH, ivOW, storeOC});
 
     rewriter.setInsertionPointAfter(storeOutputLoop);
 
@@ -1028,152 +1031,155 @@ public:
     const int64_t TILE_K = 8;
     const int64_t TILE_N = 4;
 
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
 
-    Value boundN = rewriter.create<arith::ConstantIndexOp>(loc, N);
-    Value boundOC = rewriter.create<arith::ConstantIndexOp>(loc, OC);
-    Value boundOH = rewriter.create<arith::ConstantIndexOp>(loc, OH);
-    Value boundOW = rewriter.create<arith::ConstantIndexOp>(loc, OW);
-    Value boundIC = rewriter.create<arith::ConstantIndexOp>(loc, IC);
-    Value boundFH = rewriter.create<arith::ConstantIndexOp>(loc, FH);
-    Value boundFW = rewriter.create<arith::ConstantIndexOp>(loc, FW);
+    Value boundN = arith::ConstantIndexOp::create(rewriter, loc, N);
+    Value boundOC = arith::ConstantIndexOp::create(rewriter, loc, OC);
+    Value boundOH = arith::ConstantIndexOp::create(rewriter, loc, OH);
+    Value boundOW = arith::ConstantIndexOp::create(rewriter, loc, OW);
+    Value boundIC = arith::ConstantIndexOp::create(rewriter, loc, IC);
+    Value boundFH = arith::ConstantIndexOp::create(rewriter, loc, FH);
+    Value boundFW = arith::ConstantIndexOp::create(rewriter, loc, FW);
 
-    Value stepM = rewriter.create<arith::ConstantIndexOp>(loc, TILE_M);
-    Value stepK = rewriter.create<arith::ConstantIndexOp>(loc, TILE_K);
-    Value stepN = rewriter.create<arith::ConstantIndexOp>(loc, TILE_N);
+    Value stepM = arith::ConstantIndexOp::create(rewriter, loc, TILE_M);
+    Value stepK = arith::ConstantIndexOp::create(rewriter, loc, TILE_K);
+    Value stepN = arith::ConstantIndexOp::create(rewriter, loc, TILE_N);
 
-    Value strideHVal = rewriter.create<arith::ConstantIndexOp>(loc, strideH);
-    Value strideWVal = rewriter.create<arith::ConstantIndexOp>(loc, strideW);
+    Value strideHVal = arith::ConstantIndexOp::create(rewriter, loc, strideH);
+    Value strideWVal = arith::ConstantIndexOp::create(rewriter, loc, strideW);
 
-    auto loopN = rewriter.create<scf::ForOp>(loc, c0, boundN, c1);
+    auto loopN = scf::ForOp::create(rewriter, loc, c0, boundN, c1);
     rewriter.setInsertionPointToStart(loopN.getBody());
     Value ivN = loopN.getInductionVar();
 
-    auto loopOC = rewriter.create<scf::ForOp>(loc, c0, boundOC, stepN);
+    auto loopOC = scf::ForOp::create(rewriter, loc, c0, boundOC, stepN);
     rewriter.setInsertionPointToStart(loopOC.getBody());
     Value ivOC = loopOC.getInductionVar();
 
-    auto loopOH = rewriter.create<scf::ForOp>(loc, c0, boundOH, stepM);
+    auto loopOH = scf::ForOp::create(rewriter, loc, c0, boundOH, stepM);
     rewriter.setInsertionPointToStart(loopOH.getBody());
     Value ivOH = loopOH.getInductionVar();
 
-    auto loopOW = rewriter.create<scf::ForOp>(loc, c0, boundOW, c1);
+    auto loopOW = scf::ForOp::create(rewriter, loc, c0, boundOW, c1);
     rewriter.setInsertionPointToStart(loopOW.getBody());
     Value ivOW = loopOW.getInductionVar();
 
-    auto loopIC = rewriter.create<scf::ForOp>(loc, c0, boundIC, stepK);
+    auto loopIC = scf::ForOp::create(rewriter, loc, c0, boundIC, stepK);
     rewriter.setInsertionPointToStart(loopIC.getBody());
     Value ivIC = loopIC.getInductionVar();
 
-    auto loopFH = rewriter.create<scf::ForOp>(loc, c0, boundFH, c1);
+    auto loopFH = scf::ForOp::create(rewriter, loc, c0, boundFH, c1);
     rewriter.setInsertionPointToStart(loopFH.getBody());
     Value ivFH = loopFH.getInductionVar();
 
-    auto loopFW = rewriter.create<scf::ForOp>(loc, c0, boundFW, c1);
+    auto loopFW = scf::ForOp::create(rewriter, loc, c0, boundFW, c1);
     rewriter.setInsertionPointToStart(loopFW.getBody());
     Value ivFW = loopFW.getInductionVar();
 
-    Value ihBase = rewriter.create<arith::MulIOp>(loc, ivOH, strideHVal);
-    ihBase = rewriter.create<arith::AddIOp>(loc, ihBase, ivFH);
-    Value iw = rewriter.create<arith::MulIOp>(loc, ivOW, strideWVal);
-    iw = rewriter.create<arith::AddIOp>(loc, iw, ivFW);
+    Value ihBase = arith::MulIOp::create(rewriter, loc, ivOH, strideHVal);
+    ihBase = arith::AddIOp::create(rewriter, loc, ihBase, ivFH);
+    Value iw = arith::MulIOp::create(rewriter, loc, ivOW, strideWVal);
+    iw = arith::AddIOp::create(rewriter, loc, iw, ivFW);
 
     auto inputTileType = MemRefType::get({TILE_2M, TILE_K}, inputElemType);
     auto filterTileType = MemRefType::get({TILE_K, TILE_N}, inputElemType);
     auto outputTileType =
         MemRefType::get({TILE_M, TILE_N}, rewriter.getI32Type());
 
-    Value inputTile = rewriter.create<memref::AllocaOp>(loc, inputTileType);
-    Value filterTile = rewriter.create<memref::AllocaOp>(loc, filterTileType);
-    Value outputTile = rewriter.create<memref::AllocaOp>(loc, outputTileType);
+    Value inputTile = memref::AllocaOp::create(rewriter, loc, inputTileType);
+    Value filterTile = memref::AllocaOp::create(rewriter, loc, filterTileType);
+    Value outputTile = memref::AllocaOp::create(rewriter, loc, outputTileType);
 
-    Value tileMBound = rewriter.create<arith::ConstantIndexOp>(loc, TILE_M);
-    Value tile2MBound = rewriter.create<arith::ConstantIndexOp>(loc, TILE_2M);
-    Value tileKBound = rewriter.create<arith::ConstantIndexOp>(loc, TILE_K);
-    Value tileNBound = rewriter.create<arith::ConstantIndexOp>(loc, TILE_N);
+    Value tileMBound = arith::ConstantIndexOp::create(rewriter, loc, TILE_M);
+    Value tile2MBound = arith::ConstantIndexOp::create(rewriter, loc, TILE_2M);
+    Value tileKBound = arith::ConstantIndexOp::create(rewriter, loc, TILE_K);
+    Value tileNBound = arith::ConstantIndexOp::create(rewriter, loc, TILE_N);
 
-    auto fillInputLoop = rewriter.create<scf::ForOp>(loc, c0, tile2MBound, c1);
+    auto fillInputLoop = scf::ForOp::create(rewriter, loc, c0, tile2MBound, c1);
     rewriter.setInsertionPointToStart(fillInputLoop.getBody());
     Value fillM = fillInputLoop.getInductionVar();
 
     auto fillInputInnerLoop =
-        rewriter.create<scf::ForOp>(loc, c0, tileKBound, c1);
+        scf::ForOp::create(rewriter, loc, c0, tileKBound, c1);
     rewriter.setInsertionPointToStart(fillInputInnerLoop.getBody());
     Value fillK = fillInputInnerLoop.getInductionVar();
 
-    Value mTimesStride = rewriter.create<arith::MulIOp>(loc, fillM, strideHVal);
-    Value inputIH = rewriter.create<arith::AddIOp>(loc, ihBase, mTimesStride);
-    Value inputIC = rewriter.create<arith::AddIOp>(loc, ivIC, fillK);
-    Value inputVal = rewriter.create<memref::LoadOp>(
-        loc, input, ValueRange{ivN, inputIC, inputIH, iw});
-    rewriter.create<memref::StoreOp>(loc, inputVal, inputTile,
-                                     ValueRange{fillM, fillK});
+    Value mTimesStride =
+        arith::MulIOp::create(rewriter, loc, fillM, strideHVal);
+    Value inputIH = arith::AddIOp::create(rewriter, loc, ihBase, mTimesStride);
+    Value inputIC = arith::AddIOp::create(rewriter, loc, ivIC, fillK);
+    Value inputVal = memref::LoadOp::create(
+        rewriter, loc, input, ValueRange{ivN, inputIC, inputIH, iw});
+    memref::StoreOp::create(rewriter, loc, inputVal, inputTile,
+                            ValueRange{fillM, fillK});
 
     rewriter.setInsertionPointAfter(fillInputLoop);
 
-    auto fillFilterLoop = rewriter.create<scf::ForOp>(loc, c0, tileKBound, c1);
+    auto fillFilterLoop = scf::ForOp::create(rewriter, loc, c0, tileKBound, c1);
     rewriter.setInsertionPointToStart(fillFilterLoop.getBody());
     Value fillFK = fillFilterLoop.getInductionVar();
 
     auto fillFilterInnerLoop =
-        rewriter.create<scf::ForOp>(loc, c0, tileNBound, c1);
+        scf::ForOp::create(rewriter, loc, c0, tileNBound, c1);
     rewriter.setInsertionPointToStart(fillFilterInnerLoop.getBody());
     Value fillFN = fillFilterInnerLoop.getInductionVar();
 
-    Value filterOC = rewriter.create<arith::AddIOp>(loc, ivOC, fillFN);
-    Value filterIC = rewriter.create<arith::AddIOp>(loc, ivIC, fillFK);
-    Value filterVal = rewriter.create<memref::LoadOp>(
-        loc, filter, ValueRange{filterOC, filterIC, ivFH, ivFW});
-    rewriter.create<memref::StoreOp>(loc, filterVal, filterTile,
-                                     ValueRange{fillFK, fillFN});
+    Value filterOC = arith::AddIOp::create(rewriter, loc, ivOC, fillFN);
+    Value filterIC = arith::AddIOp::create(rewriter, loc, ivIC, fillFK);
+    Value filterVal = memref::LoadOp::create(
+        rewriter, loc, filter, ValueRange{filterOC, filterIC, ivFH, ivFW});
+    memref::StoreOp::create(rewriter, loc, filterVal, filterTile,
+                            ValueRange{fillFK, fillFN});
 
     rewriter.setInsertionPointAfter(fillFilterLoop);
 
-    auto loadOutputLoop = rewriter.create<scf::ForOp>(loc, c0, tileMBound, c1);
+    auto loadOutputLoop = scf::ForOp::create(rewriter, loc, c0, tileMBound, c1);
     rewriter.setInsertionPointToStart(loadOutputLoop.getBody());
     Value loadM = loadOutputLoop.getInductionVar();
 
     auto loadOutputInnerLoop =
-        rewriter.create<scf::ForOp>(loc, c0, tileNBound, c1);
+        scf::ForOp::create(rewriter, loc, c0, tileNBound, c1);
     rewriter.setInsertionPointToStart(loadOutputInnerLoop.getBody());
     Value loadN = loadOutputInnerLoop.getInductionVar();
 
-    Value outOC = rewriter.create<arith::AddIOp>(loc, ivOC, loadN);
-    Value outOH = rewriter.create<arith::AddIOp>(loc, ivOH, loadM);
-    Value outVal = rewriter.create<memref::LoadOp>(
-        loc, output, ValueRange{ivN, outOC, outOH, ivOW});
-    rewriter.create<memref::StoreOp>(loc, outVal, outputTile,
-                                     ValueRange{loadM, loadN});
+    Value outOC = arith::AddIOp::create(rewriter, loc, ivOC, loadN);
+    Value outOH = arith::AddIOp::create(rewriter, loc, ivOH, loadM);
+    Value outVal = memref::LoadOp::create(rewriter, loc, output,
+                                          ValueRange{ivN, outOC, outOH, ivOW});
+    memref::StoreOp::create(rewriter, loc, outVal, outputTile,
+                            ValueRange{loadM, loadN});
 
     rewriter.setInsertionPointAfter(loadOutputLoop);
 
     if (strideH == 1) {
-      rewriter.create<Vmadot1Op>(loc, outputTile, inputTile, filterTile);
+      Vmadot1Op::create(rewriter, loc, outputTile, inputTile, filterTile);
     } else if (strideH == 2) {
-      rewriter.create<Vmadot2Op>(loc, outputTile, inputTile, filterTile);
+      Vmadot2Op::create(rewriter, loc, outputTile, inputTile, filterTile);
     } else if (strideH == 3) {
-      rewriter.create<Vmadot3Op>(loc, outputTile, inputTile, filterTile);
+      Vmadot3Op::create(rewriter, loc, outputTile, inputTile, filterTile);
     } else {
-      Value slide = rewriter.create<arith::ConstantIntOp>(loc, 0, 64);
-      rewriter.create<VmadotnOp>(loc, outputTile, inputTile, filterTile, slide);
+      Value slide = arith::ConstantIntOp::create(rewriter, loc, 0, 64);
+      VmadotnOp::create(rewriter, loc, outputTile, inputTile, filterTile,
+                        slide);
     }
 
-    auto storeOutputLoop = rewriter.create<scf::ForOp>(loc, c0, tileMBound, c1);
+    auto storeOutputLoop =
+        scf::ForOp::create(rewriter, loc, c0, tileMBound, c1);
     rewriter.setInsertionPointToStart(storeOutputLoop.getBody());
     Value storeM = storeOutputLoop.getInductionVar();
 
     auto storeOutputInnerLoop =
-        rewriter.create<scf::ForOp>(loc, c0, tileNBound, c1);
+        scf::ForOp::create(rewriter, loc, c0, tileNBound, c1);
     rewriter.setInsertionPointToStart(storeOutputInnerLoop.getBody());
     Value storeN = storeOutputInnerLoop.getInductionVar();
 
-    Value storeOC = rewriter.create<arith::AddIOp>(loc, ivOC, storeN);
-    Value storeOH = rewriter.create<arith::AddIOp>(loc, ivOH, storeM);
-    Value storeVal = rewriter.create<memref::LoadOp>(
-        loc, outputTile, ValueRange{storeM, storeN});
-    rewriter.create<memref::StoreOp>(loc, storeVal, output,
-                                     ValueRange{ivN, storeOC, storeOH, ivOW});
+    Value storeOC = arith::AddIOp::create(rewriter, loc, ivOC, storeN);
+    Value storeOH = arith::AddIOp::create(rewriter, loc, ivOH, storeM);
+    Value storeVal = memref::LoadOp::create(rewriter, loc, outputTile,
+                                            ValueRange{storeM, storeN});
+    memref::StoreOp::create(rewriter, loc, storeVal, output,
+                            ValueRange{ivN, storeOC, storeOH, ivOW});
 
     rewriter.setInsertionPointAfter(storeOutputLoop);
 

--- a/midend/lib/Conversion/LowerVectorExp/LowerVectorExpPass.cpp
+++ b/midend/lib/Conversion/LowerVectorExp/LowerVectorExpPass.cpp
@@ -64,26 +64,26 @@ public:
       //
       if (isa<arith::AddFOp>(innerOp)) {
         Type resultType = cast<arith::AddFOp>(innerOp).getResult().getType();
-        Value result = rewriter.create<LLVM::VPFAddOp>(
-            loc, resultType, cast<arith::AddFOp>(innerOp).getLhs(),
+        Value result = LLVM::VPFAddOp::create(
+            rewriter, loc, resultType, cast<arith::AddFOp>(innerOp).getLhs(),
             cast<arith::AddFOp>(innerOp).getRhs(), op.getMask(), op.getVl());
         rewriter.replaceOp(op, result);
       } else if (isa<arith::MulFOp>(innerOp)) {
         Type resultType = cast<arith::MulFOp>(innerOp).getResult().getType();
-        Value result = rewriter.create<LLVM::VPFMulOp>(
-            loc, resultType, cast<arith::MulFOp>(innerOp).getLhs(),
+        Value result = LLVM::VPFMulOp::create(
+            rewriter, loc, resultType, cast<arith::MulFOp>(innerOp).getLhs(),
             cast<arith::MulFOp>(innerOp).getRhs(), op.getMask(), op.getVl());
         rewriter.replaceOp(op, result);
       } else if (isa<arith::AddIOp>(innerOp)) {
         Type resultType = cast<arith::AddIOp>(innerOp).getResult().getType();
-        Value result = rewriter.create<LLVM::VPAddOp>(
-            loc, resultType, cast<arith::AddIOp>(innerOp).getLhs(),
+        Value result = LLVM::VPAddOp::create(
+            rewriter, loc, resultType, cast<arith::AddIOp>(innerOp).getLhs(),
             cast<arith::AddIOp>(innerOp).getRhs(), op.getMask(), op.getVl());
         rewriter.replaceOp(op, result);
       } else if (isa<arith::MulIOp>(innerOp)) {
         Type resultType = cast<arith::MulIOp>(innerOp).getResult().getType();
-        Value result = rewriter.create<LLVM::VPMulOp>(
-            loc, resultType, cast<arith::MulIOp>(innerOp).getLhs(),
+        Value result = LLVM::VPMulOp::create(
+            rewriter, loc, resultType, cast<arith::MulIOp>(innerOp).getLhs(),
             cast<arith::MulIOp>(innerOp).getRhs(), op.getMask(), op.getVl());
         rewriter.replaceOp(op, result);
       } else if (isa<vector::LoadOp>(innerOp)) {
@@ -94,9 +94,8 @@ public:
         // - Create UnrealizedConversionCastOp to provide the descriptor value.
         MemRefType memRefTy = loadOp.getMemRefType();
         Type structType = this->getTypeConverter()->convertType(memRefTy);
-        Value memDesc = rewriter
-                            .create<UnrealizedConversionCastOp>(
-                                loc, structType, loadOp.getBase())
+        Value memDesc = UnrealizedConversionCastOp::create(
+                            rewriter, loc, structType, loadOp.getBase())
                             .getResult(0);
         // Prepare the integer indices for the `getStridedElementPtr`.
         // - Interate the indices of the load operation.
@@ -107,7 +106,7 @@ public:
           Type idxType = idx.getType();
           Type intType = this->getTypeConverter()->convertType(idxType);
           Value intIdx =
-              rewriter.create<UnrealizedConversionCastOp>(loc, intType, idx)
+              UnrealizedConversionCastOp::create(rewriter, loc, intType, idx)
                   .getResult(0);
           indices.push_back(intIdx);
         }
@@ -121,8 +120,8 @@ public:
         // - Replace original predication operation.
         VectorType resultType =
             mlir::cast<mlir::VectorType>(op.getResult().getType());
-        Value resultValue = rewriter.create<LLVM::VPLoadOp>(
-            loc, resultType, dataPtr, op.getMask(), op.getVl());
+        Value resultValue = LLVM::VPLoadOp::create(
+            rewriter, loc, resultType, dataPtr, op.getMask(), op.getVl());
         rewriter.replaceOp(op, resultValue);
       } else if (isa<vector::StoreOp>(innerOp)) {
         // The conversion to VP operation is similar to the load operation.
@@ -134,23 +133,22 @@ public:
         Value valueToStore = storeOp.getValueToStore();
         MemRefType memRefTy = storeOp.getMemRefType();
         Type structType = this->getTypeConverter()->convertType(memRefTy);
-        Value memDesc = rewriter
-                            .create<UnrealizedConversionCastOp>(
-                                loc, structType, storeOp.getBase())
+        Value memDesc = UnrealizedConversionCastOp::create(
+                            rewriter, loc, structType, storeOp.getBase())
                             .getResult(0);
         SmallVector<Value, 4> indices;
         for (Value idx : storeOp.getIndices()) {
           Type idxType = idx.getType();
           Type intType = this->getTypeConverter()->convertType(idxType);
           Value intIdx =
-              rewriter.create<UnrealizedConversionCastOp>(loc, intType, idx)
+              UnrealizedConversionCastOp::create(rewriter, loc, intType, idx)
                   .getResult(0);
           indices.push_back(intIdx);
         }
         Value dataPtr = this->getStridedElementPtr(rewriter, loc, memRefTy,
                                                    memDesc, indices);
-        rewriter.create<LLVM::VPStoreOp>(loc, valueToStore, dataPtr,
-                                         op.getMask(), op.getVl());
+        LLVM::VPStoreOp::create(rewriter, loc, valueToStore, dataPtr,
+                                op.getMask(), op.getVl());
         rewriter.eraseOp(op);
       } else if (isa<vector::YieldOp>(innerOp)) {
         // Skip the YieldOp.
@@ -193,7 +191,7 @@ public:
     /// Max SetVL
     IndexType indexType = IndexType::get(ctx);
     // TODO: Find a more reasonable way to obtain the max VL.
-    auto maxVLVal = rewriter.create<arith::ConstantIndexOp>(loc, 4096);
+    auto maxVLVal = arith::ConstantIndexOp::create(rewriter, loc, 4096);
     // Supported data types: i32, i64, f32, f64.
     // Type mapping relationship:
     // 8 bit - arith.constant 0
@@ -220,7 +218,7 @@ public:
       emitError(loc, "Unsupported data type width");
       return failure();
     }
-    auto sewVal = rewriter.create<arith::ConstantIndexOp>(loc, dtypeConfig);
+    auto sewVal = arith::ConstantIndexOp::create(rewriter, loc, dtypeConfig);
     // Supported LMUL values: 1, 2, 4, 8.
     // LMUL = 1 - arith.constant 0
     // LMUL = 2 - arith.constant 1
@@ -246,9 +244,9 @@ public:
       emitError(loc, "Unsupported LMUL value: " + std::to_string(lmulAttr));
       return failure();
     }
-    auto lmulVal = rewriter.create<arith::ConstantIndexOp>(loc, lmulConfig);
-    auto maxVLOp = rewriter.create<buddy::rvv::RVVSetVlOp>(
-        loc, indexType, maxVLVal, sewVal, lmulVal);
+    auto lmulVal = arith::ConstantIndexOp::create(rewriter, loc, lmulConfig);
+    auto maxVLOp = buddy::rvv::RVVSetVlOp::create(rewriter, loc, indexType,
+                                                  maxVLVal, sewVal, lmulVal);
 
     rewriter.replaceOp(op, maxVLOp);
     return success();
@@ -327,7 +325,7 @@ public:
       emitError(loc, "Unsupported data type width");
       return failure();
     }
-    auto sewVal = rewriter.create<arith::ConstantIndexOp>(loc, dtypeConfig);
+    auto sewVal = arith::ConstantIndexOp::create(rewriter, loc, dtypeConfig);
     // Supported LMUL values: 1, 2, 4, 8.
     // LMUL = 1 - arith.constant 0
     // LMUL = 2 - arith.constant 1
@@ -353,11 +351,11 @@ public:
       emitError(loc, "Unsupported LMUL value: " + std::to_string(lmulAttr));
       return failure();
     }
-    auto lmulVal = rewriter.create<arith::ConstantIndexOp>(loc, lmulConfig);
+    auto lmulVal = arith::ConstantIndexOp::create(rewriter, loc, lmulConfig);
     // Generate RVV SetVL operation.
     IndexType indexType = IndexType::get(ctx);
-    rewriter.create<buddy::rvv::RVVSetVlOp>(loc, indexType, avlValue, sewVal,
-                                            lmulVal);
+    buddy::rvv::RVVSetVlOp::create(rewriter, loc, indexType, avlValue, sewVal,
+                                   lmulVal);
 
     // Access the Region
     Region &region = op.getRegion();
@@ -382,15 +380,15 @@ public:
         Value lhsVal = symbolTable[lhsOrigVal];
         Value rhsOrigVal = addIOp.getRhs();
         Value rhsVal = symbolTable[rhsOrigVal];
-        Value resultValue = rewriter.create<buddy::rvv::RVVAddOp>(
-            loc, scalableVectorType, lhsVal, rhsVal, avlValue);
+        Value resultValue = buddy::rvv::RVVAddOp::create(
+            rewriter, loc, scalableVectorType, lhsVal, rhsVal, avlValue);
         symbolTable[innerOp.getResult(0)] = resultValue;
       } else if (isa<vector::LoadOp>(innerOp)) {
         vector::LoadOp loadOp = cast<vector::LoadOp>(innerOp);
         auto baseOp = loadOp.getBase();
         auto idx = loadOp.getIndices().front();
-        Value resultValue = rewriter.create<buddy::rvv::RVVLoadOp>(
-            loc, scalableVectorType, baseOp, idx, avlValue);
+        Value resultValue = buddy::rvv::RVVLoadOp::create(
+            rewriter, loc, scalableVectorType, baseOp, idx, avlValue);
         symbolTable[innerOp.getResult(0)] = resultValue;
       } else if (isa<vector::StoreOp>(innerOp)) {
         vector::StoreOp storeOp = cast<vector::StoreOp>(innerOp);
@@ -398,8 +396,8 @@ public:
         Value valueToStore = symbolTable[origValueToStore];
         auto baseOp = storeOp.getBase();
         auto idx = storeOp.getIndices().front();
-        rewriter.create<buddy::rvv::RVVStoreOp>(loc, valueToStore, baseOp, idx,
-                                                avlValue);
+        buddy::rvv::RVVStoreOp::create(rewriter, loc, valueToStore, baseOp, idx,
+                                       avlValue);
       }
     }
 

--- a/midend/lib/Conversion/MLIRGPU/ConvertMemcpyToGPU.cpp
+++ b/midend/lib/Conversion/MLIRGPU/ConvertMemcpyToGPU.cpp
@@ -107,13 +107,13 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
       // TODO: Move this out of operation, make the copy process async
       auto memrefType = dyn_cast<MemRefType>(arg.getType());
 
-      auto gpuAllocOp = builder.create<gpu::AllocOp>(
-          builder.getUnknownLoc(), TypeRange({stripMemRefLayout(memrefType)}),
-          ValueRange({}));
+      auto gpuAllocOp = gpu::AllocOp::create(
+          builder, builder.getUnknownLoc(),
+          TypeRange({stripMemRefLayout(memrefType)}), ValueRange({}));
       unDeallocatedValue.push_back(gpuAllocOp->getResult(0));
-      auto gpuMemcpyOp = builder.create<gpu::MemcpyOp>(
-          gpuAllocOp.getLoc(), TypeRange(), ValueRange(),
-          gpuAllocOp.getResult(0), arg);
+      auto gpuMemcpyOp =
+          gpu::MemcpyOp::create(builder, gpuAllocOp.getLoc(), TypeRange(),
+                                ValueRange(), gpuAllocOp.getResult(0), arg);
       arg.replaceAllUsesExcept(gpuAllocOp->getResult(0), gpuMemcpyOp);
     }
   }
@@ -142,15 +142,15 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
           return WalkResult::advance();
       }
 
-      auto gpuAllocOp = builder.create<gpu::AllocOp>(
-          allocOp->getLoc(), TypeRange({stripMemRefLayout(memrefType)}),
-          ValueRange({}));
+      auto gpuAllocOp = gpu::AllocOp::create(
+          builder, allocOp->getLoc(),
+          TypeRange({stripMemRefLayout(memrefType)}), ValueRange({}));
 
       for (auto user : llvm::make_early_inc_range(result.getUsers())) {
         if (auto deallocOp = dyn_cast<memref::DeallocOp>(user)) {
           builder.setInsertionPointAfter(deallocOp);
-          builder.create<gpu::DeallocOp>(deallocOp->getLoc(), TypeRange(),
-                                         ValueRange(), gpuAllocOp.getResult(0));
+          gpu::DeallocOp::create(builder, deallocOp->getLoc(), TypeRange(),
+                                 ValueRange(), gpuAllocOp.getResult(0));
           deallocOp->erase();
         } else {
           for (auto &opOperand : user->getOpOperands()) {
@@ -168,8 +168,8 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
       auto dst = copyOp.getOperand(1);
       // Notice: GPU.memcpy has a different src dst order
       builder.setInsertionPointAfter(copyOp);
-      auto gpuMemcpyOp = builder.create<gpu::MemcpyOp>(
-          copyOp->getLoc(), TypeRange(), ValueRange(), dst, src);
+      auto gpuMemcpyOp = gpu::MemcpyOp::create(
+          builder, copyOp->getLoc(), TypeRange(), ValueRange(), dst, src);
       src.replaceAllUsesWith(gpuMemcpyOp->getResult(1));
       dst.replaceAllUsesWith(gpuMemcpyOp->getResult(0));
       copyOp->erase();
@@ -179,15 +179,15 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
       builder.setInsertionPointAfter(getGlobalOp);
       auto result = getGlobalOp->getResult(0);
       auto memrefType = dyn_cast<MemRefType>(result.getType());
-      auto gpuAllocOp = builder.create<gpu::AllocOp>(
-          getGlobalOp->getLoc(), TypeRange({stripMemRefLayout(memrefType)}),
-          ValueRange({}));
+      auto gpuAllocOp = gpu::AllocOp::create(
+          builder, getGlobalOp->getLoc(),
+          TypeRange({stripMemRefLayout(memrefType)}), ValueRange({}));
       unDeallocatedValue.push_back(gpuAllocOp->getResult(0));
 
       auto src = result;
       auto dst = gpuAllocOp->getResult(0);
-      auto gpuMemcpyOp = builder.create<gpu::MemcpyOp>(
-          gpuAllocOp->getLoc(), TypeRange(), ValueRange(), dst, src);
+      auto gpuMemcpyOp = gpu::MemcpyOp::create(
+          builder, gpuAllocOp->getLoc(), TypeRange(), ValueRange(), dst, src);
       src.replaceAllUsesExcept(dst, gpuMemcpyOp);
     }
     // Copy data back to CPU, deallocate GPU, then return
@@ -199,11 +199,10 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
         auto val = returnOp->getOperand(i);
         if (auto memrefType = dyn_cast<MemRefType>(val.getType())) {
           auto identityMemrefType = stripMemRefLayout(memrefType);
-          auto allocOp = builder.create<memref::AllocOp>(returnOp->getLoc(),
-                                                         identityMemrefType);
-          builder.create<gpu::MemcpyOp>(allocOp.getLoc(), TypeRange(),
-                                        ValueRange(), allocOp->getResult(0),
-                                        val);
+          auto allocOp = memref::AllocOp::create(builder, returnOp->getLoc(),
+                                                 identityMemrefType);
+          gpu::MemcpyOp::create(builder, allocOp.getLoc(), TypeRange(),
+                                ValueRange(), allocOp->getResult(0), val);
           // FIXME: may be leak memory
           // auto gpuDeallocOp = builder.create<gpu::DeallocOp>(
           //     gpuMemcpyOp->getLoc(), TypeRange(), ValueRange(), val);
@@ -212,8 +211,8 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
         }
       }
       for (auto value : unDeallocatedValue) {
-        builder.create<gpu::DeallocOp>(returnOp->getLoc(), TypeRange(),
-                                       ValueRange(), value);
+        gpu::DeallocOp::create(builder, returnOp->getLoc(), TypeRange(),
+                               ValueRange(), value);
       }
       funcOp.setType(
           builder.getFunctionType(funcOp.getArgumentTypes(), outputTypes));

--- a/midend/lib/Conversion/MLIRGPU/LegalizeShmemOutlining.cpp
+++ b/midend/lib/Conversion/MLIRGPU/LegalizeShmemOutlining.cpp
@@ -81,7 +81,7 @@ template <typename OpTy>
 static void createForAllDimensions(OpBuilder &builder, Location loc,
                                    SmallVectorImpl<Value> &values) {
   for (auto dim : {gpu::Dimension::x, gpu::Dimension::y, gpu::Dimension::z})
-    values.push_back(builder.create<OpTy>(loc, builder.getIndexType(), dim));
+    values.push_back(OpTy::create(builder, loc, builder.getIndexType(), dim));
 }
 
 /// Adds operations generating block/thread ids and grid/block dimensions at the
@@ -197,11 +197,11 @@ static gpu::GPUFuncOp outlineKernelFuncImpl(gpu::LaunchOp launchOp,
   Block &launchOpEntry = launchOpBody.front();
   Block *clonedLaunchOpEntry = map.lookup(&launchOpEntry);
   builder.setInsertionPointToEnd(&entryBlock);
-  builder.create<cf::BranchOp>(loc, clonedLaunchOpEntry);
+  cf::BranchOp::create(builder, loc, clonedLaunchOpEntry);
 
   outlinedFunc.walk([](gpu::TerminatorOp op) {
     OpBuilder replacer(op);
-    replacer.create<gpu::ReturnOp>(op.getLoc());
+    gpu::ReturnOp::create(replacer, op.getLoc());
     op.erase();
   });
   return outlinedFunc;
@@ -217,9 +217,9 @@ static void convertToLaunchFuncOp(gpu::LaunchOp launchOp,
   // The launch op has an optional dynamic shared memory size. If it doesn't
   // exist, we use zero.
   Value asyncToken = launchOp.getAsyncToken();
-  auto launchFunc = builder.create<gpu::LaunchFuncOp>(
-      launchOp.getLoc(), kernelFunc, launchOp.getGridSizeOperandValues(),
-      launchOp.getBlockSizeOperandValues(),
+  auto launchFunc = gpu::LaunchFuncOp::create(
+      builder, launchOp.getLoc(), kernelFunc,
+      launchOp.getGridSizeOperandValues(), launchOp.getBlockSizeOperandValues(),
       launchOp.getDynamicSharedMemorySize(), operands,
       asyncToken ? asyncToken.getType() : nullptr,
       launchOp.getAsyncDependencies());
@@ -293,7 +293,7 @@ public:
           builder.setInsertionPointToStart(
               &launchOp.getBody().getBlocks().front());
           auto newAllocOp =
-              builder.create<memref::AllocOp>(launchOp.getLoc(), memrefType);
+              memref::AllocOp::create(builder, launchOp.getLoc(), memrefType);
           allocOp->replaceAllUsesWith(newAllocOp);
           allocOp->erase();
           break;
@@ -344,8 +344,8 @@ public:
 
           auto name = Twine("shmem_", std::to_string(counter++)).str();
 
-          auto globalOp = builder.create<memref::GlobalOp>(
-              kernelModule->getLoc(),
+          auto globalOp = memref::GlobalOp::create(
+              builder, kernelModule->getLoc(),
               /*sym_name=*/name,
               /*sym_visibility=*/builder.getStringAttr("private"),
               /*type=*/memrefType,
@@ -354,8 +354,8 @@ public:
               /*alignment=*/builder.getI64IntegerAttr(64));
           // symbolTable.insert(globalOp);
           builder.setInsertionPointAfter(allocOp);
-          Value getGlobalOp = builder.create<memref::GetGlobalOp>(
-              allocOp->getLoc(), globalOp.getType(), name);
+          Value getGlobalOp = memref::GetGlobalOp::create(
+              builder, allocOp->getLoc(), globalOp.getType(), name);
           allocOp.replaceAllUsesWith(getGlobalOp);
           allocOp->erase();
           return WalkResult::advance();
@@ -387,8 +387,8 @@ private:
     // and then this needs to use the OpBuilder.
     auto *context = getOperation().getContext();
     OpBuilder builder(context);
-    auto kernelModule = builder.create<gpu::GPUModuleOp>(kernelFunc.getLoc(),
-                                                         kernelFunc.getName());
+    auto kernelModule = gpu::GPUModuleOp::create(builder, kernelFunc.getLoc(),
+                                                 kernelFunc.getName());
 
     SymbolTable symbolTable(kernelModule);
     symbolTable.insert(kernelFunc);

--- a/midend/lib/Conversion/MatMulOptimization/BatchMatMulOptimize.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/BatchMatMulOptimize.cpp
@@ -88,16 +88,16 @@ public:
     llvm::SmallVector<Value, 8> constantVals;
     for (int i = 0; i <= 8; ++i) {
       auto val =
-          rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(i));
+          arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(i));
       constantVals.push_back(val);
     }
-    Value vlStep = rewriter.create<arith::ConstantIndexOp>(loc, vecSize);
+    Value vlStep = arith::ConstantIndexOp::create(rewriter, loc, vecSize);
 
     // Get dimensions of input tensors.
-    Value batch = rewriter.create<memref::DimOp>(loc, A, constantVals[0]);
-    Value aRow = rewriter.create<memref::DimOp>(loc, A, constantVals[1]);
-    Value aCol = rewriter.create<memref::DimOp>(loc, A, constantVals[2]);
-    Value bCol = rewriter.create<memref::DimOp>(loc, C, constantVals[2]);
+    Value batch = memref::DimOp::create(rewriter, loc, A, constantVals[0]);
+    Value aRow = memref::DimOp::create(rewriter, loc, A, constantVals[1]);
+    Value aCol = memref::DimOp::create(rewriter, loc, A, constantVals[2]);
+    Value bCol = memref::DimOp::create(rewriter, loc, C, constantVals[2]);
 
     AffineMap unrollMap = AffineMap::get(
         /*dimCount=*/1,
@@ -110,18 +110,18 @@ public:
         /*symbolCount=*/0, {d0 - d1 + rewriter.getAffineConstantExpr(1)}, ctx);
 
     Value tailSize =
-        rewriter.create<AffineApplyOp>(loc, unrollMap, ValueRange{aRow});
-    Value parallelSize = rewriter.create<AffineApplyOp>(
-        loc, tailMap, ValueRange{aRow, tailSize});
+        AffineApplyOp::create(rewriter, loc, unrollMap, ValueRange{aRow});
+    Value parallelSize = AffineApplyOp::create(rewriter, loc, tailMap,
+                                               ValueRange{aRow, tailSize});
 
-    Value nUpperBound = rewriter.create<AffineApplyOp>(
-        loc, affineMapVec, ValueRange{bCol, vlStep});
+    Value nUpperBound = AffineApplyOp::create(rewriter, loc, affineMapVec,
+                                              ValueRange{bCol, vlStep});
 
     auto createUnrollParallel = [&](int unrollSize, Value lowerBound,
                                     Value upperBound) {
       // Create the primary parallel batch level loop.
-      auto parOp = rewriter.create<scf::ParallelOp>(
-          loc,
+      auto parOp = scf::ParallelOp::create(
+          rewriter, loc,
           /*lowerBounds=*/ValueRange{constantVals[0], lowerBound},
           /*upperBounds=*/ValueRange{batch, upperBound},
           /*steps=*/ValueRange{constantVals[1], constantVals[unrollSize]},
@@ -129,118 +129,124 @@ public:
             llvm::SmallVector<Value, 8> mIndices;
             for (int i = 0; i < unrollSize; ++i) {
               auto mIndex =
-                  rewriter.create<arith::AddIOp>(loc, ivs[1], constantVals[i]);
+                  arith::AddIOp::create(rewriter, loc, ivs[1], constantVals[i]);
               mIndices.push_back(mIndex);
             }
 
-            auto iter_idx = rewriter.create<scf::ForOp>(
-                loc, constantVals[0], nUpperBound,
+            auto iter_idx = scf::ForOp::create(
+                rewriter, loc, constantVals[0], nUpperBound,
                 /*Step=*/vlStep, ValueRange{constantVals[0]},
                 [&](OpBuilder &builder, Location loc, Value iv0,
                     ValueRange iterArgs0) {
                   SmallVector<Value> cVecs;
                   for (auto mIndex : mIndices) {
-                    auto cInitVec = rewriter.create<vector::LoadOp>(
-                        loc, vectorTy, C, ValueRange{ivs[0], mIndex, iv0});
+                    auto cInitVec =
+                        vector::LoadOp::create(rewriter, loc, vectorTy, C,
+                                               ValueRange{ivs[0], mIndex, iv0});
                     cVecs.push_back(cInitVec);
                   }
-                  auto sumIterVecs = builder.create<scf::ForOp>(
-                      loc, constantVals[0], aCol, /*Step=*/constantVals[1],
-                      ValueRange{cVecs},
+                  auto sumIterVecs = scf::ForOp::create(
+                      builder, loc, constantVals[0], aCol,
+                      /*Step=*/constantVals[1], ValueRange{cVecs},
                       [&](OpBuilder &builder, Location loc, Value iv1,
                           ValueRange iterArgs1) {
-                        auto bVec = rewriter.create<vector::LoadOp>(
-                            loc, vectorTy, B, ValueRange{ivs[0], iv1, iv0});
+                        auto bVec = vector::LoadOp::create(
+                            rewriter, loc, vectorTy, B,
+                            ValueRange{ivs[0], iv1, iv0});
                         SmallVector<Value> resSumVecs;
                         if (isa<IntegerType>(elementType)) {
                           for (int i = 0; i < unrollSize; ++i) {
-                            auto aEle = rewriter.create<memref::LoadOp>(
-                                loc, A, ValueRange{ivs[0], mIndices[i], iv1});
-                            auto aVec = rewriter.create<vector::BroadcastOp>(
-                                loc, vectorTy, aEle);
+                            auto aEle = memref::LoadOp::create(
+                                rewriter, loc, A,
+                                ValueRange{ivs[0], mIndices[i], iv1});
+                            auto aVec = vector::BroadcastOp::create(
+                                rewriter, loc, vectorTy, aEle);
                             Value mulVec =
-                                builder.create<arith::MulIOp>(loc, aVec, bVec);
-                            Value resSumVec = builder.create<arith::AddIOp>(
-                                loc, mulVec, iterArgs1[0]);
+                                arith::MulIOp::create(builder, loc, aVec, bVec);
+                            Value resSumVec = arith::AddIOp::create(
+                                builder, loc, mulVec, iterArgs1[0]);
                             resSumVecs.push_back(resSumVec);
                           }
                         } else {
                           for (int i = 0; i < unrollSize; ++i) {
-                            auto aEle = rewriter.create<memref::LoadOp>(
-                                loc, A, ValueRange{ivs[0], mIndices[i], iv1});
-                            auto aVec = rewriter.create<vector::BroadcastOp>(
-                                loc, vectorTy, aEle);
-                            Value resSumVec = rewriter.create<vector::FMAOp>(
-                                loc, aVec, bVec, iterArgs1[i]);
+                            auto aEle = memref::LoadOp::create(
+                                rewriter, loc, A,
+                                ValueRange{ivs[0], mIndices[i], iv1});
+                            auto aVec = vector::BroadcastOp::create(
+                                rewriter, loc, vectorTy, aEle);
+                            Value resSumVec = vector::FMAOp::create(
+                                rewriter, loc, aVec, bVec, iterArgs1[i]);
                             resSumVecs.push_back(resSumVec);
                           }
                         }
-                        builder.create<scf::YieldOp>(loc,
-                                                     ValueRange{resSumVecs});
+                        scf::YieldOp::create(builder, loc,
+                                             ValueRange{resSumVecs});
                       });
                   for (int i = 0; i < unrollSize; ++i) {
-                    rewriter.create<vector::StoreOp>(
-                        loc, sumIterVecs.getResult(i), C,
+                    vector::StoreOp::create(
+                        rewriter, loc, sumIterVecs.getResult(i), C,
                         ValueRange{ivs[0], mIndices[i], iv0});
                   }
 
                   auto nextIdx =
-                      rewriter.create<arith::AddIOp>(loc, iv0, vlStep);
-                  builder.create<scf::YieldOp>(loc, ValueRange{nextIdx});
+                      arith::AddIOp::create(rewriter, loc, iv0, vlStep);
+                  scf::YieldOp::create(builder, loc, ValueRange{nextIdx});
                 });
             // Compute the tail size and Process the remaining elements
             // using masked vector operations.
             Value idx = iter_idx.getResult(0);
-            rewriter.create<scf::ForOp>(
-                loc, idx, bCol,
+            scf::ForOp::create(
+                rewriter, loc, idx, bCol,
                 /*Step=*/constantVals[1], ValueRange{},
                 [&](OpBuilder &builder, Location loc, Value iv0,
                     ValueRange itrArgs0) {
                   SmallVector<Value> cEles;
                   for (auto mIndex : mIndices) {
-                    auto cInit = rewriter.create<memref::LoadOp>(
-                        loc, C, ValueRange{ivs[0], mIndex, iv0});
+                    auto cInit = memref::LoadOp::create(
+                        rewriter, loc, C, ValueRange{ivs[0], mIndex, iv0});
                     cEles.push_back(cInit);
                   }
-                  auto sumIterVecs = rewriter.create<scf::ForOp>(
-                      loc, constantVals[0], aCol, constantVals[1],
+                  auto sumIterVecs = scf::ForOp::create(
+                      rewriter, loc, constantVals[0], aCol, constantVals[1],
                       ValueRange{cEles},
                       [&](OpBuilder &builder, Location loc, Value iv1,
                           ValueRange iterArgs1) {
-                        auto bEle = rewriter.create<memref::LoadOp>(
-                            loc, B, ValueRange{ivs[0], iv1, iv0});
+                        auto bEle = memref::LoadOp::create(
+                            rewriter, loc, B, ValueRange{ivs[0], iv1, iv0});
                         SmallVector<Value> resSums;
                         if (isa<IntegerType>(elementType)) {
                           for (int i = 0; i < unrollSize; ++i) {
-                            auto aEle = rewriter.create<memref::LoadOp>(
-                                loc, A, ValueRange{ivs[0], mIndices[i], iv1});
-                            auto tmpEle =
-                                rewriter.create<arith::MulIOp>(loc, aEle, bEle);
-                            auto resSum = rewriter.create<arith::AddIOp>(
-                                loc, tmpEle, iterArgs1[i]);
+                            auto aEle = memref::LoadOp::create(
+                                rewriter, loc, A,
+                                ValueRange{ivs[0], mIndices[i], iv1});
+                            auto tmpEle = arith::MulIOp::create(rewriter, loc,
+                                                                aEle, bEle);
+                            auto resSum = arith::AddIOp::create(
+                                rewriter, loc, tmpEle, iterArgs1[i]);
                             resSums.push_back(resSum);
                           }
                         } else {
                           for (int i = 0; i < unrollSize; ++i) {
-                            auto aEle = rewriter.create<memref::LoadOp>(
-                                loc, A, ValueRange{ivs[0], mIndices[i], iv1});
-                            auto tmpEle =
-                                rewriter.create<arith::MulFOp>(loc, aEle, bEle);
-                            auto resSum = rewriter.create<arith::AddFOp>(
-                                loc, tmpEle, iterArgs1[i]);
+                            auto aEle = memref::LoadOp::create(
+                                rewriter, loc, A,
+                                ValueRange{ivs[0], mIndices[i], iv1});
+                            auto tmpEle = arith::MulFOp::create(rewriter, loc,
+                                                                aEle, bEle);
+                            auto resSum = arith::AddFOp::create(
+                                rewriter, loc, tmpEle, iterArgs1[i]);
                             resSums.push_back(resSum);
                           }
                         }
 
-                        builder.create<scf::YieldOp>(loc, ValueRange{resSums});
+                        scf::YieldOp::create(builder, loc, ValueRange{resSums});
                       });
 
                   for (int i = 0; i < unrollSize; i++) {
-                    rewriter.create<memref::StoreOp>(
-                        loc, sumIterVecs.getResult(i), C,
+                    memref::StoreOp::create(
+                        rewriter, loc, sumIterVecs.getResult(i), C,
                         ValueRange{ivs[0], mIndices[i], iv0});
                   }
-                  builder.create<scf::YieldOp>(loc);
+                  scf::YieldOp::create(builder, loc);
                 });
           });
     };

--- a/midend/lib/Conversion/MatMulOptimization/BatchMatMulSCFOptimize.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/BatchMatMulSCFOptimize.cpp
@@ -76,11 +76,11 @@ public:
 
     // Define constants.
     const Value c0 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(0));
     const Value c1 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
-    const Value cVecSize =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(vecSize));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(1));
+    const Value cVecSize = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getIndexAttr(vecSize));
     const AffineExpr d0 = rewriter.getAffineDimExpr(0);
     // TODO: remove the following values?
     // const AffineExpr d1 = rewriter.getAffineDimExpr(1);
@@ -88,100 +88,102 @@ public:
     // const AffineExpr s0 = rewriter.getAffineSymbolExpr(0);
     // const AffineExpr zeroAffine = rewriter.getAffineConstantExpr(0);
 
-    const Value zeroElementType = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getZeroAttr(elementType));
+    const Value zeroElementType = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getZeroAttr(elementType));
 
     // Get dimensions of input tensors.
-    Value batch = rewriter.create<memref::DimOp>(loc, A, 0);
-    Value aRow = rewriter.create<memref::DimOp>(loc, A, 1);
-    Value bCol = rewriter.create<memref::DimOp>(loc, B, 2);
-    Value bRow = rewriter.create<memref::DimOp>(loc, B, 1);
+    Value batch = memref::DimOp::create(rewriter, loc, A, 0);
+    Value aRow = memref::DimOp::create(rewriter, loc, A, 1);
+    Value bCol = memref::DimOp::create(rewriter, loc, B, 2);
+    Value bRow = memref::DimOp::create(rewriter, loc, B, 1);
 
     VectorType vecTy = VectorType::get({vecSize}, elementType);
     Value zeroElementTypeVec;
     if (isa<IntegerType>(elementType))
       zeroElementTypeVec =
-          rewriter.create<vector::BroadcastOp>(loc, vecTy, zeroElementType);
+          vector::BroadcastOp::create(rewriter, loc, vecTy, zeroElementType);
     else
       zeroElementTypeVec =
-          rewriter.create<vector::BroadcastOp>(loc, vecTy, zeroElementType);
+          vector::BroadcastOp::create(rewriter, loc, vecTy, zeroElementType);
     // Calculate the length of the tail, which might not fit in a
     // vector.
-    Value tailLength = rewriter.create<affine::AffineApplyOp>(
-        loc, AffineMap::get(1, 0, d0 % vecSize), ValueRange{bCol});
+    Value tailLength = affine::AffineApplyOp::create(
+        rewriter, loc, AffineMap::get(1, 0, d0 % vecSize), ValueRange{bCol});
 
     // Generate a mask vector based on the tail length.
-    Value maskVector = rewriter.create<vector::CreateMaskOp>(
-        loc, VectorType::get({vecSize}, rewriter.getI1Type()),
+    Value maskVector = vector::CreateMaskOp::create(
+        rewriter, loc, VectorType::get({vecSize}, rewriter.getI1Type()),
         ValueRange{tailLength});
 
-    Value ApplyBCol = rewriter.create<affine::AffineApplyOp>(
-        loc, AffineMap::get(1, 0, d0.floorDiv(vecSize) * vecSize), bCol);
+    Value ApplyBCol = affine::AffineApplyOp::create(
+        rewriter, loc, AffineMap::get(1, 0, d0.floorDiv(vecSize) * vecSize),
+        bCol);
 
-    rewriter.create<scf::ForallOp>(
-        loc, SmallVector<OpFoldResult, 1>({c0}),
+    scf::ForallOp::create(
+        rewriter, loc, SmallVector<OpFoldResult, 1>({c0}),
         SmallVector<OpFoldResult, 1>({batch}),
         SmallVector<OpFoldResult, 1>({c1}), ValueRange{},
         std::nullopt, // No mapping specified in this example
         [&](OpBuilder &builder, Location loc, ValueRange loopIndices) {
           Value loopVarBatchIdx = loopIndices[0];
-          builder.create<scf::ForOp>(
-              loc, c0, aRow, c1, ValueRange{},
+          scf::ForOp::create(
+              builder, loc, c0, aRow, c1, ValueRange{},
               [&](OpBuilder &builder, Location loc, Value loopVarRowOfA,
                   ValueRange iargs) {
-                builder.create<scf::ForOp>(
-                    loc, c0, bRow, c1, ValueRange{},
+                scf::ForOp::create(
+                    builder, loc, c0, bRow, c1, ValueRange{},
                     [&](OpBuilder &builder, Location loc, Value loopVarRowOfB,
                         ValueRange iargs) {
-                      Value aElement = builder.create<memref::LoadOp>(
-                          loc, A,
+                      Value aElement = memref::LoadOp::create(
+                          builder, loc, A,
                           ValueRange{loopVarBatchIdx, loopVarRowOfA,
                                      loopVarRowOfB});
-                      Value aVec = builder.create<vector::BroadcastOp>(
-                          loc, vecTy, aElement);
-                      builder.create<scf::ForOp>(
-                          loc, c0, ApplyBCol, cVecSize, ValueRange{},
+                      Value aVec = vector::BroadcastOp::create(builder, loc,
+                                                               vecTy, aElement);
+                      scf::ForOp::create(
+                          builder, loc, c0, ApplyBCol, cVecSize, ValueRange{},
                           [&](OpBuilder &builder, Location loc,
                               Value loopVarColOfB, ValueRange iargs) {
-                            Value bVec = builder.create<vector::LoadOp>(
-                                loc, vecTy, B,
+                            Value bVec = vector::LoadOp::create(
+                                builder, loc, vecTy, B,
                                 ValueRange{loopVarBatchIdx, loopVarRowOfB,
                                            loopVarColOfB});
 
-                            Value cVec = builder.create<vector::LoadOp>(
-                                loc, vecTy, C,
+                            Value cVec = vector::LoadOp::create(
+                                builder, loc, vecTy, C,
                                 ValueRange{loopVarBatchIdx, loopVarRowOfA,
                                            loopVarColOfB});
                             Value computedVec;
 
                             if (isa<IntegerType>(elementType)) {
-                              Value mulVec = builder.create<arith::MulIOp>(
-                                  loc, aVec, bVec);
-                              computedVec = builder.create<arith::AddIOp>(
-                                  loc, mulVec, cVec);
+                              Value mulVec = arith::MulIOp::create(builder, loc,
+                                                                   aVec, bVec);
+                              computedVec = arith::AddIOp::create(builder, loc,
+                                                                  mulVec, cVec);
                             } else {
-                              computedVec = builder.create<vector::FMAOp>(
-                                  loc, aVec, bVec, cVec);
+                              computedVec = vector::FMAOp::create(
+                                  builder, loc, aVec, bVec, cVec);
                             }
-                            builder.create<vector::StoreOp>(
-                                loc, computedVec, C,
+                            vector::StoreOp::create(
+                                builder, loc, computedVec, C,
                                 ValueRange{loopVarBatchIdx, loopVarRowOfA,
                                            loopVarColOfB});
-                            builder.create<scf::YieldOp>(loc, ValueRange{});
+                            scf::YieldOp::create(builder, loc, ValueRange{});
                           });
-                      Value condition = builder.create<arith::CmpIOp>(
-                          loc, arith::CmpIPredicate::sgt, tailLength, c0);
-                      builder.create<scf::IfOp>(
-                          loc, condition,
+                      Value condition = arith::CmpIOp::create(
+                          builder, loc, arith::CmpIPredicate::sgt, tailLength,
+                          c0);
+                      scf::IfOp::create(
+                          builder, loc, condition,
                           [&](OpBuilder &builder, Location loc) {
-                            Value bVec = builder.create<vector::MaskedLoadOp>(
-                                loc, vecTy, B,
+                            Value bVec = vector::MaskedLoadOp::create(
+                                builder, loc, vecTy, B,
                                 ValueRange{loopVarBatchIdx, loopVarRowOfB,
                                            ApplyBCol},
                                 maskVector, zeroElementTypeVec);
 
-                            Value cVec = builder.create<vector::MaskedLoadOp>(
-                                loc, vecTy, C,
+                            Value cVec = vector::MaskedLoadOp::create(
+                                builder, loc, vecTy, C,
                                 ValueRange{loopVarBatchIdx, loopVarRowOfA,
                                            ApplyBCol},
                                 maskVector, zeroElementTypeVec);
@@ -189,28 +191,28 @@ public:
                             Value computedVec;
 
                             if (isa<IntegerType>(elementType)) {
-                              Value mulVec = builder.create<arith::MulIOp>(
-                                  loc, aVec, bVec);
-                              computedVec = builder.create<arith::AddIOp>(
-                                  loc, mulVec, cVec);
+                              Value mulVec = arith::MulIOp::create(builder, loc,
+                                                                   aVec, bVec);
+                              computedVec = arith::AddIOp::create(builder, loc,
+                                                                  mulVec, cVec);
                             } else {
-                              computedVec = builder.create<vector::FMAOp>(
-                                  loc, aVec, bVec, cVec);
+                              computedVec = vector::FMAOp::create(
+                                  builder, loc, aVec, bVec, cVec);
                             }
 
-                            builder.create<vector::MaskedStoreOp>(
-                                loc, C,
+                            vector::MaskedStoreOp::create(
+                                builder, loc, C,
                                 ValueRange{loopVarBatchIdx, loopVarRowOfA,
                                            ApplyBCol},
                                 maskVector, computedVec);
-                            builder.create<scf::YieldOp>(loc);
+                            scf::YieldOp::create(builder, loc);
                           });
-                      builder.create<scf::YieldOp>(loc, ValueRange{});
+                      scf::YieldOp::create(builder, loc, ValueRange{});
                     });
-                builder.create<scf::YieldOp>(loc, ValueRange{});
+                scf::YieldOp::create(builder, loc, ValueRange{});
               });
 
-          builder.create<scf::InParallelOp>(loc);
+          scf::InParallelOp::create(builder, loc);
         });
 
     rewriter.eraseOp(op);

--- a/midend/lib/Conversion/MatMulOptimization/BatchMatMulTileOptimize.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/BatchMatMulTileOptimize.cpp
@@ -81,9 +81,9 @@ public:
 
     // Define constants.
     const Value c0 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(0));
     const Value c1 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(1));
 
     const AffineExpr d0 = rewriter.getAffineDimExpr(0);
     const AffineExpr d1 = rewriter.getAffineDimExpr(1);
@@ -95,10 +95,10 @@ public:
     const AffineExpr zeroAffine = rewriter.getAffineConstantExpr(0);
 
     // Get dimensions of input tensors.
-    Value batch = rewriter.create<memref::DimOp>(loc, A, 0);
-    Value M = rewriter.create<memref::DimOp>(loc, A, 1); // aRow
-    Value K = rewriter.create<memref::DimOp>(loc, B, 1); // bRow
-    Value N = rewriter.create<memref::DimOp>(loc, B, 2); // bCol
+    Value batch = memref::DimOp::create(rewriter, loc, A, 0);
+    Value M = memref::DimOp::create(rewriter, loc, A, 1); // aRow
+    Value K = memref::DimOp::create(rewriter, loc, B, 1); // bRow
+    Value N = memref::DimOp::create(rewriter, loc, B, 2); // bCol
 
     SmallVector<Value, 4U> reducedValues = llvm::to_vector<4>(
         llvm::map_range(ArrayRef<LoopReduction>{},
@@ -108,23 +108,22 @@ public:
     int64_t kNLen = vecSize * kernelN;
 
     // Create the primary parallel batch level loop.
-    AffineParallelOp parallelBatchLoop =
-        rewriter.create<affine::AffineParallelOp>(
-            loc, ValueRange(reducedValues).getTypes(), ValueRange{batch},
-            ArrayRef<NamedAttribute>{
-                rewriter.getNamedAttr("lowerBoundsGroups",
-                                      rewriter.getI32TensorAttr({1})),
-                rewriter.getNamedAttr("upperBoundsGroups",
-                                      rewriter.getI32TensorAttr({1})),
-                rewriter.getNamedAttr(
-                    "lowerBoundsMap",
-                    AffineMapAttr::get(AffineMap::get(0, 0, {zeroAffine},
-                                                      rewriter.getContext()))),
-                rewriter.getNamedAttr("upperBoundsMap",
-                                      AffineMapAttr::get(AffineMap::get(
-                                          1, 0, {d0}, rewriter.getContext()))),
-                rewriter.getNamedAttr("reductions", rewriter.getArrayAttr({})),
-                rewriter.getNamedAttr("steps", rewriter.getI64ArrayAttr({1}))});
+    AffineParallelOp parallelBatchLoop = affine::AffineParallelOp::create(
+        rewriter, loc, ValueRange(reducedValues).getTypes(), ValueRange{batch},
+        ArrayRef<NamedAttribute>{
+            rewriter.getNamedAttr("lowerBoundsGroups",
+                                  rewriter.getI32TensorAttr({1})),
+            rewriter.getNamedAttr("upperBoundsGroups",
+                                  rewriter.getI32TensorAttr({1})),
+            rewriter.getNamedAttr(
+                "lowerBoundsMap",
+                AffineMapAttr::get(
+                    AffineMap::get(0, 0, {zeroAffine}, rewriter.getContext()))),
+            rewriter.getNamedAttr("upperBoundsMap",
+                                  AffineMapAttr::get(AffineMap::get(
+                                      1, 0, {d0}, rewriter.getContext()))),
+            rewriter.getNamedAttr("reductions", rewriter.getArrayAttr({})),
+            rewriter.getNamedAttr("steps", rewriter.getI64ArrayAttr({1}))});
 
     // Create the loop body for the parallel loop.
     Block *loopBody = new Block();
@@ -133,8 +132,9 @@ public:
     Value loopVarBatchIdx = loopBody->getArguments()[0];
 
     // Prefetching data from tensor 'A' for better cache utilization.
-    rewriter.create<affine::AffinePrefetchOp>(
-        loc, A, AffineMap::get(3, 0, {d0, d1, d2}, rewriter.getContext()),
+    affine::AffinePrefetchOp::create(
+        rewriter, loc, A,
+        AffineMap::get(3, 0, {d0, d1, d2}, rewriter.getContext()),
         ArrayRef<Value>{loopVarBatchIdx, M, K}, false, 3, true);
 
     // build loop body
@@ -152,16 +152,16 @@ public:
                     VectorType::get(vecSize, ATy.getElementType());
 
                 for (int i = 0; i < kernelM; i++) {
-                  Value fixedIV = builder.create<affine::AffineMinOp>(
-                      loc,
+                  Value fixedIV = affine::AffineMinOp::create(
+                      builder, loc,
                       AffineMap::get(1, 1, {d0 + i, s0 - 1},
                                      builder.getContext()),
                       SmallVector<Value>{ivI, M});
                   MemRefType resTy = MemRefType::get(
                       ATy.getShape(), ATy.getElementType(),
                       AffineMap::get(3, 3, d1 * s2 + d0 * s1 + s0 + d2));
-                  auto cptr = builder.create<memref::SubViewOp>(
-                      loc, resTy, C,
+                  auto cptr = memref::SubViewOp::create(
+                      builder, loc, resTy, C,
                       SmallVector<OpFoldResult>{loopVarBatchIdx, fixedIV, c0},
                       SmallVector<OpFoldResult>{c1, c1, N},
                       SmallVector<OpFoldResult>{c1, c1, c1});
@@ -176,71 +176,67 @@ public:
                       for (int j = 0; j < kernelN; j++) {
                         Value fixedJV = ivJ;
                         if (j != 0) {
-                          fixedJV = builder.create<affine::AffineApplyOp>(
-                              loc, AffineMap::get(1, 0, d0 + j * vecSize), ivJ);
+                          fixedJV = affine::AffineApplyOp::create(
+                              builder, loc,
+                              AffineMap::get(1, 0, d0 + j * vecSize), ivJ);
                         }
-                        bs.push_back(builder.create<LoadOp>(
-                            loc, vTy, B,
+                        bs.push_back(LoadOp::create(
+                            builder, loc, vTy, B,
                             ValueRange{loopVarBatchIdx, ivK, fixedJV}));
                       }
 
                       for (int i = 0; i < kernelM; ++i) {
                         Value fixedIV = ivI;
                         if (i != 0) {
-                          fixedIV = builder.create<affine::AffineApplyOp>(
-                              loc,
+                          fixedIV = affine::AffineApplyOp::create(
+                              builder, loc,
                               AffineMap::get(1, 0, {d0 + i},
                                              builder.getContext()),
                               SmallVector<Value>{ivI});
                         }
                         affine::AffineIfOp mBranchingOp =
-                            builder.create<affine::AffineIfOp>(
-                                loc,
+                            affine::AffineIfOp::create(
+                                builder, loc,
                                 IntegerSet::get(1, 1, {-d0 + s0 - 1}, {false}),
                                 ValueRange{fixedIV, M}, false);
                         OpBuilder mTrueBranchBuilder =
                             mBranchingOp.getThenBodyBuilder();
-                        Value ksubAElement =
-                            mTrueBranchBuilder.create<memref::LoadOp>(
-                                loc, A,
-                                ValueRange{loopVarBatchIdx, fixedIV, ivK});
+                        Value ksubAElement = memref::LoadOp::create(
+                            mTrueBranchBuilder, loc, A,
+                            ValueRange{loopVarBatchIdx, fixedIV, ivK});
 
                         for (int j = 0; j < kernelN; j++) {
                           Value fixedJV = ivJ;
                           if (j != 0) {
-                            fixedJV =
-                                mTrueBranchBuilder
-                                    .create<affine::AffineApplyOp>(
-                                        loc,
-                                        AffineMap::get(1, 0, d0 + j * vecSize),
-                                        ivJ);
+                            fixedJV = affine::AffineApplyOp::create(
+                                mTrueBranchBuilder, loc,
+                                AffineMap::get(1, 0, d0 + j * vecSize), ivJ);
                           }
-                          Value vecC = mTrueBranchBuilder.create<LoadOp>(
-                              loc, vTy, cptrs[i], ValueRange{c0, c0, fixedJV});
+                          Value vecC = LoadOp::create(
+                              mTrueBranchBuilder, loc, vTy, cptrs[i],
+                              ValueRange{c0, c0, fixedJV});
                           if (isa<IntegerType>(elementType)) {
-                            Value vecA =
-                                mTrueBranchBuilder.create<vector::BroadcastOp>(
-                                    loc, vTy, ksubAElement);
-                            Value vecMul =
-                                mTrueBranchBuilder.create<arith::MulIOp>(
-                                    loc, vTy, vecA, bs[j]);
-                            vecC = mTrueBranchBuilder.create<arith::AddIOp>(
-                                loc, vTy, vecMul, vecC);
+                            Value vecA = vector::BroadcastOp::create(
+                                mTrueBranchBuilder, loc, vTy, ksubAElement);
+                            Value vecMul = arith::MulIOp::create(
+                                mTrueBranchBuilder, loc, vTy, vecA, bs[j]);
+                            vecC = arith::AddIOp::create(
+                                mTrueBranchBuilder, loc, vTy, vecMul, vecC);
                           } else {
-                            Value vecA =
-                                mTrueBranchBuilder.create<vector::BroadcastOp>(
-                                    loc, vTy, ksubAElement);
-                            vecC = mTrueBranchBuilder.create<vector::FMAOp>(
-                                loc, vTy, vecA, bs[j], vecC);
+                            Value vecA = vector::BroadcastOp::create(
+                                mTrueBranchBuilder, loc, vTy, ksubAElement);
+                            vecC =
+                                vector::FMAOp::create(mTrueBranchBuilder, loc,
+                                                      vTy, vecA, bs[j], vecC);
                           }
                           // store vecC
-                          Value tailLength =
-                              mTrueBranchBuilder.create<affine::AffineApplyOp>(
-                                  loc, AffineMap::get(2, 0, -d0 + d1),
-                                  ValueRange{fixedJV, N});
+                          Value tailLength = affine::AffineApplyOp::create(
+                              mTrueBranchBuilder, loc,
+                              AffineMap::get(2, 0, -d0 + d1),
+                              ValueRange{fixedJV, N});
                           affine::AffineIfOp nBranchingOp =
-                              mTrueBranchBuilder.create<affine::AffineIfOp>(
-                                  loc,
+                              affine::AffineIfOp::create(
+                                  mTrueBranchBuilder, loc,
                                   IntegerSet::get(1, 0, {-vecSize + d0},
                                                   {false}),
                                   ValueRange{tailLength}, true);
@@ -248,27 +244,26 @@ public:
                           // fit in a vector.
                           OpBuilder nTrueBranchBuilder =
                               nBranchingOp.getThenBodyBuilder();
-                          nTrueBranchBuilder.create<StoreOp>(
-                              loc, vecC, cptrs[i], ValueRange{c0, c0, fixedJV});
+                          StoreOp::create(nTrueBranchBuilder, loc, vecC,
+                                          cptrs[i],
+                                          ValueRange{c0, c0, fixedJV});
                           OpBuilder nFalseBranchBuilder =
                               nBranchingOp.getElseBodyBuilder();
                           // Generate a mask vector based on the tail length.
-                          Value maskVector =
-                              nFalseBranchBuilder.create<vector::CreateMaskOp>(
-                                  loc,
-                                  VectorType::get({vecSize},
-                                                  rewriter.getI1Type()),
-                                  ValueRange{tailLength});
-                          nFalseBranchBuilder.create<MaskedStoreOp>(
-                              loc, cptrs[i], ValueRange{c0, c0, fixedJV},
-                              maskVector, vecC);
+                          Value maskVector = vector::CreateMaskOp::create(
+                              nFalseBranchBuilder, loc,
+                              VectorType::get({vecSize}, rewriter.getI1Type()),
+                              ValueRange{tailLength});
+                          MaskedStoreOp::create(
+                              nFalseBranchBuilder, loc, cptrs[i],
+                              ValueRange{c0, c0, fixedJV}, maskVector, vecC);
                         }
                       }
                     });
               });
         });
 
-    rewriter.create<affine::AffineYieldOp>(loc);
+    affine::AffineYieldOp::create(rewriter, loc);
 
     // Finalize the loop and erase the original operation.
     parallelBatchLoop.getRegion().push_back(loopBody);

--- a/midend/lib/Conversion/MatMulOptimization/BatchMatMulTransBVec.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/BatchMatMulTransBVec.cpp
@@ -82,107 +82,111 @@ public:
         mlir::VectorType::get({vecSize}, elementType, {scalable});
 
     // Define constants.
-    const Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    const Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    const Value c2 = rewriter.create<arith::ConstantIndexOp>(loc, 2);
-    Value vlStep = rewriter.create<arith::ConstantIndexOp>(loc, vecSize);
+    const Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    const Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    const Value c2 = arith::ConstantIndexOp::create(rewriter, loc, 2);
+    Value vlStep = arith::ConstantIndexOp::create(rewriter, loc, vecSize);
     if (scalable) {
-      Value vscale = rewriter.create<vector::VectorScaleOp>(loc);
-      vlStep = rewriter.create<arith::MulIOp>(loc, vlStep, vscale);
+      Value vscale = vector::VectorScaleOp::create(rewriter, loc);
+      vlStep = arith::MulIOp::create(rewriter, loc, vlStep, vscale);
     }
-    const Value zero = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getZeroAttr(elementType));
+    const Value zero = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getZeroAttr(elementType));
 
     // Create initial zero vector for accumulation.
-    Value zeroVec = rewriter.create<vector::BroadcastOp>(loc, vectorTy, zero);
+    Value zeroVec = vector::BroadcastOp::create(rewriter, loc, vectorTy, zero);
 
     // Get dimensions of input tensors.
-    Value batch = rewriter.create<memref::DimOp>(loc, A, c0);
-    Value aRow = rewriter.create<memref::DimOp>(loc, A, c1);
-    Value bRow = rewriter.create<memref::DimOp>(loc, A, c2);
-    Value bCol = rewriter.create<memref::DimOp>(loc, B, c1);
+    Value batch = memref::DimOp::create(rewriter, loc, A, c0);
+    Value aRow = memref::DimOp::create(rewriter, loc, A, c1);
+    Value bRow = memref::DimOp::create(rewriter, loc, A, c2);
+    Value bCol = memref::DimOp::create(rewriter, loc, B, c1);
 
     // Compute main (vectorized) part and tail part sizes along reduction dim.
-    Value tailSize = rewriter.create<arith::RemUIOp>(loc, bRow, vlStep);
-    Value mainSize = rewriter.create<arith::SubIOp>(loc, bRow, tailSize);
+    Value tailSize = arith::RemUIOp::create(rewriter, loc, bRow, vlStep);
+    Value mainSize = arith::SubIOp::create(rewriter, loc, bRow, tailSize);
 
     // Create nested scf.for loops instead of affine loops.
-    auto batchLoop = rewriter.create<scf::ForOp>(loc, c0, batch, c1);
+    auto batchLoop = scf::ForOp::create(rewriter, loc, c0, batch, c1);
     rewriter.setInsertionPointToStart(batchLoop.getBody());
     Value batchIdx = batchLoop.getInductionVar();
 
-    auto aRowLoop = rewriter.create<scf::ForOp>(loc, c0, aRow, c1);
+    auto aRowLoop = scf::ForOp::create(rewriter, loc, c0, aRow, c1);
     rewriter.setInsertionPointToStart(aRowLoop.getBody());
     Value aRowIdx = aRowLoop.getInductionVar();
 
-    auto bColLoop = rewriter.create<scf::ForOp>(loc, c0, bCol, c1);
+    auto bColLoop = scf::ForOp::create(rewriter, loc, c0, bCol, c1);
     rewriter.setInsertionPointToStart(bColLoop.getBody());
     Value bColIdx = bColLoop.getInductionVar();
 
     // Inner vectorized loop using vector.fma for accumulation.
-    auto vecLoop = rewriter.create<scf::ForOp>(
-        loc, c0, mainSize, vlStep, ValueRange{zeroVec},
+    auto vecLoop = scf::ForOp::create(
+        rewriter, loc, c0, mainSize, vlStep, ValueRange{zeroVec},
         [&](OpBuilder &nestedBuilder, Location nestedLoc, Value iv,
             ValueRange itrArgs) {
-          Value aVec = nestedBuilder.create<vector::LoadOp>(
-              nestedLoc, vectorTy, A, ValueRange{batchIdx, aRowIdx, iv});
-          Value bVec = nestedBuilder.create<vector::LoadOp>(
-              nestedLoc, vectorTy, B, ValueRange{batchIdx, bColIdx, iv});
+          Value aVec =
+              vector::LoadOp::create(nestedBuilder, nestedLoc, vectorTy, A,
+                                     ValueRange{batchIdx, aRowIdx, iv});
+          Value bVec =
+              vector::LoadOp::create(nestedBuilder, nestedLoc, vectorTy, B,
+                                     ValueRange{batchIdx, bColIdx, iv});
           // Use vector.fma for fused multiply-add accumulation.
           Value resultVec;
           if (isa<IntegerType>(elementType)) {
             // For integer types, use mul + add since fma doesn't apply.
             Value mulVec =
-                nestedBuilder.create<arith::MulIOp>(nestedLoc, aVec, bVec);
-            resultVec = nestedBuilder.create<arith::AddIOp>(nestedLoc, mulVec,
-                                                            itrArgs[0]);
+                arith::MulIOp::create(nestedBuilder, nestedLoc, aVec, bVec);
+            resultVec = arith::AddIOp::create(nestedBuilder, nestedLoc, mulVec,
+                                              itrArgs[0]);
           } else {
             // For floating point types, use vector.fma.
-            resultVec = nestedBuilder.create<vector::FMAOp>(nestedLoc, aVec,
-                                                            bVec, itrArgs[0]);
+            resultVec = vector::FMAOp::create(nestedBuilder, nestedLoc, aVec,
+                                              bVec, itrArgs[0]);
           }
-          nestedBuilder.create<scf::YieldOp>(nestedLoc, resultVec);
+          scf::YieldOp::create(nestedBuilder, nestedLoc, resultVec);
         });
 
     // Load the initial value from output memref.
-    Value initVal = rewriter.create<memref::LoadOp>(
-        loc, elementType, C, ValueRange{batchIdx, aRowIdx, bColIdx});
+    Value initVal = memref::LoadOp::create(
+        rewriter, loc, elementType, C, ValueRange{batchIdx, aRowIdx, bColIdx});
 
     // Perform reduction on the accumulated vector (main vectorized part).
-    Value partialResult = rewriter.create<vector::ReductionOp>(
-        loc, vector::CombiningKind::ADD, vecLoop.getResult(0), initVal,
-        ::mlir::arith::FastMathFlags::reassoc);
+    Value partialResult = vector::ReductionOp::create(
+        rewriter, loc, vector::CombiningKind::ADD, vecLoop.getResult(0),
+        initVal, ::mlir::arith::FastMathFlags::reassoc);
 
     // Tail processing for remaining elements that do not fit into a full
     // vector.
-    auto tailLoop = rewriter.create<scf::ForOp>(
-        loc, mainSize, bRow, c1, ValueRange{partialResult},
+    auto tailLoop = scf::ForOp::create(
+        rewriter, loc, mainSize, bRow, c1, ValueRange{partialResult},
         [&](OpBuilder &nestedBuilder, Location nestedLoc, Value iv,
             ValueRange itrArgs) {
-          Value aElem = nestedBuilder.create<memref::LoadOp>(
-              nestedLoc, elementType, A, ValueRange{batchIdx, aRowIdx, iv});
-          Value bElem = nestedBuilder.create<memref::LoadOp>(
-              nestedLoc, elementType, B, ValueRange{batchIdx, bColIdx, iv});
+          Value aElem =
+              memref::LoadOp::create(nestedBuilder, nestedLoc, elementType, A,
+                                     ValueRange{batchIdx, aRowIdx, iv});
+          Value bElem =
+              memref::LoadOp::create(nestedBuilder, nestedLoc, elementType, B,
+                                     ValueRange{batchIdx, bColIdx, iv});
           Value resultScalar;
           if (isa<IntegerType>(elementType)) {
             Value mulVal =
-                nestedBuilder.create<arith::MulIOp>(nestedLoc, aElem, bElem);
-            resultScalar = nestedBuilder.create<arith::AddIOp>(
-                nestedLoc, mulVal, itrArgs[0]);
+                arith::MulIOp::create(nestedBuilder, nestedLoc, aElem, bElem);
+            resultScalar = arith::AddIOp::create(nestedBuilder, nestedLoc,
+                                                 mulVal, itrArgs[0]);
           } else {
             Value mulVal =
-                nestedBuilder.create<arith::MulFOp>(nestedLoc, aElem, bElem);
-            resultScalar = nestedBuilder.create<arith::AddFOp>(
-                nestedLoc, mulVal, itrArgs[0]);
+                arith::MulFOp::create(nestedBuilder, nestedLoc, aElem, bElem);
+            resultScalar = arith::AddFOp::create(nestedBuilder, nestedLoc,
+                                                 mulVal, itrArgs[0]);
           }
-          nestedBuilder.create<scf::YieldOp>(nestedLoc, resultScalar);
+          scf::YieldOp::create(nestedBuilder, nestedLoc, resultScalar);
         });
 
     Value finalResult = tailLoop.getResult(0);
 
     // Store the result back.
-    rewriter.create<memref::StoreOp>(loc, finalResult, C,
-                                     ValueRange{batchIdx, aRowIdx, bColIdx});
+    memref::StoreOp::create(rewriter, loc, finalResult, C,
+                            ValueRange{batchIdx, aRowIdx, bColIdx});
     rewriter.eraseOp(op);
     return success();
   }

--- a/midend/lib/Conversion/MatMulOptimization/BatchMatMulVectorizationDecode.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/BatchMatMulVectorizationDecode.cpp
@@ -85,19 +85,19 @@ public:
     llvm::SmallVector<Value, 8> constantVals;
     for (int i = 0; i <= 8; ++i) {
       auto val =
-          rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(i));
+          arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(i));
       constantVals.push_back(val);
     }
-    Value vlStep = rewriter.create<arith::ConstantIndexOp>(loc, vecSize);
+    Value vlStep = arith::ConstantIndexOp::create(rewriter, loc, vecSize);
     if (scalable) {
-      Value vscale = rewriter.create<vector::VectorScaleOp>(loc);
-      vlStep = rewriter.create<arith::MulIOp>(loc, vlStep, vscale);
+      Value vscale = vector::VectorScaleOp::create(rewriter, loc);
+      vlStep = arith::MulIOp::create(rewriter, loc, vlStep, vscale);
     }
 
     // Get dimensions of input tensors.
-    Value batch = rewriter.create<memref::DimOp>(loc, A, constantVals[0]);
-    Value aCol = rewriter.create<memref::DimOp>(loc, A, constantVals[2]);
-    Value bCol = rewriter.create<memref::DimOp>(loc, C, constantVals[2]);
+    Value batch = memref::DimOp::create(rewriter, loc, A, constantVals[0]);
+    Value aCol = memref::DimOp::create(rewriter, loc, A, constantVals[2]);
+    Value bCol = memref::DimOp::create(rewriter, loc, C, constantVals[2]);
 
     // Decode-specialized loop structure:
     // scf.parallel (b) = (0) to (batch) step (1) {
@@ -114,48 +114,51 @@ public:
     //     vector.store %sum, C[b, 0, n]
     //   }
     // }
-    auto parOp = rewriter.create<scf::ParallelOp>(
-        loc,
+    auto parOp = scf::ParallelOp::create(
+        rewriter, loc,
         /*lowerBounds=*/ValueRange{constantVals[0]},
         /*upperBounds=*/ValueRange{batch},
         /*steps=*/ValueRange{constantVals[1]},
         [&](OpBuilder &builder, Location loc, ValueRange ivs) {
           Value bIdx = ivs[0];
           (void)builder;
-          auto outerFor = rewriter.create<scf::ForOp>(
-              loc, constantVals[0], bCol, vlStep, ValueRange{},
+          auto outerFor = scf::ForOp::create(
+              rewriter, loc, constantVals[0], bCol, vlStep, ValueRange{},
               [&](OpBuilder &builder, Location loc, Value nIdx,
                   ValueRange /*iterArgs*/) {
                 // Load initial C vector
-                auto cVecInit = rewriter.create<vector::LoadOp>(
-                    loc, vectorTy, C, ValueRange{bIdx, constantVals[0], nIdx});
-                auto kFor = rewriter.create<scf::ForOp>(
-                    loc, constantVals[0], aCol, constantVals[1],
+                auto cVecInit = vector::LoadOp::create(
+                    rewriter, loc, vectorTy, C,
+                    ValueRange{bIdx, constantVals[0], nIdx});
+                auto kFor = scf::ForOp::create(
+                    rewriter, loc, constantVals[0], aCol, constantVals[1],
                     ValueRange{cVecInit},
                     [&](OpBuilder &builder, Location loc, Value kIdx,
                         ValueRange accVecs) {
-                      Value aEle = rewriter.create<memref::LoadOp>(
-                          loc, A, ValueRange{bIdx, constantVals[0], kIdx});
-                      Value aVec = rewriter.create<vector::BroadcastOp>(
-                          loc, vectorTy, aEle);
-                      Value bVec = rewriter.create<vector::LoadOp>(
-                          loc, vectorTy, B, ValueRange{bIdx, kIdx, nIdx});
+                      Value aEle = memref::LoadOp::create(
+                          rewriter, loc, A,
+                          ValueRange{bIdx, constantVals[0], kIdx});
+                      Value aVec = vector::BroadcastOp::create(rewriter, loc,
+                                                               vectorTy, aEle);
+                      Value bVec =
+                          vector::LoadOp::create(rewriter, loc, vectorTy, B,
+                                                 ValueRange{bIdx, kIdx, nIdx});
                       Value newAcc;
                       if (isa<IntegerType>(elementType)) {
                         Value mulVec =
-                            rewriter.create<arith::MulIOp>(loc, aVec, bVec);
-                        newAcc = rewriter.create<arith::AddIOp>(loc, mulVec,
-                                                                accVecs[0]);
+                            arith::MulIOp::create(rewriter, loc, aVec, bVec);
+                        newAcc = arith::AddIOp::create(rewriter, loc, mulVec,
+                                                       accVecs[0]);
                       } else {
-                        newAcc = rewriter.create<vector::FMAOp>(loc, aVec, bVec,
-                                                                accVecs[0]);
+                        newAcc = vector::FMAOp::create(rewriter, loc, aVec,
+                                                       bVec, accVecs[0]);
                       }
-                      builder.create<scf::YieldOp>(loc, ValueRange{newAcc});
+                      scf::YieldOp::create(builder, loc, ValueRange{newAcc});
                     });
-                rewriter.create<vector::StoreOp>(
-                    loc, kFor.getResult(0), C,
+                vector::StoreOp::create(
+                    rewriter, loc, kFor.getResult(0), C,
                     ValueRange{bIdx, constantVals[0], nIdx});
-                builder.create<scf::YieldOp>(loc);
+                scf::YieldOp::create(builder, loc);
               });
         });
 

--- a/midend/lib/Conversion/MatMulOptimization/DequantMatMulVectorizationDecode.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/DequantMatMulVectorizationDecode.cpp
@@ -229,17 +229,17 @@ public:
     auto f32VecType = VectorType::get({vecSize}, f32Type);
     auto i8VecType = VectorType::get({vecSize}, rewriter.getI8Type());
 
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    Value step = rewriter.create<arith::ConstantIndexOp>(loc, vecSize);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    Value step = arith::ConstantIndexOp::create(rewriter, loc, vecSize);
 
-    Value n = rewriter.create<memref::DimOp>(loc, C, c1);
-    Value k = rewriter.create<memref::DimOp>(loc, A, c1);
+    Value n = memref::DimOp::create(rewriter, loc, C, c1);
+    Value k = memref::DimOp::create(rewriter, loc, A, c1);
 
-    Value zeroF32 = rewriter.create<arith::ConstantOp>(
-        loc, f32Type, rewriter.getFloatAttr(f32Type, 0.0));
+    Value zeroF32 = arith::ConstantOp::create(
+        rewriter, loc, f32Type, rewriter.getFloatAttr(f32Type, 0.0));
     Value zeroVec =
-        rewriter.create<vector::BroadcastOp>(loc, f32VecType, zeroF32);
+        vector::BroadcastOp::create(rewriter, loc, f32VecType, zeroF32);
 
     // Determine scale load indices. For scale shape [1, N], the non-1 dim
     // is at axis 1, so we load scale[0, j].
@@ -247,8 +247,8 @@ public:
     // For w8a32 matmul, scale should be along the N axis (last dim of weight).
     bool scaleAlongN = (chain->scaleAxis == (int)scaleType.getRank() - 1);
 
-    rewriter.create<scf::ParallelOp>(
-        loc,
+    scf::ParallelOp::create(
+        rewriter, loc,
         /*lowerBounds=*/ValueRange{c0},
         /*upperBounds=*/ValueRange{n},
         /*steps=*/ValueRange{step},
@@ -256,29 +256,30 @@ public:
           Value nIdx = ivs.front();
 
           // Inner reduction loop over k, accumulating i8-cast-to-f32 * A
-          auto sumIter = builder.create<scf::ForOp>(
-              loc, c0, k, c1, ValueRange{zeroVec},
+          auto sumIter = scf::ForOp::create(
+              builder, loc, c0, k, c1, ValueRange{zeroVec},
               [&](OpBuilder &builder, Location loc, Value kIdx,
                   ValueRange iterArgs) {
                 // Load activation element A[0, k]
-                Value aElem = builder.create<memref::LoadOp>(
-                    loc, A, ValueRange{c0, kIdx});
-                Value aVec =
-                    builder.create<vector::BroadcastOp>(loc, f32VecType, aElem);
+                Value aElem = memref::LoadOp::create(builder, loc, A,
+                                                     ValueRange{c0, kIdx});
+                Value aVec = vector::BroadcastOp::create(builder, loc,
+                                                         f32VecType, aElem);
 
                 // Load i8 weight vector B_i8[k, j:j+vecSize]
-                Value bI8Vec = builder.create<vector::LoadOp>(
-                    loc, i8VecType, chain->i8Weight, ValueRange{kIdx, nIdx});
+                Value bI8Vec = vector::LoadOp::create(builder, loc, i8VecType,
+                                                      chain->i8Weight,
+                                                      ValueRange{kIdx, nIdx});
 
                 // Cast i8 -> f32
                 Value bF32Vec =
-                    builder.create<arith::SIToFPOp>(loc, f32VecType, bI8Vec);
+                    arith::SIToFPOp::create(builder, loc, f32VecType, bI8Vec);
 
                 // FMA: acc += A[0,k] * (float)B_i8[k,j]
-                Value res = builder.create<vector::FMAOp>(loc, aVec, bF32Vec,
-                                                          iterArgs.front());
+                Value res = vector::FMAOp::create(builder, loc, aVec, bF32Vec,
+                                                  iterArgs.front());
 
-                builder.create<scf::YieldOp>(loc, res);
+                scf::YieldOp::create(builder, loc, res);
               });
 
           Value accVec = sumIter.getResult(0);
@@ -295,27 +296,28 @@ public:
               else
                 scaleIndices.push_back(c0);
             }
-            scaleVec = builder.create<vector::LoadOp>(
-                loc, f32VecType, chain->scale, scaleIndices);
+            scaleVec = vector::LoadOp::create(builder, loc, f32VecType,
+                                              chain->scale, scaleIndices);
           } else {
             // Fallback: load scale as scalar and broadcast
             SmallVector<Value> scaleIndices(scaleType.getRank(), c0);
-            Value scaleScalar =
-                builder.create<memref::LoadOp>(loc, chain->scale, scaleIndices);
-            scaleVec = builder.create<vector::BroadcastOp>(loc, f32VecType,
-                                                           scaleScalar);
+            Value scaleScalar = memref::LoadOp::create(
+                builder, loc, chain->scale, scaleIndices);
+            scaleVec = vector::BroadcastOp::create(builder, loc, f32VecType,
+                                                   scaleScalar);
           }
 
           Value scaledVec =
-              builder.create<arith::MulFOp>(loc, accVec, scaleVec);
+              arith::MulFOp::create(builder, loc, accVec, scaleVec);
 
           // Add to existing C value (for correctness if C is pre-initialized)
-          Value cVec = builder.create<vector::LoadOp>(loc, f32VecType, C,
-                                                      ValueRange{c0, nIdx});
-          Value resultVec = builder.create<arith::AddFOp>(loc, cVec, scaledVec);
+          Value cVec = vector::LoadOp::create(builder, loc, f32VecType, C,
+                                              ValueRange{c0, nIdx});
+          Value resultVec =
+              arith::AddFOp::create(builder, loc, cVec, scaledVec);
 
-          builder.create<vector::StoreOp>(loc, resultVec, C,
-                                          ValueRange{c0, nIdx});
+          vector::StoreOp::create(builder, loc, resultVec, C,
+                                  ValueRange{c0, nIdx});
         });
 
     rewriter.eraseOp(op);

--- a/midend/lib/Conversion/MatMulOptimization/Int4DequantMatMulVectorizationDecode.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/Int4DequantMatMulVectorizationDecode.cpp
@@ -359,77 +359,77 @@ public:
     Type elemType = cType.getElementType();
     auto floatVecType = VectorType::get({vecSize}, elemType);
     auto halfI8VecType = VectorType::get({vecSize / 2}, rewriter.getI8Type());
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    Value c2 = rewriter.create<arith::ConstantIndexOp>(loc, 2);
-    Value step = rewriter.create<arith::ConstantIndexOp>(loc, vecSize);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    Value c2 = arith::ConstantIndexOp::create(rewriter, loc, 2);
+    Value step = arith::ConstantIndexOp::create(rewriter, loc, vecSize);
 
-    Value N = rewriter.create<memref::DimOp>(loc, C, c1);
-    Value K = rewriter.create<memref::DimOp>(loc, A, c1);
+    Value N = memref::DimOp::create(rewriter, loc, C, c1);
+    Value K = memref::DimOp::create(rewriter, loc, A, c1);
 
-    Value zeroFloat = rewriter.create<arith::ConstantOp>(
-        loc, elemType, rewriter.getFloatAttr(elemType, 0.0));
+    Value zeroFloat = arith::ConstantOp::create(
+        rewriter, loc, elemType, rewriter.getFloatAttr(elemType, 0.0));
     Value zeroVec =
-        rewriter.create<vector::BroadcastOp>(loc, floatVecType, zeroFloat);
-    Value mask15 = rewriter.create<arith::ConstantOp>(
-        loc,
+        vector::BroadcastOp::create(rewriter, loc, floatVecType, zeroFloat);
+    Value mask15 = arith::ConstantOp::create(
+        rewriter, loc,
         DenseElementsAttr::get(halfI8VecType, rewriter.getI8IntegerAttr(15)));
-    Value shift4 = rewriter.create<arith::ConstantOp>(
-        loc,
+    Value shift4 = arith::ConstantOp::create(
+        rewriter, loc,
         DenseElementsAttr::get(halfI8VecType, rewriter.getI8IntegerAttr(4)));
 
     bool scaleAlongN = (dchain->scaleAxis == (int)scaleType.getRank() - 1);
 
     Value packedWeight = unpackInfo->packedWeight;
 
-    rewriter.create<scf::ParallelOp>(
-        loc, ValueRange{c0}, ValueRange{N}, ValueRange{step},
+    scf::ParallelOp::create(
+        rewriter, loc, ValueRange{c0}, ValueRange{N}, ValueRange{step},
         [&](OpBuilder &builder, Location loc, ValueRange ivs) {
           Value nIdx = ivs.front();
 
           // Packed index = nIdx / 2
-          Value packedIdx = builder.create<arith::DivUIOp>(loc, nIdx, c2);
+          Value packedIdx = arith::DivUIOp::create(builder, loc, nIdx, c2);
 
-          auto forOp = builder.create<scf::ForOp>(
-              loc, c0, K, c1, ValueRange{zeroVec},
+          auto forOp = scf::ForOp::create(
+              builder, loc, c0, K, c1, ValueRange{zeroVec},
               [&](OpBuilder &builder, Location loc, Value kIdx,
                   ValueRange iterArgs) {
                 // Load activation A[0, k]
-                Value aElem = builder.create<memref::LoadOp>(
-                    loc, A, ValueRange{c0, kIdx});
-                Value aVec = builder.create<vector::BroadcastOp>(
-                    loc, floatVecType, aElem);
+                Value aElem = memref::LoadOp::create(builder, loc, A,
+                                                     ValueRange{c0, kIdx});
+                Value aVec = vector::BroadcastOp::create(builder, loc,
+                                                         floatVecType, aElem);
 
                 // Load vecSize/2 packed bytes
-                Value packedVec = builder.create<vector::LoadOp>(
-                    loc, halfI8VecType, packedWeight,
+                Value packedVec = vector::LoadOp::create(
+                    builder, loc, halfI8VecType, packedWeight,
                     ValueRange{kIdx, packedIdx});
 
                 // Unpack low nibbles: (byte & 0x0F) << 4 >> 4
                 Value lowMasked =
-                    builder.create<arith::AndIOp>(loc, packedVec, mask15);
+                    arith::AndIOp::create(builder, loc, packedVec, mask15);
                 Value lowShifted =
-                    builder.create<arith::ShLIOp>(loc, lowMasked, shift4);
+                    arith::ShLIOp::create(builder, loc, lowMasked, shift4);
                 Value low =
-                    builder.create<arith::ShRSIOp>(loc, lowShifted, shift4);
+                    arith::ShRSIOp::create(builder, loc, lowShifted, shift4);
 
                 // Unpack high nibbles: byte >> 4
                 Value high =
-                    builder.create<arith::ShRSIOp>(loc, packedVec, shift4);
+                    arith::ShRSIOp::create(builder, loc, packedVec, shift4);
 
                 // Interleave: [low0, high0, low1, high1, ...]
                 Value unpacked =
-                    builder.create<vector::InterleaveOp>(loc, low, high);
+                    vector::InterleaveOp::create(builder, loc, low, high);
 
                 // Cast i8 -> float
-                Value floatVec = builder.create<arith::SIToFPOp>(
-                    loc, floatVecType, unpacked);
+                Value floatVec = arith::SIToFPOp::create(
+                    builder, loc, floatVecType, unpacked);
 
                 // FMA: acc += a * float_weight
-                Value res = builder.create<vector::FMAOp>(loc, aVec, floatVec,
-                                                          iterArgs.front());
+                Value res = vector::FMAOp::create(builder, loc, aVec, floatVec,
+                                                  iterArgs.front());
 
-                builder.create<scf::YieldOp>(loc, res);
+                scf::YieldOp::create(builder, loc, res);
               });
 
           Value accVec = forOp.getResult(0);
@@ -444,26 +444,27 @@ public:
               else
                 scaleIndices.push_back(c0);
             }
-            scaleVec = builder.create<vector::LoadOp>(
-                loc, floatVecType, dchain->scale, scaleIndices);
+            scaleVec = vector::LoadOp::create(builder, loc, floatVecType,
+                                              dchain->scale, scaleIndices);
           } else {
             SmallVector<Value> scaleIndices(scaleType.getRank(), c0);
-            Value scaleScalar = builder.create<memref::LoadOp>(
-                loc, dchain->scale, scaleIndices);
-            scaleVec = builder.create<vector::BroadcastOp>(loc, floatVecType,
-                                                           scaleScalar);
+            Value scaleScalar = memref::LoadOp::create(
+                builder, loc, dchain->scale, scaleIndices);
+            scaleVec = vector::BroadcastOp::create(builder, loc, floatVecType,
+                                                   scaleScalar);
           }
 
           Value scaledVec =
-              builder.create<arith::MulFOp>(loc, accVec, scaleVec);
+              arith::MulFOp::create(builder, loc, accVec, scaleVec);
 
           // Add to existing C
-          Value cVec = builder.create<vector::LoadOp>(loc, floatVecType, C,
-                                                      ValueRange{c0, nIdx});
-          Value resultVec = builder.create<arith::AddFOp>(loc, cVec, scaledVec);
+          Value cVec = vector::LoadOp::create(builder, loc, floatVecType, C,
+                                              ValueRange{c0, nIdx});
+          Value resultVec =
+              arith::AddFOp::create(builder, loc, cVec, scaledVec);
 
-          builder.create<vector::StoreOp>(loc, resultVec, C,
-                                          ValueRange{c0, nIdx});
+          vector::StoreOp::create(builder, loc, resultVec, C,
+                                  ValueRange{c0, nIdx});
         });
 
     rewriter.eraseOp(op);

--- a/midend/lib/Conversion/MatMulOptimization/MatMulBlisVectorization.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/MatMulBlisVectorization.cpp
@@ -331,33 +331,33 @@ public:
 
     // Create constant indices
     const Value c0 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(0));
     const Value c1 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(1));
     const Value c2 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(2));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(2));
     const Value c3 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(3));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(3));
     const Value c4 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(4));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(4));
     const Value c5 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(5));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(5));
     const Value c6 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(6));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(6));
     const Value c7 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(7));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(7));
 
     // Fixed BLIS blocking parameters from txt file
-    const Value nc = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getIndexAttr(256)); // nc = 256
-    const Value kc = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getIndexAttr(128)); // kc = 128
-    const Value mc = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getIndexAttr(64)); // mc = 64
-    const Value mr = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getIndexAttr(8)); // mr = 8
-    const Value nr = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getIndexAttr(32)); // nr = 32
+    const Value nc = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getIndexAttr(256)); // nc = 256
+    const Value kc = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getIndexAttr(128)); // kc = 128
+    const Value mc = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getIndexAttr(64)); // mc = 64
+    const Value mr = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getIndexAttr(8)); // mr = 8
+    const Value nr = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getIndexAttr(32)); // nr = 32
 
     // Get input A, B, C
     Value A = op->getOperand(0);
@@ -371,9 +371,9 @@ public:
       int4Info = findInt4UnpackChain(dequantChain->i8Weight);
 
     // Get dimensions
-    const Value m = rewriter.create<memref::DimOp>(loc, A, c0);
-    const Value n = rewriter.create<memref::DimOp>(loc, C, c1);
-    const Value k = rewriter.create<memref::DimOp>(loc, A, c1);
+    const Value m = memref::DimOp::create(rewriter, loc, A, c0);
+    const Value n = memref::DimOp::create(rewriter, loc, C, c1);
+    const Value k = memref::DimOp::create(rewriter, loc, A, c1);
 
     // Get element types: input type from A, accumulation type from C
     ShapedType ATy = cast<ShapedType>(A.getType());
@@ -389,67 +389,97 @@ public:
     Value i8Mask15 = nullptr;
     Value i8Shift4 = nullptr;
     if (dequantChain && int4Info) {
-      i8Mask15 = rewriter.create<arith::ConstantOp>(
-          loc, rewriter.getIntegerAttr(rewriter.getI8Type(), 15));
-      i8Shift4 = rewriter.create<arith::ConstantOp>(
-          loc, rewriter.getIntegerAttr(rewriter.getI8Type(), 4));
+      i8Mask15 = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getIntegerAttr(rewriter.getI8Type(), 15));
+      i8Shift4 = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getIntegerAttr(rewriter.getI8Type(), 4));
     }
 
     // BLIS 5-loop structure
     // Loop 1: jc - column blocking
-    rewriter.create<scf::ParallelOp>(
-        loc, c0, n, nc, [&](OpBuilder &builder, Location loc, ValueRange ivs) {
-          Value jc = ivs[0];
-          // Compute actual nc for this block
-          auto jcEnd = builder.create<arith::AddIOp>(loc, jc, nc);
-          auto jcBound = builder.create<arith::CmpIOp>(
-              loc, arith::CmpIPredicate::slt, jcEnd, n);
-          auto jcActualEnd =
-              builder.create<arith::SelectOp>(loc, jcBound, jcEnd, n);
-          auto ncActual = builder.create<arith::SubIOp>(loc, jcActualEnd, jc);
+    scf::ParallelOp::create(rewriter, loc, c0, n, nc,
+                            [&](OpBuilder &builder, Location loc,
+                                ValueRange ivs) {
+                              Value jc = ivs[0];
+                              // Compute actual nc for this block
+                              auto jcEnd =
+                                  arith::AddIOp::create(builder, loc, jc, nc);
+                              auto jcBound = arith::CmpIOp::create(
+                                  builder, loc, arith::CmpIPredicate::slt,
+                                  jcEnd, n);
+                              auto jcActualEnd = arith::SelectOp::create(
+                                  builder, loc, jcBound, jcEnd, n);
+                              auto ncActual = arith::SubIOp::create(
+                                  builder, loc, jcActualEnd, jc);
 
-          // Loop 2: pc - k blocking
-          builder.create<scf::ForOp>(
-              loc, c0, k, kc, ValueRange{},
-              [&](OpBuilder &builder, Location loc, Value pc, ValueRange) {
-                // Compute actual kc for this block
-                auto pcEnd = builder.create<arith::AddIOp>(loc, pc, kc);
-                auto pcBound = builder.create<arith::CmpIOp>(
-                    loc, arith::CmpIPredicate::slt, pcEnd, k);
-                auto pcActualEnd =
-                    builder.create<arith::SelectOp>(loc, pcBound, pcEnd, k);
-                auto kcActual =
-                    builder.create<arith::SubIOp>(loc, pcActualEnd, pc);
+                              // Loop 2: pc - k blocking
+                              scf::ForOp::
+                                  create(builder, loc, c0, k, kc, ValueRange{},
+                                         [&](OpBuilder &builder, Location loc,
+                                             Value pc, ValueRange) {
+                                           // Compute actual kc for this block
+                                           auto pcEnd = arith::AddIOp::create(
+                                               builder, loc, pc, kc);
+                                           auto pcBound = arith::CmpIOp::create(
+                                               builder, loc,
+                                               arith::CmpIPredicate::slt, pcEnd,
+                                               k);
+                                           auto pcActualEnd =
+                                               arith::SelectOp::create(
+                                                   builder, loc, pcBound, pcEnd,
+                                                   k);
+                                           auto kcActual =
+                                               arith::SubIOp::create(
+                                                   builder, loc, pcActualEnd,
+                                                   pc);
 
-                // Check if we should allocate B_packed (avoid
-                // allocation for empty blocks)
-                auto kcActualPositive = builder.create<arith::CmpIOp>(
-                    loc, arith::CmpIPredicate::sgt, kcActual, c0);
-                auto ncActualPositive = builder.create<arith::CmpIOp>(
-                    loc, arith::CmpIPredicate::sgt, ncActual, c0);
-                auto shouldAllocB = builder.create<arith::AndIOp>(
-                    loc, kcActualPositive, ncActualPositive);
+                                           // Check if we should allocate
+                                           // B_packed (avoid allocation for
+                                           // empty blocks)
+                                           auto kcActualPositive =
+                                               arith::CmpIOp::create(
+                                                   builder, loc,
+                                                   arith::CmpIPredicate::sgt,
+                                                   kcActual, c0);
+                                           auto ncActualPositive =
+                                               arith::CmpIOp::create(
+                                                   builder, loc,
+                                                   arith::CmpIPredicate::sgt,
+                                                   ncActual, c0);
+                                           auto shouldAllocB =
+                                               arith::AndIOp::create(
+                                                   builder, loc,
+                                                   kcActualPositive,
+                                                   ncActualPositive);
 
-                builder.create<scf::IfOp>(
-                    loc, shouldAllocB,
-                    [&](OpBuilder &builder, Location loc) {
-                      // Allocate and pack B block
-                      auto B_packedType = MemRefType::get(
-                          {ShapedType::kDynamic, ShapedType::kDynamic}, eleTy,
-                          AffineMap(), nullptr);
-                      Value B_packed = builder.create<memref::AllocOp>(
-                          loc, B_packedType, ValueRange{kcActual, ncActual});
+                                           scf::IfOp::create(
+                                               builder, loc, shouldAllocB,
+                                               [&](OpBuilder &builder,
+                                                   Location loc) {
+                                                 // Allocate and pack B block
+                                                 auto B_packedType =
+                                                     MemRefType::get(
+                                                         {ShapedType::kDynamic,
+                                                          ShapedType::kDynamic},
+                                                         eleTy, AffineMap(),
+                                                         nullptr);
+                                                 Value B_packed =
+                                                     memref::AllocOp::create(
+                                                         builder, loc,
+                                                         B_packedType,
+                                                         ValueRange{kcActual,
+                                                                    ncActual});
 
-                      // Pack B block
-                      // clang-format off
-                    builder.create<scf::ForOp>(
+                                                 // Pack B block
+                                                 // clang-format off
+                    scf::ForOp::create(builder,
                         loc, c0, kcActual, c1, ValueRange{},
                         [&](OpBuilder &builder, Location loc, Value kp, ValueRange) {
-                          builder.create<scf::ForOp>(
+                          scf::ForOp::create(builder,
                               loc, c0, ncActual, c1, ValueRange{},
                               [&](OpBuilder &builder, Location loc, Value j, ValueRange) {
-                                auto bRowIdx = builder.create<arith::AddIOp>(loc, pc, kp);
-                                auto bColIdx = builder.create<arith::AddIOp>(loc, jc, j);
+                                auto bRowIdx = arith::AddIOp::create(builder, loc, pc, kp);
+                                auto bColIdx = arith::AddIOp::create(builder, loc, jc, j);
 
                                 // If B is produced by a dequant chain, fuse dequant into packing.
                                 if (dequantChain) {
@@ -466,479 +496,494 @@ public:
                                       else
                                         scaleIdx.push_back(c0);
                                     }
-                                    scaleScalar = builder.create<memref::LoadOp>(
+                                    scaleScalar = memref::LoadOp::create(builder,
                                         loc, dequantChain->scale, scaleIdx);
                                   }
 
                                   Value weightI8 = nullptr;
                                   if (int4Info) {
                                     // packed index = bColIdx / 2
-                                    Value packedColIdx = builder.create<arith::DivUIOp>(loc, bColIdx, c2);
-                                    Value packedByte = builder.create<memref::LoadOp>(
+                                    Value packedColIdx = arith::DivUIOp::create(builder, loc, bColIdx, c2);
+                                    Value packedByte = memref::LoadOp::create(builder,
                                         loc, int4Info->packedWeight, ValueRange{bRowIdx, packedColIdx});
                                     // low = ((packed & 0x0F) << 4) >> 4
-                                    Value lowMasked = builder.create<arith::AndIOp>(loc, packedByte, i8Mask15);
-                                    Value lowShifted = builder.create<arith::ShLIOp>(loc, lowMasked, i8Shift4);
-                                    Value low = builder.create<arith::ShRSIOp>(loc, lowShifted, i8Shift4);
+                                    Value lowMasked = arith::AndIOp::create(builder, loc, packedByte, i8Mask15);
+                                    Value lowShifted = arith::ShLIOp::create(builder, loc, lowMasked, i8Shift4);
+                                    Value low = arith::ShRSIOp::create(builder, loc, lowShifted, i8Shift4);
                                     // high = packed >> 4
-                                    Value high = builder.create<arith::ShRSIOp>(loc, packedByte, i8Shift4);
+                                    Value high = arith::ShRSIOp::create(builder, loc, packedByte, i8Shift4);
                                     // select based on parity
-                                    Value rem = builder.create<arith::RemUIOp>(loc, bColIdx, c2);
-                                    Value isLow = builder.create<arith::CmpIOp>(
+                                    Value rem = arith::RemUIOp::create(builder, loc, bColIdx, c2);
+                                    Value isLow = arith::CmpIOp::create(builder,
                                         loc, arith::CmpIPredicate::eq, rem, c0);
-                                    weightI8 = builder.create<arith::SelectOp>(loc, isLow, low, high);
+                                    weightI8 = arith::SelectOp::create(builder, loc, isLow, low, high);
                                   } else {
-                                    weightI8 = builder.create<memref::LoadOp>(
+                                    weightI8 = memref::LoadOp::create(builder,
                                         loc, dequantChain->i8Weight, ValueRange{bRowIdx, bColIdx});
                                   }
 
                                   // i8 -> eleTy, then * scale
-                                  Value wFloat = builder.create<arith::SIToFPOp>(loc, eleTy, weightI8);
+                                  Value wFloat = arith::SIToFPOp::create(builder, loc, eleTy, weightI8);
                                   Value wDequant = scaleScalar
-                                                       ? builder.create<arith::MulFOp>(loc, wFloat, scaleScalar)
+                                                       ? arith::MulFOp::create(builder, loc, wFloat, scaleScalar)
                                                        : wFloat;
-                                  builder.create<memref::StoreOp>(loc, wDequant, B_packed,
+                                  memref::StoreOp::create(builder, loc, wDequant, B_packed,
                                                                   ValueRange{kp, j});
                                 } else {
                                   // Default path: just pack from B.
-                                  auto bVal = builder.create<memref::LoadOp>(loc, B,
+                                  auto bVal = memref::LoadOp::create(builder, loc, B,
                                                                            ValueRange{bRowIdx, bColIdx});
-                                  builder.create<memref::StoreOp>(loc, bVal, B_packed,
+                                  memref::StoreOp::create(builder, loc, bVal, B_packed,
                                                                 ValueRange{kp, j});
                                 }
-                                builder.create<scf::YieldOp>(loc);
+                                scf::YieldOp::create(builder, loc);
                               });
-                          builder.create<scf::YieldOp>(loc);
+                          scf::YieldOp::create(builder, loc);
                         });
                     // Loop 3: ic - row blocking
-                    builder.create<scf::ParallelOp>(
+                    scf::ParallelOp::create(builder,
                             loc, c0, m, mc,
                             [&](OpBuilder &builder, Location loc, ValueRange ivs) {
                             Value ic = ivs[0];
                           // Compute actual mc for this block
-                          auto icEnd = builder.create<arith::AddIOp>(loc, ic, mc);
-                          auto icBound = builder.create<arith::CmpIOp>(loc,
+                          auto icEnd = arith::AddIOp::create(builder, loc, ic, mc);
+                          auto icBound = arith::CmpIOp::create(builder, loc,
                                                         arith::CmpIPredicate::slt, icEnd, m);
-                          auto icActualEnd = builder.create<arith::SelectOp>(loc, icBound, icEnd, m);
-                          auto mcActual = builder.create<arith::SubIOp>(loc, icActualEnd, ic);
+                          auto icActualEnd = arith::SelectOp::create(builder, loc, icBound, icEnd, m);
+                          auto mcActual = arith::SubIOp::create(builder, loc, icActualEnd, ic);
 
                           // Check if we should allocate A_packed
-                          auto mcActualPositive = builder.create<arith::CmpIOp>(
+                          auto mcActualPositive = arith::CmpIOp::create(builder,
                               loc, arith::CmpIPredicate::sgt, mcActual, c0);
-                          auto shouldAllocA = builder.create<arith::AndIOp>(
+                          auto shouldAllocA = arith::AndIOp::create(builder,
                               loc, mcActualPositive, kcActualPositive);
-                          builder.create<scf::IfOp>(loc, shouldAllocA,
+                          scf::IfOp::create(builder, loc, shouldAllocA,
                             [&](OpBuilder &builder, Location loc) {
                               // Allocate and pack A block
                               auto A_packedType = MemRefType::get({ShapedType::kDynamic, ShapedType::kDynamic},
                                                 eleTy,AffineMap(),  nullptr);
-                              Value A_packed = builder.create<memref::AllocOp>(loc, A_packedType,
+                              Value A_packed = memref::AllocOp::create(builder, loc, A_packedType,
                                                                              ValueRange{mcActual, kcActual});
 
                               // Pack A block
-                              builder.create<scf::ForOp>(
+                              scf::ForOp::create(builder,
                                   loc, c0, mcActual, c1, ValueRange{},
                                   [&](OpBuilder &builder, Location loc, Value i, ValueRange) {
-                                    builder.create<scf::ForOp>(
+                                    scf::ForOp::create(builder,
                                         loc, c0, kcActual, c1, ValueRange{},
                                         [&](OpBuilder &builder, Location loc, Value kp, ValueRange) {
-                                          auto aRowIdx = builder.create<arith::AddIOp>(loc, ic, i);
-                                          auto aColIdx = builder.create<arith::AddIOp>(loc, pc, kp);
-                                          auto aVal = builder.create<memref::LoadOp>(loc, A,
+                                          auto aRowIdx = arith::AddIOp::create(builder, loc, ic, i);
+                                          auto aColIdx = arith::AddIOp::create(builder, loc, pc, kp);
+                                          auto aVal = memref::LoadOp::create(builder, loc, A,
                                                                                    ValueRange{aRowIdx, aColIdx});
-                                          builder.create<memref::StoreOp>(loc, aVal, A_packed,
+                                          memref::StoreOp::create(builder, loc, aVal, A_packed,
                                                                         ValueRange{i, kp});
-                                          builder.create<scf::YieldOp>(loc);
+                                          scf::YieldOp::create(builder, loc);
                                         });
-                                    builder.create<scf::YieldOp>(loc);
+                                    scf::YieldOp::create(builder, loc);
                                   });
 
                               // Loop 4: jr - micro column blocking
-                              builder.create<scf::ForOp>(
+                              scf::ForOp::create(builder,
                                   loc, c0, ncActual, nr, ValueRange{},
                                   [&](OpBuilder &builder, Location loc, Value jr, ValueRange) {
-                                    auto jrEnd = builder.create<arith::AddIOp>(loc, jr, nr);
-                                    auto jrBound = builder.create<arith::CmpIOp>(
+                                    auto jrEnd = arith::AddIOp::create(builder, loc, jr, nr);
+                                    auto jrBound = arith::CmpIOp::create(builder,
                                     loc, arith::CmpIPredicate::slt, jrEnd, ncActual);
-                                    auto jrActualEnd = builder.create<arith::SelectOp>(
+                                    auto jrActualEnd = arith::SelectOp::create(builder,
                                     loc, jrBound, jrEnd, ncActual);
-                                    auto nrActual = builder.create<arith::SubIOp>(
+                                    auto nrActual = arith::SubIOp::create(builder,
                                     loc, jrActualEnd, jr);
                                     // Process micro blocks
-                                    builder.create<scf::ForOp>(
+                                    scf::ForOp::create(builder,
                                         loc, c0, nrActual, nr, ValueRange{},
                                         [&](OpBuilder &builder, Location loc, Value nIdx, ValueRange) {
-                                          auto nIdxEnd = builder.create<arith::AddIOp>(loc, nIdx, nr);
-                                          auto nIdxBound = builder.create<arith::CmpIOp>(
+                                          auto nIdxEnd = arith::AddIOp::create(builder, loc, nIdx, nr);
+                                          auto nIdxBound = arith::CmpIOp::create(builder,
                                           loc, arith::CmpIPredicate::slt, nIdxEnd, nrActual);
-                                          auto nIdxActualEnd = builder.create<arith::SelectOp>(
+                                          auto nIdxActualEnd = arith::SelectOp::create(builder,
                                           loc, nIdxBound, nIdxEnd, nrActual);
-                                          auto colsToProcess = builder.create<arith::SubIOp>(
+                                          auto colsToProcess = arith::SubIOp::create(builder,
                                           loc, nIdxActualEnd, nIdx);
                                           // Check if we can vectorize (at least 32 columns)
-                                          auto canVectorize = builder.create<arith::CmpIOp>(
+                                          auto canVectorize = arith::CmpIOp::create(builder,
                                               loc, arith::CmpIPredicate::sge, colsToProcess, nr);
 
-                                          builder.create<scf::IfOp>(
+                                          scf::IfOp::create(builder,
                                               loc, canVectorize,
                                               [&](OpBuilder &builder, Location loc) {
                                                 // Vectorized path 32
-                                                builder.create<scf::ForOp>(
+                                                scf::ForOp::create(builder,
                                                     loc, c0, mcActual, mr, ValueRange{},
                                                     [&](OpBuilder &builder, Location loc, Value ir, ValueRange) {
-                                                      auto irEnd = builder.create<arith::AddIOp>(loc, ir, mr);
-                                                      auto irBound = builder.create<arith::CmpIOp>(
+                                                      auto irEnd = arith::AddIOp::create(builder, loc, ir, mr);
+                                                      auto irBound = arith::CmpIOp::create(builder,
                                                       loc, arith::CmpIPredicate::slt, irEnd, mcActual);
-                                                      auto irActualEnd = builder.create<arith::SelectOp>(
+                                                      auto irActualEnd = arith::SelectOp::create(builder,
                                                       loc, irBound, irEnd, mcActual);
-                                                      auto mrActual = builder.create<arith::SubIOp>(loc, irActualEnd, ir);
+                                                      auto mrActual = arith::SubIOp::create(builder, loc, irActualEnd, ir);
                                                       // Check if we have full 8 rows - FIXED: use mr instead of c8
-                                                      auto hasFullRows = builder.create<arith::CmpIOp>(
+                                                      auto hasFullRows = arith::CmpIOp::create(builder,
                                                           loc, arith::CmpIPredicate::sge, mrActual, mr);
-                                                      builder.create<scf::IfOp>(
+                                                      scf::IfOp::create(builder,
                                                           loc, hasFullRows,
                                                           [&](OpBuilder &builder, Location loc) {
                                                             // Full rows vectorized processing
-                                                            auto ir0 = builder.create<arith::AddIOp>(loc, ir, c0);
-                                                            auto ir1 = builder.create<arith::AddIOp>(loc, ir, c1);
-                                                            auto ir2 = builder.create<arith::AddIOp>(loc, ir, c2);
-                                                            auto ir3 = builder.create<arith::AddIOp>(loc, ir, c3);
-                                                            auto ir4 = builder.create<arith::AddIOp>(loc, ir, c4);
-                                                            auto ir5 = builder.create<arith::AddIOp>(loc, ir, c5);
-                                                            auto ir6 = builder.create<arith::AddIOp>(loc, ir, c6);
-                                                            auto ir7 = builder.create<arith::AddIOp>(loc, ir, c7);
+                                                            auto ir0 = arith::AddIOp::create(builder, loc, ir, c0);
+                                                            auto ir1 = arith::AddIOp::create(builder, loc, ir, c1);
+                                                            auto ir2 = arith::AddIOp::create(builder, loc, ir, c2);
+                                                            auto ir3 = arith::AddIOp::create(builder, loc, ir, c3);
+                                                            auto ir4 = arith::AddIOp::create(builder, loc, ir, c4);
+                                                            auto ir5 = arith::AddIOp::create(builder, loc, ir, c5);
+                                                            auto ir6 = arith::AddIOp::create(builder, loc, ir, c6);
+                                                            auto ir7 = arith::AddIOp::create(builder, loc, ir, c7);
 
-                                                            auto sumInit = builder.create<arith::ConstantOp>(
+                                                            auto sumInit = arith::ConstantOp::create(builder,
                                                                 loc, accVecTy, builder.getZeroAttr(accVecTy));
 
-                                                            auto sumIterVecs = builder.create<scf::ForOp>(
+                                                            auto sumIterVecs = scf::ForOp::create(builder,
                                                                 loc, c0, kcActual, c1,
                                                                 ValueRange{sumInit, sumInit, sumInit, sumInit,
                                                                          sumInit, sumInit, sumInit, sumInit},
                                                                 [&](OpBuilder &builder, Location loc, Value kInner,
                                                                     ValueRange iterArgs) {
                                                                   // Load A values for 8 rows
-                                                                  Value aVal0 = builder.create<memref::LoadOp>(
+                                                                  Value aVal0 = memref::LoadOp::create(builder,
                                                                       loc, A_packed, ValueRange{ir0, kInner});
-                                                                  Value aVal1 = builder.create<memref::LoadOp>(
+                                                                  Value aVal1 = memref::LoadOp::create(builder,
                                                                       loc, A_packed, ValueRange{ir1, kInner});
-                                                                  Value aVal2 = builder.create<memref::LoadOp>(
+                                                                  Value aVal2 = memref::LoadOp::create(builder,
                                                                       loc, A_packed, ValueRange{ir2, kInner});
-                                                                  Value aVal3 = builder.create<memref::LoadOp>(
+                                                                  Value aVal3 = memref::LoadOp::create(builder,
                                                                       loc, A_packed, ValueRange{ir3, kInner});
-                                                                  Value aVal4 = builder.create<memref::LoadOp>(
+                                                                  Value aVal4 = memref::LoadOp::create(builder,
                                                                       loc, A_packed, ValueRange{ir4, kInner});
-                                                                  Value aVal5 = builder.create<memref::LoadOp>(
+                                                                  Value aVal5 = memref::LoadOp::create(builder,
                                                                       loc, A_packed, ValueRange{ir5, kInner});
-                                                                  Value aVal6 = builder.create<memref::LoadOp>(
+                                                                  Value aVal6 = memref::LoadOp::create(builder,
                                                                       loc, A_packed, ValueRange{ir6, kInner});
-                                                                  Value aVal7 = builder.create<memref::LoadOp>(
+                                                                  Value aVal7 = memref::LoadOp::create(builder,
                                                                       loc, A_packed, ValueRange{ir7, kInner});
 
                                                                   if (isInteger) {
-                                                                    aVal0 = builder.create<arith::ExtSIOp>(loc, accEleTy, aVal0);
-                                                                    aVal1 = builder.create<arith::ExtSIOp>(loc, accEleTy, aVal1);
-                                                                    aVal2 = builder.create<arith::ExtSIOp>(loc, accEleTy, aVal2);
-                                                                    aVal3 = builder.create<arith::ExtSIOp>(loc, accEleTy, aVal3);
-                                                                    aVal4 = builder.create<arith::ExtSIOp>(loc, accEleTy, aVal4);
-                                                                    aVal5 = builder.create<arith::ExtSIOp>(loc, accEleTy, aVal5);
-                                                                    aVal6 = builder.create<arith::ExtSIOp>(loc, accEleTy, aVal6);
-                                                                    aVal7 = builder.create<arith::ExtSIOp>(loc, accEleTy, aVal7);
+                                                                    aVal0 = arith::ExtSIOp::create(builder, loc, accEleTy, aVal0);
+                                                                    aVal1 = arith::ExtSIOp::create(builder, loc, accEleTy, aVal1);
+                                                                    aVal2 = arith::ExtSIOp::create(builder, loc, accEleTy, aVal2);
+                                                                    aVal3 = arith::ExtSIOp::create(builder, loc, accEleTy, aVal3);
+                                                                    aVal4 = arith::ExtSIOp::create(builder, loc, accEleTy, aVal4);
+                                                                    aVal5 = arith::ExtSIOp::create(builder, loc, accEleTy, aVal5);
+                                                                    aVal6 = arith::ExtSIOp::create(builder, loc, accEleTy, aVal6);
+                                                                    aVal7 = arith::ExtSIOp::create(builder, loc, accEleTy, aVal7);
                                                                   }
 
                                                                   // Broadcast A values to accumulation vectors
-                                                                  auto aVec0 = builder.create<vector::BroadcastOp>(
+                                                                  auto aVec0 = vector::BroadcastOp::create(builder,
                                                                       loc, accVecTy, aVal0);
-                                                                  auto aVec1 = builder.create<vector::BroadcastOp>(
+                                                                  auto aVec1 = vector::BroadcastOp::create(builder,
                                                                       loc, accVecTy, aVal1);
-                                                                  auto aVec2 = builder.create<vector::BroadcastOp>(
+                                                                  auto aVec2 = vector::BroadcastOp::create(builder,
                                                                       loc, accVecTy, aVal2);
-                                                                  auto aVec3 = builder.create<vector::BroadcastOp>(
+                                                                  auto aVec3 = vector::BroadcastOp::create(builder,
                                                                       loc, accVecTy, aVal3);
-                                                                  auto aVec4 = builder.create<vector::BroadcastOp>(
+                                                                  auto aVec4 = vector::BroadcastOp::create(builder,
                                                                       loc, accVecTy, aVal4);
-                                                                  auto aVec5 = builder.create<vector::BroadcastOp>(
+                                                                  auto aVec5 = vector::BroadcastOp::create(builder,
                                                                       loc, accVecTy, aVal5);
-                                                                  auto aVec6 = builder.create<vector::BroadcastOp>(
+                                                                  auto aVec6 = vector::BroadcastOp::create(builder,
                                                                       loc, accVecTy, aVal6);
-                                                                  auto aVec7 = builder.create<vector::BroadcastOp>(
+                                                                  auto aVec7 = vector::BroadcastOp::create(builder,
                                                                       loc, accVecTy, aVal7);
 
                                                                   // Load B vector and sign-extend for integer
-                                                                  auto bColIdx = builder.create<arith::AddIOp>(loc, jr, nIdx);
-                                                                  Value bVec = builder.create<vector::LoadOp>(
+                                                                  auto bColIdx = arith::AddIOp::create(builder, loc, jr, nIdx);
+                                                                  Value bVec = vector::LoadOp::create(builder,
                                                                       loc, vectorTy, B_packed,
                                                                       ValueRange{kInner, bColIdx});
                                                                   if (isInteger)
-                                                                    bVec = builder.create<arith::ExtSIOp>(loc, accVecTy, bVec);
+                                                                    bVec = arith::ExtSIOp::create(builder, loc, accVecTy, bVec);
 
                                                                   // Multiply-accumulate
                                                                   Value resSumVec0, resSumVec1, resSumVec2, resSumVec3,
                                                                         resSumVec4, resSumVec5, resSumVec6, resSumVec7;
                                                                   if (isInteger) {
-                                                                    resSumVec0 = builder.create<arith::AddIOp>(loc, iterArgs[0],
-                                                                        builder.create<arith::MulIOp>(loc, aVec0, bVec));
-                                                                    resSumVec1 = builder.create<arith::AddIOp>(loc, iterArgs[1],
-                                                                        builder.create<arith::MulIOp>(loc, aVec1, bVec));
-                                                                    resSumVec2 = builder.create<arith::AddIOp>(loc, iterArgs[2],
-                                                                        builder.create<arith::MulIOp>(loc, aVec2, bVec));
-                                                                    resSumVec3 = builder.create<arith::AddIOp>(loc, iterArgs[3],
-                                                                        builder.create<arith::MulIOp>(loc, aVec3, bVec));
-                                                                    resSumVec4 = builder.create<arith::AddIOp>(loc, iterArgs[4],
-                                                                        builder.create<arith::MulIOp>(loc, aVec4, bVec));
-                                                                    resSumVec5 = builder.create<arith::AddIOp>(loc, iterArgs[5],
-                                                                        builder.create<arith::MulIOp>(loc, aVec5, bVec));
-                                                                    resSumVec6 = builder.create<arith::AddIOp>(loc, iterArgs[6],
-                                                                        builder.create<arith::MulIOp>(loc, aVec6, bVec));
-                                                                    resSumVec7 = builder.create<arith::AddIOp>(loc, iterArgs[7],
-                                                                        builder.create<arith::MulIOp>(loc, aVec7, bVec));
+                                                                    resSumVec0 = arith::AddIOp::create(builder, loc, iterArgs[0],
+                                                                        arith::MulIOp::create(builder, loc, aVec0, bVec));
+                                                                    resSumVec1 = arith::AddIOp::create(builder, loc, iterArgs[1],
+                                                                        arith::MulIOp::create(builder, loc, aVec1, bVec));
+                                                                    resSumVec2 = arith::AddIOp::create(builder, loc, iterArgs[2],
+                                                                        arith::MulIOp::create(builder, loc, aVec2, bVec));
+                                                                    resSumVec3 = arith::AddIOp::create(builder, loc, iterArgs[3],
+                                                                        arith::MulIOp::create(builder, loc, aVec3, bVec));
+                                                                    resSumVec4 = arith::AddIOp::create(builder, loc, iterArgs[4],
+                                                                        arith::MulIOp::create(builder, loc, aVec4, bVec));
+                                                                    resSumVec5 = arith::AddIOp::create(builder, loc, iterArgs[5],
+                                                                        arith::MulIOp::create(builder, loc, aVec5, bVec));
+                                                                    resSumVec6 = arith::AddIOp::create(builder, loc, iterArgs[6],
+                                                                        arith::MulIOp::create(builder, loc, aVec6, bVec));
+                                                                    resSumVec7 = arith::AddIOp::create(builder, loc, iterArgs[7],
+                                                                        arith::MulIOp::create(builder, loc, aVec7, bVec));
                                                                   } else {
-                                                                    resSumVec0 = builder.create<vector::FMAOp>(loc, aVec0, bVec, iterArgs[0]);
-                                                                    resSumVec1 = builder.create<vector::FMAOp>(loc, aVec1, bVec, iterArgs[1]);
-                                                                    resSumVec2 = builder.create<vector::FMAOp>(loc, aVec2, bVec, iterArgs[2]);
-                                                                    resSumVec3 = builder.create<vector::FMAOp>(loc, aVec3, bVec, iterArgs[3]);
-                                                                    resSumVec4 = builder.create<vector::FMAOp>(loc, aVec4, bVec, iterArgs[4]);
-                                                                    resSumVec5 = builder.create<vector::FMAOp>(loc, aVec5, bVec, iterArgs[5]);
-                                                                    resSumVec6 = builder.create<vector::FMAOp>(loc, aVec6, bVec, iterArgs[6]);
-                                                                    resSumVec7 = builder.create<vector::FMAOp>(loc, aVec7, bVec, iterArgs[7]);
+                                                                    resSumVec0 = vector::FMAOp::create(builder, loc, aVec0, bVec, iterArgs[0]);
+                                                                    resSumVec1 = vector::FMAOp::create(builder, loc, aVec1, bVec, iterArgs[1]);
+                                                                    resSumVec2 = vector::FMAOp::create(builder, loc, aVec2, bVec, iterArgs[2]);
+                                                                    resSumVec3 = vector::FMAOp::create(builder, loc, aVec3, bVec, iterArgs[3]);
+                                                                    resSumVec4 = vector::FMAOp::create(builder, loc, aVec4, bVec, iterArgs[4]);
+                                                                    resSumVec5 = vector::FMAOp::create(builder, loc, aVec5, bVec, iterArgs[5]);
+                                                                    resSumVec6 = vector::FMAOp::create(builder, loc, aVec6, bVec, iterArgs[6]);
+                                                                    resSumVec7 = vector::FMAOp::create(builder, loc, aVec7, bVec, iterArgs[7]);
                                                                   }
 
-                                                                  builder.create<scf::YieldOp>(
+                                                                  scf::YieldOp::create(builder,
                                                                       loc, ValueRange{resSumVec0, resSumVec1, resSumVec2,
                                                                                       resSumVec3, resSumVec4, resSumVec5,
                                                                                       resSumVec6, resSumVec7});
                                                                 });
 
                                                             // Store results with accumulation
-                                                            auto cRow0 = builder.create<arith::AddIOp>(loc, ic, ir0);
-                                                            auto cRow1 = builder.create<arith::AddIOp>(loc, ic, ir1);
-                                                            auto cRow2 = builder.create<arith::AddIOp>(loc, ic, ir2);
-                                                            auto cRow3 = builder.create<arith::AddIOp>(loc, ic, ir3);
-                                                            auto cRow4 = builder.create<arith::AddIOp>(loc, ic, ir4);
-                                                            auto cRow5 = builder.create<arith::AddIOp>(loc, ic, ir5);
-                                                            auto cRow6 = builder.create<arith::AddIOp>(loc, ic, ir6);
-                                                            auto cRow7 = builder.create<arith::AddIOp>(loc, ic, ir7);
-                                                            auto cColBase = builder.create<arith::AddIOp>(loc, jc, jr);
-                                                            auto cColIdx = builder.create<arith::AddIOp>(loc, cColBase, nIdx);
+                                                            auto cRow0 = arith::AddIOp::create(builder, loc, ic, ir0);
+                                                            auto cRow1 = arith::AddIOp::create(builder, loc, ic, ir1);
+                                                            auto cRow2 = arith::AddIOp::create(builder, loc, ic, ir2);
+                                                            auto cRow3 = arith::AddIOp::create(builder, loc, ic, ir3);
+                                                            auto cRow4 = arith::AddIOp::create(builder, loc, ic, ir4);
+                                                            auto cRow5 = arith::AddIOp::create(builder, loc, ic, ir5);
+                                                            auto cRow6 = arith::AddIOp::create(builder, loc, ic, ir6);
+                                                            auto cRow7 = arith::AddIOp::create(builder, loc, ic, ir7);
+                                                            auto cColBase = arith::AddIOp::create(builder, loc, jc, jr);
+                                                            auto cColIdx = arith::AddIOp::create(builder, loc, cColBase, nIdx);
 
                                                             // Load current C values (accumulation type)
-                                                            auto cVec0 = builder.create<vector::LoadOp>(
+                                                            auto cVec0 = vector::LoadOp::create(builder,
                                                                 loc, accVecTy, C, ValueRange{cRow0, cColIdx});
-                                                            auto cVec1 = builder.create<vector::LoadOp>(
+                                                            auto cVec1 = vector::LoadOp::create(builder,
                                                                 loc, accVecTy, C, ValueRange{cRow1, cColIdx});
-                                                            auto cVec2 = builder.create<vector::LoadOp>(
+                                                            auto cVec2 = vector::LoadOp::create(builder,
                                                                 loc, accVecTy, C, ValueRange{cRow2, cColIdx});
-                                                            auto cVec3 = builder.create<vector::LoadOp>(
+                                                            auto cVec3 = vector::LoadOp::create(builder,
                                                                 loc, accVecTy, C, ValueRange{cRow3, cColIdx});
-                                                            auto cVec4 = builder.create<vector::LoadOp>(
+                                                            auto cVec4 = vector::LoadOp::create(builder,
                                                                 loc, accVecTy, C, ValueRange{cRow4, cColIdx});
-                                                            auto cVec5 = builder.create<vector::LoadOp>(
+                                                            auto cVec5 = vector::LoadOp::create(builder,
                                                                 loc, accVecTy, C, ValueRange{cRow5, cColIdx});
-                                                            auto cVec6 = builder.create<vector::LoadOp>(
+                                                            auto cVec6 = vector::LoadOp::create(builder,
                                                                 loc, accVecTy, C, ValueRange{cRow6, cColIdx});
-                                                            auto cVec7 = builder.create<vector::LoadOp>(
+                                                            auto cVec7 = vector::LoadOp::create(builder,
                                                                 loc, accVecTy, C, ValueRange{cRow7, cColIdx});
 
                                                             // Accumulate: C = C + A*B
                                                             Value finalVec0, finalVec1, finalVec2, finalVec3,
                                                                   finalVec4, finalVec5, finalVec6, finalVec7;
                                                             if (isInteger) {
-                                                              finalVec0 = builder.create<arith::AddIOp>(loc, cVec0, sumIterVecs.getResult(0));
-                                                              finalVec1 = builder.create<arith::AddIOp>(loc, cVec1, sumIterVecs.getResult(1));
-                                                              finalVec2 = builder.create<arith::AddIOp>(loc, cVec2, sumIterVecs.getResult(2));
-                                                              finalVec3 = builder.create<arith::AddIOp>(loc, cVec3, sumIterVecs.getResult(3));
-                                                              finalVec4 = builder.create<arith::AddIOp>(loc, cVec4, sumIterVecs.getResult(4));
-                                                              finalVec5 = builder.create<arith::AddIOp>(loc, cVec5, sumIterVecs.getResult(5));
-                                                              finalVec6 = builder.create<arith::AddIOp>(loc, cVec6, sumIterVecs.getResult(6));
-                                                              finalVec7 = builder.create<arith::AddIOp>(loc, cVec7, sumIterVecs.getResult(7));
+                                                              finalVec0 = arith::AddIOp::create(builder, loc, cVec0, sumIterVecs.getResult(0));
+                                                              finalVec1 = arith::AddIOp::create(builder, loc, cVec1, sumIterVecs.getResult(1));
+                                                              finalVec2 = arith::AddIOp::create(builder, loc, cVec2, sumIterVecs.getResult(2));
+                                                              finalVec3 = arith::AddIOp::create(builder, loc, cVec3, sumIterVecs.getResult(3));
+                                                              finalVec4 = arith::AddIOp::create(builder, loc, cVec4, sumIterVecs.getResult(4));
+                                                              finalVec5 = arith::AddIOp::create(builder, loc, cVec5, sumIterVecs.getResult(5));
+                                                              finalVec6 = arith::AddIOp::create(builder, loc, cVec6, sumIterVecs.getResult(6));
+                                                              finalVec7 = arith::AddIOp::create(builder, loc, cVec7, sumIterVecs.getResult(7));
                                                             } else {
-                                                              finalVec0 = builder.create<arith::AddFOp>(loc, cVec0, sumIterVecs.getResult(0));
-                                                              finalVec1 = builder.create<arith::AddFOp>(loc, cVec1, sumIterVecs.getResult(1));
-                                                              finalVec2 = builder.create<arith::AddFOp>(loc, cVec2, sumIterVecs.getResult(2));
-                                                              finalVec3 = builder.create<arith::AddFOp>(loc, cVec3, sumIterVecs.getResult(3));
-                                                              finalVec4 = builder.create<arith::AddFOp>(loc, cVec4, sumIterVecs.getResult(4));
-                                                              finalVec5 = builder.create<arith::AddFOp>(loc, cVec5, sumIterVecs.getResult(5));
-                                                              finalVec6 = builder.create<arith::AddFOp>(loc, cVec6, sumIterVecs.getResult(6));
-                                                              finalVec7 = builder.create<arith::AddFOp>(loc, cVec7, sumIterVecs.getResult(7));
+                                                              finalVec0 = arith::AddFOp::create(builder, loc, cVec0, sumIterVecs.getResult(0));
+                                                              finalVec1 = arith::AddFOp::create(builder, loc, cVec1, sumIterVecs.getResult(1));
+                                                              finalVec2 = arith::AddFOp::create(builder, loc, cVec2, sumIterVecs.getResult(2));
+                                                              finalVec3 = arith::AddFOp::create(builder, loc, cVec3, sumIterVecs.getResult(3));
+                                                              finalVec4 = arith::AddFOp::create(builder, loc, cVec4, sumIterVecs.getResult(4));
+                                                              finalVec5 = arith::AddFOp::create(builder, loc, cVec5, sumIterVecs.getResult(5));
+                                                              finalVec6 = arith::AddFOp::create(builder, loc, cVec6, sumIterVecs.getResult(6));
+                                                              finalVec7 = arith::AddFOp::create(builder, loc, cVec7, sumIterVecs.getResult(7));
                                                             }
 
                                                             // Store back to C
-                                                            builder.create<vector::StoreOp>(
+                                                            vector::StoreOp::create(builder,
                                                                 loc, finalVec0, C, ValueRange{cRow0, cColIdx});
-                                                            builder.create<vector::StoreOp>(
+                                                            vector::StoreOp::create(builder,
                                                                 loc, finalVec1, C, ValueRange{cRow1, cColIdx});
-                                                            builder.create<vector::StoreOp>(
+                                                            vector::StoreOp::create(builder,
                                                                 loc, finalVec2, C, ValueRange{cRow2, cColIdx});
-                                                            builder.create<vector::StoreOp>(
+                                                            vector::StoreOp::create(builder,
                                                                 loc, finalVec3, C, ValueRange{cRow3, cColIdx});
-                                                            builder.create<vector::StoreOp>(
+                                                            vector::StoreOp::create(builder,
                                                                 loc, finalVec4, C, ValueRange{cRow4, cColIdx});
-                                                            builder.create<vector::StoreOp>(
+                                                            vector::StoreOp::create(builder,
                                                                 loc, finalVec5, C, ValueRange{cRow5, cColIdx});
-                                                            builder.create<vector::StoreOp>(
+                                                            vector::StoreOp::create(builder,
                                                                 loc, finalVec6, C, ValueRange{cRow6, cColIdx});
-                                                            builder.create<vector::StoreOp>(
+                                                            vector::StoreOp::create(builder,
                                                                 loc, finalVec7, C, ValueRange{cRow7, cColIdx});
 
-                                                            builder.create<scf::YieldOp>(loc);
+                                                            scf::YieldOp::create(builder, loc);
                                                           },
                                                           [&](OpBuilder &builder, Location loc) {
                                                             // Scalar path for incomplete rows
-                                                            builder.create<scf::ForOp>(
+                                                            scf::ForOp::create(builder,
                                                                 loc, c0, nr, c1, ValueRange{},
                                                                 [&](OpBuilder &builder, Location loc, Value jj, ValueRange) {
-                                                                  builder.create<scf::ForOp>(
+                                                                  scf::ForOp::create(builder,
                                                                       loc, ir, irActualEnd, c1, ValueRange{},
                                                                       [&](OpBuilder &builder, Location loc, Value ii, ValueRange) {
                                                                         Value sumInit;
                                                                         if (isInteger)
-                                                                          sumInit = builder.create<arith::ConstantOp>(
+                                                                          sumInit = arith::ConstantOp::create(builder,
                                                                               loc, accEleTy, builder.getIntegerAttr(accEleTy, 0));
                                                                         else
-                                                                          sumInit = builder.create<arith::ConstantOp>(
+                                                                          sumInit = arith::ConstantOp::create(builder,
                                                                               loc, accEleTy, builder.getFloatAttr(accEleTy, 0.0));
-                                                                        auto sumIter = builder.create<scf::ForOp>(
+                                                                        auto sumIter = scf::ForOp::create(builder,
                                                                             loc, c0, kcActual, c1,
                                                                             ValueRange{sumInit},
                                                                             [&](OpBuilder &builder, Location loc, Value kInner,
                                                                                 ValueRange iterArgs) {
-                                                                              Value aVal = builder.create<memref::LoadOp>(
+                                                                              Value aVal = memref::LoadOp::create(builder,
                                                                                   loc, A_packed, ValueRange{ii, kInner});
-                                                                              auto bColBase = builder.create<arith::AddIOp>(loc, jr, nIdx);
-                                                                              auto bColIdx = builder.create<arith::AddIOp>(loc, bColBase, jj);
-                                                                              Value bVal = builder.create<memref::LoadOp>(
+                                                                              auto bColBase = arith::AddIOp::create(builder, loc, jr, nIdx);
+                                                                              auto bColIdx = arith::AddIOp::create(builder, loc, bColBase, jj);
+                                                                              Value bVal = memref::LoadOp::create(builder,
                                                                                   loc, B_packed, ValueRange{kInner, bColIdx});
                                                                               Value prod, newSum;
                                                                               if (isInteger) {
-                                                                                aVal = builder.create<arith::ExtSIOp>(loc, accEleTy, aVal);
-                                                                                bVal = builder.create<arith::ExtSIOp>(loc, accEleTy, bVal);
-                                                                                prod = builder.create<arith::MulIOp>(loc, aVal, bVal);
-                                                                                newSum = builder.create<arith::AddIOp>(loc, iterArgs[0], prod);
+                                                                                aVal = arith::ExtSIOp::create(builder, loc, accEleTy, aVal);
+                                                                                bVal = arith::ExtSIOp::create(builder, loc, accEleTy, bVal);
+                                                                                prod = arith::MulIOp::create(builder, loc, aVal, bVal);
+                                                                                newSum = arith::AddIOp::create(builder, loc, iterArgs[0], prod);
                                                                               } else {
-                                                                                prod = builder.create<arith::MulFOp>(loc, aVal, bVal);
-                                                                                newSum = builder.create<arith::AddFOp>(loc, iterArgs[0], prod);
+                                                                                prod = arith::MulFOp::create(builder, loc, aVal, bVal);
+                                                                                newSum = arith::AddFOp::create(builder, loc, iterArgs[0], prod);
                                                                               }
-                                                                              builder.create<scf::YieldOp>(loc, ValueRange{newSum});
+                                                                              scf::YieldOp::create(builder, loc, ValueRange{newSum});
                                                                             });
-                                                                        auto cRowIdx = builder.create<arith::AddIOp>(loc, ic, ii);
-                                                                        auto cColBase = builder.create<arith::AddIOp>(loc, jc, jr);
-                                                                        auto cColBase2 = builder.create<arith::AddIOp>(loc, cColBase, nIdx);
-                                                                        auto cColIdx = builder.create<arith::AddIOp>(loc, cColBase2, jj);
-                                                                        auto currentVal = builder.create<memref::LoadOp>(
+                                                                        auto cRowIdx = arith::AddIOp::create(builder, loc, ic, ii);
+                                                                        auto cColBase = arith::AddIOp::create(builder, loc, jc, jr);
+                                                                        auto cColBase2 = arith::AddIOp::create(builder, loc, cColBase, nIdx);
+                                                                        auto cColIdx = arith::AddIOp::create(builder, loc, cColBase2, jj);
+                                                                        auto currentVal = memref::LoadOp::create(builder,
                                                                             loc, C, ValueRange{cRowIdx, cColIdx});
                                                                         Value finalSum;
                                                                         if (isInteger)
-                                                                          finalSum = builder.create<arith::AddIOp>(loc, currentVal, sumIter.getResult(0));
+                                                                          finalSum = arith::AddIOp::create(builder, loc, currentVal, sumIter.getResult(0));
                                                                         else
-                                                                          finalSum = builder.create<arith::AddFOp>(loc, currentVal, sumIter.getResult(0));
-                                                                        builder.create<memref::StoreOp>(
+                                                                          finalSum = arith::AddFOp::create(builder, loc, currentVal, sumIter.getResult(0));
+                                                                        memref::StoreOp::create(builder,
                                                                             loc, finalSum, C, ValueRange{cRowIdx, cColIdx});
-                                                                        builder.create<scf::YieldOp>(loc);
+                                                                        scf::YieldOp::create(builder, loc);
                                                                       });
-                                                                  builder.create<scf::YieldOp>(loc);
+                                                                  scf::YieldOp::create(builder, loc);
                                                                 });
-                                                            builder.create<scf::YieldOp>(loc);
+                                                            scf::YieldOp::create(builder, loc);
                                                           });
 
-                                                      builder.create<scf::YieldOp>(loc);
+                                                      scf::YieldOp::create(builder, loc);
                                                     });
-                                                builder.create<scf::YieldOp>(loc);
+                                                scf::YieldOp::create(builder, loc);
                                               },
                                               [&](OpBuilder &builder, Location loc) {
                                                 // Scalar path for incomplete columns
-                                                builder.create<scf::ForOp>(
+                                                scf::ForOp::create(builder,
                                                     loc, nIdx, nIdxActualEnd, c1, ValueRange{},
                                                     [&](OpBuilder &builder, Location loc, Value nIdxTail, ValueRange) {
-                                                      builder.create<scf::ForOp>(
+                                                      scf::ForOp::create(builder,
                                                           loc, c0, mcActual, mr, ValueRange{},
                                                           [&](OpBuilder &builder, Location loc, Value ir, ValueRange) {
-                                                            auto irEnd = builder.create<arith::AddIOp>(loc, ir, mr);
-                                                            auto irBound = builder.create<arith::CmpIOp>(
+                                                            auto irEnd = arith::AddIOp::create(builder, loc, ir, mr);
+                                                            auto irBound = arith::CmpIOp::create(builder,
                                                             loc, arith::CmpIPredicate::slt, irEnd, mcActual);
-                                                            auto irActualEnd = builder.create<arith::SelectOp>(
+                                                            auto irActualEnd = arith::SelectOp::create(builder,
                                                             loc, irBound, irEnd, mcActual);
 
-                                                            builder.create<scf::ForOp>(
+                                                            scf::ForOp::create(builder,
                                                                 loc, ir, irActualEnd, c1, ValueRange{},
                                                                 [&](OpBuilder &builder, Location loc, Value ii, ValueRange) {
                                                                   Value sumInit;
                                                                   if (isInteger)
-                                                                    sumInit = builder.create<arith::ConstantOp>(
+                                                                    sumInit = arith::ConstantOp::create(builder,
                                                                         loc, accEleTy, builder.getIntegerAttr(accEleTy, 0));
                                                                   else
-                                                                    sumInit = builder.create<arith::ConstantOp>(
+                                                                    sumInit = arith::ConstantOp::create(builder,
                                                                         loc, accEleTy, builder.getFloatAttr(accEleTy, 0.0));
-                                                                  auto sumIter = builder.create<scf::ForOp>(
+                                                                  auto sumIter = scf::ForOp::create(builder,
                                                                       loc, c0, kcActual, c1,
                                                                       ValueRange{sumInit},
                                                                       [&](OpBuilder &builder, Location loc, Value kInner,
                                                                           ValueRange iterArgs) {
-                                                                        Value aVal = builder.create<memref::LoadOp>(
+                                                                        Value aVal = memref::LoadOp::create(builder,
                                                                             loc, A_packed, ValueRange{ii, kInner});
-                                                                        auto bColBase = builder.create<arith::AddIOp>(loc, jr, nIdxTail);
-                                                                        Value bVal = builder.create<memref::LoadOp>(
+                                                                        auto bColBase = arith::AddIOp::create(builder, loc, jr, nIdxTail);
+                                                                        Value bVal = memref::LoadOp::create(builder,
                                                                             loc, B_packed, ValueRange{kInner, bColBase});
                                                                         Value prod, newSum;
                                                                         if (isInteger) {
-                                                                          aVal = builder.create<arith::ExtSIOp>(loc, accEleTy, aVal);
-                                                                          bVal = builder.create<arith::ExtSIOp>(loc, accEleTy, bVal);
-                                                                          prod = builder.create<arith::MulIOp>(loc, aVal, bVal);
-                                                                          newSum = builder.create<arith::AddIOp>(loc, iterArgs[0], prod);
+                                                                          aVal = arith::ExtSIOp::create(builder, loc, accEleTy, aVal);
+                                                                          bVal = arith::ExtSIOp::create(builder, loc, accEleTy, bVal);
+                                                                          prod = arith::MulIOp::create(builder, loc, aVal, bVal);
+                                                                          newSum = arith::AddIOp::create(builder, loc, iterArgs[0], prod);
                                                                         } else {
-                                                                          prod = builder.create<arith::MulFOp>(loc, aVal, bVal);
-                                                                          newSum = builder.create<arith::AddFOp>(loc, iterArgs[0], prod);
+                                                                          prod = arith::MulFOp::create(builder, loc, aVal, bVal);
+                                                                          newSum = arith::AddFOp::create(builder, loc, iterArgs[0], prod);
                                                                         }
-                                                                        builder.create<scf::YieldOp>(loc, ValueRange{newSum});
+                                                                        scf::YieldOp::create(builder, loc, ValueRange{newSum});
                                                                       });
-                                                                  auto cRowIdx = builder.create<arith::AddIOp>(loc, ic, ii);
-                                                                  auto cColBase = builder.create<arith::AddIOp>(loc, jc, jr);
-                                                                  auto cColIdx = builder.create<arith::AddIOp>(loc, cColBase, nIdxTail);
-                                                                  auto currentVal = builder.create<memref::LoadOp>(
+                                                                  auto cRowIdx = arith::AddIOp::create(builder, loc, ic, ii);
+                                                                  auto cColBase = arith::AddIOp::create(builder, loc, jc, jr);
+                                                                  auto cColIdx = arith::AddIOp::create(builder, loc, cColBase, nIdxTail);
+                                                                  auto currentVal = memref::LoadOp::create(builder,
                                                                       loc, C, ValueRange{cRowIdx, cColIdx});
                                                                   Value finalSum;
                                                                   if (isInteger)
-                                                                    finalSum = builder.create<arith::AddIOp>(loc, currentVal, sumIter.getResult(0));
+                                                                    finalSum = arith::AddIOp::create(builder, loc, currentVal, sumIter.getResult(0));
                                                                   else
-                                                                    finalSum = builder.create<arith::AddFOp>(loc, currentVal, sumIter.getResult(0));
-                                                                  builder.create<memref::StoreOp>(
+                                                                    finalSum = arith::AddFOp::create(builder, loc, currentVal, sumIter.getResult(0));
+                                                                  memref::StoreOp::create(builder,
                                                                       loc, finalSum, C, ValueRange{cRowIdx, cColIdx});
-                                                                  builder.create<scf::YieldOp>(loc);
+                                                                  scf::YieldOp::create(builder, loc);
                                                                 });
-                                                            builder.create<scf::YieldOp>(loc);
+                                                            scf::YieldOp::create(builder, loc);
                                                           });
-                                                      builder.create<scf::YieldOp>(loc);
+                                                      scf::YieldOp::create(builder, loc);
                                                     });
-                                                builder.create<scf::YieldOp>(loc);
+                                                scf::YieldOp::create(builder, loc);
                                               });
 
-                                          builder.create<scf::YieldOp>(loc);
+                                          scf::YieldOp::create(builder, loc);
                                         });
-                                    builder.create<scf::YieldOp>(loc);
+                                    scf::YieldOp::create(builder, loc);
                                   });
-                                  // clang-format on
-                                  // Deallocate A_packed
-                                  builder.create<memref::DeallocOp>(loc,
-                                                                    A_packed);
-                                  builder.create<scf::YieldOp>(loc);
-                                },
-                                [&](OpBuilder &builder, Location loc) {
-                                  // Skip A_packed allocation for empty blocks
-                                  builder.create<scf::YieldOp>(loc);
-                                });
-                          });
+                                                                                 // clang-format on
+                                                                                 // Deallocate A_packed
+                                                                                 memref::DeallocOp::
+                                                                                     create(
+                                                                                         builder,
+                                                                                         loc,
+                                                                                         A_packed);
+                                                                                 scf::YieldOp::create(
+                                                                                     builder,
+                                                                                     loc);
+                                                                               },
+                                                                               [&](OpBuilder
+                                                                                       &builder,
+                                                                                   Location
+                                                                                       loc) {
+                                                                                 // Skip A_packed allocation for empty blocks
+                                                                                 scf::YieldOp::create(
+                                                                                     builder,
+                                                                                     loc);
+                                                                               });
+                                                                         });
 
-                      // Deallocate B_packed
-                      builder.create<memref::DeallocOp>(loc, B_packed);
-                      builder.create<scf::YieldOp>(loc);
-                    },
-                    [&](OpBuilder &builder, Location loc) {
-                      // Skip B_packed allocation for empty blocks
-                      builder.create<scf::YieldOp>(loc);
-                    });
+                                                 // Deallocate B_packed
+                                                 memref::DeallocOp::create(
+                                                     builder, loc, B_packed);
+                                                 scf::YieldOp::create(builder,
+                                                                      loc);
+                                               },
+                                               [&](OpBuilder &builder,
+                                                   Location loc) {
+                                                 // Skip B_packed allocation for
+                                                 // empty blocks
+                                                 scf::YieldOp::create(builder,
+                                                                      loc);
+                                               });
 
-                builder.create<scf::YieldOp>(loc);
-              });
-        });
+                                           scf::YieldOp::create(builder, loc);
+                                         });
+                            });
 
     rewriter.eraseOp(op);
 

--- a/midend/lib/Conversion/MatMulOptimization/MatMulOptimize.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/MatMulOptimize.cpp
@@ -62,9 +62,9 @@ public:
 
     // Some constants.
     const Value c0 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(0));
     const Value c1 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(1));
     const AffineExpr s0 = rewriter.getAffineSymbolExpr(0);
     const AffineExpr s1 = rewriter.getAffineSymbolExpr(1);
     const AffineExpr d0 = rewriter.getAffineDimExpr(0);
@@ -77,9 +77,9 @@ public:
     int64_t kNLen = vecSize * kernelN;
 
     // Dims
-    Value M = rewriter.create<memref::DimOp>(loc, A, 0);
-    Value N = rewriter.create<memref::DimOp>(loc, B, 1);
-    Value K = rewriter.create<memref::DimOp>(loc, A, 1);
+    Value M = memref::DimOp::create(rewriter, loc, A, 0);
+    Value N = memref::DimOp::create(rewriter, loc, B, 1);
+    Value K = memref::DimOp::create(rewriter, loc, A, 1);
 
     // build loop body
     affine::buildAffineLoopNest(
@@ -95,8 +95,8 @@ public:
                 for (int i = 0; i < kernelM; ++i) {
                   Value fixedIV = ivI;
                   if (i != 0) {
-                    fixedIV = builder.create<affine::AffineMinOp>(
-                        loc,
+                    fixedIV = affine::AffineMinOp::create(
+                        builder, loc,
                         AffineMap::get(1, 1, {d0 + i, s0 - 1},
                                        builder.getContext()),
                         SmallVector<Value>{ivI, M});
@@ -104,23 +104,25 @@ public:
                   MemRefType resTy =
                       MemRefType::get(ATy.getShape(), ATy.getElementType(),
                                       AffineMap::get(2, 2, d0 * s1 + s0 + d1));
-                  auto aptr = builder.create<memref::SubViewOp>(
-                      loc, resTy, A, SmallVector<OpFoldResult>{fixedIV, c0},
+                  auto aptr = memref::SubViewOp::create(
+                      builder, loc, resTy, A,
+                      SmallVector<OpFoldResult>{fixedIV, c0},
                       SmallVector<OpFoldResult>{c1, K},
                       SmallVector<OpFoldResult>{c1, c1});
                   aptrs.push_back(aptr);
                 }
                 for (int i = 0; i < kernelM; ++i) {
-                  Value fixedIV = builder.create<affine::AffineMinOp>(
-                      loc,
+                  Value fixedIV = affine::AffineMinOp::create(
+                      builder, loc,
                       AffineMap::get(1, 1, {d0 + i, s0 - 1},
                                      builder.getContext()),
                       SmallVector<Value>{ivI, M});
                   MemRefType resTy =
                       MemRefType::get(ATy.getShape(), ATy.getElementType(),
                                       AffineMap::get(2, 2, d0 * s1 + s0 + d1));
-                  auto cptr = builder.create<memref::SubViewOp>(
-                      loc, resTy, C, SmallVector<OpFoldResult>{fixedIV, c0},
+                  auto cptr = memref::SubViewOp::create(
+                      builder, loc, resTy, C,
+                      SmallVector<OpFoldResult>{fixedIV, c0},
                       SmallVector<OpFoldResult>{c1, N},
                       SmallVector<OpFoldResult>{c1, c1});
                   cptrs.push_back(cptr);
@@ -132,8 +134,8 @@ public:
                       SmallVector<Value> as;
                       SmallVector<Value> bs;
                       for (int i = 0; i < kernelM; ++i) {
-                        Value a = builder.create<TransferReadOp>(
-                            loc, vTy, aptrs[i], ValueRange{c0, ivK},
+                        Value a = TransferReadOp::create(
+                            builder, loc, vTy, aptrs[i], ValueRange{c0, ivK},
                             mapBroadcast, /*padding=*/nullptr,
                             /*inBounds=*/nullptr, /*mask=*/nullptr);
                         as.push_back(a);
@@ -142,42 +144,46 @@ public:
                       for (int i = 0; i < kernelM; ++i) {
                         Value c = cptrs[i];
                         for (int j = 0; j < kernelN; ++j) {
-                          Value fixedIV = builder.create<affine::AffineApplyOp>(
-                              loc, AffineMap::get(1, 0, d0 + j * vecSize), ivJ);
-                          Value d = builder.create<TransferReadOp>(
-                            loc, vTy, c, ValueRange{c0, fixedIV},
-                            /*padding=*/nullptr, /*inBounds=*/nullptr,
-                            /*mask=*/nullptr);
+                          Value fixedIV = affine::AffineApplyOp::create(
+                              builder, loc,
+                              AffineMap::get(1, 0, d0 + j * vecSize), ivJ);
+                          Value d = TransferReadOp::create(
+                              builder, loc, vTy, c, ValueRange{c0, fixedIV},
+                              /*padding=*/nullptr, /*inBounds=*/nullptr,
+                              /*mask=*/nullptr);
                           ds.push_back(d);
                         }
                       }
                       for (int i = 0; i < kernelN; ++i) {
                         Value fixedIV = ivJ;
                         if (i != 0) {
-                          fixedIV = builder.create<affine::AffineApplyOp>(
-                              loc, AffineMap::get(1, 0, d0 + i * vecSize), ivJ);
+                          fixedIV = affine::AffineApplyOp::create(
+                              builder, loc,
+                              AffineMap::get(1, 0, d0 + i * vecSize), ivJ);
                         }
-                        Value b = builder.create<TransferReadOp>(
-                          loc, vTy, B, ValueRange{ivK, fixedIV},
-                          /*padding=*/nullptr, /*inBounds=*/nullptr,
-                          /*mask=*/nullptr);
+                        Value b = TransferReadOp::create(
+                            builder, loc, vTy, B, ValueRange{ivK, fixedIV},
+                            /*padding=*/nullptr, /*inBounds=*/nullptr,
+                            /*mask=*/nullptr);
                         bs.push_back(b);
                       }
 
                       for (int i = 0; i < kernelM; ++i) {
                         for (int j = 0; j < kernelN; ++j) {
-                          ds[i * kernelN + j] = builder.create<vector::FMAOp>(
-                              loc, vTy, as[i], bs[j], ds[i * kernelN + j]);
+                          ds[i * kernelN + j] =
+                              vector::FMAOp::create(builder, loc, vTy, as[i],
+                                                    bs[j], ds[i * kernelN + j]);
                         }
                       }
 
                       for (int i = 0; i < kernelM; ++i) {
                         for (int j = 0; j < kernelN; ++j) {
-                          Value fixedIV = builder.create<affine::AffineApplyOp>(
-                              loc, AffineMap::get(1, 0, d0 + j * vecSize), ivJ);
-                          builder.create<TransferWriteOp>(
-                              loc, ds[i * kernelN + j], cptrs[i],
-                              ValueRange{c0, fixedIV});
+                          Value fixedIV = affine::AffineApplyOp::create(
+                              builder, loc,
+                              AffineMap::get(1, 0, d0 + j * vecSize), ivJ);
+                          TransferWriteOp::create(builder, loc,
+                                                  ds[i * kernelN + j], cptrs[i],
+                                                  ValueRange{c0, fixedIV});
                         }
                       }
                     });

--- a/midend/lib/Conversion/MatMulOptimization/MatMulParallelVectorization.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/MatMulParallelVectorization.cpp
@@ -77,29 +77,32 @@ public:
 
     // Define constants.
     const Value zeroIndex =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(0));
     const AffineExpr d0 = rewriter.getAffineDimExpr(0);
     const AffineExpr d1 = rewriter.getAffineDimExpr(1);
     const AffineExpr s0 = rewriter.getAffineSymbolExpr(0);
     const AffineExpr zeroAffine = rewriter.getAffineConstantExpr(0);
 
-    const Value zeroElementType = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getZeroAttr(elementType));
-    const Value zeroElementTypeVec = rewriter.create<vector::BroadcastOp>(
-        loc, VectorType::get({affineVectorSize}, elementType), zeroElementType);
+    const Value zeroElementType = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getZeroAttr(elementType));
+    const Value zeroElementTypeVec = vector::BroadcastOp::create(
+        rewriter, loc, VectorType::get({affineVectorSize}, elementType),
+        zeroElementType);
 
     // Get dimensions of input tensors.
-    Value aRow = rewriter.create<memref::DimOp>(loc, A, 0);
-    Value bCol = rewriter.create<memref::DimOp>(loc, B, 1);
-    Value bRow = rewriter.create<memref::DimOp>(loc, B, 0);
+    Value aRow = memref::DimOp::create(rewriter, loc, A, 0);
+    Value bCol = memref::DimOp::create(rewriter, loc, B, 1);
+    Value bRow = memref::DimOp::create(rewriter, loc, B, 0);
 
     // Calculate the length of the tail, which might not fit in a vector.
-    Value tailLength = rewriter.create<affine::AffineApplyOp>(
-        loc, AffineMap::get(1, 0, d0 % affineVectorSize), ValueRange{bCol});
+    Value tailLength = affine::AffineApplyOp::create(
+        rewriter, loc, AffineMap::get(1, 0, d0 % affineVectorSize),
+        ValueRange{bCol});
 
     // Generate a mask vector based on the tail length.
-    Value maskVector = rewriter.create<vector::CreateMaskOp>(
-        loc, VectorType::get({affineVectorSize}, rewriter.getI1Type()),
+    Value maskVector = vector::CreateMaskOp::create(
+        rewriter, loc,
+        VectorType::get({affineVectorSize}, rewriter.getI1Type()),
         ValueRange{tailLength});
 
     SmallVector<Value, 4U> reducedValues = llvm::to_vector<4>(
@@ -107,13 +110,14 @@ public:
                         [](const LoopReduction &red) { return red.value; }));
 
     // Apply the column of matrix B.
-    Value appliedColOfB = rewriter.create<affine::AffineApplyOp>(
-        loc, AffineMap::get(1, 0, d0.ceilDiv(affineVectorSize)),
+    Value appliedColOfB = affine::AffineApplyOp::create(
+        rewriter, loc, AffineMap::get(1, 0, d0.ceilDiv(affineVectorSize)),
         ValueRange{bCol});
 
     // Create the primary parallel loop for matrix multiplication.
-    AffineParallelOp parallelLoop = rewriter.create<affine::AffineParallelOp>(
-        loc, ValueRange(reducedValues).getTypes(), ValueRange{appliedColOfB},
+    AffineParallelOp parallelLoop = affine::AffineParallelOp::create(
+        rewriter, loc, ValueRange(reducedValues).getTypes(),
+        ValueRange{appliedColOfB},
         ArrayRef<NamedAttribute>{
             rewriter.getNamedAttr("lowerBoundsGroups",
                                   rewriter.getI32TensorAttr({1})),
@@ -136,8 +140,8 @@ public:
     Value loopVarColOfB = loopBody->getArguments()[0];
 
     // Prefetching data from tensor 'A' for better cache utilization.
-    rewriter.create<affine::AffinePrefetchOp>(
-        loc, A, AffineMap::get(2, 0, {d0, d1}, rewriter.getContext()),
+    affine::AffinePrefetchOp::create(
+        rewriter, loc, A, AffineMap::get(2, 0, {d0, d1}, rewriter.getContext()),
         ArrayRef<Value>{aRow, bRow}, false, 3, true);
 
     // Tail handling (compile-time + runtime checks).
@@ -150,8 +154,8 @@ public:
     if (cType.isDynamicDim(1) ||
         (cType.getDimSize(1) % affineVectorSize) != 0) {
       // Depending on the position, use either full vectors or tail vectors.
-      affine::AffineIfOp branchingOp = rewriter.create<affine::AffineIfOp>(
-          loc,
+      affine::AffineIfOp branchingOp = affine::AffineIfOp::create(
+          rewriter, loc,
           IntegerSet::get(
               1, 1, {d0 * -affineVectorSize + s0 - affineVectorSize}, {false}),
           ValueRange{loopVarColOfB, bCol}, true);
@@ -162,8 +166,9 @@ public:
           trueBranchBuilder, loc, {zeroIndex}, {bRow}, 1,
           [&](OpBuilder &builder, Location loc, ValueRange ivRange) {
             Value loopVarRowOfB = ivRange.front();
-            Value bVec = builder.create<affine::AffineVectorLoadOp>(
-                loc, VectorType::get({affineVectorSize}, elementType), B,
+            Value bVec = affine::AffineVectorLoadOp::create(
+                builder, loc, VectorType::get({affineVectorSize}, elementType),
+                B,
                 AffineMap::get(2, 0, {d0, d1 * affineVectorSize},
                                rewriter.getContext()),
                 ValueRange{loopVarRowOfB, loopVarColOfB});
@@ -171,13 +176,16 @@ public:
                 builder, loc, {zeroIndex}, {aRow}, 1,
                 [&](OpBuilder &builder, Location loc, ValueRange ivRange) {
                   Value loopVarRowOfA = ivRange.front();
-                  Value aElement = builder.create<memref::LoadOp>(
-                      loc, A, ValueRange{loopVarRowOfA, loopVarRowOfB});
-                  Value aVec = builder.create<vector::BroadcastOp>(
-                      loc, VectorType::get({affineVectorSize}, elementType),
+                  Value aElement = memref::LoadOp::create(
+                      builder, loc, A,
+                      ValueRange{loopVarRowOfA, loopVarRowOfB});
+                  Value aVec = vector::BroadcastOp::create(
+                      builder, loc,
+                      VectorType::get({affineVectorSize}, elementType),
                       aElement);
-                  Value cVec = builder.create<affine::AffineVectorLoadOp>(
-                      loc, VectorType::get({affineVectorSize}, elementType), C,
+                  Value cVec = affine::AffineVectorLoadOp::create(
+                      builder, loc,
+                      VectorType::get({affineVectorSize}, elementType), C,
                       AffineMap::get(2, 0, {d0, d1 * affineVectorSize},
                                      builder.getContext()),
                       ValueRange{loopVarRowOfA, loopVarColOfB});
@@ -188,15 +196,15 @@ public:
                   // based on the element type.
                   if (isa<IntegerType>(elementType)) {
                     Value mulVec =
-                        builder.create<arith::MulIOp>(loc, aVec, bVec);
+                        arith::MulIOp::create(builder, loc, aVec, bVec);
                     computedVec =
-                        builder.create<arith::AddIOp>(loc, mulVec, cVec);
+                        arith::AddIOp::create(builder, loc, mulVec, cVec);
                   } else {
                     computedVec =
-                        builder.create<vector::FMAOp>(loc, aVec, bVec, cVec);
+                        vector::FMAOp::create(builder, loc, aVec, bVec, cVec);
                   }
-                  builder.create<affine::AffineVectorStoreOp>(
-                      loc, computedVec, C,
+                  affine::AffineVectorStoreOp::create(
+                      builder, loc, computedVec, C,
                       AffineMap::get(2, 0, {d0, d1 * affineVectorSize},
                                      builder.getContext()),
                       ValueRange{loopVarRowOfA, loopVarColOfB});
@@ -209,24 +217,27 @@ public:
           falseBranchBuilder, loc, {zeroIndex}, {bRow}, 1,
           [&](OpBuilder &builder, Location loc, ValueRange ivRange) {
             Value loopVarRowOfB = ivRange.front();
-            Value tailIdxColOfB = builder.create<affine::AffineApplyOp>(
-                loc, AffineMap::get(1, 0, d0 * affineVectorSize),
+            Value tailIdxColOfB = affine::AffineApplyOp::create(
+                builder, loc, AffineMap::get(1, 0, d0 * affineVectorSize),
                 ValueRange{loopVarColOfB});
-            Value bVec = builder.create<vector::MaskedLoadOp>(
-                loc, VectorType::get({affineVectorSize}, elementType), B,
-                ValueRange{loopVarRowOfB, tailIdxColOfB}, maskVector,
+            Value bVec = vector::MaskedLoadOp::create(
+                builder, loc, VectorType::get({affineVectorSize}, elementType),
+                B, ValueRange{loopVarRowOfB, tailIdxColOfB}, maskVector,
                 zeroElementTypeVec);
             affine::buildAffineLoopNest(
                 builder, loc, {zeroIndex}, {aRow}, 1,
                 [&](OpBuilder &builder, Location loc, ValueRange ivRange) {
                   Value loopVarRowOfA = ivRange.front();
-                  Value aElement = builder.create<memref::LoadOp>(
-                      loc, A, ValueRange{loopVarRowOfA, loopVarRowOfB});
-                  Value aVec = builder.create<vector::BroadcastOp>(
-                      loc, VectorType::get({affineVectorSize}, elementType),
+                  Value aElement = memref::LoadOp::create(
+                      builder, loc, A,
+                      ValueRange{loopVarRowOfA, loopVarRowOfB});
+                  Value aVec = vector::BroadcastOp::create(
+                      builder, loc,
+                      VectorType::get({affineVectorSize}, elementType),
                       aElement);
-                  Value cVec = builder.create<vector::MaskedLoadOp>(
-                      loc, VectorType::get({affineVectorSize}, elementType), C,
+                  Value cVec = vector::MaskedLoadOp::create(
+                      builder, loc,
+                      VectorType::get({affineVectorSize}, elementType), C,
                       ValueRange{loopVarRowOfA, tailIdxColOfB}, maskVector,
                       zeroElementTypeVec);
                   Value computedVec;
@@ -236,15 +247,15 @@ public:
                   // the element type.
                   if (isa<IntegerType>(elementType)) {
                     Value mulVec =
-                        builder.create<arith::MulIOp>(loc, aVec, bVec);
+                        arith::MulIOp::create(builder, loc, aVec, bVec);
                     computedVec =
-                        builder.create<arith::AddIOp>(loc, mulVec, cVec);
+                        arith::AddIOp::create(builder, loc, mulVec, cVec);
                   } else {
                     computedVec =
-                        builder.create<vector::FMAOp>(loc, aVec, bVec, cVec);
+                        vector::FMAOp::create(builder, loc, aVec, bVec, cVec);
                   }
-                  builder.create<vector::MaskedStoreOp>(
-                      loc, C, ValueRange{loopVarRowOfA, tailIdxColOfB},
+                  vector::MaskedStoreOp::create(
+                      builder, loc, C, ValueRange{loopVarRowOfA, tailIdxColOfB},
                       maskVector, computedVec);
                 });
           });
@@ -253,8 +264,9 @@ public:
           rewriter, loc, {zeroIndex}, {bRow}, 1,
           [&](OpBuilder &builder, Location loc, ValueRange ivRange) {
             Value loopVarRowOfB = ivRange.front();
-            Value bVec = builder.create<affine::AffineVectorLoadOp>(
-                loc, VectorType::get({affineVectorSize}, elementType), B,
+            Value bVec = affine::AffineVectorLoadOp::create(
+                builder, loc, VectorType::get({affineVectorSize}, elementType),
+                B,
                 AffineMap::get(2, 0, {d0, d1 * affineVectorSize},
                                rewriter.getContext()),
                 ValueRange{loopVarRowOfB, loopVarColOfB});
@@ -262,13 +274,16 @@ public:
                 builder, loc, {zeroIndex}, {aRow}, 1,
                 [&](OpBuilder &builder, Location loc, ValueRange ivRange) {
                   Value loopVarRowOfA = ivRange.front();
-                  Value aElement = builder.create<memref::LoadOp>(
-                      loc, A, ValueRange{loopVarRowOfA, loopVarRowOfB});
-                  Value aVec = builder.create<vector::BroadcastOp>(
-                      loc, VectorType::get({affineVectorSize}, elementType),
+                  Value aElement = memref::LoadOp::create(
+                      builder, loc, A,
+                      ValueRange{loopVarRowOfA, loopVarRowOfB});
+                  Value aVec = vector::BroadcastOp::create(
+                      builder, loc,
+                      VectorType::get({affineVectorSize}, elementType),
                       aElement);
-                  Value cVec = builder.create<affine::AffineVectorLoadOp>(
-                      loc, VectorType::get({affineVectorSize}, elementType), C,
+                  Value cVec = affine::AffineVectorLoadOp::create(
+                      builder, loc,
+                      VectorType::get({affineVectorSize}, elementType), C,
                       AffineMap::get(2, 0, {d0, d1 * affineVectorSize},
                                      builder.getContext()),
                       ValueRange{loopVarRowOfA, loopVarColOfB});
@@ -279,15 +294,15 @@ public:
                   // based on the element type.
                   if (isa<IntegerType>(elementType)) {
                     Value mulVec =
-                        builder.create<arith::MulIOp>(loc, aVec, bVec);
+                        arith::MulIOp::create(builder, loc, aVec, bVec);
                     computedVec =
-                        builder.create<arith::AddIOp>(loc, mulVec, cVec);
+                        arith::AddIOp::create(builder, loc, mulVec, cVec);
                   } else {
                     computedVec =
-                        builder.create<vector::FMAOp>(loc, aVec, bVec, cVec);
+                        vector::FMAOp::create(builder, loc, aVec, bVec, cVec);
                   }
-                  builder.create<affine::AffineVectorStoreOp>(
-                      loc, computedVec, C,
+                  affine::AffineVectorStoreOp::create(
+                      builder, loc, computedVec, C,
                       AffineMap::get(2, 0, {d0, d1 * affineVectorSize},
                                      builder.getContext()),
                       ValueRange{loopVarRowOfA, loopVarColOfB});
@@ -295,7 +310,7 @@ public:
           });
     }
 
-    rewriter.create<affine::AffineYieldOp>(loc);
+    affine::AffineYieldOp::create(rewriter, loc);
 
     // Finalize the loop and erase the original operation.
     parallelLoop.getRegion().push_back(loopBody);

--- a/midend/lib/Conversion/MatMulOptimization/MatMulParallelVectorizationTiling.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/MatMulParallelVectorizationTiling.cpp
@@ -81,35 +81,38 @@ public:
 
     // Define constants.
     const Value zeroIndex =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(0));
     const Value oneIndex =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(1));
     const AffineExpr d0 = rewriter.getAffineDimExpr(0);
     const AffineExpr d1 = rewriter.getAffineDimExpr(1);
     const AffineExpr s0 = rewriter.getAffineSymbolExpr(0);
     const AffineExpr zeroAffine = rewriter.getAffineConstantExpr(0);
 
-    const Value zeroElementType = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getZeroAttr(elementType));
-    const Value zeroElementTypeVec = rewriter.create<vector::BroadcastOp>(
-        loc, VectorType::get({affineVectorSize}, elementType), zeroElementType);
+    const Value zeroElementType = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getZeroAttr(elementType));
+    const Value zeroElementTypeVec = vector::BroadcastOp::create(
+        rewriter, loc, VectorType::get({affineVectorSize}, elementType),
+        zeroElementType);
 
     // Get dimensions of input tensors.
-    Value aRow = rewriter.create<memref::DimOp>(loc, A, zeroIndex);
-    Value bCol = rewriter.create<memref::DimOp>(loc, B, oneIndex);
-    Value bRow = rewriter.create<memref::DimOp>(loc, B, zeroIndex);
+    Value aRow = memref::DimOp::create(rewriter, loc, A, zeroIndex);
+    Value bCol = memref::DimOp::create(rewriter, loc, B, oneIndex);
+    Value bRow = memref::DimOp::create(rewriter, loc, B, zeroIndex);
 
     SmallVector<Value, 4U> reducedValues = llvm::to_vector<4>(
         llvm::map_range(ArrayRef<LoopReduction>{},
                         [](const LoopReduction &red) { return red.value; }));
 
     // Apply the column of matrix B
-    Value appliedColOfB = rewriter.create<affine::AffineApplyOp>(
-        loc, AffineMap::get(1, 0, d0 - affineVectorSize + 1), ValueRange{bCol});
+    Value appliedColOfB = affine::AffineApplyOp::create(
+        rewriter, loc, AffineMap::get(1, 0, d0 - affineVectorSize + 1),
+        ValueRange{bCol});
 
     // Create the primary parallel loop for matrix multiplication.
-    AffineParallelOp parallelLoop = rewriter.create<affine::AffineParallelOp>(
-        loc, ValueRange(reducedValues).getTypes(), ValueRange{appliedColOfB},
+    AffineParallelOp parallelLoop = affine::AffineParallelOp::create(
+        rewriter, loc, ValueRange(reducedValues).getTypes(),
+        ValueRange{appliedColOfB},
         ArrayRef<NamedAttribute>{
             rewriter.getNamedAttr("lowerBoundsGroups",
                                   rewriter.getI32TensorAttr({1})),
@@ -133,37 +136,41 @@ public:
     Value loopVarColOfB = loopBody->getArguments()[0];
 
     // Prefetching data from tensor 'A' for better cache utilization.
-    rewriter.create<affine::AffinePrefetchOp>(
-        loc, A, AffineMap::get(2, 0, {d0, d1}, rewriter.getContext()),
+    affine::AffinePrefetchOp::create(
+        rewriter, loc, A, AffineMap::get(2, 0, {d0, d1}, rewriter.getContext()),
         ArrayRef<Value>{aRow, bRow}, false, 3, true);
 
     affine::buildAffineLoopNest(
         rewriter, loc, {zeroIndex}, {bRow}, /*Step=*/{kBlockSize},
         [&](OpBuilder &builder, Location loc, ValueRange ivRange) {
           Value kLow = ivRange.front();
-          Value kHigh = builder.create<affine::AffineMinOp>(
-              loc,
+          Value kHigh = affine::AffineMinOp::create(
+              builder, loc,
               AffineMap::get(1, 1, {d0 + kBlockSize, s0}, builder.getContext()),
               SmallVector<Value>{kLow, bRow});
           affine::buildAffineLoopNest(
               builder, loc, {zeroIndex}, {aRow}, 1,
               [&](OpBuilder &builder, Location loc, ValueRange ivRange) {
                 Value loopVarRowOfA = ivRange.front();
-                Value cVec = builder.create<affine::AffineVectorLoadOp>(
-                    loc, VectorType::get({affineVectorSize}, elementType), C,
+                Value cVec = affine::AffineVectorLoadOp::create(
+                    builder, loc,
+                    VectorType::get({affineVectorSize}, elementType), C,
                     AffineMap::get(2, 0, {d0, d1}, rewriter.getContext()),
                     ValueRange{loopVarRowOfA, loopVarColOfB});
-                auto iter_vec = builder.create<scf::ForOp>(
-                    loc, kLow, kHigh, /*Step=*/oneIndex, ValueRange{cVec},
+                auto iter_vec = scf::ForOp::create(
+                    builder, loc, kLow, kHigh, /*Step=*/oneIndex,
+                    ValueRange{cVec},
                     [&](OpBuilder &builder, Location loc, Value iv1,
                         ValueRange itrArgs0) {
-                      Value bVec = builder.create<vector::LoadOp>(
-                          loc, VectorType::get({affineVectorSize}, elementType),
-                          B, ValueRange{iv1, loopVarColOfB});
-                      Value aElement = builder.create<memref::LoadOp>(
-                          loc, A, ValueRange{loopVarRowOfA, iv1});
-                      Value aVec = builder.create<vector::BroadcastOp>(
-                          loc, VectorType::get({affineVectorSize}, elementType),
+                      Value bVec = vector::LoadOp::create(
+                          builder, loc,
+                          VectorType::get({affineVectorSize}, elementType), B,
+                          ValueRange{iv1, loopVarColOfB});
+                      Value aElement = memref::LoadOp::create(
+                          builder, loc, A, ValueRange{loopVarRowOfA, iv1});
+                      Value aVec = vector::BroadcastOp::create(
+                          builder, loc,
+                          VectorType::get({affineVectorSize}, elementType),
                           aElement);
                       Value computedVec;
 
@@ -172,21 +179,21 @@ public:
                       // based on the element type.
                       if (isa<IntegerType>(elementType)) {
                         Value mulVec =
-                            builder.create<arith::MulIOp>(loc, aVec, bVec);
-                        computedVec = builder.create<arith::AddIOp>(
-                            loc, mulVec, itrArgs0[0]);
+                            arith::MulIOp::create(builder, loc, aVec, bVec);
+                        computedVec = arith::AddIOp::create(
+                            builder, loc, mulVec, itrArgs0[0]);
                       } else {
-                        computedVec = builder.create<vector::FMAOp>(
-                            loc, aVec, bVec, itrArgs0[0]);
+                        computedVec = vector::FMAOp::create(builder, loc, aVec,
+                                                            bVec, itrArgs0[0]);
                       }
-                      builder.create<scf::YieldOp>(loc, computedVec);
+                      scf::YieldOp::create(builder, loc, computedVec);
                     });
-                builder.create<vector::StoreOp>(
-                    loc, iter_vec.getResult(0), C,
+                vector::StoreOp::create(
+                    builder, loc, iter_vec.getResult(0), C,
                     ValueRange{loopVarRowOfA, loopVarColOfB});
               });
         });
-    rewriter.create<affine::AffineYieldOp>(loc);
+    affine::AffineYieldOp::create(rewriter, loc);
 
     // Finalize the loop and erase the original operation.
     parallelLoop.getRegion().push_back(loopBody);
@@ -197,26 +204,29 @@ public:
         cast<MemRefType>(C.getType()).getDimSize(1) % affineVectorSize != 0) {
 
       // Depending on the position, use either full vectors or tail vectors.
-      affine::AffineIfOp branchingOp = rewriter.create<affine::AffineIfOp>(
-          loc, IntegerSet::get(1, 0, {d0 % affineVectorSize - 1}, {false}),
+      affine::AffineIfOp branchingOp = affine::AffineIfOp::create(
+          rewriter, loc,
+          IntegerSet::get(1, 0, {d0 % affineVectorSize - 1}, {false}),
           ValueRange{bCol}, /*hasElse=*/false);
 
       // Branch handling operations on the tail.
       OpBuilder trueBranchBuilder = branchingOp.getThenBodyBuilder();
-      Value tailSize = trueBranchBuilder.create<affine::AffineApplyOp>(
-          loc, AffineMap::get(1, 0, d0 % affineVectorSize), ValueRange{bCol});
-      Value maskVector = trueBranchBuilder.create<vector::CreateMaskOp>(
-          loc, VectorType::get({affineVectorSize}, rewriter.getI1Type()),
+      Value tailSize = affine::AffineApplyOp::create(
+          trueBranchBuilder, loc, AffineMap::get(1, 0, d0 % affineVectorSize),
+          ValueRange{bCol});
+      Value maskVector = vector::CreateMaskOp::create(
+          trueBranchBuilder, loc,
+          VectorType::get({affineVectorSize}, rewriter.getI1Type()),
           ValueRange{tailSize});
       Value loopVarColOfBTail =
-          trueBranchBuilder.create<arith::SubIOp>(loc, bCol, tailSize);
+          arith::SubIOp::create(trueBranchBuilder, loc, bCol, tailSize);
 
       affine::buildAffineLoopNest(
           trueBranchBuilder, loc, {zeroIndex}, {bRow}, {kBlockSize},
           [&](OpBuilder &builder, Location loc, ValueRange ivRange) {
             Value kLow = ivRange.front();
-            Value kHigh = builder.create<affine::AffineMinOp>(
-                loc,
+            Value kHigh = affine::AffineMinOp::create(
+                builder, loc,
                 AffineMap::get(1, 1, {d0 + kBlockSize, s0},
                                builder.getContext()),
                 SmallVector<Value>{kLow, bRow});
@@ -224,24 +234,26 @@ public:
                 builder, loc, {zeroIndex}, {aRow}, 1,
                 [&](OpBuilder &builder, Location loc, ValueRange ivRange) {
                   Value loopVarRowOfA = ivRange.front();
-                  Value cVec = builder.create<vector::MaskedLoadOp>(
-                      loc, VectorType::get({affineVectorSize}, elementType), C,
+                  Value cVec = vector::MaskedLoadOp::create(
+                      builder, loc,
+                      VectorType::get({affineVectorSize}, elementType), C,
                       ValueRange{loopVarRowOfA, loopVarColOfBTail}, maskVector,
                       zeroElementTypeVec);
-                  auto iter_vec = builder.create<scf::ForOp>(
-                      loc, kLow, kHigh, /*Step=*/oneIndex, ValueRange{cVec},
+                  auto iter_vec = scf::ForOp::create(
+                      builder, loc, kLow, kHigh, /*Step=*/oneIndex,
+                      ValueRange{cVec},
                       [&](OpBuilder &builder, Location loc, Value iv1,
                           ValueRange itrArgs0) {
-                        Value bVec = builder.create<vector::MaskedLoadOp>(
-                            loc,
+                        Value bVec = vector::MaskedLoadOp::create(
+                            builder, loc,
                             VectorType::get({affineVectorSize}, elementType), B,
                             ValueRange{iv1, loopVarColOfBTail}, maskVector,
                             zeroElementTypeVec);
 
-                        Value aElement = builder.create<memref::LoadOp>(
-                            loc, A, ValueRange{loopVarRowOfA, iv1});
-                        Value aVec = builder.create<vector::BroadcastOp>(
-                            loc,
+                        Value aElement = memref::LoadOp::create(
+                            builder, loc, A, ValueRange{loopVarRowOfA, iv1});
+                        Value aVec = vector::BroadcastOp::create(
+                            builder, loc,
                             VectorType::get({affineVectorSize}, elementType),
                             aElement);
                         Value computedVec;
@@ -251,18 +263,19 @@ public:
                         // based on the element type.
                         if (isa<IntegerType>(elementType)) {
                           Value mulVec =
-                              builder.create<arith::MulIOp>(loc, aVec, bVec);
-                          computedVec = builder.create<arith::AddIOp>(
-                              loc, mulVec, itrArgs0[0]);
+                              arith::MulIOp::create(builder, loc, aVec, bVec);
+                          computedVec = arith::AddIOp::create(
+                              builder, loc, mulVec, itrArgs0[0]);
                         } else {
-                          computedVec = builder.create<vector::FMAOp>(
-                              loc, aVec, bVec, itrArgs0[0]);
+                          computedVec = vector::FMAOp::create(
+                              builder, loc, aVec, bVec, itrArgs0[0]);
                         }
-                        builder.create<scf::YieldOp>(loc, computedVec);
+                        scf::YieldOp::create(builder, loc, computedVec);
                       });
-                  builder.create<vector::MaskedStoreOp>(
-                      loc, C, ValueRange{loopVarRowOfA, loopVarColOfBTail},
-                      maskVector, iter_vec.getResult(0));
+                  vector::MaskedStoreOp::create(
+                      builder, loc, C,
+                      ValueRange{loopVarRowOfA, loopVarColOfBTail}, maskVector,
+                      iter_vec.getResult(0));
                 });
           });
     }

--- a/midend/lib/Conversion/MatMulOptimization/MatMulTransposeBUnrollVec.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/MatMulTransposeBUnrollVec.cpp
@@ -82,28 +82,28 @@ public:
     VectorType vectorTy = mlir::VectorType::get({vecSize}, elementType);
 
     // Define constants.
-    const Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    const Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    const Value c2 = rewriter.create<arith::ConstantIndexOp>(loc, 2);
-    const Value c3 = rewriter.create<arith::ConstantIndexOp>(loc, 3);
-    const Value c4 = rewriter.create<arith::ConstantIndexOp>(loc, 4);
-    const Value c5 = rewriter.create<arith::ConstantIndexOp>(loc, 5);
-    const Value c6 = rewriter.create<arith::ConstantIndexOp>(loc, 6);
-    const Value c7 = rewriter.create<arith::ConstantIndexOp>(loc, 7);
-    const Value vlStep = rewriter.create<arith::ConstantIndexOp>(loc, vecSize);
-    const Value initVal = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getZeroAttr(elementType));
+    const Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    const Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    const Value c2 = arith::ConstantIndexOp::create(rewriter, loc, 2);
+    const Value c3 = arith::ConstantIndexOp::create(rewriter, loc, 3);
+    const Value c4 = arith::ConstantIndexOp::create(rewriter, loc, 4);
+    const Value c5 = arith::ConstantIndexOp::create(rewriter, loc, 5);
+    const Value c6 = arith::ConstantIndexOp::create(rewriter, loc, 6);
+    const Value c7 = arith::ConstantIndexOp::create(rewriter, loc, 7);
+    const Value vlStep = arith::ConstantIndexOp::create(rewriter, loc, vecSize);
+    const Value initVal = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getZeroAttr(elementType));
     const Value unroll =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(8));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(8));
     // const Value initVec = rewriter.create<arith::ConstantOp>(
     //     loc, vectorTy, DenseElementsAttr::get(vectorTy, APFloat(0.0f)));
     Value initVec =
-        rewriter.create<vector::BroadcastOp>(loc, vectorTy, initVal);
+        vector::BroadcastOp::create(rewriter, loc, vectorTy, initVal);
 
     // Get dimensions of input tensors.
-    Value aRow = rewriter.create<memref::DimOp>(loc, A, c0);
-    Value aCol = rewriter.create<memref::DimOp>(loc, A, c1);
-    Value bCol = rewriter.create<memref::DimOp>(loc, C, c1);
+    Value aRow = memref::DimOp::create(rewriter, loc, A, c0);
+    Value aCol = memref::DimOp::create(rewriter, loc, A, c1);
+    Value bCol = memref::DimOp::create(rewriter, loc, C, c1);
 
     const AffineExpr d0 = rewriter.getAffineDimExpr(0);
     const AffineExpr d1 = rewriter.getAffineDimExpr(1);
@@ -112,61 +112,61 @@ public:
     AffineMap map2 = AffineMap::get(2, 0, d0 - d1, ctx);
 
     Value upperBound_tmp =
-        rewriter.create<AffineApplyOp>(loc, map2, ValueRange{aCol, vlStep});
-    Value upperBound = rewriter.create<AffineApplyOp>(
-        loc, map1, ValueRange{upperBound_tmp, c1});
+        AffineApplyOp::create(rewriter, loc, map2, ValueRange{aCol, vlStep});
+    Value upperBound = AffineApplyOp::create(rewriter, loc, map1,
+                                             ValueRange{upperBound_tmp, c1});
 
-    auto parOp = rewriter.create<scf::ParallelOp>(
-        loc,
+    auto parOp = scf::ParallelOp::create(
+        rewriter, loc,
         /*lowerBounds=*/ValueRange{c0},
         /*upperBounds=*/ValueRange{aRow},
         /*steps=*/ValueRange{unroll},
         [&](OpBuilder &builder, Location loc, ValueRange ivs) {
-          auto aRowIdx1 = builder.create<affine::AffineApplyOp>(
-              loc, map1, ValueRange{ivs[0], c1});
-          auto aRowIdx2 = builder.create<affine::AffineApplyOp>(
-              loc, map1, ValueRange{ivs[0], c2});
-          auto aRowIdx3 = builder.create<affine::AffineApplyOp>(
-              loc, map1, ValueRange{ivs[0], c3});
-          auto aRowIdx4 = builder.create<affine::AffineApplyOp>(
-              loc, map1, ValueRange{ivs[0], c4});
-          auto aRowIdx5 = builder.create<affine::AffineApplyOp>(
-              loc, map1, ValueRange{ivs[0], c5});
-          auto aRowIdx6 = builder.create<affine::AffineApplyOp>(
-              loc, map1, ValueRange{ivs[0], c6});
-          auto aRowIdx7 = builder.create<affine::AffineApplyOp>(
-              loc, map1, ValueRange{ivs[0], c7});
+          auto aRowIdx1 = affine::AffineApplyOp::create(builder, loc, map1,
+                                                        ValueRange{ivs[0], c1});
+          auto aRowIdx2 = affine::AffineApplyOp::create(builder, loc, map1,
+                                                        ValueRange{ivs[0], c2});
+          auto aRowIdx3 = affine::AffineApplyOp::create(builder, loc, map1,
+                                                        ValueRange{ivs[0], c3});
+          auto aRowIdx4 = affine::AffineApplyOp::create(builder, loc, map1,
+                                                        ValueRange{ivs[0], c4});
+          auto aRowIdx5 = affine::AffineApplyOp::create(builder, loc, map1,
+                                                        ValueRange{ivs[0], c5});
+          auto aRowIdx6 = affine::AffineApplyOp::create(builder, loc, map1,
+                                                        ValueRange{ivs[0], c6});
+          auto aRowIdx7 = affine::AffineApplyOp::create(builder, loc, map1,
+                                                        ValueRange{ivs[0], c7});
 
-          builder.create<scf::ForOp>(
-              loc, c0, bCol,
+          scf::ForOp::create(
+              builder, loc, c0, bCol,
               /*Step=*/c1, ValueRange{},
               [&](OpBuilder &builder, Location loc, Value iv0,
                   ValueRange itrArgs0) {
-                auto iterVals = builder.create<scf::ForOp>(
-                    loc, c0, upperBound,
+                auto iterVals = scf::ForOp::create(
+                    builder, loc, c0, upperBound,
                     /*Step=*/vlStep,
                     ValueRange{initVec, initVec, initVec, initVec, initVec,
                                initVec, initVec, initVec, c0},
                     [&](OpBuilder &builder, Location loc, Value iv1,
                         ValueRange itrArgs) {
-                      Value aVec0 = builder.create<vector::LoadOp>(
-                          loc, vectorTy, A, ValueRange{ivs[0], iv1});
-                      Value aVec1 = builder.create<vector::LoadOp>(
-                          loc, vectorTy, A, ValueRange{aRowIdx1, iv1});
-                      Value aVec2 = builder.create<vector::LoadOp>(
-                          loc, vectorTy, A, ValueRange{aRowIdx2, iv1});
-                      Value aVec3 = builder.create<vector::LoadOp>(
-                          loc, vectorTy, A, ValueRange{aRowIdx3, iv1});
-                      Value aVec4 = builder.create<vector::LoadOp>(
-                          loc, vectorTy, A, ValueRange{aRowIdx4, iv1});
-                      Value aVec5 = builder.create<vector::LoadOp>(
-                          loc, vectorTy, A, ValueRange{aRowIdx5, iv1});
-                      Value aVec6 = builder.create<vector::LoadOp>(
-                          loc, vectorTy, A, ValueRange{aRowIdx6, iv1});
-                      Value aVec7 = builder.create<vector::LoadOp>(
-                          loc, vectorTy, A, ValueRange{aRowIdx7, iv1});
-                      Value bVec = builder.create<vector::LoadOp>(
-                          loc, vectorTy, B, ValueRange{iv0, iv1});
+                      Value aVec0 = vector::LoadOp::create(
+                          builder, loc, vectorTy, A, ValueRange{ivs[0], iv1});
+                      Value aVec1 = vector::LoadOp::create(
+                          builder, loc, vectorTy, A, ValueRange{aRowIdx1, iv1});
+                      Value aVec2 = vector::LoadOp::create(
+                          builder, loc, vectorTy, A, ValueRange{aRowIdx2, iv1});
+                      Value aVec3 = vector::LoadOp::create(
+                          builder, loc, vectorTy, A, ValueRange{aRowIdx3, iv1});
+                      Value aVec4 = vector::LoadOp::create(
+                          builder, loc, vectorTy, A, ValueRange{aRowIdx4, iv1});
+                      Value aVec5 = vector::LoadOp::create(
+                          builder, loc, vectorTy, A, ValueRange{aRowIdx5, iv1});
+                      Value aVec6 = vector::LoadOp::create(
+                          builder, loc, vectorTy, A, ValueRange{aRowIdx6, iv1});
+                      Value aVec7 = vector::LoadOp::create(
+                          builder, loc, vectorTy, A, ValueRange{aRowIdx7, iv1});
+                      Value bVec = vector::LoadOp::create(
+                          builder, loc, vectorTy, B, ValueRange{iv0, iv1});
                       Value computedVec0;
                       Value computedVec1;
                       Value computedVec2;
@@ -177,172 +177,181 @@ public:
                       Value computedVec7;
                       if (isa<IntegerType>(elementType)) {
                         Value mulVec0 =
-                            builder.create<arith::MulIOp>(loc, aVec0, bVec);
-                        computedVec0 = builder.create<arith::AddIOp>(
-                            loc, mulVec0, itrArgs[0]);
+                            arith::MulIOp::create(builder, loc, aVec0, bVec);
+                        computedVec0 = arith::AddIOp::create(
+                            builder, loc, mulVec0, itrArgs[0]);
                         Value mulVec1 =
-                            builder.create<arith::MulIOp>(loc, aVec1, bVec);
-                        computedVec1 = builder.create<arith::AddIOp>(
-                            loc, mulVec1, itrArgs[1]);
+                            arith::MulIOp::create(builder, loc, aVec1, bVec);
+                        computedVec1 = arith::AddIOp::create(
+                            builder, loc, mulVec1, itrArgs[1]);
                         Value mulVec2 =
-                            builder.create<arith::MulIOp>(loc, aVec2, bVec);
-                        computedVec2 = builder.create<arith::AddIOp>(
-                            loc, mulVec2, itrArgs[2]);
+                            arith::MulIOp::create(builder, loc, aVec2, bVec);
+                        computedVec2 = arith::AddIOp::create(
+                            builder, loc, mulVec2, itrArgs[2]);
                         Value mulVec3 =
-                            builder.create<arith::MulIOp>(loc, aVec3, bVec);
-                        computedVec3 = builder.create<arith::AddIOp>(
-                            loc, mulVec3, itrArgs[3]);
+                            arith::MulIOp::create(builder, loc, aVec3, bVec);
+                        computedVec3 = arith::AddIOp::create(
+                            builder, loc, mulVec3, itrArgs[3]);
                         Value mulVec4 =
-                            builder.create<arith::MulIOp>(loc, aVec4, bVec);
-                        computedVec4 = builder.create<arith::AddIOp>(
-                            loc, mulVec4, itrArgs[4]);
+                            arith::MulIOp::create(builder, loc, aVec4, bVec);
+                        computedVec4 = arith::AddIOp::create(
+                            builder, loc, mulVec4, itrArgs[4]);
                         Value mulVec5 =
-                            builder.create<arith::MulIOp>(loc, aVec5, bVec);
-                        computedVec5 = builder.create<arith::AddIOp>(
-                            loc, mulVec5, itrArgs[5]);
+                            arith::MulIOp::create(builder, loc, aVec5, bVec);
+                        computedVec5 = arith::AddIOp::create(
+                            builder, loc, mulVec5, itrArgs[5]);
                         Value mulVec6 =
-                            builder.create<arith::MulIOp>(loc, aVec6, bVec);
-                        computedVec6 = builder.create<arith::AddIOp>(
-                            loc, mulVec6, itrArgs[6]);
+                            arith::MulIOp::create(builder, loc, aVec6, bVec);
+                        computedVec6 = arith::AddIOp::create(
+                            builder, loc, mulVec6, itrArgs[6]);
                         Value mulVec7 =
-                            builder.create<arith::MulIOp>(loc, aVec7, bVec);
-                        computedVec7 = builder.create<arith::AddIOp>(
-                            loc, mulVec7, itrArgs[7]);
+                            arith::MulIOp::create(builder, loc, aVec7, bVec);
+                        computedVec7 = arith::AddIOp::create(
+                            builder, loc, mulVec7, itrArgs[7]);
                       } else {
-                        computedVec0 = builder.create<vector::FMAOp>(
-                            loc, aVec0, bVec, itrArgs[0]);
-                        computedVec1 = builder.create<vector::FMAOp>(
-                            loc, aVec1, bVec, itrArgs[1]);
-                        computedVec2 = builder.create<vector::FMAOp>(
-                            loc, aVec2, bVec, itrArgs[2]);
-                        computedVec3 = builder.create<vector::FMAOp>(
-                            loc, aVec3, bVec, itrArgs[3]);
-                        computedVec4 = builder.create<vector::FMAOp>(
-                            loc, aVec4, bVec, itrArgs[4]);
-                        computedVec5 = builder.create<vector::FMAOp>(
-                            loc, aVec5, bVec, itrArgs[5]);
-                        computedVec6 = builder.create<vector::FMAOp>(
-                            loc, aVec6, bVec, itrArgs[6]);
-                        computedVec7 = builder.create<vector::FMAOp>(
-                            loc, aVec7, bVec, itrArgs[7]);
+                        computedVec0 = vector::FMAOp::create(
+                            builder, loc, aVec0, bVec, itrArgs[0]);
+                        computedVec1 = vector::FMAOp::create(
+                            builder, loc, aVec1, bVec, itrArgs[1]);
+                        computedVec2 = vector::FMAOp::create(
+                            builder, loc, aVec2, bVec, itrArgs[2]);
+                        computedVec3 = vector::FMAOp::create(
+                            builder, loc, aVec3, bVec, itrArgs[3]);
+                        computedVec4 = vector::FMAOp::create(
+                            builder, loc, aVec4, bVec, itrArgs[4]);
+                        computedVec5 = vector::FMAOp::create(
+                            builder, loc, aVec5, bVec, itrArgs[5]);
+                        computedVec6 = vector::FMAOp::create(
+                            builder, loc, aVec6, bVec, itrArgs[6]);
+                        computedVec7 = vector::FMAOp::create(
+                            builder, loc, aVec7, bVec, itrArgs[7]);
                       }
-                      Value idx = builder.create<affine::AffineApplyOp>(
-                          loc, map1, ValueRange{iv1, vlStep});
-                      builder.create<scf::YieldOp>(
-                          loc,
+                      Value idx = affine::AffineApplyOp::create(
+                          builder, loc, map1, ValueRange{iv1, vlStep});
+                      scf::YieldOp::create(
+                          builder, loc,
                           ValueRange{computedVec0, computedVec1, computedVec2,
                                      computedVec3, computedVec4, computedVec5,
                                      computedVec6, computedVec7, idx});
                     });
                 auto tmpVals = iterVals.getResults();
-                Value reduction0 = builder.create<vector::ReductionOp>(
-                    loc, CombiningKind::ADD, tmpVals[0], initVal,
+                Value reduction0 = vector::ReductionOp::create(
+                    builder, loc, CombiningKind::ADD, tmpVals[0], initVal,
                     arith::FastMathFlags::reassoc);
-                Value reduction1 = builder.create<vector::ReductionOp>(
-                    loc, CombiningKind::ADD, tmpVals[1], initVal,
+                Value reduction1 = vector::ReductionOp::create(
+                    builder, loc, CombiningKind::ADD, tmpVals[1], initVal,
                     arith::FastMathFlags::reassoc);
-                Value reduction2 = builder.create<vector::ReductionOp>(
-                    loc, CombiningKind::ADD, tmpVals[2], initVal,
+                Value reduction2 = vector::ReductionOp::create(
+                    builder, loc, CombiningKind::ADD, tmpVals[2], initVal,
                     arith::FastMathFlags::reassoc);
-                Value reduction3 = builder.create<vector::ReductionOp>(
-                    loc, CombiningKind::ADD, tmpVals[3], initVal,
+                Value reduction3 = vector::ReductionOp::create(
+                    builder, loc, CombiningKind::ADD, tmpVals[3], initVal,
                     arith::FastMathFlags::reassoc);
-                Value reduction4 = builder.create<vector::ReductionOp>(
-                    loc, CombiningKind::ADD, tmpVals[4], initVal,
+                Value reduction4 = vector::ReductionOp::create(
+                    builder, loc, CombiningKind::ADD, tmpVals[4], initVal,
                     arith::FastMathFlags::reassoc);
-                Value reduction5 = builder.create<vector::ReductionOp>(
-                    loc, CombiningKind::ADD, tmpVals[5], initVal,
+                Value reduction5 = vector::ReductionOp::create(
+                    builder, loc, CombiningKind::ADD, tmpVals[5], initVal,
                     arith::FastMathFlags::reassoc);
-                Value reduction6 = builder.create<vector::ReductionOp>(
-                    loc, CombiningKind::ADD, tmpVals[6], initVal,
+                Value reduction6 = vector::ReductionOp::create(
+                    builder, loc, CombiningKind::ADD, tmpVals[6], initVal,
                     arith::FastMathFlags::reassoc);
-                Value reduction7 = builder.create<vector::ReductionOp>(
-                    loc, CombiningKind::ADD, tmpVals[7], initVal,
+                Value reduction7 = vector::ReductionOp::create(
+                    builder, loc, CombiningKind::ADD, tmpVals[7], initVal,
                     arith::FastMathFlags::reassoc);
                 Value idx = tmpVals[8];
-                auto sumIters = builder.create<scf::ForOp>(
-                    loc, idx, aCol,
+                auto sumIters = scf::ForOp::create(
+                    builder, loc, idx, aCol,
                     /*Step=*/c1,
                     ValueRange{reduction0, reduction1, reduction2, reduction3,
                                reduction4, reduction5, reduction6, reduction7},
                     [&](OpBuilder &builder, Location loc, Value iv1,
                         ValueRange iterArgs) {
-                      auto aEle0 = builder.create<memref::LoadOp>(
-                          loc, A, ValueRange{ivs[0], iv1});
-                      auto aEle1 = builder.create<memref::LoadOp>(
-                          loc, A, ValueRange{aRowIdx1, iv1});
-                      auto aEle2 = builder.create<memref::LoadOp>(
-                          loc, A, ValueRange{aRowIdx2, iv1});
-                      auto aEle3 = builder.create<memref::LoadOp>(
-                          loc, A, ValueRange{aRowIdx3, iv1});
-                      auto aEle4 = builder.create<memref::LoadOp>(
-                          loc, A, ValueRange{aRowIdx4, iv1});
-                      auto aEle5 = builder.create<memref::LoadOp>(
-                          loc, A, ValueRange{aRowIdx5, iv1});
-                      auto aEle6 = builder.create<memref::LoadOp>(
-                          loc, A, ValueRange{aRowIdx6, iv1});
-                      auto aEle7 = builder.create<memref::LoadOp>(
-                          loc, A, ValueRange{aRowIdx7, iv1});
+                      auto aEle0 = memref::LoadOp::create(
+                          builder, loc, A, ValueRange{ivs[0], iv1});
+                      auto aEle1 = memref::LoadOp::create(
+                          builder, loc, A, ValueRange{aRowIdx1, iv1});
+                      auto aEle2 = memref::LoadOp::create(
+                          builder, loc, A, ValueRange{aRowIdx2, iv1});
+                      auto aEle3 = memref::LoadOp::create(
+                          builder, loc, A, ValueRange{aRowIdx3, iv1});
+                      auto aEle4 = memref::LoadOp::create(
+                          builder, loc, A, ValueRange{aRowIdx4, iv1});
+                      auto aEle5 = memref::LoadOp::create(
+                          builder, loc, A, ValueRange{aRowIdx5, iv1});
+                      auto aEle6 = memref::LoadOp::create(
+                          builder, loc, A, ValueRange{aRowIdx6, iv1});
+                      auto aEle7 = memref::LoadOp::create(
+                          builder, loc, A, ValueRange{aRowIdx7, iv1});
 
-                      auto bEle = builder.create<memref::LoadOp>(
-                          loc, B, ValueRange{iv0, iv1});
+                      auto bEle = memref::LoadOp::create(builder, loc, B,
+                                                         ValueRange{iv0, iv1});
 
                       auto tmpEle0 =
-                          builder.create<arith::MulFOp>(loc, aEle0, bEle);
+                          arith::MulFOp::create(builder, loc, aEle0, bEle);
                       auto tmpEle1 =
-                          builder.create<arith::MulFOp>(loc, aEle1, bEle);
+                          arith::MulFOp::create(builder, loc, aEle1, bEle);
                       auto tmpEle2 =
-                          builder.create<arith::MulFOp>(loc, aEle2, bEle);
+                          arith::MulFOp::create(builder, loc, aEle2, bEle);
                       auto tmpEle3 =
-                          builder.create<arith::MulFOp>(loc, aEle3, bEle);
+                          arith::MulFOp::create(builder, loc, aEle3, bEle);
                       auto tmpEle4 =
-                          builder.create<arith::MulFOp>(loc, aEle4, bEle);
+                          arith::MulFOp::create(builder, loc, aEle4, bEle);
                       auto tmpEle5 =
-                          builder.create<arith::MulFOp>(loc, aEle5, bEle);
+                          arith::MulFOp::create(builder, loc, aEle5, bEle);
                       auto tmpEle6 =
-                          builder.create<arith::MulFOp>(loc, aEle6, bEle);
+                          arith::MulFOp::create(builder, loc, aEle6, bEle);
                       auto tmpEle7 =
-                          builder.create<arith::MulFOp>(loc, aEle7, bEle);
+                          arith::MulFOp::create(builder, loc, aEle7, bEle);
 
-                      auto resSum0 = builder.create<arith::AddFOp>(loc, tmpEle0,
-                                                                   iterArgs[0]);
-                      auto resSum1 = builder.create<arith::AddFOp>(loc, tmpEle1,
-                                                                   iterArgs[1]);
-                      auto resSum2 = builder.create<arith::AddFOp>(loc, tmpEle2,
-                                                                   iterArgs[2]);
-                      auto resSum3 = builder.create<arith::AddFOp>(loc, tmpEle3,
-                                                                   iterArgs[3]);
-                      auto resSum4 = builder.create<arith::AddFOp>(loc, tmpEle4,
-                                                                   iterArgs[4]);
-                      auto resSum5 = builder.create<arith::AddFOp>(loc, tmpEle5,
-                                                                   iterArgs[5]);
-                      auto resSum6 = builder.create<arith::AddFOp>(loc, tmpEle6,
-                                                                   iterArgs[6]);
-                      auto resSum7 = builder.create<arith::AddFOp>(loc, tmpEle7,
-                                                                   iterArgs[7]);
+                      auto resSum0 = arith::AddFOp::create(
+                          builder, loc, tmpEle0, iterArgs[0]);
+                      auto resSum1 = arith::AddFOp::create(
+                          builder, loc, tmpEle1, iterArgs[1]);
+                      auto resSum2 = arith::AddFOp::create(
+                          builder, loc, tmpEle2, iterArgs[2]);
+                      auto resSum3 = arith::AddFOp::create(
+                          builder, loc, tmpEle3, iterArgs[3]);
+                      auto resSum4 = arith::AddFOp::create(
+                          builder, loc, tmpEle4, iterArgs[4]);
+                      auto resSum5 = arith::AddFOp::create(
+                          builder, loc, tmpEle5, iterArgs[5]);
+                      auto resSum6 = arith::AddFOp::create(
+                          builder, loc, tmpEle6, iterArgs[6]);
+                      auto resSum7 = arith::AddFOp::create(
+                          builder, loc, tmpEle7, iterArgs[7]);
 
-                      builder.create<scf::YieldOp>(
-                          loc, ValueRange{resSum0, resSum1, resSum2, resSum3,
-                                          resSum4, resSum5, resSum6, resSum7});
+                      scf::YieldOp::create(builder, loc,
+                                           ValueRange{resSum0, resSum1, resSum2,
+                                                      resSum3, resSum4, resSum5,
+                                                      resSum6, resSum7});
                     });
-                auto sumIter0 = builder.create<memref::StoreOp>(
-                    loc, sumIters.getResult(0), C, ValueRange{ivs[0], iv0});
-                auto sumIter1 = builder.create<memref::StoreOp>(
-                    loc, sumIters.getResult(1), C, ValueRange{aRowIdx1, iv0});
-                auto sumIter2 = builder.create<memref::StoreOp>(
-                    loc, sumIters.getResult(2), C, ValueRange{aRowIdx2, iv0});
-                auto sumIter3 = builder.create<memref::StoreOp>(
-                    loc, sumIters.getResult(3), C, ValueRange{aRowIdx3, iv0});
-                auto sumIter4 = builder.create<memref::StoreOp>(
-                    loc, sumIters.getResult(4), C, ValueRange{aRowIdx4, iv0});
-                auto sumIter5 = builder.create<memref::StoreOp>(
-                    loc, sumIters.getResult(5), C, ValueRange{aRowIdx5, iv0});
-                auto sumIter6 = builder.create<memref::StoreOp>(
-                    loc, sumIters.getResult(6), C, ValueRange{aRowIdx6, iv0});
-                auto sumIter7 = builder.create<memref::StoreOp>(
-                    loc, sumIters.getResult(7), C, ValueRange{aRowIdx7, iv0});
+                auto sumIter0 =
+                    memref::StoreOp::create(builder, loc, sumIters.getResult(0),
+                                            C, ValueRange{ivs[0], iv0});
+                auto sumIter1 =
+                    memref::StoreOp::create(builder, loc, sumIters.getResult(1),
+                                            C, ValueRange{aRowIdx1, iv0});
+                auto sumIter2 =
+                    memref::StoreOp::create(builder, loc, sumIters.getResult(2),
+                                            C, ValueRange{aRowIdx2, iv0});
+                auto sumIter3 =
+                    memref::StoreOp::create(builder, loc, sumIters.getResult(3),
+                                            C, ValueRange{aRowIdx3, iv0});
+                auto sumIter4 =
+                    memref::StoreOp::create(builder, loc, sumIters.getResult(4),
+                                            C, ValueRange{aRowIdx4, iv0});
+                auto sumIter5 =
+                    memref::StoreOp::create(builder, loc, sumIters.getResult(5),
+                                            C, ValueRange{aRowIdx5, iv0});
+                auto sumIter6 =
+                    memref::StoreOp::create(builder, loc, sumIters.getResult(6),
+                                            C, ValueRange{aRowIdx6, iv0});
+                auto sumIter7 =
+                    memref::StoreOp::create(builder, loc, sumIters.getResult(7),
+                                            C, ValueRange{aRowIdx7, iv0});
 
-                builder.create<scf::YieldOp>(loc);
+                scf::YieldOp::create(builder, loc);
               });
         });
     rewriter.eraseOp(op);

--- a/midend/lib/Conversion/MatMulOptimization/MatMulTransposeBVec.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/MatMulTransposeBVec.cpp
@@ -111,23 +111,23 @@ public:
     VectorType vectorMaskTy = VectorType::get({vf}, i1, {scalable});
 
     const Value c0 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(0));
     const Value c1 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(1));
     // Single-vf step used for scalable offset computation inside the loop.
-    Value step = rewriter.create<arith::ConstantIndexOp>(loc, vf);
+    Value step = arith::ConstantIndexOp::create(rewriter, loc, vf);
     if (scalable) {
-      Value vscale = rewriter.create<vector::VectorScaleOp>(loc);
-      step = rewriter.create<arith::MulIOp>(loc, step, vscale);
+      Value vscale = vector::VectorScaleOp::create(rewriter, loc);
+      step = arith::MulIOp::create(rewriter, loc, step, vscale);
     }
 
     const Value c0Ele = buddy::insertZeroConstantOp(ctx, rewriter, loc, eleTy);
     Value passthruVec =
-        rewriter.create<vector::BroadcastOp>(loc, vectorTy, c0Ele);
+        vector::BroadcastOp::create(rewriter, loc, vectorTy, c0Ele);
 
-    const Value aRow = rewriter.create<memref::DimOp>(loc, A, c0);
-    const Value bRow = rewriter.create<memref::DimOp>(loc, B, c0);
-    const Value bCol = rewriter.create<memref::DimOp>(loc, B, c1);
+    const Value aRow = memref::DimOp::create(rewriter, loc, A, c0);
+    const Value bRow = memref::DimOp::create(rewriter, loc, B, c0);
+    const Value bCol = memref::DimOp::create(rewriter, loc, B, c1);
 
     // Permutation map for transfer_read: (d0, d1) -> (d1)
     AffineExpr d0, d1;
@@ -139,21 +139,21 @@ public:
     // ── K-loop step = vf * unroll ─────────────────────────────────────────
     Value kStep;
     if (scalable) {
-      Value ufVal = rewriter.create<arith::ConstantIndexOp>(loc, unroll);
-      kStep = rewriter.create<arith::MulIOp>(loc, step, ufVal);
+      Value ufVal = arith::ConstantIndexOp::create(rewriter, loc, unroll);
+      kStep = arith::MulIOp::create(rewriter, loc, step, ufVal);
     } else {
-      kStep = rewriter.create<arith::ConstantIndexOp>(loc, vf * unroll);
+      kStep = arith::ConstantIndexOp::create(rewriter, loc, vf * unroll);
     }
 
     // ── N-column parallel step ────────────────────────────────────────────
-    Value nStep = rewriter.create<arith::ConstantIndexOp>(loc, nTile);
+    Value nStep = arith::ConstantIndexOp::create(rewriter, loc, nTile);
 
     // nTile * unroll initial accumulator vectors (all zero).
     llvm::SmallVector<Value> initAccs(nTile * unroll, passthruVec);
 
     // ── Outer parallel loop: rows of A ────────────────────────────────────
-    auto outerParallelLoop = rewriter.create<scf::ParallelOp>(
-        loc,
+    auto outerParallelLoop = scf::ParallelOp::create(
+        rewriter, loc,
         /*lowerBounds=*/ValueRange{c0},
         /*upperBounds=*/ValueRange{aRow},
         /*steps=*/ValueRange{c1},
@@ -161,8 +161,8 @@ public:
           Value rowIdx = ivs[0];
 
           // ── Inner parallel loop: columns of B (step = nTile) ───────────
-          auto innerParallelLoop = builder.create<scf::ParallelOp>(
-              loc,
+          auto innerParallelLoop = scf::ParallelOp::create(
+              builder, loc,
               /*lowerBounds=*/ValueRange{c0},
               /*upperBounds=*/ValueRange{bRow},
               /*steps=*/ValueRange{nStep},
@@ -173,17 +173,18 @@ public:
                 llvm::SmallVector<Value> colIdxs(nTile);
                 colIdxs[0] = colBase;
                 for (int j = 1; j < nTile; ++j) {
-                  Value jConst = builder.create<arith::ConstantIndexOp>(loc, j);
+                  Value jConst =
+                      arith::ConstantIndexOp::create(builder, loc, j);
                   colIdxs[j] =
-                      builder.create<arith::AddIOp>(loc, colBase, jConst);
+                      arith::AddIOp::create(builder, loc, colBase, jConst);
                 }
 
                 // ── K reduction loop with nTile * unroll accumulators ────
                 // Opt1 (K-unroll): unroll independent accumulator chains to
                 //   hide FMA latency (4–5 cycles on modern x86).
                 // Opt2 (N-tile):   share A loads across nTile columns.
-                auto kLoop = builder.create<scf::ForOp>(
-                    loc, c0, bCol, kStep, ValueRange(initAccs),
+                auto kLoop = scf::ForOp::create(
+                    builder, loc, c0, bCol, kStep, ValueRange(initAccs),
                     [&](OpBuilder &nb, Location nl, Value iv,
                         ValueRange itrArgs) {
                       // K offsets within the unrolled body
@@ -194,35 +195,36 @@ public:
                         if (scalable) {
                           // offset = i * (vscale * vf)  [runtime]
                           Value iConst =
-                              nb.create<arith::ConstantIndexOp>(nl, i);
-                          offset = nb.create<arith::MulIOp>(nl, iConst, step);
+                              arith::ConstantIndexOp::create(nb, nl, i);
+                          offset = arith::MulIOp::create(nb, nl, iConst, step);
                         } else {
                           offset =
-                              nb.create<arith::ConstantIndexOp>(nl, i * vf);
+                              arith::ConstantIndexOp::create(nb, nl, i * vf);
                         }
-                        ki[i] = nb.create<arith::AddIOp>(nl, iv, offset);
+                        ki[i] = arith::AddIOp::create(nb, nl, iv, offset);
                       }
 
                       // Load A vectors – shared across all nTile columns
                       llvm::SmallVector<Value> aVecs(unroll);
                       for (int i = 0; i < unroll; ++i) {
-                        aVecs[i] = nb.create<vector::TransferReadOp>(
-                            nl, vectorTy, A, ValueRange{rowIdx, ki[i]}, c0Ele,
-                            permMapAttr, inBoundsAttr);
+                        aVecs[i] = vector::TransferReadOp::create(
+                            nb, nl, vectorTy, A, ValueRange{rowIdx, ki[i]},
+                            c0Ele, permMapAttr, inBoundsAttr);
                       }
 
                       // For each column: load B chunks and FMA independently
                       llvm::SmallVector<Value> newAccs(nTile * unroll);
                       for (int j = 0; j < nTile; ++j) {
                         for (int i = 0; i < unroll; ++i) {
-                          auto bVec = nb.create<vector::TransferReadOp>(
-                              nl, vectorTy, B, ValueRange{colIdxs[j], ki[i]},
-                              c0Ele, permMapAttr, inBoundsAttr);
-                          newAccs[j * unroll + i] = nb.create<vector::FMAOp>(
-                              nl, aVecs[i], bVec, itrArgs[j * unroll + i]);
+                          auto bVec = vector::TransferReadOp::create(
+                              nb, nl, vectorTy, B,
+                              ValueRange{colIdxs[j], ki[i]}, c0Ele, permMapAttr,
+                              inBoundsAttr);
+                          newAccs[j * unroll + i] = vector::FMAOp::create(
+                              nb, nl, aVecs[i], bVec, itrArgs[j * unroll + i]);
                         }
                       }
-                      nb.create<scf::YieldOp>(nl, ValueRange(newAccs));
+                      scf::YieldOp::create(nb, nl, ValueRange(newAccs));
                     });
 
                 // For each column: sum unroll accumulators, reduce, store
@@ -230,16 +232,16 @@ public:
                   // Tree-reduce the unroll accumulator vectors
                   Value sumVec = kLoop->getResult(j * unroll);
                   for (int i = 1; i < unroll; ++i) {
-                    sumVec = builder.create<arith::AddFOp>(
-                        loc, sumVec, kLoop->getResult(j * unroll + i));
+                    sumVec = arith::AddFOp::create(
+                        builder, loc, sumVec, kLoop->getResult(j * unroll + i));
                   }
-                  Value load = builder.create<memref::LoadOp>(
-                      loc, C, ValueRange{rowIdx, colIdxs[j]});
-                  Value result = builder.create<vector::ReductionOp>(
-                      loc, CombiningKind::ADD, sumVec, load,
+                  Value load = memref::LoadOp::create(
+                      builder, loc, C, ValueRange{rowIdx, colIdxs[j]});
+                  Value result = vector::ReductionOp::create(
+                      builder, loc, CombiningKind::ADD, sumVec, load,
                       arith::FastMathFlags::reassoc);
-                  builder.create<memref::StoreOp>(
-                      loc, result, C, ValueRange{rowIdx, colIdxs[j]});
+                  memref::StoreOp::create(builder, loc, result, C,
+                                          ValueRange{rowIdx, colIdxs[j]});
                 }
               });
         });

--- a/midend/lib/Conversion/MatMulOptimization/MatMulTransposeBVecDecode.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/MatMulTransposeBVecDecode.cpp
@@ -114,31 +114,31 @@ public:
       return failure();
 
     // Constants.
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    Value cVf = rewriter.create<arith::ConstantIndexOp>(loc, vf);
-    Value cStep = rewriter.create<arith::ConstantIndexOp>(loc, vf * unroll);
-    Value cNTile = rewriter.create<arith::ConstantIndexOp>(loc, nTile);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    Value cVf = arith::ConstantIndexOp::create(rewriter, loc, vf);
+    Value cStep = arith::ConstantIndexOp::create(rewriter, loc, vf * unroll);
+    Value cNTile = arith::ConstantIndexOp::create(rewriter, loc, nTile);
 
-    Value f0 = rewriter.create<arith::ConstantFloatOp>(
-        loc, rewriter.getF32Type(), APFloat(0.0f));
+    Value f0 = arith::ConstantFloatOp::create(
+        rewriter, loc, rewriter.getF32Type(), APFloat(0.0f));
 
     auto vecTy = VectorType::get({vf}, rewriter.getF32Type());
     auto maskTy = VectorType::get({vf}, rewriter.getI1Type());
-    Value vzero = rewriter.create<vector::BroadcastOp>(loc, vecTy, f0);
+    Value vzero = vector::BroadcastOp::create(rewriter, loc, vecTy, f0);
 
     // Runtime dimensions.
-    Value M = rewriter.create<memref::DimOp>(loc, A, c0);
-    Value K = rewriter.create<memref::DimOp>(loc, A, c1);
-    Value N = rewriter.create<memref::DimOp>(loc, B, c0);
+    Value M = memref::DimOp::create(rewriter, loc, A, c0);
+    Value K = memref::DimOp::create(rewriter, loc, A, c1);
+    Value N = memref::DimOp::create(rewriter, loc, B, c0);
 
     // mainBound = floor(K / (vf * unroll)) * (vf * unroll)
-    Value kDiv = rewriter.create<arith::DivUIOp>(loc, K, cStep);
-    Value mainBound = rewriter.create<arith::MulIOp>(loc, kDiv, cStep);
+    Value kDiv = arith::DivUIOp::create(rewriter, loc, K, cStep);
+    Value mainBound = arith::MulIOp::create(rewriter, loc, kDiv, cStep);
 
     // nMainBound = floor(N / nTile) * nTile
-    Value nDiv = rewriter.create<arith::DivUIOp>(loc, N, cNTile);
-    Value nMainBound = rewriter.create<arith::MulIOp>(loc, nDiv, cNTile);
+    Value nDiv = arith::DivUIOp::create(rewriter, loc, N, cNTile);
+    Value nMainBound = arith::MulIOp::create(rewriter, loc, nDiv, cNTile);
 
     //===------------------------------------------------------------------===//
     // Main loop:
@@ -157,8 +157,8 @@ public:
 
     SmallVector<Value> initTileAccs(nTile * unroll, vzero);
 
-    rewriter.create<scf::ParallelOp>(
-        loc,
+    scf::ParallelOp::create(
+        rewriter, loc,
         /*lowerBounds=*/ValueRange{c0, c0},
         /*upperBounds=*/ValueRange{M, nMainBound},
         /*steps=*/ValueRange{c1, cNTile},
@@ -169,16 +169,16 @@ public:
           SmallVector<Value> colIdxs(nTile);
           colIdxs[0] = nBase;
           for (int64_t j = 1; j < nTile; ++j) {
-            Value cj = pb.create<arith::ConstantIndexOp>(ploc, j);
-            colIdxs[j] = pb.create<arith::AddIOp>(ploc, nBase, cj);
+            Value cj = arith::ConstantIndexOp::create(pb, ploc, j);
+            colIdxs[j] = arith::AddIOp::create(pb, ploc, nBase, cj);
           }
 
           // Main K loop.
           //
           // iterArgs layout:
           //   iterArgs[j * unroll + u]
-          auto mainFor = pb.create<scf::ForOp>(
-              ploc, c0, mainBound, cStep, ValueRange(initTileAccs),
+          auto mainFor = scf::ForOp::create(
+              pb, ploc, c0, mainBound, cStep, ValueRange(initTileAccs),
               [&](OpBuilder &fb, Location forLoc, Value kBase,
                   ValueRange iterArgs) {
                 SmallVector<Value> newAccs;
@@ -195,30 +195,30 @@ public:
                     kOff = kBase;
                   } else {
                     Value cOff =
-                        fb.create<arith::ConstantIndexOp>(forLoc, u * vf);
-                    kOff = fb.create<arith::AddIOp>(forLoc, kBase, cOff);
+                        arith::ConstantIndexOp::create(fb, forLoc, u * vf);
+                    kOff = arith::AddIOp::create(fb, forLoc, kBase, cOff);
                   }
 
                   kOffs[u] = kOff;
 
-                  aVecs[u] = fb.create<vector::LoadOp>(forLoc, vecTy, A,
-                                                       ValueRange{m, kOff});
+                  aVecs[u] = vector::LoadOp::create(fb, forLoc, vecTy, A,
+                                                    ValueRange{m, kOff});
                 }
 
                 // For each tiled N column, load B and FMA with shared A.
                 for (int64_t j = 0; j < nTile; ++j) {
                   for (int64_t u = 0; u < unroll; ++u) {
-                    Value bVec = fb.create<vector::LoadOp>(
-                        forLoc, vecTy, B, ValueRange{colIdxs[j], kOffs[u]});
+                    Value bVec = vector::LoadOp::create(
+                        fb, forLoc, vecTy, B, ValueRange{colIdxs[j], kOffs[u]});
 
-                    Value acc = fb.create<vector::FMAOp>(
-                        forLoc, aVecs[u], bVec, iterArgs[j * unroll + u]);
+                    Value acc = vector::FMAOp::create(
+                        fb, forLoc, aVecs[u], bVec, iterArgs[j * unroll + u]);
 
                     newAccs.push_back(acc);
                   }
                 }
 
-                fb.create<scf::YieldOp>(forLoc, newAccs);
+                scf::YieldOp::create(fb, forLoc, newAccs);
               });
 
           // Sum unroll accumulators for each output column.
@@ -228,8 +228,8 @@ public:
           for (int64_t j = 0; j < nTile; ++j) {
             Value sumVec = mainFor.getResult(j * unroll);
             for (int64_t u = 1; u < unroll; ++u) {
-              sumVec = pb.create<arith::AddFOp>(
-                  ploc, sumVec, mainFor.getResult(j * unroll + u));
+              sumVec = arith::AddFOp::create(pb, ploc, sumVec,
+                                             mainFor.getResult(j * unroll + u));
             }
             sumVecs.push_back(sumVec);
           }
@@ -240,40 +240,40 @@ public:
           //
           // iterArgs layout:
           //   iterArgs[j]
-          auto tailFor = pb.create<scf::ForOp>(
-              ploc, mainBound, K, cVf, ValueRange(sumVecs),
+          auto tailFor = scf::ForOp::create(
+              pb, ploc, mainBound, K, cVf, ValueRange(sumVecs),
               [&](OpBuilder &tb, Location tailLoc, Value kBase,
                   ValueRange iterArgs) {
-                Value remaining = tb.create<arith::SubIOp>(tailLoc, K, kBase);
+                Value remaining = arith::SubIOp::create(tb, tailLoc, K, kBase);
 
-                Value gt = tb.create<arith::CmpIOp>(
-                    tailLoc, arith::CmpIPredicate::ugt, remaining, cVf);
+                Value gt = arith::CmpIOp::create(
+                    tb, tailLoc, arith::CmpIPredicate::ugt, remaining, cVf);
 
                 Value valid =
-                    tb.create<arith::SelectOp>(tailLoc, gt, cVf, remaining);
+                    arith::SelectOp::create(tb, tailLoc, gt, cVf, remaining);
 
-                Value mask = tb.create<vector::CreateMaskOp>(tailLoc, maskTy,
-                                                             ValueRange{valid});
+                Value mask = vector::CreateMaskOp::create(tb, tailLoc, maskTy,
+                                                          ValueRange{valid});
 
                 // A tail vector is shared across nTile output columns.
-                Value aVec = tb.create<vector::MaskedLoadOp>(
-                    tailLoc, vecTy, A, ValueRange{m, kBase}, mask, vzero);
+                Value aVec = vector::MaskedLoadOp::create(
+                    tb, tailLoc, vecTy, A, ValueRange{m, kBase}, mask, vzero);
 
                 SmallVector<Value> newTailAccs;
                 newTailAccs.reserve(nTile);
 
                 for (int64_t j = 0; j < nTile; ++j) {
-                  Value bVec = tb.create<vector::MaskedLoadOp>(
-                      tailLoc, vecTy, B, ValueRange{colIdxs[j], kBase}, mask,
-                      vzero);
+                  Value bVec = vector::MaskedLoadOp::create(
+                      tb, tailLoc, vecTy, B, ValueRange{colIdxs[j], kBase},
+                      mask, vzero);
 
-                  Value acc = tb.create<vector::FMAOp>(tailLoc, aVec, bVec,
-                                                       iterArgs[j]);
+                  Value acc = vector::FMAOp::create(tb, tailLoc, aVec, bVec,
+                                                    iterArgs[j]);
 
                   newTailAccs.push_back(acc);
                 }
 
-                tb.create<scf::YieldOp>(tailLoc, newTailAccs);
+                scf::YieldOp::create(tb, tailLoc, newTailAccs);
               });
 
           // Reduce vector accumulators and store C[m, nBase + j].
@@ -281,14 +281,14 @@ public:
             Value finalVec = tailFor.getResult(j);
 
             Value oldVal =
-                pb.create<memref::LoadOp>(ploc, C, ValueRange{m, colIdxs[j]});
+                memref::LoadOp::create(pb, ploc, C, ValueRange{m, colIdxs[j]});
 
-            Value result = pb.create<vector::ReductionOp>(
-                ploc, vector::CombiningKind::ADD, finalVec, oldVal,
+            Value result = vector::ReductionOp::create(
+                pb, ploc, vector::CombiningKind::ADD, finalVec, oldVal,
                 arith::FastMathFlags::reassoc);
 
-            pb.create<memref::StoreOp>(ploc, result, C,
-                                       ValueRange{m, colIdxs[j]});
+            memref::StoreOp::create(pb, ploc, result, C,
+                                    ValueRange{m, colIdxs[j]});
           }
         });
 
@@ -303,8 +303,8 @@ public:
 
     SmallVector<Value> initAccs(unroll, vzero);
 
-    rewriter.create<scf::ParallelOp>(
-        loc,
+    scf::ParallelOp::create(
+        rewriter, loc,
         /*lowerBounds=*/ValueRange{c0, nMainBound},
         /*upperBounds=*/ValueRange{M, N},
         /*steps=*/ValueRange{c1, c1},
@@ -313,8 +313,8 @@ public:
           Value n = ivs[1];
 
           // Main K loop for one tail output column.
-          auto mainFor = pb.create<scf::ForOp>(
-              ploc, c0, mainBound, cStep, ValueRange(initAccs),
+          auto mainFor = scf::ForOp::create(
+              pb, ploc, c0, mainBound, cStep, ValueRange(initAccs),
               [&](OpBuilder &fb, Location forLoc, Value kBase,
                   ValueRange iterArgs) {
                 SmallVector<Value> newAccs;
@@ -326,69 +326,69 @@ public:
                     kOff = kBase;
                   } else {
                     Value cOff =
-                        fb.create<arith::ConstantIndexOp>(forLoc, u * vf);
-                    kOff = fb.create<arith::AddIOp>(forLoc, kBase, cOff);
+                        arith::ConstantIndexOp::create(fb, forLoc, u * vf);
+                    kOff = arith::AddIOp::create(fb, forLoc, kBase, cOff);
                   }
 
-                  Value aVec = fb.create<vector::LoadOp>(forLoc, vecTy, A,
-                                                         ValueRange{m, kOff});
+                  Value aVec = vector::LoadOp::create(fb, forLoc, vecTy, A,
+                                                      ValueRange{m, kOff});
 
-                  Value bVec = fb.create<vector::LoadOp>(forLoc, vecTy, B,
-                                                         ValueRange{n, kOff});
+                  Value bVec = vector::LoadOp::create(fb, forLoc, vecTy, B,
+                                                      ValueRange{n, kOff});
 
-                  Value acc =
-                      fb.create<vector::FMAOp>(forLoc, aVec, bVec, iterArgs[u]);
+                  Value acc = vector::FMAOp::create(fb, forLoc, aVec, bVec,
+                                                    iterArgs[u]);
 
                   newAccs.push_back(acc);
                 }
 
-                fb.create<scf::YieldOp>(forLoc, newAccs);
+                scf::YieldOp::create(fb, forLoc, newAccs);
               });
 
           // Sum unroll accumulators.
           Value sumVec = mainFor.getResult(0);
           for (int64_t u = 1; u < unroll; ++u) {
             sumVec =
-                pb.create<arith::AddFOp>(ploc, sumVec, mainFor.getResult(u));
+                arith::AddFOp::create(pb, ploc, sumVec, mainFor.getResult(u));
           }
 
           // Tail K loop for one tail output column.
-          auto tailFor = pb.create<scf::ForOp>(
-              ploc, mainBound, K, cVf, ValueRange{sumVec},
+          auto tailFor = scf::ForOp::create(
+              pb, ploc, mainBound, K, cVf, ValueRange{sumVec},
               [&](OpBuilder &tb, Location tailLoc, Value kBase,
                   ValueRange iterArgs) {
-                Value remaining = tb.create<arith::SubIOp>(tailLoc, K, kBase);
+                Value remaining = arith::SubIOp::create(tb, tailLoc, K, kBase);
 
-                Value gt = tb.create<arith::CmpIOp>(
-                    tailLoc, arith::CmpIPredicate::ugt, remaining, cVf);
+                Value gt = arith::CmpIOp::create(
+                    tb, tailLoc, arith::CmpIPredicate::ugt, remaining, cVf);
 
                 Value valid =
-                    tb.create<arith::SelectOp>(tailLoc, gt, cVf, remaining);
+                    arith::SelectOp::create(tb, tailLoc, gt, cVf, remaining);
 
-                Value mask = tb.create<vector::CreateMaskOp>(tailLoc, maskTy,
-                                                             ValueRange{valid});
+                Value mask = vector::CreateMaskOp::create(tb, tailLoc, maskTy,
+                                                          ValueRange{valid});
 
-                Value aVec = tb.create<vector::MaskedLoadOp>(
-                    tailLoc, vecTy, A, ValueRange{m, kBase}, mask, vzero);
+                Value aVec = vector::MaskedLoadOp::create(
+                    tb, tailLoc, vecTy, A, ValueRange{m, kBase}, mask, vzero);
 
-                Value bVec = tb.create<vector::MaskedLoadOp>(
-                    tailLoc, vecTy, B, ValueRange{n, kBase}, mask, vzero);
+                Value bVec = vector::MaskedLoadOp::create(
+                    tb, tailLoc, vecTy, B, ValueRange{n, kBase}, mask, vzero);
 
                 Value acc =
-                    tb.create<vector::FMAOp>(tailLoc, aVec, bVec, iterArgs[0]);
+                    vector::FMAOp::create(tb, tailLoc, aVec, bVec, iterArgs[0]);
 
-                tb.create<scf::YieldOp>(tailLoc, acc);
+                scf::YieldOp::create(tb, tailLoc, acc);
               });
 
           Value finalVec = tailFor.getResult(0);
 
-          Value oldVal = pb.create<memref::LoadOp>(ploc, C, ValueRange{m, n});
+          Value oldVal = memref::LoadOp::create(pb, ploc, C, ValueRange{m, n});
 
-          Value result = pb.create<vector::ReductionOp>(
-              ploc, vector::CombiningKind::ADD, finalVec, oldVal,
+          Value result = vector::ReductionOp::create(
+              pb, ploc, vector::CombiningKind::ADD, finalVec, oldVal,
               arith::FastMathFlags::reassoc);
 
-          pb.create<memref::StoreOp>(ploc, result, C, ValueRange{m, n});
+          memref::StoreOp::create(pb, ploc, result, C, ValueRange{m, n});
         });
 
     rewriter.eraseOp(op);

--- a/midend/lib/Conversion/MatMulOptimization/MatMulVectorization.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/MatMulVectorization.cpp
@@ -56,13 +56,13 @@ public:
 
     // Create constant 0-7 values.
     const Value c0 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(0));
     const Value c1 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(1));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(1));
     // unroll size
     // Note: the unroll factor is not the same as the vector size.
     const Value c8 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(8));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(8));
 
     // Get input A, B, C.
     Value A = op->getOperand(0);
@@ -70,9 +70,9 @@ public:
     Value C = op->getOperand(2);
 
     // Create DimOp for m, n, k.
-    const Value m = rewriter.create<memref::DimOp>(loc, A, c0);
-    const Value n = rewriter.create<memref::DimOp>(loc, C, c1);
-    const Value k = rewriter.create<memref::DimOp>(loc, A, c1);
+    const Value m = memref::DimOp::create(rewriter, loc, A, c0);
+    const Value n = memref::DimOp::create(rewriter, loc, C, c1);
+    const Value k = memref::DimOp::create(rewriter, loc, A, c1);
 
     // Get element type and create vector type.
     ShapedType ATy = mlir::cast<mlir::ShapedType>(A.getType());
@@ -80,44 +80,44 @@ public:
     VectorType vectorTy = VectorType::get({vecSize}, eleTy, {scalable});
 
     // Define step.
-    Value step = rewriter.create<arith::ConstantIndexOp>(loc, vecSize);
+    Value step = arith::ConstantIndexOp::create(rewriter, loc, vecSize);
     if (scalable) {
-      Value vscale = rewriter.create<vector::VectorScaleOp>(loc);
-      step = rewriter.create<arith::MulIOp>(loc, step, vscale);
+      Value vscale = vector::VectorScaleOp::create(rewriter, loc);
+      step = arith::MulIOp::create(rewriter, loc, step, vscale);
     }
     FloatType eleFloatTy =
         eleTy.isF32()
             ? static_cast<FloatType>(Float32Type::get(rewriter.getContext()))
             : static_cast<FloatType>(Float64Type::get(rewriter.getContext()));
 
-    auto tail_size = rewriter.create<arith::RemUIOp>(loc, m, c8);
-    auto parallel_size = rewriter.create<arith::SubIOp>(loc, m, tail_size);
+    auto tail_size = arith::RemUIOp::create(rewriter, loc, m, c8);
+    auto parallel_size = arith::SubIOp::create(rewriter, loc, m, tail_size);
 
     auto createUnrollParallel = [&](int unroll_size, Value lowerBound,
                                     Value upperBound) {
-      const Value unroll = rewriter.create<arith::ConstantOp>(
-          loc, rewriter.getIndexAttr(unroll_size));
-      auto parOp = rewriter.create<scf::ParallelOp>(
-          loc,
+      const Value unroll = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getIndexAttr(unroll_size));
+      auto parOp = scf::ParallelOp::create(
+          rewriter, loc,
           /*lowerBounds=*/ValueRange{lowerBound},
           /*upperBounds=*/ValueRange{upperBound},
           /*steps=*/ValueRange{unroll},
           [&](OpBuilder &builder, Location loc, ValueRange mIdx) {
             llvm::SmallVector<Value, 8> mIndices;
             for (int i = 0; i < unroll_size; i++) {
-              auto offset = rewriter.create<arith::ConstantOp>(
-                  loc, rewriter.getIndexAttr(i));
+              auto offset = arith::ConstantOp::create(rewriter, loc,
+                                                      rewriter.getIndexAttr(i));
               auto m_index =
-                  rewriter.create<arith::AddIOp>(loc, mIdx[0], offset);
+                  arith::AddIOp::create(rewriter, loc, mIdx[0], offset);
               mIndices.push_back(m_index);
             }
 
-            auto nBodyBoundTmp = rewriter.create<arith::SubIOp>(loc, n, step);
+            auto nBodyBoundTmp = arith::SubIOp::create(rewriter, loc, n, step);
             auto nBodyBound =
-                rewriter.create<arith::AddIOp>(loc, nBodyBoundTmp, c1);
+                arith::AddIOp::create(rewriter, loc, nBodyBoundTmp, c1);
 
-            auto nIterIdx = rewriter.create<scf::ForOp>(
-                loc,
+            auto nIterIdx = scf::ForOp::create(
+                rewriter, loc,
                 /*lowerBound=*/c0,
                 /*upperBound=*/nBodyBound,
                 /*step=*/step,
@@ -126,13 +126,13 @@ public:
                     ValueRange iterArgs) {
                   SmallVector<Value> sumInitVecs;
                   for (auto mIndex : mIndices) {
-                    auto sumInitVec = rewriter.create<vector::LoadOp>(
-                        loc, vectorTy, C, ValueRange{mIndex, iv});
+                    auto sumInitVec = vector::LoadOp::create(
+                        rewriter, loc, vectorTy, C, ValueRange{mIndex, iv});
                     sumInitVecs.push_back(sumInitVec);
                   }
 
-                  auto sumIterVecs = rewriter.create<scf::ForOp>(
-                      loc,
+                  auto sumIterVecs = scf::ForOp::create(
+                      rewriter, loc,
                       /*lowerBound=*/c0,
                       /*upperBound=*/k,
                       /*step=*/c1,
@@ -140,46 +140,46 @@ public:
                       ValueRange(sumInitVecs),
                       [&](OpBuilder &builder, Location loc, Value kIdx,
                           ValueRange iterArgs) {
-                        auto bVec = rewriter.create<vector::LoadOp>(
-                            loc, vectorTy, B, ValueRange{kIdx, iv});
+                        auto bVec = vector::LoadOp::create(
+                            rewriter, loc, vectorTy, B, ValueRange{kIdx, iv});
 
                         SmallVector<Value> resSumVecs;
                         for (int i = 0; i < unroll_size; i++) {
-                          auto aEle = rewriter.create<memref::LoadOp>(
-                              loc, A, ValueRange{mIndices[i], kIdx});
-                          auto aVec = rewriter.create<vector::BroadcastOp>(
-                              loc, vectorTy, aEle);
-                          auto resSumVec = rewriter.create<vector::FMAOp>(
-                              loc, aVec, bVec, iterArgs[i]);
+                          auto aEle = memref::LoadOp::create(
+                              rewriter, loc, A, ValueRange{mIndices[i], kIdx});
+                          auto aVec = vector::BroadcastOp::create(
+                              rewriter, loc, vectorTy, aEle);
+                          auto resSumVec = vector::FMAOp::create(
+                              rewriter, loc, aVec, bVec, iterArgs[i]);
                           resSumVecs.push_back(resSumVec);
                         }
-                        builder.create<scf::YieldOp>(loc,
-                                                     ValueRange(resSumVecs));
+                        scf::YieldOp::create(builder, loc,
+                                             ValueRange(resSumVecs));
                       });
 
                   for (int i = 0; i < unroll_size; i++) {
-                    rewriter.create<vector::StoreOp>(
-                        loc, sumIterVecs.getResult(i), C,
-                        ValueRange{mIndices[i], iv});
+                    vector::StoreOp::create(rewriter, loc,
+                                            sumIterVecs.getResult(i), C,
+                                            ValueRange{mIndices[i], iv});
                   }
 
-                  auto kNext = rewriter.create<arith::AddIOp>(loc, iv, step);
-                  builder.create<scf::YieldOp>(loc, ValueRange{kNext});
+                  auto kNext = arith::AddIOp::create(rewriter, loc, iv, step);
+                  scf::YieldOp::create(builder, loc, ValueRange{kNext});
                 });
 
             // Tail processing.
-            builder.create<scf::ForOp>(
-                loc, nIterIdx.getResult(0), n, c1, ValueRange{},
+            scf::ForOp::create(
+                builder, loc, nIterIdx.getResult(0), n, c1, ValueRange{},
                 [&](OpBuilder &builder, Location loc, Value iv,
                     ValueRange iterArgs) {
                   SmallVector<Value> sumInits;
                   for (auto mIndex : mIndices) {
-                    auto sumInit = rewriter.create<memref::LoadOp>(
-                        loc, eleFloatTy, C, ValueRange{mIndex, iv});
+                    auto sumInit = memref::LoadOp::create(
+                        rewriter, loc, eleFloatTy, C, ValueRange{mIndex, iv});
                     sumInits.push_back(sumInit);
                   }
-                  auto sumIterVecs = rewriter.create<scf::ForOp>(
-                      loc,
+                  auto sumIterVecs = scf::ForOp::create(
+                      rewriter, loc,
                       /*lowerBound=*/c0,
                       /*upperBound=*/k,
                       /*step=*/c1,
@@ -188,27 +188,27 @@ public:
                       [&](OpBuilder &builder, Location loc, Value kIdx,
                           ValueRange iterArgs) {
                         SmallVector<Value> resSums;
-                        auto bEle = rewriter.create<memref::LoadOp>(
-                            loc, B, ValueRange{kIdx, iv});
+                        auto bEle = memref::LoadOp::create(
+                            rewriter, loc, B, ValueRange{kIdx, iv});
                         for (int i = 0; i < unroll_size; i++) {
-                          auto aEle = rewriter.create<memref::LoadOp>(
-                              loc, A, ValueRange{mIndices[i], kIdx});
+                          auto aEle = memref::LoadOp::create(
+                              rewriter, loc, A, ValueRange{mIndices[i], kIdx});
                           auto tmpEle =
-                              rewriter.create<arith::MulFOp>(loc, aEle, bEle);
-                          auto resSum = rewriter.create<arith::AddFOp>(
-                              loc, tmpEle, iterArgs[i]);
+                              arith::MulFOp::create(rewriter, loc, aEle, bEle);
+                          auto resSum = arith::AddFOp::create(
+                              rewriter, loc, tmpEle, iterArgs[i]);
                           resSums.push_back(resSum);
                         }
 
-                        builder.create<scf::YieldOp>(loc, ValueRange(resSums));
+                        scf::YieldOp::create(builder, loc, ValueRange(resSums));
                       });
 
                   for (int i = 0; i < unroll_size; i++) {
-                    rewriter.create<memref::StoreOp>(
-                        loc, sumIterVecs.getResult(i), C,
-                        ValueRange{mIndices[i], iv});
+                    memref::StoreOp::create(rewriter, loc,
+                                            sumIterVecs.getResult(i), C,
+                                            ValueRange{mIndices[i], iv});
                   }
-                  builder.create<scf::YieldOp>(loc);
+                  scf::YieldOp::create(builder, loc);
                 });
           });
     };

--- a/midend/lib/Conversion/MatMulOptimization/MatMulVectorizationDecode.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/MatMulVectorizationDecode.cpp
@@ -126,21 +126,21 @@ public:
     Type elementType = cType.getElementType();
     auto vectorType = VectorType::get({vecSize}, elementType, {scalable});
 
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    Value step = rewriter.create<arith::ConstantIndexOp>(loc, vecSize);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    Value step = arith::ConstantIndexOp::create(rewriter, loc, vecSize);
     if (scalable) {
-      Value vscale = rewriter.create<vector::VectorScaleOp>(loc);
-      step = rewriter.create<arith::MulIOp>(loc, step, vscale);
+      Value vscale = vector::VectorScaleOp::create(rewriter, loc);
+      step = arith::MulIOp::create(rewriter, loc, step, vscale);
     }
 
-    Value n = rewriter.create<memref::DimOp>(loc, C, c1);
-    Value k = rewriter.create<memref::DimOp>(loc, A, c1);
+    Value n = memref::DimOp::create(rewriter, loc, C, c1);
+    Value k = memref::DimOp::create(rewriter, loc, A, c1);
     memref::CopyOp zeroInitCopy = findZeroInitCopy(C, matmulOp, module);
     bool zeroInitialized = zeroInitCopy != nullptr;
 
-    rewriter.create<scf::ParallelOp>(
-        loc,
+    scf::ParallelOp::create(
+        rewriter, loc,
         /*lowerBounds=*/ValueRange{c0},
         /*upperBounds=*/ValueRange{n},
         /*steps=*/ValueRange{step},
@@ -148,30 +148,30 @@ public:
           Value nIdx = ivs.front();
           Value cVec;
           if (zeroInitialized) {
-            Value zero = builder.create<arith::ConstantOp>(
-                loc, elementType, builder.getZeroAttr(elementType));
-            cVec = builder.create<vector::BroadcastOp>(loc, vectorType, zero);
+            Value zero = arith::ConstantOp::create(
+                builder, loc, elementType, builder.getZeroAttr(elementType));
+            cVec = vector::BroadcastOp::create(builder, loc, vectorType, zero);
           } else {
-            cVec = builder.create<vector::LoadOp>(loc, vectorType, C,
-                                                  ValueRange{c0, nIdx});
+            cVec = vector::LoadOp::create(builder, loc, vectorType, C,
+                                          ValueRange{c0, nIdx});
           }
-          auto sumIter = builder.create<scf::ForOp>(
-              loc, c0, k, c1, ValueRange{cVec},
+          auto sumIter = scf::ForOp::create(
+              builder, loc, c0, k, c1, ValueRange{cVec},
               [&](OpBuilder &builder, Location loc, Value kIdx,
                   ValueRange iterArgs) {
-                Value aElem = builder.create<memref::LoadOp>(
-                    loc, A, ValueRange{c0, kIdx});
-                Value aVec =
-                    builder.create<vector::BroadcastOp>(loc, vectorType, aElem);
-                Value bVec = builder.create<vector::LoadOp>(
-                    loc, vectorType, B, ValueRange{kIdx, nIdx});
-                Value res = builder.create<vector::FMAOp>(loc, aVec, bVec,
-                                                          iterArgs.front());
-                builder.create<scf::YieldOp>(loc, res);
+                Value aElem = memref::LoadOp::create(builder, loc, A,
+                                                     ValueRange{c0, kIdx});
+                Value aVec = vector::BroadcastOp::create(builder, loc,
+                                                         vectorType, aElem);
+                Value bVec = vector::LoadOp::create(builder, loc, vectorType, B,
+                                                    ValueRange{kIdx, nIdx});
+                Value res = vector::FMAOp::create(builder, loc, aVec, bVec,
+                                                  iterArgs.front());
+                scf::YieldOp::create(builder, loc, res);
               });
 
-          builder.create<vector::StoreOp>(loc, sumIter.getResult(0), C,
-                                          ValueRange{c0, nIdx});
+          vector::StoreOp::create(builder, loc, sumIter.getResult(0), C,
+                                  ValueRange{c0, nIdx});
         });
 
     rewriter.eraseOp(op);

--- a/midend/lib/Conversion/MatMulOptimization/MatmulAMX.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/MatmulAMX.cpp
@@ -111,13 +111,13 @@ Value createPackedBMatrix(OpBuilder &builder, Location loc, Value B, int64_t K,
   SmallVector<Value> dynamicSizes;
   SmallVector<int64_t> staticShape;
 
-  Value c0 = builder.create<arith::ConstantIndexOp>(loc, 0);
-  Value c1 = builder.create<arith::ConstantIndexOp>(loc, 1);
+  Value c0 = arith::ConstantIndexOp::create(builder, loc, 0);
+  Value c1 = arith::ConstantIndexOp::create(builder, loc, 1);
 
   // For K dimension
   if (K == ShapedType::kDynamic) {
     staticShape.push_back(ShapedType::kDynamic);
-    dynamicSizes.push_back(builder.create<memref::DimOp>(loc, B, c0));
+    dynamicSizes.push_back(memref::DimOp::create(builder, loc, B, c0));
   } else {
     staticShape.push_back(K);
   }
@@ -125,7 +125,7 @@ Value createPackedBMatrix(OpBuilder &builder, Location loc, Value B, int64_t K,
   // For N dimension
   if (N == ShapedType::kDynamic) {
     staticShape.push_back(ShapedType::kDynamic);
-    dynamicSizes.push_back(builder.create<memref::DimOp>(loc, B, c1));
+    dynamicSizes.push_back(memref::DimOp::create(builder, loc, B, c1));
   } else {
     staticShape.push_back(N);
   }
@@ -135,37 +135,37 @@ Value createPackedBMatrix(OpBuilder &builder, Location loc, Value B, int64_t K,
   // will be handled by later passes
   auto packedBType = MemRefType::get(staticShape, elementType);
   Value packedB =
-      builder.create<memref::AllocOp>(loc, packedBType, dynamicSizes);
+      memref::AllocOp::create(builder, loc, packedBType, dynamicSizes);
 
   // Get actual dimension sizes (handle both static and dynamic cases)
   Value cK, cN;
   if (K == ShapedType::kDynamic) {
-    cK = builder.create<memref::DimOp>(loc, B, c0).getResult();
+    cK = memref::DimOp::create(builder, loc, B, c0).getResult();
   } else {
-    cK = builder.create<arith::ConstantIndexOp>(loc, K).getResult();
+    cK = arith::ConstantIndexOp::create(builder, loc, K).getResult();
   }
 
   if (N == ShapedType::kDynamic) {
-    cN = builder.create<memref::DimOp>(loc, B, c1).getResult();
+    cN = memref::DimOp::create(builder, loc, B, c1).getResult();
   } else {
-    cN = builder.create<arith::ConstantIndexOp>(loc, N).getResult();
+    cN = arith::ConstantIndexOp::create(builder, loc, N).getResult();
   }
 
   // Simple copy for now - in a real implementation, this would be
   // a more sophisticated packing operation
-  builder.create<scf::ForOp>(
-      loc, c0, cK, c1, ValueRange{},
+  scf::ForOp::create(
+      builder, loc, c0, cK, c1, ValueRange{},
       [&](OpBuilder &builder, Location loc, Value i, ValueRange) {
-        builder.create<scf::ForOp>(
-            loc, c0, cN, c1, ValueRange{},
+        scf::ForOp::create(
+            builder, loc, c0, cN, c1, ValueRange{},
             [&](OpBuilder &builder, Location loc, Value j, ValueRange) {
               Value val =
-                  builder.create<memref::LoadOp>(loc, B, ValueRange{i, j});
-              builder.create<memref::StoreOp>(loc, val, packedB,
-                                              ValueRange{i, j});
-              builder.create<scf::YieldOp>(loc);
+                  memref::LoadOp::create(builder, loc, B, ValueRange{i, j});
+              memref::StoreOp::create(builder, loc, val, packedB,
+                                      ValueRange{i, j});
+              scf::YieldOp::create(builder, loc);
             });
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 
   return packedB;
@@ -226,29 +226,29 @@ public:
     int64_t N = BShape[1];
 
     // Create constants
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    Value c16 = rewriter.create<arith::ConstantIndexOp>(loc, 16);
-    Value c32 = rewriter.create<arith::ConstantIndexOp>(loc, 32);
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    Value c16 = arith::ConstantIndexOp::create(rewriter, loc, 16);
+    Value c32 = arith::ConstantIndexOp::create(rewriter, loc, 32);
 
     // Handle dynamic dimensions
     Value cM, cN, cK;
     if (M == ShapedType::kDynamic) {
-      cM = rewriter.create<memref::DimOp>(loc, A, c0);
+      cM = memref::DimOp::create(rewriter, loc, A, c0);
     } else {
-      cM = rewriter.create<arith::ConstantIndexOp>(loc, M);
+      cM = arith::ConstantIndexOp::create(rewriter, loc, M);
     }
 
     if (N == ShapedType::kDynamic) {
-      cN = rewriter.create<memref::DimOp>(loc, B, c1);
+      cN = memref::DimOp::create(rewriter, loc, B, c1);
     } else {
-      cN = rewriter.create<arith::ConstantIndexOp>(loc, N);
+      cN = arith::ConstantIndexOp::create(rewriter, loc, N);
     }
 
     if (K == ShapedType::kDynamic) {
-      cK = rewriter.create<memref::DimOp>(loc, A, c1);
+      cK = memref::DimOp::create(rewriter, loc, A, c1);
     } else {
-      cK = rewriter.create<arith::ConstantIndexOp>(loc, K);
+      cK = arith::ConstantIndexOp::create(rewriter, loc, K);
     }
 
     // Create pre-packed B matrix for AMX-friendly tile loads
@@ -262,45 +262,46 @@ public:
 
     // Generate AMX tile computation loops
     // Outer loops: iterate over M and N dimensions in 16x16 tiles
-    rewriter.create<scf::ForOp>(
-        loc, c0, cM, c16, ValueRange{},
+    scf::ForOp::create(
+        rewriter, loc, c0, cM, c16, ValueRange{},
         [&](OpBuilder &builder, Location loc, Value m, ValueRange) {
-          builder.create<scf::ForOp>(
-              loc, c0, cN, c16, ValueRange{},
+          scf::ForOp::create(
+              builder, loc, c0, cN, c16, ValueRange{},
               [&](OpBuilder &builder, Location loc, Value n, ValueRange) {
                 // Initialize accumulator tile to zero
-                Value zeroTile = builder.create<TileZeroOp>(loc, tileTypeF32);
-                builder.create<TileStoreOp>(loc, C, ValueRange{m, n}, zeroTile);
+                Value zeroTile = TileZeroOp::create(builder, loc, tileTypeF32);
+                TileStoreOp::create(builder, loc, C, ValueRange{m, n},
+                                    zeroTile);
 
                 // Inner loop: iterate over K dimension in chunks of 32
-                builder.create<scf::ForOp>(
-                    loc, c0, cK, c32, ValueRange{},
+                scf::ForOp::create(
+                    builder, loc, c0, cK, c32, ValueRange{},
                     [&](OpBuilder &builder, Location loc, Value k, ValueRange) {
                       // Load A tile: 16x32xbf16 from [%m, %k]
-                      Value tA = builder.create<TileLoadOp>(
-                          loc, tileTypeBF16, A, ValueRange{m, k});
+                      Value tA = TileLoadOp::create(builder, loc, tileTypeBF16,
+                                                    A, ValueRange{m, k});
 
                       // Load B tile (pre-packed): 16x32xbf16 from [%k, %n]
-                      Value tB = builder.create<TileLoadOp>(
-                          loc, tileTypeBF16, Bpack, ValueRange{k, n});
+                      Value tB = TileLoadOp::create(builder, loc, tileTypeBF16,
+                                                    Bpack, ValueRange{k, n});
 
                       // Load current accumulator from C
-                      Value tAcc = builder.create<TileLoadOp>(
-                          loc, tileTypeF32, C, ValueRange{m, n});
+                      Value tAcc = TileLoadOp::create(builder, loc, tileTypeF32,
+                                                      C, ValueRange{m, n});
 
                       // Perform tile multiplication with accumulation
-                      Value tAcc2 = builder.create<TileMulFOp>(loc, tileTypeF32,
-                                                               tA, tB, tAcc);
+                      Value tAcc2 = TileMulFOp::create(
+                          builder, loc, tileTypeF32, tA, tB, tAcc);
 
                       // Store result back to C
-                      builder.create<TileStoreOp>(loc, C, ValueRange{m, n},
-                                                  tAcc2);
+                      TileStoreOp::create(builder, loc, C, ValueRange{m, n},
+                                          tAcc2);
 
-                      builder.create<scf::YieldOp>(loc);
+                      scf::YieldOp::create(builder, loc);
                     });
-                builder.create<scf::YieldOp>(loc);
+                scf::YieldOp::create(builder, loc);
               });
-          builder.create<scf::YieldOp>(loc);
+          scf::YieldOp::create(builder, loc);
         });
 
     // Remove the original linalg.matmul operation

--- a/midend/lib/Conversion/StaticizeMemRefLayout/StaticizeMemRefLayout.cpp
+++ b/midend/lib/Conversion/StaticizeMemRefLayout/StaticizeMemRefLayout.cpp
@@ -146,9 +146,9 @@ public:
 
       // Create new reinterpret_cast with static layout
       builder.setInsertionPointAfter(reinterpretOp);
-      auto newReinterpretOp = builder.create<memref::ReinterpretCastOp>(
-          reinterpretOp.getLoc(), staticType, baseBuffer, staticOffsetOfr,
-          staticSizes, staticStridesOfr);
+      auto newReinterpretOp = memref::ReinterpretCastOp::create(
+          builder, reinterpretOp.getLoc(), staticType, baseBuffer,
+          staticOffsetOfr, staticSizes, staticStridesOfr);
 
       // Replace all uses of the old reinterpret_cast result with the new one
       Value oldResult = reinterpretOp.getResult();

--- a/midend/lib/Conversion/TosaElementwiseFusion/SiLUFusion.cpp
+++ b/midend/lib/Conversion/TosaElementwiseFusion/SiLUFusion.cpp
@@ -96,26 +96,26 @@ public:
         rank, utils::IteratorType::parallel);
 
     // Create empty tensor for output
-    tensor::EmptyOp emptyTensor = rewriter.create<tensor::EmptyOp>(
-        loc, outputType.getShape(), elementType);
+    tensor::EmptyOp emptyTensor = tensor::EmptyOp::create(
+        rewriter, loc, outputType.getShape(), elementType);
 
     // Create fused SiLU operation using linalg.generic
-    linalg::GenericOp fusedOp = rewriter.create<linalg::GenericOp>(
-        loc, outputType, ValueRange{inputValue}, ValueRange{emptyTensor},
-        indexingMaps, iteratorTypes,
+    linalg::GenericOp fusedOp = linalg::GenericOp::create(
+        rewriter, loc, outputType, ValueRange{inputValue},
+        ValueRange{emptyTensor}, indexingMaps, iteratorTypes,
         [&](OpBuilder &b, Location loc, ValueRange args) {
           Value input = args[0];
 
           // SiLU: x * sigmoid(x) = x * (1 / (1 + exp(-x)))
-          Value one = b.create<arith::ConstantOp>(
-              loc, b.getFloatAttr(elementType, 1.0));
-          Value negInput = b.create<arith::NegFOp>(loc, input);
-          Value expNegInput = b.create<math::ExpOp>(loc, negInput);
-          Value onePlusExp = b.create<arith::AddFOp>(loc, one, expNegInput);
-          Value sigmoid = b.create<arith::DivFOp>(loc, one, onePlusExp);
-          Value silu = b.create<arith::MulFOp>(loc, input, sigmoid);
+          Value one = arith::ConstantOp::create(
+              b, loc, b.getFloatAttr(elementType, 1.0));
+          Value negInput = arith::NegFOp::create(b, loc, input);
+          Value expNegInput = math::ExpOp::create(b, loc, negInput);
+          Value onePlusExp = arith::AddFOp::create(b, loc, one, expNegInput);
+          Value sigmoid = arith::DivFOp::create(b, loc, one, onePlusExp);
+          Value silu = arith::MulFOp::create(b, loc, input, sigmoid);
 
-          b.create<linalg::YieldOp>(loc, silu);
+          linalg::YieldOp::create(b, loc, silu);
         });
 
     // Replace the original multiply operation

--- a/midend/lib/Conversion/TransposeOptimization/BuiltinTransposeVectorization.cpp
+++ b/midend/lib/Conversion/TransposeOptimization/BuiltinTransposeVectorization.cpp
@@ -84,49 +84,51 @@ public:
 
     // Define constants.
     const Value index0 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
-    const Value indexVecSize = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getIndexAttr(affineVectorSize));
+        arith::ConstantOp::create(rewriter, loc, rewriter.getIndexAttr(0));
+    const Value indexVecSize = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getIndexAttr(affineVectorSize));
     const AffineExpr d0 = rewriter.getAffineDimExpr(0);
     const AffineExpr d1 = rewriter.getAffineDimExpr(1);
     const AffineExpr s0 = rewriter.getAffineSymbolExpr(0);
     const AffineExpr zeroAffine = rewriter.getAffineConstantExpr(0);
 
-    const Value zeroElementType = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getZeroAttr(elementType));
+    const Value zeroElementType = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getZeroAttr(elementType));
 
     // Get dimensions of input tensor.
-    Value Row = rewriter.create<memref::DimOp>(loc, A, 0);
-    Value Col = rewriter.create<memref::DimOp>(loc, A, 1);
+    Value Row = memref::DimOp::create(rewriter, loc, A, 0);
+    Value Col = memref::DimOp::create(rewriter, loc, A, 1);
 
     // Calculate the length of the tail, which might not fit in a vector.
-    Value rowUnalignedLength = rewriter.create<affine::AffineApplyOp>(
-        loc, AffineMap::get(1, 0, d0 % affineVectorSize), ValueRange{Row});
-    Value colUnalignedLength = rewriter.create<affine::AffineApplyOp>(
-        loc, AffineMap::get(1, 0, d0 % affineVectorSize), ValueRange{Col});
-    Value rowUpperBound = rewriter.create<affine::AffineApplyOp>(
-        loc,
+    Value rowUnalignedLength = affine::AffineApplyOp::create(
+        rewriter, loc, AffineMap::get(1, 0, d0 % affineVectorSize),
+        ValueRange{Row});
+    Value colUnalignedLength = affine::AffineApplyOp::create(
+        rewriter, loc, AffineMap::get(1, 0, d0 % affineVectorSize),
+        ValueRange{Col});
+    Value rowUpperBound = affine::AffineApplyOp::create(
+        rewriter, loc,
         AffineMap::get(1, 0, d0.floorDiv(affineVectorSize) * affineVectorSize),
         ValueRange{Row});
 
     // Generate a mask vector based on the tail length.
-    Value rowEndMaskLoad = rewriter.create<vector::CreateMaskOp>(
-        loc,
+    Value rowEndMaskLoad = vector::CreateMaskOp::create(
+        rewriter, loc,
         VectorType::get({affineVectorSize, affineVectorSize},
                         rewriter.getI1Type()),
         ValueRange{rowUnalignedLength, indexVecSize});
-    Value colEndMaskLoad = rewriter.create<vector::CreateMaskOp>(
-        loc,
+    Value colEndMaskLoad = vector::CreateMaskOp::create(
+        rewriter, loc,
         VectorType::get({affineVectorSize, affineVectorSize},
                         rewriter.getI1Type()),
         ValueRange{indexVecSize, colUnalignedLength});
-    Value rowEndMaskStore = rewriter.create<vector::CreateMaskOp>(
-        loc,
+    Value rowEndMaskStore = vector::CreateMaskOp::create(
+        rewriter, loc,
         VectorType::get({affineVectorSize, affineVectorSize},
                         rewriter.getI1Type()),
         ValueRange{indexVecSize, rowUnalignedLength});
-    Value colEndMaskStore = rewriter.create<vector::CreateMaskOp>(
-        loc,
+    Value colEndMaskStore = vector::CreateMaskOp::create(
+        rewriter, loc,
         VectorType::get({affineVectorSize, affineVectorSize},
                         rewriter.getI1Type()),
         ValueRange{colUnalignedLength, indexVecSize});
@@ -136,27 +138,25 @@ public:
                         [](const LoopReduction &red) { return red.value; }));
 
     // Create the primary parallel loop.
-    AffineParallelOp parallelColLoop =
-        rewriter.create<affine::AffineParallelOp>(
-            loc, ValueRange(reducedValues).getTypes(), ValueRange{Col},
-            ArrayRef<NamedAttribute>{
-                rewriter.getNamedAttr("lowerBoundsGroups",
-                                      rewriter.getI32TensorAttr({1})),
-                rewriter.getNamedAttr("upperBoundsGroups",
-                                      rewriter.getI32TensorAttr({1})),
-                rewriter.getNamedAttr(
-                    "lowerBoundsMap",
-                    AffineMapAttr::get(AffineMap::get(0, 0, {zeroAffine},
-                                                      rewriter.getContext()))),
-                rewriter.getNamedAttr(
-                    "upperBoundsMap",
-                    AffineMapAttr::get(AffineMap::get(
-                        0, 1,
-                        {s0.floorDiv(affineVectorSize) * affineVectorSize},
-                        rewriter.getContext()))),
-                rewriter.getNamedAttr("reductions", rewriter.getArrayAttr({})),
-                rewriter.getNamedAttr(
-                    "steps", rewriter.getI64ArrayAttr({affineVectorSize}))});
+    AffineParallelOp parallelColLoop = affine::AffineParallelOp::create(
+        rewriter, loc, ValueRange(reducedValues).getTypes(), ValueRange{Col},
+        ArrayRef<NamedAttribute>{
+            rewriter.getNamedAttr("lowerBoundsGroups",
+                                  rewriter.getI32TensorAttr({1})),
+            rewriter.getNamedAttr("upperBoundsGroups",
+                                  rewriter.getI32TensorAttr({1})),
+            rewriter.getNamedAttr(
+                "lowerBoundsMap",
+                AffineMapAttr::get(
+                    AffineMap::get(0, 0, {zeroAffine}, rewriter.getContext()))),
+            rewriter.getNamedAttr(
+                "upperBoundsMap",
+                AffineMapAttr::get(AffineMap::get(
+                    0, 1, {s0.floorDiv(affineVectorSize) * affineVectorSize},
+                    rewriter.getContext()))),
+            rewriter.getNamedAttr("reductions", rewriter.getArrayAttr({})),
+            rewriter.getNamedAttr(
+                "steps", rewriter.getI64ArrayAttr({affineVectorSize}))});
 
     // Create the loop body for the parallel loop.
     Block *loopBody = new Block();
@@ -169,8 +169,8 @@ public:
         [&](OpBuilder &builder, Location loc, ValueRange ivRange) {
           Value rowIdx = ivRange.front();
 
-          auto tiledMatrix = rewriter.create<vector::TransferReadOp>(
-              loc,
+          auto tiledMatrix = vector::TransferReadOp::create(
+              rewriter, loc,
               TypeRange{VectorType::get(
                   ArrayRef<int64_t>{affineVectorSize, affineVectorSize},
                   elementType)},
@@ -188,8 +188,9 @@ public:
                           2, 0, {d0, d1}, rewriter.getContext()))),
               });
 
-          rewriter.create<vector::TransferWriteOp>(
-              loc, TypeRange{}, ValueRange{tiledMatrix, B, colIdx, rowIdx},
+          vector::TransferWriteOp::create(
+              rewriter, loc, TypeRange{},
+              ValueRange{tiledMatrix, B, colIdx, rowIdx},
               ArrayRef<NamedAttribute>{
                   rewriter.getNamedAttr(
                       "in_bounds",
@@ -211,8 +212,8 @@ public:
             // Depending on the position, use either full vectors or tail
             // vectors.
             affine::AffineIfOp branchingRowUnaligned =
-                builder.create<affine::AffineIfOp>(
-                    loc,
+                affine::AffineIfOp::create(
+                    builder, loc,
                     IntegerSet::get(1, 0, {d0 % affineVectorSize - 1}, {false}),
                     ValueRange{Row}, false);
 
@@ -220,28 +221,27 @@ public:
             OpBuilder trueRowUnalignedBranchBuilder =
                 branchingRowUnaligned.getThenBodyBuilder();
 
-            auto rowUnalignedTiledMatrix =
-                trueRowUnalignedBranchBuilder.create<vector::TransferReadOp>(
-                    loc,
-                    TypeRange{VectorType::get(
-                        ArrayRef<int64_t>{affineVectorSize, affineVectorSize},
-                        elementType)},
-                    ValueRange{A, rowUpperBound, colIdx, zeroElementType,
-                               rowEndMaskLoad},
-                    ArrayRef<NamedAttribute>{
-                        rewriter.getNamedAttr("in_bounds",
-                                              rewriter.getBoolArrayAttr(
-                                                  ArrayRef<bool>{false, true})),
-                        rewriter.getNamedAttr("operand_segment_sizes",
-                                              rewriter.getDenseI32ArrayAttr(
-                                                  ArrayRef<int>{1, 2, 1, 1})),
-                        rewriter.getNamedAttr(
-                            "permutation_map",
-                            AffineMapAttr::get(AffineMap::get(
-                                2, 0, {d0, d1}, rewriter.getContext()))),
-                    });
-            trueRowUnalignedBranchBuilder.create<vector::TransferWriteOp>(
-                loc, TypeRange{},
+            auto rowUnalignedTiledMatrix = vector::TransferReadOp::create(
+                trueRowUnalignedBranchBuilder, loc,
+                TypeRange{VectorType::get(
+                    ArrayRef<int64_t>{affineVectorSize, affineVectorSize},
+                    elementType)},
+                ValueRange{A, rowUpperBound, colIdx, zeroElementType,
+                           rowEndMaskLoad},
+                ArrayRef<NamedAttribute>{
+                    rewriter.getNamedAttr(
+                        "in_bounds",
+                        rewriter.getBoolArrayAttr(ArrayRef<bool>{false, true})),
+                    rewriter.getNamedAttr("operand_segment_sizes",
+                                          rewriter.getDenseI32ArrayAttr(
+                                              ArrayRef<int>{1, 2, 1, 1})),
+                    rewriter.getNamedAttr(
+                        "permutation_map",
+                        AffineMapAttr::get(AffineMap::get(
+                            2, 0, {d0, d1}, rewriter.getContext()))),
+                });
+            vector::TransferWriteOp::create(
+                trueRowUnalignedBranchBuilder, loc, TypeRange{},
                 ValueRange{rowUnalignedTiledMatrix, B, colIdx, rowUpperBound,
                            rowEndMaskStore},
                 ArrayRef<NamedAttribute>{
@@ -259,7 +259,7 @@ public:
           }
         });
 
-    rewriter.create<affine::AffineYieldOp>(loc);
+    affine::AffineYieldOp::create(rewriter, loc);
 
     // Finalize the loop.
     parallelColLoop.getRegion().push_back(loopBody);
@@ -270,47 +270,45 @@ public:
                 affineVectorSize !=
             0) {
 
-      affine::AffineIfOp branchingColUnaligned =
-          rewriter.create<affine::AffineIfOp>(
-              loc, IntegerSet::get(1, 0, {d0 % affineVectorSize - 1}, {false}),
-              ValueRange{Col}, false);
+      affine::AffineIfOp branchingColUnaligned = affine::AffineIfOp::create(
+          rewriter, loc,
+          IntegerSet::get(1, 0, {d0 % affineVectorSize - 1}, {false}),
+          ValueRange{Col}, false);
 
       OpBuilder trueColUnalignedBranchBuilder =
           branchingColUnaligned.getThenBodyBuilder();
-      Value colUpperBound =
-          trueColUnalignedBranchBuilder.create<affine::AffineApplyOp>(
-              loc,
-              AffineMap::get(1, 0,
-                             d0.floorDiv(affineVectorSize) * affineVectorSize),
-              ValueRange{Col});
+      Value colUpperBound = affine::AffineApplyOp::create(
+          trueColUnalignedBranchBuilder, loc,
+          AffineMap::get(1, 0,
+                         d0.floorDiv(affineVectorSize) * affineVectorSize),
+          ValueRange{Col});
 
       affine::buildAffineLoopNest(
           trueColUnalignedBranchBuilder, loc, {index0}, {rowUpperBound},
           affineVectorSize,
           [&](OpBuilder &builder, Location loc, ValueRange ivRange) {
             Value rowIdx = ivRange.front();
-            auto colUnalignedTiledMatrix =
-                builder.create<vector::TransferReadOp>(
-                    loc,
-                    TypeRange{VectorType::get(
-                        ArrayRef<int64_t>{affineVectorSize, affineVectorSize},
-                        elementType)},
-                    ValueRange{A, rowIdx, colUpperBound, zeroElementType,
-                               colEndMaskLoad},
-                    ArrayRef<NamedAttribute>{
-                        builder.getNamedAttr("in_bounds",
-                                             builder.getBoolArrayAttr(
-                                                 ArrayRef<bool>{false, false})),
-                        builder.getNamedAttr("operand_segment_sizes",
-                                             builder.getDenseI32ArrayAttr(
-                                                 ArrayRef<int>{1, 2, 1, 1})),
-                        builder.getNamedAttr(
-                            "permutation_map",
-                            AffineMapAttr::get(AffineMap::get(
-                                2, 0, {d0, d1}, builder.getContext()))),
-                    });
-            builder.create<vector::TransferWriteOp>(
-                loc, TypeRange{},
+            auto colUnalignedTiledMatrix = vector::TransferReadOp::create(
+                builder, loc,
+                TypeRange{VectorType::get(
+                    ArrayRef<int64_t>{affineVectorSize, affineVectorSize},
+                    elementType)},
+                ValueRange{A, rowIdx, colUpperBound, zeroElementType,
+                           colEndMaskLoad},
+                ArrayRef<NamedAttribute>{
+                    builder.getNamedAttr(
+                        "in_bounds",
+                        builder.getBoolArrayAttr(ArrayRef<bool>{false, false})),
+                    builder.getNamedAttr("operand_segment_sizes",
+                                         builder.getDenseI32ArrayAttr(
+                                             ArrayRef<int>{1, 2, 1, 1})),
+                    builder.getNamedAttr(
+                        "permutation_map",
+                        AffineMapAttr::get(AffineMap::get(
+                            2, 0, {d0, d1}, builder.getContext()))),
+                });
+            vector::TransferWriteOp::create(
+                builder, loc, TypeRange{},
                 ValueRange{colUnalignedTiledMatrix, B, colUpperBound, rowIdx,
                            colEndMaskStore},
                 ArrayRef<NamedAttribute>{
@@ -332,50 +330,47 @@ public:
                   affineVectorSize !=
               0) {
         affine::AffineIfOp branchingRowColUnaligned =
-            trueColUnalignedBranchBuilder.create<affine::AffineIfOp>(
-                loc,
+            affine::AffineIfOp::create(
+                trueColUnalignedBranchBuilder, loc,
                 IntegerSet::get(1, 0, {d0 % affineVectorSize - 1}, {false}),
                 ValueRange{Col}, false);
 
         OpBuilder trueRowColUnalignedBranchBuilder =
             branchingRowColUnaligned.getThenBodyBuilder();
-        Value rowColEndMaskLoad =
-            trueRowColUnalignedBranchBuilder.create<vector::CreateMaskOp>(
-                loc,
-                VectorType::get({affineVectorSize, affineVectorSize},
-                                trueRowColUnalignedBranchBuilder.getI1Type()),
-                ValueRange{rowUnalignedLength, colUnalignedLength});
-        Value rowColEndMaskStore =
-            trueRowColUnalignedBranchBuilder.create<vector::CreateMaskOp>(
-                loc,
-                VectorType::get({affineVectorSize, affineVectorSize},
-                                trueRowColUnalignedBranchBuilder.getI1Type()),
-                ValueRange{colUnalignedLength, rowUnalignedLength});
-        auto rowColUnalignedTiledMatrix =
-            trueRowColUnalignedBranchBuilder.create<vector::TransferReadOp>(
-                loc,
-                TypeRange{VectorType::get(
-                    ArrayRef<int64_t>{affineVectorSize, affineVectorSize},
-                    elementType)},
-                ValueRange{A, rowUpperBound, colUpperBound, zeroElementType,
-                           rowColEndMaskLoad},
-                ArrayRef<NamedAttribute>{
-                    trueRowColUnalignedBranchBuilder.getNamedAttr(
-                        "in_bounds",
-                        trueRowColUnalignedBranchBuilder.getBoolArrayAttr(
-                            ArrayRef<bool>{false, false})),
-                    trueRowColUnalignedBranchBuilder.getNamedAttr(
-                        "operand_segment_sizes",
-                        trueRowColUnalignedBranchBuilder.getDenseI32ArrayAttr(
-                            ArrayRef<int>{1, 2, 1, 1})),
-                    trueRowColUnalignedBranchBuilder.getNamedAttr(
-                        "permutation_map",
-                        AffineMapAttr::get(AffineMap::get(
-                            2, 0, {d0, d1},
-                            trueRowColUnalignedBranchBuilder.getContext()))),
-                });
-        trueRowColUnalignedBranchBuilder.create<vector::TransferWriteOp>(
-            loc, TypeRange{},
+        Value rowColEndMaskLoad = vector::CreateMaskOp::create(
+            trueRowColUnalignedBranchBuilder, loc,
+            VectorType::get({affineVectorSize, affineVectorSize},
+                            trueRowColUnalignedBranchBuilder.getI1Type()),
+            ValueRange{rowUnalignedLength, colUnalignedLength});
+        Value rowColEndMaskStore = vector::CreateMaskOp::create(
+            trueRowColUnalignedBranchBuilder, loc,
+            VectorType::get({affineVectorSize, affineVectorSize},
+                            trueRowColUnalignedBranchBuilder.getI1Type()),
+            ValueRange{colUnalignedLength, rowUnalignedLength});
+        auto rowColUnalignedTiledMatrix = vector::TransferReadOp::create(
+            trueRowColUnalignedBranchBuilder, loc,
+            TypeRange{VectorType::get(
+                ArrayRef<int64_t>{affineVectorSize, affineVectorSize},
+                elementType)},
+            ValueRange{A, rowUpperBound, colUpperBound, zeroElementType,
+                       rowColEndMaskLoad},
+            ArrayRef<NamedAttribute>{
+                trueRowColUnalignedBranchBuilder.getNamedAttr(
+                    "in_bounds",
+                    trueRowColUnalignedBranchBuilder.getBoolArrayAttr(
+                        ArrayRef<bool>{false, false})),
+                trueRowColUnalignedBranchBuilder.getNamedAttr(
+                    "operand_segment_sizes",
+                    trueRowColUnalignedBranchBuilder.getDenseI32ArrayAttr(
+                        ArrayRef<int>{1, 2, 1, 1})),
+                trueRowColUnalignedBranchBuilder.getNamedAttr(
+                    "permutation_map",
+                    AffineMapAttr::get(AffineMap::get(
+                        2, 0, {d0, d1},
+                        trueRowColUnalignedBranchBuilder.getContext()))),
+            });
+        vector::TransferWriteOp::create(
+            trueRowColUnalignedBranchBuilder, loc, TypeRange{},
             ValueRange{rowColUnalignedTiledMatrix, B, colUpperBound,
                        rowUpperBound, rowColEndMaskStore},
             ArrayRef<NamedAttribute>{

--- a/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
+++ b/midend/lib/Conversion/VIRToVector/VIRToVectorPass.cpp
@@ -98,19 +98,19 @@ static Value buildScalarizedI1VectorLoad(OpBuilder &builder, Location loc,
                                          VectorType vecTy, Value base,
                                          ArrayRef<Value> baseIndices) {
   assert(!baseIndices.empty() && "expected at least one memref index");
-  auto zero = builder.create<arith::ConstantOp>(
-      loc, vecTy,
+  auto zero = arith::ConstantOp::create(
+      builder, loc, vecTy,
       DenseElementsAttr::get(vecTy,
                              builder.getZeroAttr(vecTy.getElementType())));
   Value result = zero.getResult();
   for (int64_t lane = 0, e = vecTy.getNumElements(); lane < e; ++lane) {
-    auto laneIdx = builder.create<arith::ConstantIndexOp>(loc, lane);
+    auto laneIdx = arith::ConstantIndexOp::create(builder, loc, lane);
     SmallVector<Value> laneIndices(baseIndices.begin(), baseIndices.end());
     laneIndices.back() =
-        builder.create<arith::AddIOp>(loc, laneIndices.back(), laneIdx);
-    Value scalar = builder.create<memref::LoadOp>(loc, base, laneIndices);
-    result = builder.create<vector::InsertOp>(loc, scalar, result,
-                                              OpFoldResult(laneIdx));
+        arith::AddIOp::create(builder, loc, laneIndices.back(), laneIdx);
+    Value scalar = memref::LoadOp::create(builder, loc, base, laneIndices);
+    result = vector::InsertOp::create(builder, loc, scalar, result,
+                                      OpFoldResult(laneIdx));
   }
   return result;
 }
@@ -121,13 +121,13 @@ static void buildScalarizedI1VectorStore(OpBuilder &builder, Location loc,
   assert(!baseIndices.empty() && "expected at least one memref index");
   auto vecTy = cast<VectorType>(vectorValue.getType());
   for (int64_t lane = 0, e = vecTy.getNumElements(); lane < e; ++lane) {
-    auto laneIdx = builder.create<arith::ConstantIndexOp>(loc, lane);
+    auto laneIdx = arith::ConstantIndexOp::create(builder, loc, lane);
     SmallVector<Value> laneIndices(baseIndices.begin(), baseIndices.end());
     laneIndices.back() =
-        builder.create<arith::AddIOp>(loc, laneIndices.back(), laneIdx);
-    Value scalar = builder.create<vector::ExtractOp>(loc, vectorValue,
-                                                     OpFoldResult(laneIdx));
-    builder.create<memref::StoreOp>(loc, scalar, base, laneIndices);
+        arith::AddIOp::create(builder, loc, laneIndices.back(), laneIdx);
+    Value scalar = vector::ExtractOp::create(builder, loc, vectorValue,
+                                             OpFoldResult(laneIdx));
+    memref::StoreOp::create(builder, loc, scalar, base, laneIndices);
   }
 }
 
@@ -463,7 +463,7 @@ private:
                   destIndices.push_back(leadingIVs[i]);
                 } else {
                   destIndices.push_back(
-                      builder.create<arith::ConstantIndexOp>(loc, 0));
+                      arith::ConstantIndexOp::create(builder, loc, 0));
                 }
               }
               destIndices.push_back(mainLoopIV);
@@ -471,7 +471,7 @@ private:
               // the last index is dynamic and global
               Value lastIndex = sourceIndices.back();
               Value baseOffset =
-                  builder.create<arith::AddIOp>(loc, mainLoopIV, lastIndex);
+                  arith::AddIOp::create(builder, loc, mainLoopIV, lastIndex);
               // collect indices for load op
               for (size_t i = 0, e = sourceIndices.size() - 1; i < e; ++i) {
                 Value destOp = findValue(sourceIndices[i]);
@@ -482,7 +482,7 @@ private:
 
             if (isTailLoop) {
               auto memrefLoadOp =
-                  builder.create<memref::LoadOp>(loc, base, destIndices);
+                  memref::LoadOp::create(builder, loc, base, destIndices);
               virSymbolTable[op.getResult()] = memrefLoadOp.getResult();
             } else {
               auto vecTyOr = deriveVectorTypeFor(op.getResult().getType());
@@ -496,14 +496,15 @@ private:
                 return;
               }
               if (hasStaticallyUnitStrideInVectorizedDim(base)) {
-                auto vectorLoadOp = builder.create<vector::LoadOp>(
-                    loc, *vecTyOr, base, destIndices);
+                auto vectorLoadOp = vector::LoadOp::create(
+                    builder, loc, *vecTyOr, base, destIndices);
                 virSymbolTable[op.getResult()] = vectorLoadOp.getResult();
               } else {
-                auto padding = builder.create<arith::ConstantOp>(
-                    loc, builder.getZeroAttr((*vecTyOr).getElementType()));
-                auto transferReadOp = builder.create<vector::TransferReadOp>(
-                    loc, *vecTyOr, base, destIndices, padding);
+                auto padding = arith::ConstantOp::create(
+                    builder, loc,
+                    builder.getZeroAttr((*vecTyOr).getElementType()));
+                auto transferReadOp = vector::TransferReadOp::create(
+                    builder, loc, *vecTyOr, base, destIndices, padding);
                 virSymbolTable[op.getResult()] = transferReadOp.getResult();
               }
             }
@@ -530,14 +531,14 @@ private:
                   destIndices.push_back(leadingIVs[i]);
                 } else {
                   destIndices.push_back(
-                      builder.create<arith::ConstantIndexOp>(loc, 0));
+                      arith::ConstantIndexOp::create(builder, loc, 0));
                 }
               }
               destIndices.push_back(mainLoopIV);
             } else {
               Value lastIndex = sourceIndices.back();
               Value baseOffset =
-                  builder.create<arith::AddIOp>(loc, mainLoopIV, lastIndex);
+                  arith::AddIOp::create(builder, loc, mainLoopIV, lastIndex);
               // collect indices for store op
               for (size_t i = 0, e = sourceIndices.size() - 1; i < e; ++i) {
                 Value destOp = findValue(sourceIndices[i]);
@@ -547,8 +548,8 @@ private:
             }
 
             if (isTailLoop) {
-              builder.create<memref::StoreOp>(loc, valueToStore, base,
-                                              destIndices);
+              memref::StoreOp::create(builder, loc, valueToStore, base,
+                                      destIndices);
             } else {
               if (auto vecTy = dyn_cast<VectorType>(valueToStore.getType());
                   shouldScalarizeI1VectorMemoryOp(vecTy)) {
@@ -557,11 +558,11 @@ private:
                 return;
               }
               if (hasStaticallyUnitStrideInVectorizedDim(base)) {
-                builder.create<vector::StoreOp>(loc, valueToStore, base,
-                                                destIndices);
+                vector::StoreOp::create(builder, loc, valueToStore, base,
+                                        destIndices);
               } else {
-                builder.create<vector::TransferWriteOp>(loc, valueToStore, base,
-                                                        destIndices);
+                vector::TransferWriteOp::create(builder, loc, valueToStore,
+                                                base, destIndices);
               }
             }
           })
@@ -569,7 +570,7 @@ private:
             auto constValue = op.getValue();
             if (isTailLoop) {
               auto arithConstOp =
-                  builder.create<arith::ConstantOp>(loc, constValue);
+                  arith::ConstantOp::create(builder, loc, constValue);
               virSymbolTable[op.getResult()] = arithConstOp.getResult();
             } else {
               auto vecTyOr = deriveVectorTypeFor(op.getResult().getType());
@@ -579,8 +580,8 @@ private:
               }
               auto vectorConstAttr = DenseElementsAttr::get(
                   cast<ShapedType>(*vecTyOr), constValue);
-              auto vectorConstOp = builder.create<arith::ConstantOp>(
-                  loc, *vecTyOr, vectorConstAttr);
+              auto vectorConstOp = arith::ConstantOp::create(
+                  builder, loc, *vecTyOr, vectorConstAttr);
               virSymbolTable[op.getResult()] = vectorConstOp.getResult();
             }
           })
@@ -594,8 +595,8 @@ private:
                 op.emitError("failed to derive vector type for vir.broadcast");
                 return;
               }
-              auto vectorBroadcastOp = builder.create<vector::BroadcastOp>(
-                  loc, *vecTyOr, scalarValue);
+              auto vectorBroadcastOp = vector::BroadcastOp::create(
+                  builder, loc, *vecTyOr, scalarValue);
               virSymbolTable[op.getResult()] = vectorBroadcastOp.getResult();
             }
           })
@@ -608,13 +609,13 @@ private:
               return;
             }
             if (isTailLoop) {
-              auto mulResult = builder.create<arith::MulFOp>(loc, lhs, rhs);
+              auto mulResult = arith::MulFOp::create(builder, loc, lhs, rhs);
               auto addResult =
-                  builder.create<arith::AddFOp>(loc, mulResult, acc);
+                  arith::AddFOp::create(builder, loc, mulResult, acc);
               virSymbolTable[op.getResult()] = addResult;
             } else {
               auto vectorFMAOp =
-                  builder.create<vector::FMAOp>(loc, lhs, rhs, acc);
+                  vector::FMAOp::create(builder, loc, lhs, rhs, acc);
               virSymbolTable[op.getResult()] = vectorFMAOp.getResult();
             }
           })
@@ -636,9 +637,9 @@ private:
             if (isTailLoop) {
               Value out;
               if (kind == "add") {
-                out = builder.create<arith::AddFOp>(loc, input, acc);
+                out = arith::AddFOp::create(builder, loc, input, acc);
               } else if (kind == "maxnum") {
-                out = builder.create<arith::MaxNumFOp>(loc, input, acc);
+                out = arith::MaxNumFOp::create(builder, loc, input, acc);
               } else {
                 op.emitError(
                     "unsupported vir.reduce kind (expected add/maxnum)");
@@ -664,8 +665,8 @@ private:
               return;
             }
 
-            auto reduced = builder.create<vector::ReductionOp>(loc, combineKind,
-                                                               input, acc);
+            auto reduced = vector::ReductionOp::create(builder, loc,
+                                                       combineKind, input, acc);
             virSymbolTable[op.getResult()] = reduced.getResult();
           })
           .Case<vir::SelectOp>([&](vir::SelectOp op) {
@@ -678,11 +679,11 @@ private:
             }
             if (isTailLoop) {
               auto newOp =
-                  builder.create<arith::SelectOp>(loc, cond, tVal, fVal);
+                  arith::SelectOp::create(builder, loc, cond, tVal, fVal);
               virSymbolTable[op.getResult()] = newOp.getResult();
             } else {
-              auto newOp = builder.create<LLVM::SelectOp>(loc, tVal.getType(),
-                                                          cond, tVal, fVal);
+              auto newOp = LLVM::SelectOp::create(builder, loc, tVal.getType(),
+                                                  cond, tVal, fVal);
               virSymbolTable[op.getResult()] = newOp.getResult();
             }
           })
@@ -698,7 +699,7 @@ private:
                 outTy = elem;
               }
             }
-            auto newOp = builder.create<arith::ExtFOp>(loc, outTy, in);
+            auto newOp = arith::ExtFOp::create(builder, loc, outTy, in);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<vir::TruncFOp>([&](vir::TruncFOp op) {
@@ -713,7 +714,7 @@ private:
                 outTy = elem;
               }
             }
-            auto newOp = builder.create<arith::TruncFOp>(loc, outTy, in);
+            auto newOp = arith::TruncFOp::create(builder, loc, outTy, in);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<affine::AffineForOp>([&](affine::AffineForOp op) {
@@ -730,8 +731,8 @@ private:
             }
 
             // create a new affine.for
-            auto newForOp = builder.create<affine::AffineForOp>(
-                loc, ValueRange(op.getLowerBoundOperands()),
+            auto newForOp = affine::AffineForOp::create(
+                builder, loc, ValueRange(op.getLowerBoundOperands()),
                 op.getLowerBoundMap(), ValueRange(op.getUpperBoundOperands()),
                 op.getUpperBoundMap(), op.getStep().getLimitedValue(),
                 ValueRange(initialIterArgs),
@@ -768,7 +769,7 @@ private:
                       }
                       yieldOperands.push_back(mappedOperand);
                     }
-                    b.create<affine::AffineYieldOp>(bodyLoc, yieldOperands);
+                    affine::AffineYieldOp::create(b, bodyLoc, yieldOperands);
                   }
                 });
 
@@ -785,19 +786,19 @@ private:
           })
           .Case<arith::ConstantOp>([&](arith::ConstantOp op) {
             auto newConst =
-                builder.create<arith::ConstantOp>(loc, op.getValue());
+                arith::ConstantOp::create(builder, loc, op.getValue());
             virSymbolTable[op.getResult()] = newConst.getResult();
           })
           .Case<memref::DimOp>([&](memref::DimOp op) {
             Value src = findValue(op.getSource());
             Value idx = findValue(op.getIndex());
-            auto newDim = builder.create<memref::DimOp>(loc, src, idx);
+            auto newDim = memref::DimOp::create(builder, loc, src, idx);
             virSymbolTable[op.getResult()] = newDim.getResult();
           })
           .Case<memref::TransposeOp>([&](memref::TransposeOp op) {
             Value src = findValue(op.getIn());
-            auto newOp = builder.create<memref::TransposeOp>(
-                loc, op.getResult().getType(), src,
+            auto newOp = memref::TransposeOp::create(
+                builder, loc, op.getResult().getType(), src,
                 AffineMapAttr::get(op.getPermutation()));
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
@@ -812,9 +813,9 @@ private:
                 remappedOutputShape.push_back(cast<Attribute>(ofr));
               }
             }
-            auto newOp = builder.create<memref::ExpandShapeOp>(
-                loc, op.getResultType(), src, op.getReassociationIndices(),
-                remappedOutputShape);
+            auto newOp = memref::ExpandShapeOp::create(
+                builder, loc, op.getResultType(), src,
+                op.getReassociationIndices(), remappedOutputShape);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<memref::SubViewOp>([&](memref::SubViewOp op) {
@@ -839,9 +840,9 @@ private:
             SmallVector<OpFoldResult> strides =
                 remapMixed(op.getMixedStrides());
 
-            auto newOp = builder.create<memref::SubViewOp>(
-                loc, cast<MemRefType>(op.getResult().getType()), src, offsets,
-                sizes, strides);
+            auto newOp = memref::SubViewOp::create(
+                builder, loc, cast<MemRefType>(op.getResult().getType()), src,
+                offsets, sizes, strides);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<memref::LoadOp>([&](memref::LoadOp op) {
@@ -857,7 +858,8 @@ private:
               indices.push_back(mappedIndex);
             }
 
-            auto newLoadOp = builder.create<memref::LoadOp>(loc, base, indices);
+            auto newLoadOp =
+                memref::LoadOp::create(builder, loc, base, indices);
             virSymbolTable[op.getResult()] = newLoadOp.getResult();
           })
           .Case<memref::StoreOp>([&](memref::StoreOp op) {
@@ -873,183 +875,184 @@ private:
               Value mappedIndex = findValue(index);
               indices.push_back(mappedIndex);
             }
-            builder.create<memref::StoreOp>(loc, value, base, indices);
+            memref::StoreOp::create(builder, loc, value, base, indices);
           })
           .Case<arith::AddFOp>([&](arith::AddFOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::AddFOp>(loc, lhs, rhs);
+            auto newOp = arith::AddFOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::CmpFOp>([&](arith::CmpFOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp =
-                builder.create<arith::CmpFOp>(loc, op.getPredicate(), lhs, rhs);
+            auto newOp = arith::CmpFOp::create(builder, loc, op.getPredicate(),
+                                               lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::CmpIOp>([&](arith::CmpIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp =
-                builder.create<arith::CmpIOp>(loc, op.getPredicate(), lhs, rhs);
+            auto newOp = arith::CmpIOp::create(builder, loc, op.getPredicate(),
+                                               lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::SelectOp>([&](arith::SelectOp op) {
             Value cond = findValue(op.getCondition());
             Value tVal = findValue(op.getTrueValue());
             Value fVal = findValue(op.getFalseValue());
-            auto newOp = builder.create<arith::SelectOp>(loc, cond, tVal, fVal);
+            auto newOp =
+                arith::SelectOp::create(builder, loc, cond, tVal, fVal);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::AddIOp>([&](arith::AddIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::AddIOp>(loc, lhs, rhs);
+            auto newOp = arith::AddIOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::SubFOp>([&](arith::SubFOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::SubFOp>(loc, lhs, rhs);
+            auto newOp = arith::SubFOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::SubIOp>([&](arith::SubIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::SubIOp>(loc, lhs, rhs);
+            auto newOp = arith::SubIOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::MulFOp>([&](arith::MulFOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::MulFOp>(loc, lhs, rhs);
+            auto newOp = arith::MulFOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::MulIOp>([&](arith::MulIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::MulIOp>(loc, lhs, rhs);
+            auto newOp = arith::MulIOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::AndIOp>([&](arith::AndIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::AndIOp>(loc, lhs, rhs);
+            auto newOp = arith::AndIOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::OrIOp>([&](arith::OrIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::OrIOp>(loc, lhs, rhs);
+            auto newOp = arith::OrIOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::XOrIOp>([&](arith::XOrIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::XOrIOp>(loc, lhs, rhs);
+            auto newOp = arith::XOrIOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::ShLIOp>([&](arith::ShLIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::ShLIOp>(loc, lhs, rhs,
-                                                       op.getOverflowFlags());
+            auto newOp = arith::ShLIOp::create(builder, loc, lhs, rhs,
+                                               op.getOverflowFlags());
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::ShRUIOp>([&](arith::ShRUIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::ShRUIOp>(loc, lhs, rhs);
+            auto newOp = arith::ShRUIOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::ShRSIOp>([&](arith::ShRSIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::ShRSIOp>(loc, lhs, rhs);
+            auto newOp = arith::ShRSIOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::DivFOp>([&](arith::DivFOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::DivFOp>(loc, lhs, rhs);
+            auto newOp = arith::DivFOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::DivSIOp>([&](arith::DivSIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::DivSIOp>(loc, lhs, rhs);
+            auto newOp = arith::DivSIOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::DivUIOp>([&](arith::DivUIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::DivUIOp>(loc, lhs, rhs);
+            auto newOp = arith::DivUIOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::RemSIOp>([&](arith::RemSIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::RemSIOp>(loc, lhs, rhs);
+            auto newOp = arith::RemSIOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::RemUIOp>([&](arith::RemUIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::RemUIOp>(loc, lhs, rhs);
+            auto newOp = arith::RemUIOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::MaximumFOp>([&](arith::MaximumFOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::MaximumFOp>(loc, lhs, rhs);
+            auto newOp = arith::MaximumFOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::MinimumFOp>([&](arith::MinimumFOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::MinimumFOp>(loc, lhs, rhs);
+            auto newOp = arith::MinimumFOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::MaxNumFOp>([&](arith::MaxNumFOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::MaxNumFOp>(loc, lhs, rhs);
+            auto newOp = arith::MaxNumFOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::MinNumFOp>([&](arith::MinNumFOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::MinNumFOp>(loc, lhs, rhs);
+            auto newOp = arith::MinNumFOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::MaxSIOp>([&](arith::MaxSIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::MaxSIOp>(loc, lhs, rhs);
+            auto newOp = arith::MaxSIOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::MinSIOp>([&](arith::MinSIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::MinSIOp>(loc, lhs, rhs);
+            auto newOp = arith::MinSIOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::MaxUIOp>([&](arith::MaxUIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::MaxUIOp>(loc, lhs, rhs);
+            auto newOp = arith::MaxUIOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::MinUIOp>([&](arith::MinUIOp op) {
             Value lhs = findValue(op.getLhs());
             Value rhs = findValue(op.getRhs());
-            auto newOp = builder.create<arith::MinUIOp>(loc, lhs, rhs);
+            auto newOp = arith::MinUIOp::create(builder, loc, lhs, rhs);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::NegFOp>([&](arith::NegFOp op) {
             Value operand = findValue(op.getOperand());
-            auto newOp = builder.create<arith::NegFOp>(loc, operand);
+            auto newOp = arith::NegFOp::create(builder, loc, operand);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::ExtSIOp>([&](arith::ExtSIOp op) {
@@ -1064,7 +1067,7 @@ private:
                 outTy = elem;
               }
             }
-            auto newOp = builder.create<arith::ExtSIOp>(loc, outTy, in);
+            auto newOp = arith::ExtSIOp::create(builder, loc, outTy, in);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::ExtUIOp>([&](arith::ExtUIOp op) {
@@ -1079,7 +1082,7 @@ private:
                 outTy = elem;
               }
             }
-            auto newOp = builder.create<arith::ExtUIOp>(loc, outTy, in);
+            auto newOp = arith::ExtUIOp::create(builder, loc, outTy, in);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::TruncIOp>([&](arith::TruncIOp op) {
@@ -1094,7 +1097,7 @@ private:
                 outTy = elem;
               }
             }
-            auto newOp = builder.create<arith::TruncIOp>(loc, outTy, in);
+            auto newOp = arith::TruncIOp::create(builder, loc, outTy, in);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::ExtFOp>([&](arith::ExtFOp op) {
@@ -1109,7 +1112,7 @@ private:
                 outTy = elem;
               }
             }
-            auto newOp = builder.create<arith::ExtFOp>(loc, outTy, in);
+            auto newOp = arith::ExtFOp::create(builder, loc, outTy, in);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::TruncFOp>([&](arith::TruncFOp op) {
@@ -1124,7 +1127,7 @@ private:
                 outTy = elem;
               }
             }
-            auto newOp = builder.create<arith::TruncFOp>(loc, outTy, in);
+            auto newOp = arith::TruncFOp::create(builder, loc, outTy, in);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::SIToFPOp>([&](arith::SIToFPOp op) {
@@ -1139,7 +1142,7 @@ private:
                 outTy = elem;
               }
             }
-            auto newOp = builder.create<arith::SIToFPOp>(loc, outTy, in);
+            auto newOp = arith::SIToFPOp::create(builder, loc, outTy, in);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::UIToFPOp>([&](arith::UIToFPOp op) {
@@ -1154,7 +1157,7 @@ private:
                 outTy = elem;
               }
             }
-            auto newOp = builder.create<arith::UIToFPOp>(loc, outTy, in);
+            auto newOp = arith::UIToFPOp::create(builder, loc, outTy, in);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::FPToSIOp>([&](arith::FPToSIOp op) {
@@ -1169,7 +1172,7 @@ private:
                 outTy = elem;
               }
             }
-            auto newOp = builder.create<arith::FPToSIOp>(loc, outTy, in);
+            auto newOp = arith::FPToSIOp::create(builder, loc, outTy, in);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::FPToUIOp>([&](arith::FPToUIOp op) {
@@ -1184,7 +1187,7 @@ private:
                 outTy = elem;
               }
             }
-            auto newOp = builder.create<arith::FPToUIOp>(loc, outTy, in);
+            auto newOp = arith::FPToUIOp::create(builder, loc, outTy, in);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<arith::BitcastOp>([&](arith::BitcastOp op) {
@@ -1199,7 +1202,7 @@ private:
                 outTy = elem;
               }
             }
-            auto newOp = builder.create<arith::BitcastOp>(loc, outTy, in);
+            auto newOp = arith::BitcastOp::create(builder, loc, outTy, in);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<math::ExpOp>([&](math::ExpOp op) {
@@ -1214,7 +1217,7 @@ private:
                 outTy = elem;
               }
             }
-            auto newOp = builder.create<math::ExpOp>(loc, outTy, in);
+            auto newOp = math::ExpOp::create(builder, loc, outTy, in);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<math::SqrtOp>([&](math::SqrtOp op) {
@@ -1229,7 +1232,7 @@ private:
                 outTy = elem;
               }
             }
-            auto newOp = builder.create<math::SqrtOp>(loc, outTy, in);
+            auto newOp = math::SqrtOp::create(builder, loc, outTy, in);
             virSymbolTable[op.getResult()] = newOp.getResult();
           })
           .Case<math::RsqrtOp>([&](math::RsqrtOp op) {
@@ -1244,15 +1247,15 @@ private:
                 outTy = elem;
               }
             }
-            auto sqrt = builder.create<math::SqrtOp>(loc, outTy, in);
+            auto sqrt = math::SqrtOp::create(builder, loc, outTy, in);
             Type elemTy = outTy;
             if (auto vecTy = dyn_cast<VectorType>(outTy))
               elemTy = vecTy.getElementType();
             auto oneAttr = builder.getFloatAttr(elemTy, 1.0);
-            Value one = builder.create<arith::ConstantOp>(loc, oneAttr);
+            Value one = arith::ConstantOp::create(builder, loc, oneAttr);
             if (isa<VectorType>(outTy))
-              one = builder.create<vector::BroadcastOp>(loc, outTy, one);
-            auto div = builder.create<arith::DivFOp>(loc, one, sqrt);
+              one = vector::BroadcastOp::create(builder, loc, outTy, one);
+            auto div = arith::DivFOp::create(builder, loc, one, sqrt);
             virSymbolTable[op.getResult()] = div.getResult();
           })
           .Case<math::LogOp, math::AbsFOp, math::CeilOp, math::FloorOp,
@@ -1351,14 +1354,14 @@ private:
     // vectorizes along the last (dynamic) dimension.
     auto emitVectorAndTail = [&](OpBuilder &b, ArrayRef<Value> leadingIVs) {
       Value vlValue = op.getVl();
-      Value vlStep = b.create<arith::ConstantIndexOp>(loc, vectorWid);
-      Value vlUpboundPat = b.create<arith::SubIOp>(loc, vlValue, vlStep);
-      Value vlUpbound = b.create<arith::AddIOp>(
-          loc, vlUpboundPat, b.create<arith::ConstantIndexOp>(loc, 1));
-      Value zero = b.create<arith::ConstantIndexOp>(loc, 0);
+      Value vlStep = arith::ConstantIndexOp::create(b, loc, vectorWid);
+      Value vlUpboundPat = arith::SubIOp::create(b, loc, vlValue, vlStep);
+      Value vlUpbound = arith::AddIOp::create(
+          b, loc, vlUpboundPat, arith::ConstantIndexOp::create(b, loc, 1));
+      Value zero = arith::ConstantIndexOp::create(b, loc, 0);
 
-      b.create<affine::AffineForOp>(
-          loc, /*lowerBound=*/ValueRange{zero}, rewriter.getDimIdentityMap(),
+      affine::AffineForOp::create(
+          b, loc, /*lowerBound=*/ValueRange{zero}, rewriter.getDimIdentityMap(),
           /*upperBound=*/ValueRange{vlUpbound}, rewriter.getDimIdentityMap(),
           vectorWid,
           /*iterArgs=*/ValueRange{},
@@ -1369,17 +1372,17 @@ private:
             DenseMap<Value, Value> virSymbolTable;
             lowerBlock(bb, bodyLoc, &region.front(), virSymbolTable, iv,
                        leadingIVs, targetVectorType, /*isTailLoop=*/false);
-            bb.create<affine::AffineYieldOp>(bodyLoc);
+            affine::AffineYieldOp::create(bb, bodyLoc);
           });
 
       //===----------------------------------------------------------------===//
       // Step 5: Create a tail loop to process the remaining elements.
       //===----------------------------------------------------------------===//
-      Value vlRem = b.create<arith::RemSIOp>(loc, vlValue, vlStep);
-      Value tailStart = b.create<arith::SubIOp>(loc, vlValue, vlRem);
+      Value vlRem = arith::RemSIOp::create(b, loc, vlValue, vlStep);
+      Value tailStart = arith::SubIOp::create(b, loc, vlValue, vlRem);
 
-      b.create<affine::AffineForOp>(
-          loc, /*lowerBound=*/ValueRange{tailStart},
+      affine::AffineForOp::create(
+          b, loc, /*lowerBound=*/ValueRange{tailStart},
           rewriter.getDimIdentityMap(),
           /*upperBound=*/ValueRange{vlValue}, rewriter.getDimIdentityMap(),
           /*step=*/1,
@@ -1389,7 +1392,7 @@ private:
             lowerBlock(bb, bodyLoc, &region.front(), virSymbolTable, iv,
                        leadingIVs, /*targetVectorType=*/Type{},
                        /*isTailLoop=*/true);
-            bb.create<affine::AffineYieldOp>(bodyLoc);
+            affine::AffineYieldOp::create(bb, bodyLoc);
           });
     };
 
@@ -1405,17 +1408,17 @@ private:
           return;
         }
         int64_t ub = leadingStaticDims[dim];
-        Value c0 = b.create<arith::ConstantIndexOp>(loc, 0);
-        Value cub = b.create<arith::ConstantIndexOp>(loc, ub);
-        b.create<affine::AffineForOp>(
-            loc, ValueRange{c0}, rewriter.getDimIdentityMap(), ValueRange{cub},
-            rewriter.getDimIdentityMap(), /*step=*/1,
+        Value c0 = arith::ConstantIndexOp::create(b, loc, 0);
+        Value cub = arith::ConstantIndexOp::create(b, loc, ub);
+        affine::AffineForOp::create(
+            b, loc, ValueRange{c0}, rewriter.getDimIdentityMap(),
+            ValueRange{cub}, rewriter.getDimIdentityMap(), /*step=*/1,
             /*iterArgs=*/ValueRange{},
             [&](OpBuilder &bb, Location bodyLoc, Value iv, ValueRange) {
               ivs.push_back(iv);
               emitOuter(dim + 1, bb);
               ivs.pop_back();
-              bb.create<affine::AffineYieldOp>(bodyLoc);
+              affine::AffineYieldOp::create(bb, bodyLoc);
             });
       };
       emitOuter(/*dim=*/0, rewriter);

--- a/midend/lib/Dialect/AME/Transforms/LegalizeForLLVMExport.cpp
+++ b/midend/lib/Dialect/AME/Transforms/LegalizeForLLVMExport.cpp
@@ -44,9 +44,8 @@ getOrInsertIntrinsic(ConversionPatternRewriter &rewriter, ModuleOp module,
 
   auto savedInsertionPoint = rewriter.saveInsertionPoint();
   rewriter.setInsertionPointToEnd(module.getBody());
-  rewriter.create<LLVM::LLVMFuncOp>(module.getLoc(), intrinsicName, funcType,
-                                    LLVM::Linkage::External, false,
-                                    LLVM::CConv::C);
+  LLVM::LLVMFuncOp::create(rewriter, module.getLoc(), intrinsicName, funcType,
+                           LLVM::Linkage::External, false, LLVM::CConv::C);
   rewriter.restoreInsertionPoint(savedInsertionPoint);
   return FlatSymbolRefAttr::get(ctx, intrinsicName);
 }
@@ -57,9 +56,9 @@ static Value extractPointerFromMemref(ConversionPatternRewriter &rewriter,
   auto ptrType = LLVM::LLVMPointerType::get(ctx);
   auto i64Type = IntegerType::get(ctx, 64);
   Value idx =
-      rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, memref);
-  Value i64Val = rewriter.create<arith::IndexCastOp>(loc, i64Type, idx);
-  Value ptr = rewriter.create<LLVM::IntToPtrOp>(loc, ptrType, i64Val);
+      memref::ExtractAlignedPointerAsIndexOp::create(rewriter, loc, memref);
+  Value i64Val = arith::IndexCastOp::create(rewriter, loc, i64Type, idx);
+  Value ptr = LLVM::IntToPtrOp::create(rewriter, loc, ptrType, i64Val);
   return ptr;
 }
 
@@ -81,20 +80,21 @@ struct AMEMSettilemiLowering : public ConvertOpToLLVMPattern<MSettilemiOp> {
     auto loc = op.getLoc();
     auto *ctx = rewriter.getContext();
     auto module = op->getParentOfType<ModuleOp>();
-    if (!module) return failure();
+    if (!module)
+      return failure();
 
     auto i64Type = IntegerType::get(ctx, 64);
-    auto funcType = LLVM::LLVMFunctionType::get(
-        LLVM::LLVMVoidType::get(ctx), {i64Type});
+    auto funcType =
+        LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(ctx), {i64Type});
 
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.msettilemi", funcType);
 
-    Value tilemVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getTilem()));
+    Value tilemVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getTilem()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{tilemVal});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{tilemVal});
     rewriter.eraseOp(op);
     return success();
   }
@@ -110,20 +110,21 @@ struct AMEMSettileniLowering : public ConvertOpToLLVMPattern<MSettileniOp> {
     auto loc = op.getLoc();
     auto *ctx = rewriter.getContext();
     auto module = op->getParentOfType<ModuleOp>();
-    if (!module) return failure();
+    if (!module)
+      return failure();
 
     auto i64Type = IntegerType::get(ctx, 64);
-    auto funcType = LLVM::LLVMFunctionType::get(
-        LLVM::LLVMVoidType::get(ctx), {i64Type});
+    auto funcType =
+        LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(ctx), {i64Type});
 
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.msettileni", funcType);
 
-    Value tilenVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getTilen()));
+    Value tilenVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getTilen()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{tilenVal});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{tilenVal});
     rewriter.eraseOp(op);
     return success();
   }
@@ -139,20 +140,21 @@ struct AMEMSettilekiLowering : public ConvertOpToLLVMPattern<MSettilekiOp> {
     auto loc = op.getLoc();
     auto *ctx = rewriter.getContext();
     auto module = op->getParentOfType<ModuleOp>();
-    if (!module) return failure();
+    if (!module)
+      return failure();
 
     auto i64Type = IntegerType::get(ctx, 64);
-    auto funcType = LLVM::LLVMFunctionType::get(
-        LLVM::LLVMVoidType::get(ctx), {i64Type});
+    auto funcType =
+        LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(ctx), {i64Type});
 
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.msettileki", funcType);
 
-    Value tilekVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getTilek()));
+    Value tilekVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getTilek()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{tilekVal});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{tilekVal});
     rewriter.eraseOp(op);
     return success();
   }
@@ -168,20 +170,21 @@ struct AMEMzeroLowering : public ConvertOpToLLVMPattern<MzeroOp> {
     auto loc = op.getLoc();
     auto *ctx = rewriter.getContext();
     auto module = op->getParentOfType<ModuleOp>();
-    if (!module) return failure();
+    if (!module)
+      return failure();
 
     auto i64Type = IntegerType::get(ctx, 64);
-    auto funcType = LLVM::LLVMFunctionType::get(
-        LLVM::LLVMVoidType::get(ctx), {i64Type});
+    auto funcType =
+        LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(ctx), {i64Type});
 
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.mzero", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal});
     rewriter.eraseOp(op);
     return success();
   }
@@ -201,23 +204,24 @@ struct AMEMlae32mLowering : public ConvertOpToLLVMPattern<Mlae32mOp> {
     auto loc = op.getLoc();
     auto *ctx = rewriter.getContext();
     auto module = op->getParentOfType<ModuleOp>();
-    if (!module) return failure();
+    if (!module)
+      return failure();
 
     auto i64Type = IntegerType::get(ctx, 64);
     auto ptrType = LLVM::LLVMPointerType::get(ctx);
 
-    auto funcType = LLVM::LLVMFunctionType::get(
-        LLVM::LLVMVoidType::get(ctx), {i64Type, ptrType, i64Type});
+    auto funcType = LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(ctx),
+                                                {i64Type, ptrType, i64Type});
 
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.mlae32.m", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, basePtr, adaptor.getStride()});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, basePtr, adaptor.getStride()});
     rewriter.eraseOp(op);
     return success();
   }
@@ -233,23 +237,24 @@ struct AMEMlbe32mLowering : public ConvertOpToLLVMPattern<Mlbe32mOp> {
     auto loc = op.getLoc();
     auto *ctx = rewriter.getContext();
     auto module = op->getParentOfType<ModuleOp>();
-    if (!module) return failure();
+    if (!module)
+      return failure();
 
     auto i64Type = IntegerType::get(ctx, 64);
     auto ptrType = LLVM::LLVMPointerType::get(ctx);
 
-    auto funcType = LLVM::LLVMFunctionType::get(
-        LLVM::LLVMVoidType::get(ctx), {i64Type, ptrType, i64Type});
+    auto funcType = LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(ctx),
+                                                {i64Type, ptrType, i64Type});
 
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.mlbe32.m", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, basePtr, adaptor.getStride()});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, basePtr, adaptor.getStride()});
     rewriter.eraseOp(op);
     return success();
   }
@@ -269,23 +274,24 @@ struct AMEMsce32mLowering : public ConvertOpToLLVMPattern<Msce32mOp> {
     auto loc = op.getLoc();
     auto *ctx = rewriter.getContext();
     auto module = op->getParentOfType<ModuleOp>();
-    if (!module) return failure();
+    if (!module)
+      return failure();
 
     auto i64Type = IntegerType::get(ctx, 64);
     auto ptrType = LLVM::LLVMPointerType::get(ctx);
 
-    auto funcType = LLVM::LLVMFunctionType::get(
-        LLVM::LLVMVoidType::get(ctx), {i64Type, ptrType, i64Type});
+    auto funcType = LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(ctx),
+                                                {i64Type, ptrType, i64Type});
 
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.msce32.m", funcType);
 
-    Value ms3Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs3()));
+    Value ms3Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs3()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{ms3Val, basePtr, adaptor.getStride()});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{ms3Val, basePtr, adaptor.getStride()});
     rewriter.eraseOp(op);
     return success();
   }
@@ -305,24 +311,25 @@ struct AMEMmaWmmTileLowering : public ConvertOpToLLVMPattern<MmaWmmTileOp> {
     auto loc = op.getLoc();
     auto *ctx = rewriter.getContext();
     auto module = op->getParentOfType<ModuleOp>();
-    if (!module) return failure();
+    if (!module)
+      return failure();
 
     auto i64Type = IntegerType::get(ctx, 64);
-    auto funcType = LLVM::LLVMFunctionType::get(
-        LLVM::LLVMVoidType::get(ctx), {i64Type, i64Type, i64Type});
+    auto funcType = LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(ctx),
+                                                {i64Type, i64Type, i64Type});
 
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.mma.w.mm.tile", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms1Val, ms2Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms1Val, ms2Val});
     rewriter.eraseOp(op);
     return success();
   }
@@ -366,15 +373,16 @@ struct AMEMqmaBmmLowering : public ConvertOpToLLVMPattern<MqmaBmmOp> {
     Value ms2Base = extractPointerFromMemref(rewriter, loc, op.getMs2());
 
     // Create constants for dimensions
-    Value mVal = rewriter.create<LLVM::ConstantOp>(loc, i64Type,
-                                                    rewriter.getI64IntegerAttr(M));
-    Value nVal = rewriter.create<LLVM::ConstantOp>(loc, i64Type,
-                                                    rewriter.getI64IntegerAttr(N));
-    Value kVal = rewriter.create<LLVM::ConstantOp>(loc, i64Type,
-                                                    rewriter.getI64IntegerAttr(K));
+    Value mVal = LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                          rewriter.getI64IntegerAttr(M));
+    Value nVal = LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                          rewriter.getI64IntegerAttr(N));
+    Value kVal = LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                          rewriter.getI64IntegerAttr(K));
 
     // Create intrinsic function type for mqma.b.mm
-    // void @llvm.riscv.buddy.mqma.b.mm(ptr md, ptr ms1, ptr ms2, i64 M, i64 N, i64 K)
+    // void @llvm.riscv.buddy.mqma.b.mm(ptr md, ptr ms1, ptr ms2, i64 M, i64 N,
+    // i64 K)
     auto funcType = LLVM::LLVMFunctionType::get(
         LLVM::LLVMVoidType::get(ctx),
         {ptrType, ptrType, ptrType, i64Type, i64Type, i64Type});
@@ -383,9 +391,9 @@ struct AMEMqmaBmmLowering : public ConvertOpToLLVMPattern<MqmaBmmOp> {
         rewriter, module, "llvm.riscv.buddy.mqma.b.mm", funcType);
 
     // Call the intrinsic
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdBase, ms1Base, ms2Base,
-                                            mVal, nVal, kVal});
+    LLVM::CallOp::create(
+        rewriter, loc, TypeRange{}, intrinsicName,
+        ValueRange{mdBase, ms1Base, ms2Base, mVal, nVal, kVal});
 
     rewriter.eraseOp(op);
     return success();
@@ -426,12 +434,12 @@ struct AMEMmaWmmLowering : public ConvertOpToLLVMPattern<MmaWmmOp> {
     Value ms2Base = extractPointerFromMemref(rewriter, loc, op.getMs2());
 
     // Create constants for dimensions
-    Value mVal = rewriter.create<LLVM::ConstantOp>(loc, i64Type,
-                                                    rewriter.getI64IntegerAttr(M));
-    Value nVal = rewriter.create<LLVM::ConstantOp>(loc, i64Type,
-                                                    rewriter.getI64IntegerAttr(N));
-    Value kVal = rewriter.create<LLVM::ConstantOp>(loc, i64Type,
-                                                    rewriter.getI64IntegerAttr(K));
+    Value mVal = LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                          rewriter.getI64IntegerAttr(M));
+    Value nVal = LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                          rewriter.getI64IntegerAttr(N));
+    Value kVal = LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                          rewriter.getI64IntegerAttr(K));
 
     // Create intrinsic function type for mma.w.mm
     auto funcType = LLVM::LLVMFunctionType::get(
@@ -441,9 +449,9 @@ struct AMEMmaWmmLowering : public ConvertOpToLLVMPattern<MmaWmmOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.mma.w.mm", funcType);
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdBase, ms1Base, ms2Base,
-                                            mVal, nVal, kVal});
+    LLVM::CallOp::create(
+        rewriter, loc, TypeRange{}, intrinsicName,
+        ValueRange{mdBase, ms1Base, ms2Base, mVal, nVal, kVal});
 
     rewriter.eraseOp(op);
     return success();
@@ -484,12 +492,12 @@ struct AMEMmaDwmmLowering : public ConvertOpToLLVMPattern<MmaDwmmOp> {
     Value ms2Base = extractPointerFromMemref(rewriter, loc, op.getMs2());
 
     // Create constants for dimensions
-    Value mVal = rewriter.create<LLVM::ConstantOp>(loc, i64Type,
-                                                    rewriter.getI64IntegerAttr(M));
-    Value nVal = rewriter.create<LLVM::ConstantOp>(loc, i64Type,
-                                                    rewriter.getI64IntegerAttr(N));
-    Value kVal = rewriter.create<LLVM::ConstantOp>(loc, i64Type,
-                                                    rewriter.getI64IntegerAttr(K));
+    Value mVal = LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                          rewriter.getI64IntegerAttr(M));
+    Value nVal = LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                          rewriter.getI64IntegerAttr(N));
+    Value kVal = LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                          rewriter.getI64IntegerAttr(K));
 
     // Create intrinsic function type for mma.dw.mm
     auto funcType = LLVM::LLVMFunctionType::get(
@@ -499,9 +507,9 @@ struct AMEMmaDwmmLowering : public ConvertOpToLLVMPattern<MmaDwmmOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.mma.dw.mm", funcType);
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdBase, ms1Base, ms2Base,
-                                            mVal, nVal, kVal});
+    LLVM::CallOp::create(
+        rewriter, loc, TypeRange{}, intrinsicName,
+        ValueRange{mdBase, ms1Base, ms2Base, mVal, nVal, kVal});
 
     rewriter.eraseOp(op);
     return success();

--- a/midend/lib/Dialect/BOSCAME/Transforms/LegalizeForLLVMExport.cpp
+++ b/midend/lib/Dialect/BOSCAME/Transforms/LegalizeForLLVMExport.cpp
@@ -43,9 +43,8 @@ getOrInsertIntrinsic(ConversionPatternRewriter &rewriter, ModuleOp module,
 
   auto savedInsertionPoint = rewriter.saveInsertionPoint();
   rewriter.setInsertionPointToEnd(module.getBody());
-  rewriter.create<LLVM::LLVMFuncOp>(module.getLoc(), intrinsicName, funcType,
-                                    LLVM::Linkage::External, false,
-                                    LLVM::CConv::C);
+  LLVM::LLVMFuncOp::create(rewriter, module.getLoc(), intrinsicName, funcType,
+                           LLVM::Linkage::External, false, LLVM::CConv::C);
   rewriter.restoreInsertionPoint(savedInsertionPoint);
   return FlatSymbolRefAttr::get(ctx, intrinsicName);
 }
@@ -56,9 +55,9 @@ static Value extractPointerFromMemref(ConversionPatternRewriter &rewriter,
   auto ptrType = LLVM::LLVMPointerType::get(ctx);
   auto i64Type = IntegerType::get(ctx, 64);
   Value idx =
-      rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, memref);
-  Value i64Val = rewriter.create<arith::IndexCastOp>(loc, i64Type, idx);
-  Value ptr = rewriter.create<LLVM::IntToPtrOp>(loc, ptrType, i64Val);
+      memref::ExtractAlignedPointerAsIndexOp::create(rewriter, loc, memref);
+  Value i64Val = arith::IndexCastOp::create(rewriter, loc, i64Type, idx);
+  Value ptr = LLVM::IntToPtrOp::create(rewriter, loc, ptrType, i64Val);
   return ptr;
 }
 
@@ -89,11 +88,11 @@ struct BOSCAMEMSettilemiLowering : public ConvertOpToLLVMPattern<MSettilemiOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.bosc.msettilemi", funcType);
 
-    Value tilemVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getTilem()));
+    Value tilemVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getTilem()));
 
-    auto callOp = rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{i64Type}, intrinsicName, ValueRange{tilemVal});
+    auto callOp = LLVM::CallOp::create(rewriter, loc, TypeRange{i64Type},
+                                       intrinsicName, ValueRange{tilemVal});
     rewriter.replaceOp(op, callOp.getResults());
     return success();
   }
@@ -118,11 +117,11 @@ struct BOSCAMEMSettileniLowering : public ConvertOpToLLVMPattern<MSettileniOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.bosc.msettileni", funcType);
 
-    Value tilenVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getTilen()));
+    Value tilenVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getTilen()));
 
-    auto callOp = rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{i64Type}, intrinsicName, ValueRange{tilenVal});
+    auto callOp = LLVM::CallOp::create(rewriter, loc, TypeRange{i64Type},
+                                       intrinsicName, ValueRange{tilenVal});
     rewriter.replaceOp(op, callOp.getResults());
     return success();
   }
@@ -147,11 +146,11 @@ struct BOSCAMEMSettilekiLowering : public ConvertOpToLLVMPattern<MSettilekiOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.bosc.msettileki", funcType);
 
-    Value tilekVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getTilek()));
+    Value tilekVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getTilek()));
 
-    auto callOp = rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{i64Type}, intrinsicName, ValueRange{tilekVal});
+    auto callOp = LLVM::CallOp::create(rewriter, loc, TypeRange{i64Type},
+                                       intrinsicName, ValueRange{tilekVal});
     rewriter.replaceOp(op, callOp.getResults());
     return success();
   }
@@ -177,11 +176,11 @@ struct BOSCAMEMzeroLowering : public ConvertOpToLLVMPattern<MzeroOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.bosc.mzero", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal});
     rewriter.eraseOp(op);
     return success();
   }
@@ -209,13 +208,12 @@ struct BOSCAMEMlae32mLowering : public ConvertOpToLLVMPattern<Mlae32mOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.bosc.mlae32.m", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{}, intrinsicName,
-        ValueRange{mdVal, basePtr, adaptor.getStride()});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, basePtr, adaptor.getStride()});
     rewriter.eraseOp(op);
     return success();
   }
@@ -243,13 +241,12 @@ struct BOSCAMEMlbe32mLowering : public ConvertOpToLLVMPattern<Mlbe32mOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.bosc.mlbe32.m", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{}, intrinsicName,
-        ValueRange{mdVal, basePtr, adaptor.getStride()});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, basePtr, adaptor.getStride()});
     rewriter.eraseOp(op);
     return success();
   }
@@ -281,13 +278,12 @@ struct BOSCAMEMsce32mLowering : public ConvertOpToLLVMPattern<Msce32mOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.bosc.msce32.m", funcType);
 
-    Value ms3Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs3()));
+    Value ms3Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs3()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{}, intrinsicName,
-        ValueRange{ms3Val, basePtr, adaptor.getStride()});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{ms3Val, basePtr, adaptor.getStride()});
     rewriter.eraseOp(op);
     return success();
   }
@@ -317,15 +313,15 @@ struct BOSCAMEMmaWmmLowering : public ConvertOpToLLVMPattern<MmaWmmOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.bosc.mma.w.mm", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms1Val, ms2Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms1Val, ms2Val});
     rewriter.eraseOp(op);
     return success();
   }

--- a/midend/lib/Dialect/Gemmini/Transforms/LegalizeForLLVMExport.cpp
+++ b/midend/lib/Dialect/Gemmini/Transforms/LegalizeForLLVMExport.cpp
@@ -67,7 +67,7 @@ scale_t_bits scale_t_to_scale_t_bits(scale_t x) {
 // Use sequentially consistent ordering for strongest memory guarantee.
 void insertFence(Location loc, ConversionPatternRewriter &rewriter) {
   auto ordering = LLVM::AtomicOrdering::seq_cst;
-  rewriter.create<LLVM::FenceOp>(loc, ordering);
+  LLVM::FenceOp::create(rewriter, loc, ordering);
 }
 
 template <typename IntrOp = Mvin_IntrOp>
@@ -76,15 +76,16 @@ void gemminiMvinOffset(const Value &mem, const size_t offset,
                        const size_t rows, int64_t addrLen,
                        ConversionPatternRewriter &rewriter) {
   Location loc = mem.getLoc();
-  Value offsetOp = rewriter.create<arith::ConstantOp>(
-      loc, rewriter.getI64IntegerAttr(offset));
+  Value offsetOp = arith::ConstantOp::create(
+      rewriter, loc, rewriter.getI64IntegerAttr(offset));
   IntegerType i64Type = rewriter.getI64Type();
-  Value configPtr = rewriter.create<arith::AddIOp>(loc, i64Type, mem, offsetOp);
+  Value configPtr =
+      arith::AddIOp::create(rewriter, loc, i64Type, mem, offsetOp);
   uint64_t spadAddrInt = (uint64_t)rows << (addrLen + 16) |
                          (uint64_t)cols << addrLen | (uint64_t)SpAddr;
-  Value spad = rewriter.create<arith::ConstantOp>(
-      loc, rewriter.getI64IntegerAttr(spadAddrInt));
-  rewriter.create<IntrOp>(loc, configPtr, spad);
+  Value spad = arith::ConstantOp::create(
+      rewriter, loc, rewriter.getI64IntegerAttr(spadAddrInt));
+  IntrOp::create(rewriter, loc, configPtr, spad);
 }
 
 void gemminiMvoutOffset(const Value &mem, const size_t offset,
@@ -92,15 +93,16 @@ void gemminiMvoutOffset(const Value &mem, const size_t offset,
                         const size_t rows, int64_t addrLen,
                         ConversionPatternRewriter &rewriter) {
   Location loc = mem.getLoc();
-  Value offsetOp = rewriter.create<arith::ConstantOp>(
-      loc, rewriter.getI64IntegerAttr(offset));
+  Value offsetOp = arith::ConstantOp::create(
+      rewriter, loc, rewriter.getI64IntegerAttr(offset));
   IntegerType i64Type = rewriter.getI64Type();
-  Value configPtr = rewriter.create<arith::AddIOp>(loc, i64Type, mem, offsetOp);
+  Value configPtr =
+      arith::AddIOp::create(rewriter, loc, i64Type, mem, offsetOp);
   uint64_t spadAddrInt = (uint64_t)rows << (addrLen + 16) |
                          (uint64_t)cols << addrLen | (uint64_t)SpAddr;
-  Value spad = rewriter.create<arith::ConstantOp>(
-      loc, rewriter.getI64IntegerAttr(spadAddrInt));
-  rewriter.create<Mvout_IntrOp>(loc, configPtr, spad);
+  Value spad = arith::ConstantOp::create(
+      rewriter, loc, rewriter.getI64IntegerAttr(spadAddrInt));
+  Mvout_IntrOp::create(rewriter, loc, configPtr, spad);
 }
 
 } // namespace
@@ -141,8 +143,8 @@ struct GemminiFlushLowering : public ConvertOpToLLVMPattern<FlushOp> {
     Location loc = flushOp.getLoc();
     Value skip = flushOp.getSkip();
     IntegerAttr rs2Attr = rewriter.getI64IntegerAttr(0);
-    Value rs2 =
-        rewriter.create<arith::ConstantOp>(loc, rewriter.getI64Type(), rs2Attr);
+    Value rs2 = arith::ConstantOp::create(rewriter, loc, rewriter.getI64Type(),
+                                          rs2Attr);
     rewriter.replaceOpWithNewOp<Flush_IntrOp>(flushOp, skip, rs2);
     return success();
   }
@@ -161,10 +163,10 @@ struct GemminiConfigStLowering : public ConvertOpToLLVMPattern<ConfigStOp> {
     uint64_t arg = (uint64_t)acc_scale_t_to_acc_scale_t_bits((acc_scale_t)scale)
                        << 32 |
                    (uint32_t)stride;
-    Value value1 = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(rs1));
-    Value value2 = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(arg));
+    Value value1 = arith::ConstantOp::create(rewriter, loc,
+                                             rewriter.getI64IntegerAttr(rs1));
+    Value value2 = arith::ConstantOp::create(rewriter, loc,
+                                             rewriter.getI64IntegerAttr(arg));
     rewriter.replaceOpWithNewOp<Config_IntrOp>(configStOp, value1, value2);
     return success();
   }
@@ -189,8 +191,8 @@ struct GemminiConfigLdLowering : public ConvertOpToLLVMPattern<ConfigLdOp> {
                    configLdOp.getId() << 3 | configLdOp.getShrunk() << 2 |
                    CONFIG_LD;
     Location loc = configLdOp.getLoc();
-    Value rs1value = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(rs1));
+    Value rs1value = arith::ConstantOp::create(rewriter, loc,
+                                               rewriter.getI64IntegerAttr(rs1));
     rewriter.replaceOpWithNewOp<Config_IntrOp>(configLdOp, rs1value, rs2Value);
     return success();
   }
@@ -216,8 +218,8 @@ struct GemminiConfigExLowering : public ConvertOpToLLVMPattern<ConfigExOp> {
     uint64_t rs2 = configExOp.getCStride() << 48 | configExOp.getSysShift();
     IntegerAttr rs1Attr = rewriter.getI64IntegerAttr(rs1);
     IntegerAttr rs2Attr = rewriter.getI64IntegerAttr(rs2);
-    Value rs1Value = rewriter.create<arith::ConstantOp>(loc, i64Type, rs1Attr);
-    Value rs2Value = rewriter.create<arith::ConstantOp>(loc, i64Type, rs2Attr);
+    Value rs1Value = arith::ConstantOp::create(rewriter, loc, i64Type, rs1Attr);
+    Value rs2Value = arith::ConstantOp::create(rewriter, loc, i64Type, rs2Attr);
     rewriter.replaceOpWithNewOp<Config_IntrOp>(configExOp, rs1Value, rs2Value);
     return success();
   }
@@ -236,10 +238,10 @@ struct GemminiConfigNormLowering : public ConvertOpToLLVMPattern<ConfigNormOp> {
                    configNormOp.getStatsId() << 8 | CONFIG_BERT;
     uint64_t rs2 = (((uint64_t)((uint32_t)configNormOp.getIgeluQc())) << 32) |
                    ((uint64_t)((uint32_t)configNormOp.getIgeluQb()));
-    Value rs1Value = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(rs1));
-    Value rs2Value = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(rs2));
+    Value rs1Value = arith::ConstantOp::create(rewriter, loc,
+                                               rewriter.getI64IntegerAttr(rs1));
+    Value rs2Value = arith::ConstantOp::create(rewriter, loc,
+                                               rewriter.getI64IntegerAttr(rs2));
     rewriter.replaceOpWithNewOp<Config_IntrOp>(configNormOp, rs1Value,
                                                rs2Value);
     return success();
@@ -260,17 +262,17 @@ struct GemminiMvinLowering : public ConvertOpToLLVMPattern<MvinOp> {
         dyn_cast<MemRefType>(mvinOp.getOperandTypes().front());
     llvm::ArrayRef<int64_t> memRefShape = memRefType.getShape();
     TypeRange resultType = mlir::TypeRange(rewriter.getIndexType());
-    Value extractOp = rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(
-        loc, resultType, input);
+    Value extractOp = memref::ExtractAlignedPointerAsIndexOp::create(
+        rewriter, loc, resultType, input);
     IntegerType i64Type = rewriter.getI64Type();
     Value indexCastOp =
-        rewriter.create<arith::IndexCastOp>(loc, i64Type, extractOp);
+        arith::IndexCastOp::create(rewriter, loc, i64Type, extractOp);
     Value spadAddrValue = mvinOp.getAddr();
     uint64_t number = getNumberFromValue(spadAddrValue);
     uint64_t spadAddrInt = (uint64_t)memRefShape[0] << (addrLen + 16) |
                            (uint64_t)memRefShape[1] << addrLen | number;
-    Value spad = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(spadAddrInt));
+    Value spad = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64IntegerAttr(spadAddrInt));
     rewriter.replaceOpWithNewOp<Mvin_IntrOp>(mvinOp, indexCastOp, spad);
     return success();
   }
@@ -293,17 +295,17 @@ struct GemminiMvin2Lowering : public ConvertOpToLLVMPattern<Mvin2Op> {
         dyn_cast<MemRefType>(mvin2Op.getOperandTypes().front());
     llvm::ArrayRef<int64_t> memRefShape = memRefType.getShape();
     TypeRange resultType = mlir::TypeRange(rewriter.getIndexType());
-    Value extractOp = rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(
-        loc, resultType, input);
+    Value extractOp = memref::ExtractAlignedPointerAsIndexOp::create(
+        rewriter, loc, resultType, input);
     IntegerType i64Type = rewriter.getI64Type();
     Value indexCastOp =
-        rewriter.create<arith::IndexCastOp>(loc, i64Type, extractOp);
+        arith::IndexCastOp::create(rewriter, loc, i64Type, extractOp);
     Value spadAddrValue = mvin2Op.getAddr();
     uint64_t number = getNumberFromValue(spadAddrValue);
     uint64_t spadAddrInt = (uint64_t)memRefShape[0] << (addrLen + 16) |
                            (uint64_t)memRefShape[1] << addrLen | number;
-    Value spad = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(spadAddrInt));
+    Value spad = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64IntegerAttr(spadAddrInt));
     rewriter.replaceOpWithNewOp<Mvin2_IntrOp>(mvin2Op, indexCastOp, spad);
     return success();
   }
@@ -326,17 +328,17 @@ struct GemminiMvin3Lowering : public ConvertOpToLLVMPattern<Mvin3Op> {
         dyn_cast<MemRefType>(mvin3Op.getOperandTypes().front());
     llvm::ArrayRef<int64_t> memRefShape = memRefType.getShape();
     TypeRange resultType = mlir::TypeRange(rewriter.getIndexType());
-    Value extractOp = rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(
-        loc, resultType, input);
+    Value extractOp = memref::ExtractAlignedPointerAsIndexOp::create(
+        rewriter, loc, resultType, input);
     IntegerType i64Type = rewriter.getI64Type();
     Value indexCastOp =
-        rewriter.create<arith::IndexCastOp>(loc, i64Type, extractOp);
+        arith::IndexCastOp::create(rewriter, loc, i64Type, extractOp);
     Value spadAddrValue = mvin3Op.getAddr();
     uint64_t number = getNumberFromValue(spadAddrValue);
     uint64_t spadAddrInt = (uint64_t)memRefShape[0] << (addrLen + 16) |
                            (uint64_t)memRefShape[1] << addrLen | number;
-    Value spad = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(spadAddrInt));
+    Value spad = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64IntegerAttr(spadAddrInt));
     rewriter.replaceOpWithNewOp<Mvin3_IntrOp>(mvin3Op, indexCastOp, spad);
     return success();
   }
@@ -356,11 +358,11 @@ struct GemminiMvoutLowering : public ConvertOpToLLVMPattern<MvoutOp> {
     Value output = mvoutOp.getOutput();
     TypeRange resultType = mlir::TypeRange(rewriter.getIndexType());
     Location loc = mvoutOp.getLoc();
-    Value extractOp = rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(
-        loc, resultType, output);
+    Value extractOp = memref::ExtractAlignedPointerAsIndexOp::create(
+        rewriter, loc, resultType, output);
     IntegerType i64Type = rewriter.getI64Type();
     Value indexCastOp =
-        rewriter.create<arith::IndexCastOp>(loc, i64Type, extractOp);
+        arith::IndexCastOp::create(rewriter, loc, i64Type, extractOp);
     Value spadAddr = mvoutOp.getAddr();
     uint64_t number = getNumberFromValue(spadAddr);
     MemRefType memRefType =
@@ -368,8 +370,8 @@ struct GemminiMvoutLowering : public ConvertOpToLLVMPattern<MvoutOp> {
     llvm::ArrayRef<int64_t> memRefShape = memRefType.getShape();
     uint64_t spadAddrInt = (uint64_t)memRefShape[0] << (addrLen + 16) |
                            (uint64_t)memRefShape[1] << addrLen | number;
-    Value newSpad = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(spadAddrInt));
+    Value newSpad = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64IntegerAttr(spadAddrInt));
     rewriter.replaceOpWithNewOp<Mvout_IntrOp>(mvoutOp, indexCastOp, newSpad);
     return success();
   }
@@ -397,10 +399,10 @@ struct GemminiPreloadZerosLowering
     uint64_t rs1 = (uint64_t)dim << (addrLen + 16) | (uint64_t)dim << addrLen |
                    (uint64_t)-1;
     uint64_t rs2 = cRowsInt << (addrLen + 16) | cColsInt << (addrLen) | addrInt;
-    Value rs1Value = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(rs1));
-    Value rs2Value = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(rs2));
+    Value rs1Value = arith::ConstantOp::create(rewriter, loc,
+                                               rewriter.getI64IntegerAttr(rs1));
+    Value rs2Value = arith::ConstantOp::create(rewriter, loc,
+                                               rewriter.getI64IntegerAttr(rs2));
     rewriter.replaceOpWithNewOp<Preload_IntrOp>(preloadZerosOp, rs1Value,
                                                 rs2Value);
     return success();
@@ -436,10 +438,10 @@ struct GemminiPreloadLowering : public ConvertOpToLLVMPattern<PreloadOp> {
                    (uint64_t)bdAddrInt;
     uint64_t rs2 =
         cRowsInt << (addrLen + 16) | cColsInt << addrLen | (uint64_t)cAddrInt;
-    Value rs1Value = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(rs1));
-    Value rs2Value = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(rs2));
+    Value rs1Value = arith::ConstantOp::create(rewriter, loc,
+                                               rewriter.getI64IntegerAttr(rs1));
+    Value rs2Value = arith::ConstantOp::create(rewriter, loc,
+                                               rewriter.getI64IntegerAttr(rs2));
     rewriter.replaceOpWithNewOp<Preload_IntrOp>(preloadOp, rs1Value, rs2Value);
     return success();
   }
@@ -473,10 +475,10 @@ struct GemminiComputePreloadedLowering
     uint64_t rs1 = aRowsInt << (addrLen + 16) | aColsInt << addrLen | aAddrInt;
     uint64_t rs2 =
         bdRowsInt << (addrLen + 16) | bdColsInt << addrLen | bdAddrInt;
-    Value rs1Value = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(rs1));
-    Value rs2Value = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(rs2));
+    Value rs1Value = arith::ConstantOp::create(rewriter, loc,
+                                               rewriter.getI64IntegerAttr(rs1));
+    Value rs2Value = arith::ConstantOp::create(rewriter, loc,
+                                               rewriter.getI64IntegerAttr(rs2));
     rewriter.replaceOpWithNewOp<ComputePreloaded_IntrOp>(computePreloadedOp,
                                                          rs1Value, rs2Value);
     return success();
@@ -511,10 +513,10 @@ struct GemminiComputeAccumulatedLowering
     uint64_t rs1 = aRowsInt << (addrLen + 16) | aColsInt << addrLen | aAddrInt;
     uint64_t rs2 =
         bdRowsInt << (addrLen + 16) | bdColsInt << addrLen | bdAddrInt;
-    Value rs1Value = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(rs1));
-    Value rs2Value = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(rs2));
+    Value rs1Value = arith::ConstantOp::create(rewriter, loc,
+                                               rewriter.getI64IntegerAttr(rs1));
+    Value rs2Value = arith::ConstantOp::create(rewriter, loc,
+                                               rewriter.getI64IntegerAttr(rs2));
     rewriter.replaceOpWithNewOp<ComputeAccumulated_IntrOp>(computeAccumulatedOp,
                                                            rs1Value, rs2Value);
 
@@ -538,38 +540,38 @@ class GemminiTileMatMulLowering : public ConvertOpToLLVMPattern<TileMatMulOp> {
     uint64_t rs2 = (uint64_t)k << 32 | (uint64_t)j << 16 | (uint64_t)i;
     IntegerType i64Type = rewriter.getI64Type();
     Location loc = a.getLoc();
-    Value rs1Value = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(rs1));
-    Value rs2Value = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(rs2));
-    rewriter.create<LoopWsConfigBounds_IntrOp>(loc, rs1Value, rs2Value);
+    Value rs1Value = arith::ConstantOp::create(rewriter, loc,
+                                               rewriter.getI64IntegerAttr(rs1));
+    Value rs2Value = arith::ConstantOp::create(rewriter, loc,
+                                               rewriter.getI64IntegerAttr(rs2));
+    LoopWsConfigBounds_IntrOp::create(rewriter, loc, rs1Value, rs2Value);
     // loopWsConfigAddrsAB instruction.
-    rewriter.create<LoopWsConfigAddrsAB_IntrOp>(loc, a, b);
+    LoopWsConfigAddrsAB_IntrOp::create(rewriter, loc, a, b);
     // loopWsConfigAddrsDC instruction
-    rewriter.create<LoopWsConfigAddrsDC_IntrOp>(loc, d, c);
+    LoopWsConfigAddrsDC_IntrOp::create(rewriter, loc, d, c);
     // loopWsConfigStridesAB instruction
-    rs1Value = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(aRowStride));
-    rs2Value = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(bRowStride));
-    rewriter.create<LoopWsConfigStridesAB_IntrOp>(loc, rs1Value, rs2Value);
+    rs1Value = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64IntegerAttr(aRowStride));
+    rs2Value = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64IntegerAttr(bRowStride));
+    LoopWsConfigStridesAB_IntrOp::create(rewriter, loc, rs1Value, rs2Value);
     // loopWsConfigStrideDC instruction
-    rs1Value = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(dRowStride));
-    rs2Value = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(cRowStride));
-    rewriter.create<LoopWsConfigStridesDC_IntrOp>(loc, rs1Value, rs2Value);
+    rs1Value = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64IntegerAttr(dRowStride));
+    rs2Value = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64IntegerAttr(cRowStride));
+    LoopWsConfigStridesDC_IntrOp::create(rewriter, loc, rs1Value, rs2Value);
     const int aSpadId = 0;
     const int bSpadId = 0;
     const int isResadd = 0;
     rs1 = (uint64_t)aSpadId << 18 | (uint64_t)bSpadId << 16 |
           (uint64_t)act << 8 | lowD << 2 | (fullC) << 1 | exAccumulate;
     rs2 = isResadd << 2 | bTranspose << 1 | aTranspose;
-    rs1Value = rewriter.create<arith::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(rs1));
-    rs2Value = rewriter.create<arith::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(rs2));
-    rewriter.create<LoopWs_IntrOp>(loc, rs1Value, rs2Value);
+    rs1Value = arith::ConstantOp::create(rewriter, loc, i64Type,
+                                         rewriter.getI64IntegerAttr(rs1));
+    rs2Value = arith::ConstantOp::create(rewriter, loc, i64Type,
+                                         rewriter.getI64IntegerAttr(rs2));
+    LoopWs_IntrOp::create(rewriter, loc, rs1Value, rs2Value);
   }
 
   void spTiledMatmulWs(Value &a, Value &b, Value &d, Value &c,
@@ -619,10 +621,10 @@ class GemminiTileMatMulLowering : public ConvertOpToLLVMPattern<TileMatMulOp> {
     // Move-in D
     if (!dAddrNull && !noBias) {
       const size_t dStride = repeatingBias ? 0 : strideD * sizeOfAccT;
-      Value strideValue = rewriter.create<arith::ConstantOp>(
-          loc, rewriter.getI64IntegerAttr(dStride));
-      rewriter.create<ConfigLdOp>(loc, strideValue,
-                                  llvm::APFloat((float)dScaleFactor));
+      Value strideValue = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getI64IntegerAttr(dStride));
+      ConfigLdOp::create(rewriter, loc, strideValue,
+                         llvm::APFloat((float)dScaleFactor));
 
       for (size_t i0 = 0; i0 < i; i0++) {
         for (size_t j0 = 0; j0 < j; j0 += dBlocks) {
@@ -639,10 +641,10 @@ class GemminiTileMatMulLowering : public ConvertOpToLLVMPattern<TileMatMulOp> {
     }
 
     // Move-in B
-    Value strideValue = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(strideB));
-    rewriter.create<ConfigLdOp>(loc, strideValue,
-                                llvm::APFloat((float)bScaleFactor));
+    Value strideValue = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64IntegerAttr(strideB));
+    ConfigLdOp::create(rewriter, loc, strideValue,
+                       llvm::APFloat((float)bScaleFactor));
     for (size_t j0 = 0; j0 < j; j0 += bBlocks) {
       for (size_t k0 = 0; k0 < k; k0++) {
         const size_t offset = (k0 * strideB + j0) * dim * sizeOfElemT;
@@ -655,10 +657,10 @@ class GemminiTileMatMulLowering : public ConvertOpToLLVMPattern<TileMatMulOp> {
     }
 
     // Move-in A
-    strideValue = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(strideA));
-    rewriter.create<ConfigLdOp>(loc, strideValue,
-                                llvm::APFloat((float)aScaleFactor));
+    strideValue = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64IntegerAttr(strideA));
+    ConfigLdOp::create(rewriter, loc, strideValue,
+                       llvm::APFloat((float)aScaleFactor));
 
     for (size_t i0 = 0; i0 < i; i0++) {
       for (size_t k0 = 0; k0 < k; k0 += aBlocks) {
@@ -696,41 +698,41 @@ class GemminiTileMatMulLowering : public ConvertOpToLLVMPattern<TileMatMulOp> {
           const size_t cCols = dim - (j0 == j - 1 ? padJ : 0);
           const size_t cRows = dim - (i0 == i - 1 ? padI : 0);
 
-          Value aColsOp = rewriter.create<arith::ConstantOp>(
-              loc, rewriter.getI64IntegerAttr(aCols));
-          Value aRowsOp = rewriter.create<arith::ConstantOp>(
-              loc, rewriter.getI64IntegerAttr(aRows));
-          Value bColsOp = rewriter.create<arith::ConstantOp>(
-              loc, rewriter.getI64IntegerAttr(bCols));
-          Value bRowsOp = rewriter.create<arith::ConstantOp>(
-              loc, rewriter.getI64IntegerAttr(bRows));
-          Value cColsOp = rewriter.create<arith::ConstantOp>(
-              loc, rewriter.getI64IntegerAttr(cCols));
-          Value cRowsOp = rewriter.create<arith::ConstantOp>(
-              loc, rewriter.getI64IntegerAttr(cRows));
+          Value aColsOp = arith::ConstantOp::create(
+              rewriter, loc, rewriter.getI64IntegerAttr(aCols));
+          Value aRowsOp = arith::ConstantOp::create(
+              rewriter, loc, rewriter.getI64IntegerAttr(aRows));
+          Value bColsOp = arith::ConstantOp::create(
+              rewriter, loc, rewriter.getI64IntegerAttr(bCols));
+          Value bRowsOp = arith::ConstantOp::create(
+              rewriter, loc, rewriter.getI64IntegerAttr(bRows));
+          Value cColsOp = arith::ConstantOp::create(
+              rewriter, loc, rewriter.getI64IntegerAttr(cCols));
+          Value cRowsOp = arith::ConstantOp::create(
+              rewriter, loc, rewriter.getI64IntegerAttr(cRows));
 
-          Value aSpAddrOp = rewriter.create<arith::ConstantOp>(
-              loc, rewriter.getI64IntegerAttr(aSpAddr));
-          Value bSpAddrOp = rewriter.create<arith::ConstantOp>(
-              loc, rewriter.getI64IntegerAttr(bSpAddr));
-          Value outSpAddrOp = rewriter.create<arith::ConstantOp>(
-              loc, rewriter.getI64IntegerAttr(outSpAddr));
+          Value aSpAddrOp = arith::ConstantOp::create(
+              rewriter, loc, rewriter.getI64IntegerAttr(aSpAddr));
+          Value bSpAddrOp = arith::ConstantOp::create(
+              rewriter, loc, rewriter.getI64IntegerAttr(bSpAddr));
+          Value outSpAddrOp = arith::ConstantOp::create(
+              rewriter, loc, rewriter.getI64IntegerAttr(outSpAddr));
 
-          Value garbageAddrOp = rewriter.create<arith::ConstantOp>(
-              loc, rewriter.getI64IntegerAttr(GARBAGE_ADDR));
-          Value dimOp = rewriter.create<arith::ConstantOp>(
-              loc, rewriter.getI64IntegerAttr(dim));
+          Value garbageAddrOp = arith::ConstantOp::create(
+              rewriter, loc, rewriter.getI64IntegerAttr(GARBAGE_ADDR));
+          Value dimOp = arith::ConstantOp::create(
+              rewriter, loc, rewriter.getI64IntegerAttr(dim));
 
-          rewriter.create<PreloadOp>(loc, garbageAddrOp, outSpAddrOp, dimOp,
-                                     dimOp, cRowsOp, cColsOp);
+          PreloadOp::create(rewriter, loc, garbageAddrOp, outSpAddrOp, dimOp,
+                            dimOp, cRowsOp, cColsOp);
 
           if (k0 == 0) { // First iteration
-            rewriter.create<ComputePreloadedOp>(
-                loc, aSpAddrOp, bSpAddrOp, aRowsOp, aColsOp, bRowsOp, bColsOp);
+            ComputePreloadedOp::create(rewriter, loc, aSpAddrOp, bSpAddrOp,
+                                       aRowsOp, aColsOp, bRowsOp, bColsOp);
 
           } else { // All other iterations
-            rewriter.create<ComputeAccumulatedOp>(
-                loc, aSpAddrOp, bSpAddrOp, aRowsOp, aColsOp, bRowsOp, bColsOp);
+            ComputeAccumulatedOp::create(rewriter, loc, aSpAddrOp, bSpAddrOp,
+                                         aRowsOp, aColsOp, bRowsOp, bColsOp);
           }
         }
       }
@@ -785,25 +787,25 @@ class GemminiTileMatMulLowering : public ConvertOpToLLVMPattern<TileMatMulOp> {
     const size_t sizeofC = fullC ? sizeOfAccT : sizeOfElemT;
     Location loc = tileMatMulOp.getLoc();
     llvm::APFloat accScaleIdentity((float)ACC_SCALE_IDENTITY);
-    rewriter.create<ConfigExOp>(loc, /*dataflow = */ dataflow,
-                                /*sysAct = */ act & 3,
-                                /* sysShift = */ 0, accScaleIdentity);
-    Value strideValue = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(strideC * sizeofC));
-    rewriter.create<ConfigStOp>(loc, strideValue, act & 3,
-                                llvm::APFloat(scale));
-    strideValue = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(strideA * sizeOfElemT));
-    rewriter.create<ConfigLdOp>(loc, strideValue, llvm::APFloat(aScaleFactor),
-                                false, 0);
-    strideValue = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(strideB * sizeOfElemT));
-    rewriter.create<ConfigLdOp>(loc, strideValue, llvm::APFloat(bScaleFactor),
-                                false, 1);
-    strideValue = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(strideD * sizeofD));
-    rewriter.create<ConfigLdOp>(loc, strideValue,
-                                llvm::APFloat((float)dScaleFactor), lowD, 2);
+    ConfigExOp::create(rewriter, loc, /*dataflow = */ dataflow,
+                       /*sysAct = */ act & 3,
+                       /* sysShift = */ 0, accScaleIdentity);
+    Value strideValue = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64IntegerAttr(strideC * sizeofC));
+    ConfigStOp::create(rewriter, loc, strideValue, act & 3,
+                       llvm::APFloat(scale));
+    strideValue = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64IntegerAttr(strideA * sizeOfElemT));
+    ConfigLdOp::create(rewriter, loc, strideValue, llvm::APFloat(aScaleFactor),
+                       false, 0);
+    strideValue = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64IntegerAttr(strideB * sizeOfElemT));
+    ConfigLdOp::create(rewriter, loc, strideValue, llvm::APFloat(bScaleFactor),
+                       false, 1);
+    strideValue = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64IntegerAttr(strideD * sizeofD));
+    ConfigLdOp::create(rewriter, loc, strideValue,
+                       llvm::APFloat((float)dScaleFactor), lowD, 2);
 
     /*
       Add config norm op
@@ -815,7 +817,7 @@ class GemminiTileMatMulLowering : public ConvertOpToLLVMPattern<TileMatMulOp> {
 
       const uint32_t qb = -1.769 / (S / sqrt_2);
       const uint32_t qc = 1.0 / S_erf;
-      rewriter.create<ConfigNormOp>(loc, 0, 0, 0, 0, 0, qb, qc);
+      ConfigNormOp::create(rewriter, loc, 0, 0, 0, 0, 0, qb, qc);
     }
 
     if (act == SOFTMAX) {
@@ -827,8 +829,8 @@ class GemminiTileMatMulLowering : public ConvertOpToLLVMPattern<TileMatMulOp> {
       const uint32_t qln2_inv = 65536 / qln2;
       const uint32_t qb = b / bertScale;
       const uint32_t qc = c / (a * bertScale * bertScale);
-      rewriter.create<ConfigNormOp>(loc, qln2, 0, 0, 1, 0, qb, qc);
-      rewriter.create<ConfigNormOp>(loc, qln2_inv, 1, 0, 1, 0, qb, qc);
+      ConfigNormOp::create(rewriter, loc, qln2, 0, 0, 1, 0, qb, qc);
+      ConfigNormOp::create(rewriter, loc, qln2_inv, 1, 0, 1, 0, qb, qc);
     }
 
     for (size_t i0 = 0; i0 < I0; i0++)
@@ -838,16 +840,16 @@ class GemminiTileMatMulLowering : public ConvertOpToLLVMPattern<TileMatMulOp> {
           Location loc = A.getLoc();
           if (k0 != 0) {
             IntegerAttr preAttr = rewriter.getI64IntegerAttr(0);
-            pre = rewriter.create<arith::ConstantOp>(loc, rewriter.getI64Type(),
-                                                     preAttr);
+            pre = arith::ConstantOp::create(rewriter, loc,
+                                            rewriter.getI64Type(), preAttr);
           } else {
             size_t biasRow = repeatingBias ? 0 : i0 * tileI * dim;
             size_t offset = (biasRow * strideD + j0 * tileJ * dim) * sizeofD;
             IntegerAttr offsetAttr = rewriter.getI64IntegerAttr(offset);
-            Value offsetValue = rewriter.create<arith::ConstantOp>(
-                loc, rewriter.getI64Type(), offsetAttr);
-            pre = rewriter.create<arith::AddIOp>(loc, rewriter.getI64Type(), D,
-                                                 offsetValue);
+            Value offsetValue = arith::ConstantOp::create(
+                rewriter, loc, rewriter.getI64Type(), offsetAttr);
+            pre = arith::AddIOp::create(rewriter, loc, rewriter.getI64Type(), D,
+                                        offsetValue);
           }
 
           Value out;
@@ -855,14 +857,14 @@ class GemminiTileMatMulLowering : public ConvertOpToLLVMPattern<TileMatMulOp> {
             size_t offset =
                 (i0 * tileI * dim * strideC + j0 * tileJ * dim) * sizeofC;
             IntegerAttr offsetAttr = rewriter.getI64IntegerAttr(offset);
-            Value offsetValue = rewriter.create<arith::ConstantOp>(
-                loc, rewriter.getI64Type(), offsetAttr);
-            out = rewriter.create<arith::AddIOp>(loc, rewriter.getI64Type(), C,
-                                                 offsetValue);
+            Value offsetValue = arith::ConstantOp::create(
+                rewriter, loc, rewriter.getI64Type(), offsetAttr);
+            out = arith::AddIOp::create(rewriter, loc, rewriter.getI64Type(), C,
+                                        offsetValue);
           } else {
             IntegerAttr outAttr = rewriter.getI64IntegerAttr(0);
-            out = rewriter.create<arith::ConstantOp>(loc, rewriter.getI64Type(),
-                                                     outAttr);
+            out = arith::ConstantOp::create(rewriter, loc,
+                                            rewriter.getI64Type(), outAttr);
           }
           const size_t i = i0 < I0 - 1 ? tileI : lastI;
           const size_t j = j0 < J0 - 1 ? tileJ : lastJ;
@@ -875,36 +877,36 @@ class GemminiTileMatMulLowering : public ConvertOpToLLVMPattern<TileMatMulOp> {
             size_t offset =
                 (k0 * tileK * dim * strideA + i0 * tileI * dim) * sizeOfElemT;
             IntegerAttr offsetAttr = rewriter.getI64IntegerAttr(offset);
-            Value offsetValue = rewriter.create<arith::ConstantOp>(
-                loc, rewriter.getI64Type(), offsetAttr);
-            a = rewriter.create<arith::AddIOp>(loc, rewriter.getI64Type(), A,
-                                               offsetValue);
+            Value offsetValue = arith::ConstantOp::create(
+                rewriter, loc, rewriter.getI64Type(), offsetAttr);
+            a = arith::AddIOp::create(rewriter, loc, rewriter.getI64Type(), A,
+                                      offsetValue);
           } else {
             size_t offset =
                 (i0 * tileI * dim * strideA + k0 * tileK * dim) * sizeOfElemT;
             IntegerAttr offsetAttr = rewriter.getI64IntegerAttr(offset);
-            Value offsetValue = rewriter.create<arith::ConstantOp>(
-                loc, rewriter.getI64Type(), offsetAttr);
-            a = rewriter.create<arith::AddIOp>(loc, rewriter.getI64Type(), A,
-                                               offsetValue);
+            Value offsetValue = arith::ConstantOp::create(
+                rewriter, loc, rewriter.getI64Type(), offsetAttr);
+            a = arith::AddIOp::create(rewriter, loc, rewriter.getI64Type(), A,
+                                      offsetValue);
           }
           Value b;
           if (bTranspose) {
             size_t offset =
                 (j0 * tileJ * dim * strideB + k0 * tileK * dim) * sizeOfElemT;
             IntegerAttr offsetAttr = rewriter.getI64IntegerAttr(offset);
-            Value offsetValue = rewriter.create<arith::ConstantOp>(
-                loc, rewriter.getI64Type(), offsetAttr);
-            b = rewriter.create<arith::AddIOp>(loc, rewriter.getI64Type(), B,
-                                               offsetValue);
+            Value offsetValue = arith::ConstantOp::create(
+                rewriter, loc, rewriter.getI64Type(), offsetAttr);
+            b = arith::AddIOp::create(rewriter, loc, rewriter.getI64Type(), B,
+                                      offsetValue);
           } else {
             size_t offset =
                 (k0 * tileK * dim * strideB + j0 * tileJ * dim) * sizeOfElemT;
             IntegerAttr offsetAttr = rewriter.getI64IntegerAttr(offset);
-            Value offsetValue = rewriter.create<arith::ConstantOp>(
-                loc, rewriter.getI64Type(), offsetAttr);
-            b = rewriter.create<arith::AddIOp>(loc, rewriter.getI64Type(), B,
-                                               offsetValue);
+            Value offsetValue = arith::ConstantOp::create(
+                rewriter, loc, rewriter.getI64Type(), offsetAttr);
+            b = arith::AddIOp::create(rewriter, loc, rewriter.getI64Type(), B,
+                                      offsetValue);
           }
           if (dataflow == OUTPUT_STATIONARY) {
             spTiledMatmulOs(a, b, pre, out, aScaleFactor, bScaleFactor,
@@ -921,8 +923,8 @@ class GemminiTileMatMulLowering : public ConvertOpToLLVMPattern<TileMatMulOp> {
           }
         }
     IntegerAttr flushAttr = rewriter.getI64IntegerAttr(0);
-    Value flushValue = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64Type(), flushAttr);
+    Value flushValue = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64Type(), flushAttr);
     rewriter.replaceOpWithNewOp<Flush_IntrOp>(tileMatMulOp, flushValue,
                                               flushValue);
     return;
@@ -972,44 +974,40 @@ public:
     TypeRange typeRange(resultType);
     Location loc = tileMatMulOp.getLoc();
     IntegerType i64Type = rewriter.getI64Type();
-    Value aArrayExtractOp =
-        rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, typeRange,
-                                                                aArray);
+    Value aArrayExtractOp = memref::ExtractAlignedPointerAsIndexOp::create(
+        rewriter, loc, typeRange, aArray);
     if (aArrayLayout) {
-      Value offset = rewriter.create<arith::ConstantIndexOp>(
-          loc, aArrayLayout.getOffset() * sizeOfElemT);
+      Value offset = arith::ConstantIndexOp::create(
+          rewriter, loc, aArrayLayout.getOffset() * sizeOfElemT);
       aArrayExtractOp =
-          rewriter.create<arith::AddIOp>(loc, aArrayExtractOp, offset);
+          arith::AddIOp::create(rewriter, loc, aArrayExtractOp, offset);
     }
     Value aArrayindexCastOp =
-        rewriter.create<arith::IndexCastOp>(loc, i64Type, aArrayExtractOp);
-    Value bArrayExtractOp =
-        rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, typeRange,
-                                                                bArray);
+        arith::IndexCastOp::create(rewriter, loc, i64Type, aArrayExtractOp);
+    Value bArrayExtractOp = memref::ExtractAlignedPointerAsIndexOp::create(
+        rewriter, loc, typeRange, bArray);
     if (bArrayLayout) {
-      Value offset = rewriter.create<arith::ConstantIndexOp>(
-          loc, bArrayLayout.getOffset() * sizeOfElemT);
+      Value offset = arith::ConstantIndexOp::create(
+          rewriter, loc, bArrayLayout.getOffset() * sizeOfElemT);
       bArrayExtractOp =
-          rewriter.create<arith::AddIOp>(loc, bArrayExtractOp, offset);
+          arith::AddIOp::create(rewriter, loc, bArrayExtractOp, offset);
     }
     Value bArrayindexCastOp =
-        rewriter.create<arith::IndexCastOp>(loc, i64Type, bArrayExtractOp);
-    Value cArrayExtractOp =
-        rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, typeRange,
-                                                                cArray);
+        arith::IndexCastOp::create(rewriter, loc, i64Type, bArrayExtractOp);
+    Value cArrayExtractOp = memref::ExtractAlignedPointerAsIndexOp::create(
+        rewriter, loc, typeRange, cArray);
     if (cArrayLayout) {
-      Value offset = rewriter.create<arith::ConstantIndexOp>(
-          loc, cArrayLayout.getOffset() * sizeOfElemT);
+      Value offset = arith::ConstantIndexOp::create(
+          rewriter, loc, cArrayLayout.getOffset() * sizeOfElemT);
       cArrayExtractOp =
-          rewriter.create<arith::AddIOp>(loc, cArrayExtractOp, offset);
+          arith::AddIOp::create(rewriter, loc, cArrayExtractOp, offset);
     }
     Value cArrayindexCastOp =
-        rewriter.create<arith::IndexCastOp>(loc, i64Type, cArrayExtractOp);
-    Value dArrayExtractOp =
-        rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, typeRange,
-                                                                dArray);
+        arith::IndexCastOp::create(rewriter, loc, i64Type, cArrayExtractOp);
+    Value dArrayExtractOp = memref::ExtractAlignedPointerAsIndexOp::create(
+        rewriter, loc, typeRange, dArray);
     Value dArrayindexCastOp =
-        rewriter.create<arith::IndexCastOp>(loc, i64Type, dArrayExtractOp);
+        arith::IndexCastOp::create(rewriter, loc, i64Type, dArrayExtractOp);
     llvm::ArrayRef<int64_t> aArrayShape = aArrayType.getShape();
     llvm::ArrayRef<int64_t> bArrayShape = bArrayType.getShape();
     llvm::ArrayRef<int64_t> cArrayShape = cArrayType.getShape();
@@ -1120,9 +1118,9 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
                    (uint64_t)outDim;
     TypedAttr rs1Attr = rewriter.getI64IntegerAttr(rs1);
     TypedAttr rs2Attr = rewriter.getI64IntegerAttr(rs2);
-    Value rs1Value = rewriter.create<arith::ConstantOp>(loc, rs1Attr);
-    Value rs2Value = rewriter.create<arith::ConstantOp>(loc, rs2Attr);
-    rewriter.create<LoopConvWsConfig1_IntrOp>(loc, rs1Value, rs2Value);
+    Value rs1Value = arith::ConstantOp::create(rewriter, loc, rs1Attr);
+    Value rs2Value = arith::ConstantOp::create(rewriter, loc, rs2Attr);
+    LoopConvWsConfig1_IntrOp::create(rewriter, loc, rs1Value, rs2Value);
     // loopConvWsConfig2
     rs1 = (uint64_t)kernelDim << 48 | (uint64_t)poolOutDim << 32 |
           (uint64_t)poolSize << 16 | (uint64_t)poolStride << 8 |
@@ -1131,9 +1129,9 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
           (uint64_t)pocols << 16 | (uint64_t)pochs;
     rs1Attr = rewriter.getI64IntegerAttr(rs1);
     rs2Attr = rewriter.getI64IntegerAttr(rs2);
-    rs1Value = rewriter.create<arith::ConstantOp>(loc, rs1Attr);
-    rs2Value = rewriter.create<arith::ConstantOp>(loc, rs2Attr);
-    rewriter.create<LoopConvWsConfig2_IntrOp>(loc, rs1Value, rs2Value);
+    rs1Value = arith::ConstantOp::create(rewriter, loc, rs1Attr);
+    rs2Value = arith::ConstantOp::create(rewriter, loc, rs2Attr);
+    LoopConvWsConfig2_IntrOp::create(rewriter, loc, rs1Value, rs2Value);
     // loopConvWsConfig3
     rs1 = (uint64_t)krows << 48 | (uint64_t)kcols << 32 | (uint64_t)kchs << 16 |
           (uint64_t)lpad;
@@ -1141,9 +1139,9 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
           (uint64_t)plpad << 16 | (uint64_t)inDim;
     rs1Attr = rewriter.getI64IntegerAttr(rs1);
     rs2Attr = rewriter.getI64IntegerAttr(rs2);
-    rs1Value = rewriter.create<arith::ConstantOp>(loc, rs1Attr);
-    rs2Value = rewriter.create<arith::ConstantOp>(loc, rs2Attr);
-    rewriter.create<LoopConvWsConfig3_IntrOp>(loc, rs1Value, rs2Value);
+    rs1Value = arith::ConstantOp::create(rewriter, loc, rs1Attr);
+    rs2Value = arith::ConstantOp::create(rewriter, loc, rs2Attr);
+    LoopConvWsConfig3_IntrOp::create(rewriter, loc, rs1Value, rs2Value);
     // loopConvWsconfig4
     rs1 = (uint64_t)orows << 48 | (uint64_t)prpad << 32 |
           (uint64_t)pupad << 21 | (uint64_t)pdpad << 10 |
@@ -1152,13 +1150,13 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
           (uint64_t)outStride << 16 | (uint64_t)ocols;
     rs1Attr = rewriter.getI64IntegerAttr(rs1);
     rs2Attr = rewriter.getI64IntegerAttr(rs2);
-    rs1Value = rewriter.create<arith::ConstantOp>(loc, rs1Attr);
-    rs2Value = rewriter.create<arith::ConstantOp>(loc, rs2Attr);
-    rewriter.create<LoopConvWsConfig4_IntrOp>(loc, rs1Value, rs2Value);
+    rs1Value = arith::ConstantOp::create(rewriter, loc, rs1Attr);
+    rs2Value = arith::ConstantOp::create(rewriter, loc, rs2Attr);
+    LoopConvWsConfig4_IntrOp::create(rewriter, loc, rs1Value, rs2Value);
     // loopConvWsconfig5
-    rewriter.create<LoopConvWsConfig5_IntrOp>(loc, weights, output);
+    LoopConvWsConfig5_IntrOp::create(rewriter, loc, weights, output);
     // loopConvWsconfig6
-    rewriter.create<LoopConvWsConfig6_IntrOp>(loc, bias, input);
+    LoopConvWsConfig6_IntrOp::create(rewriter, loc, bias, input);
     // loopConvWs
     const int aSpadId = 0;
     const int bSpadId = 0;
@@ -1169,9 +1167,9 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
     rs2 = act << 3 | inputDilated << 2 | downsample << 1 | noPool;
     rs1Attr = rewriter.getI64IntegerAttr(rs1);
     rs2Attr = rewriter.getI64IntegerAttr(rs2);
-    rs1Value = rewriter.create<arith::ConstantOp>(loc, rs1Attr);
-    rs2Value = rewriter.create<arith::ConstantOp>(loc, rs2Attr);
-    rewriter.create<LoopConvWs_IntrOp>(loc, rs1Value, rs2Value);
+    rs1Value = arith::ConstantOp::create(rewriter, loc, rs1Attr);
+    rs2Value = arith::ConstantOp::create(rewriter, loc, rs2Attr);
+    LoopConvWs_IntrOp::create(rewriter, loc, rs1Value, rs2Value);
   }
 
   void spTiledConv(int batchSize, int inRowDim, int inColDim, int inChannels,
@@ -1281,11 +1279,11 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
       // TODO we probably don't need quite this many nested loops for this part
       const int maxOchsPerMvin =
           ochs < (int)(maxBlockLenAcc * dim) ? ochs : maxBlockLenAcc * dim;
-      Value zeroValue = rewriter.create<arith::ConstantOp>(
-          loc, rewriter.getI64IntegerAttr(0));
-      rewriter.create<ConfigLdOp>(loc, zeroValue,
-                                  llvm::APFloat((float)MVIN_SCALE_IDENTITY),
-                                  false, 2, batches * orows * ocols);
+      Value zeroValue = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getI64IntegerAttr(0));
+      ConfigLdOp::create(rewriter, loc, zeroValue,
+                         llvm::APFloat((float)MVIN_SCALE_IDENTITY), false, 2,
+                         batches * orows * ocols);
       for (int b = 0; b < batches; b++)
         for (int orow = 0; orow < orows; orow++)
           for (int ocol = 0; ocol < ocols; ocol += dim) {
@@ -1321,11 +1319,11 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
           transInput3120
               ? ichs * (irows >> downsample) * (icols >> downsample)
               : batches * (irows >> downsample) * (icols >> downsample);
-      Value strideValue = rewriter.create<arith::ConstantOp>(
-          loc, rewriter.getI64IntegerAttr(dramStride << downsample));
-      rewriter.create<ConfigLdOp>(loc, strideValue,
-                                  llvm::APFloat((float)MVIN_SCALE_IDENTITY),
-                                  false, 0, spadStride, maxPixelsPerRow);
+      Value strideValue = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getI64IntegerAttr(dramStride << downsample));
+      ConfigLdOp::create(rewriter, loc, strideValue,
+                         llvm::APFloat((float)MVIN_SCALE_IDENTITY), false, 0,
+                         spadStride, maxPixelsPerRow);
       const int b_it = transInput3120 ? maxChsPerMvin : 1;
       const int ich_it = transInput3120 ? 1 : maxChsPerMvin;
       for (int b = 0; b < batches; b += b_it)
@@ -1371,8 +1369,8 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
                   ich;
               Value memAddr = input;
               if (is_zeros) {
-                memAddr = rewriter.create<arith::ConstantOp>(
-                    loc, rewriter.getI64IntegerAttr(0));
+                memAddr = arith::ConstantOp::create(
+                    rewriter, loc, rewriter.getI64IntegerAttr(0));
                 offset = 0;
               } else if (transInput3120) {
                 offset = (ich * inRowDim * inColDim + irow * inColDim + icol) *
@@ -1404,11 +1402,11 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
       }
       const size_t spadBlockStride =
           transWeight0132 ? krows * kcols * ochs : krows * kcols * kchs;
-      Value dramStrideValue = rewriter.create<arith::ConstantOp>(
-          loc, rewriter.getI64IntegerAttr(dramStride));
-      rewriter.create<ConfigLdOp>(loc, dramStrideValue,
-                                  llvm::APFloat((float)MVIN_SCALE_IDENTITY),
-                                  false, 1, spadBlockStride);
+      Value dramStrideValue = arith::ConstantOp::create(
+          rewriter, loc, rewriter.getI64IntegerAttr(dramStride));
+      ConfigLdOp::create(rewriter, loc, dramStrideValue,
+                         llvm::APFloat((float)MVIN_SCALE_IDENTITY), false, 1,
+                         spadBlockStride);
 
       const size_t och_it = transWeight0132 ? dim : max_chs_per_mvin;
       const size_t kch_it = transWeight0132 ? max_chs_per_mvin : dim;
@@ -1458,13 +1456,13 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
       const int b_it = transInput3120 ? dim : 1;
       const int ocol_it = transInput3120 ? 1 : (dim << inputDilated);
       if (transInput3120) {
-        rewriter.create<ConfigExOp>(loc, /*dataflow = */ OUTPUT_STATIONARY,
-                                    /*act = */ 0, /*shift = */ 0,
-                                    /*scale = */ llvm::APFloat((float)0),
-                                    /*cStride = */ orows * ocols,
-                                    /*aStride = */ irows * icols,
-                                    /*aTranspose = */ 0, /*bTranspose*/ 0,
-                                    /*setOnlyStrides = */ true);
+        ConfigExOp::create(rewriter, loc, /*dataflow = */ OUTPUT_STATIONARY,
+                           /*act = */ 0, /*shift = */ 0,
+                           /*scale = */ llvm::APFloat((float)0),
+                           /*cStride = */ orows * ocols,
+                           /*aStride = */ irows * icols,
+                           /*aTranspose = */ 0, /*bTranspose*/ 0,
+                           /*setOnlyStrides = */ true);
       }
       for (int och = 0; och < ochs; och += dim) {
         for (int krow = 0; krow < krows; krow++) {
@@ -1541,29 +1539,32 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
                     const uint32_t perSpAddr =
                         newWeights ? bSpAddr : GARBAGE_ADDR;
 
-                    Value garbageAddrOp = rewriter.create<arith::ConstantOp>(
-                        loc, rewriter.getI64IntegerAttr(GARBAGE_ADDR));
-                    Value iOp = rewriter.create<arith::ConstantOp>(
-                        loc, rewriter.getI64IntegerAttr(I));
-                    Value jOp = rewriter.create<arith::ConstantOp>(
-                        loc, rewriter.getI64IntegerAttr(J));
-                    Value kOp = rewriter.create<arith::ConstantOp>(
-                        loc, rewriter.getI64IntegerAttr(K));
-                    Value perSpAddrOp = rewriter.create<arith::ConstantOp>(
-                        loc, rewriter.getI64IntegerAttr(perSpAddr));
-                    Value aSpAddrOp = rewriter.create<arith::ConstantOp>(
-                        loc, rewriter.getI64IntegerAttr(aSpAddr));
-                    Value cSpAddrOp = rewriter.create<arith::ConstantOp>(
-                        loc, rewriter.getI64IntegerAttr(cSpAddr));
+                    Value garbageAddrOp = arith::ConstantOp::create(
+                        rewriter, loc,
+                        rewriter.getI64IntegerAttr(GARBAGE_ADDR));
+                    Value iOp = arith::ConstantOp::create(
+                        rewriter, loc, rewriter.getI64IntegerAttr(I));
+                    Value jOp = arith::ConstantOp::create(
+                        rewriter, loc, rewriter.getI64IntegerAttr(J));
+                    Value kOp = arith::ConstantOp::create(
+                        rewriter, loc, rewriter.getI64IntegerAttr(K));
+                    Value perSpAddrOp = arith::ConstantOp::create(
+                        rewriter, loc, rewriter.getI64IntegerAttr(perSpAddr));
+                    Value aSpAddrOp = arith::ConstantOp::create(
+                        rewriter, loc, rewriter.getI64IntegerAttr(aSpAddr));
+                    Value cSpAddrOp = arith::ConstantOp::create(
+                        rewriter, loc, rewriter.getI64IntegerAttr(cSpAddr));
 
-                    rewriter.create<PreloadOp>(loc, perSpAddrOp, cSpAddrOp, kOp,
-                                               jOp, iOp, jOp);
+                    PreloadOp::create(rewriter, loc, perSpAddrOp, cSpAddrOp,
+                                      kOp, jOp, iOp, jOp);
                     if (newWeights) {
-                      rewriter.create<ComputePreloadedOp>(
-                          loc, aSpAddrOp, garbageAddrOp, iOp, kOp, iOp, jOp);
+                      ComputePreloadedOp::create(rewriter, loc, aSpAddrOp,
+                                                 garbageAddrOp, iOp, kOp, iOp,
+                                                 jOp);
                     } else {
-                      rewriter.create<ComputeAccumulatedOp>(
-                          loc, aSpAddrOp, garbageAddrOp, iOp, kOp, iOp, jOp);
+                      ComputeAccumulatedOp::create(rewriter, loc, aSpAddrOp,
+                                                   garbageAddrOp, iOp, kOp, iOp,
+                                                   jOp);
                     }
                     ocol += ocol_it;
                     newWeights = false;
@@ -1639,11 +1640,12 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
                                ? batchSize * outChannels * sizeOfElemT
                                : outChannels * sizeOfElemT;
     Location loc = tileConvOp.getLoc();
-    Value strideValue = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64IntegerAttr(stDramStride));
-    rewriter.create<ConfigStOp>(loc, strideValue, act, llvm::APFloat(scale));
-    rewriter.create<ConfigExOp>(
-        loc, /*dataflow = */ WEIGHT_STATIONARY, /*act = */ 0, /*shift = */ 0,
+    Value strideValue = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64IntegerAttr(stDramStride));
+    ConfigStOp::create(rewriter, loc, strideValue, act, llvm::APFloat(scale));
+    ConfigExOp::create(
+        rewriter, loc, /*dataflow = */ WEIGHT_STATIONARY, /*act = */ 0,
+        /*shift = */ 0,
         /*scale = */ llvm::APFloat((float)0), /*cStride = */ inputDilation,
         /*aStride = */ stride >> downsample,
         /*aTranspose = */ transInput3120, /*bTranspose*/ transWeight0132,
@@ -1681,10 +1683,10 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
                        poch) *
                       sizeOfElemT);
                   Value offsetValue =
-                      rewriter.create<arith::ConstantOp>(loc, offsetAttr);
-                  Value out = rewriter.create<arith::AddIOp>(
-                      tileConvOp.getLoc(), rewriter.getI64Type(), output,
-                      offsetValue);
+                      arith::ConstantOp::create(rewriter, loc, offsetAttr);
+                  Value out = arith::AddIOp::create(
+                      rewriter, tileConvOp.getLoc(), rewriter.getI64Type(),
+                      output, offsetValue);
                   if (transOutput1203) {
                     offsetAttr = rewriter.getI64IntegerAttr(
                         ((porow * poolOutColDim * batchSize +
@@ -1693,26 +1695,28 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
                          poch) *
                         sizeOfElemT);
                     offsetValue =
-                        rewriter.create<arith::ConstantOp>(loc, offsetAttr);
-                    out = rewriter.create<arith::AddIOp>(tileConvOp.getLoc(),
-                                                         rewriter.getI64Type(),
-                                                         output, offsetValue);
+                        arith::ConstantOp::create(rewriter, loc, offsetAttr);
+                    out = arith::AddIOp::create(rewriter, tileConvOp.getLoc(),
+                                                rewriter.getI64Type(), output,
+                                                offsetValue);
                   }
 
                   if (krow + krows < kernelDim || kcol + kcols < kernelDim ||
                       kch + kchs < inChannels) {
-                    out = rewriter.create<arith::ConstantOp>(
-                        tileConvOp.getLoc(), rewriter.getI64IntegerAttr(0));
+                    out = arith::ConstantOp::create(
+                        rewriter, tileConvOp.getLoc(),
+                        rewriter.getI64IntegerAttr(0));
                   }
-                  Value pochValue = rewriter.create<arith::ConstantOp>(
-                      tileConvOp.getLoc(),
+                  Value pochValue = arith::ConstantOp::create(
+                      rewriter, tileConvOp.getLoc(),
                       rewriter.getI64IntegerAttr(poch * sizeOfAccT));
-                  Value bias_ = rewriter.create<arith::AddIOp>(
-                      tileConvOp.getLoc(), rewriter.getI64Type(), bias,
-                      pochValue);
+                  Value bias_ = arith::AddIOp::create(
+                      rewriter, tileConvOp.getLoc(), rewriter.getI64Type(),
+                      bias, pochValue);
                   if (krow > 0 || kcol > 0 || kch > 0) {
-                    bias_ = rewriter.create<arith::ConstantOp>(
-                        tileConvOp.getLoc(), rewriter.getI64IntegerAttr(0));
+                    bias_ = arith::ConstantOp::create(
+                        rewriter, tileConvOp.getLoc(),
+                        rewriter.getI64IntegerAttr(0));
                   }
 
                   const int batches_ =
@@ -1780,11 +1784,11 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
                            outChannels +
                        poch) *
                       sizeOfElemT);
-                  offsetValue = rewriter.create<arith::ConstantOp>(
-                      tileConvOp.getLoc(), offsetAttr);
-                  Value weightsSlice = rewriter.create<arith::AddIOp>(
-                      tileConvOp.getLoc(), rewriter.getI64Type(), weights,
-                      offsetValue);
+                  offsetValue = arith::ConstantOp::create(
+                      rewriter, tileConvOp.getLoc(), offsetAttr);
+                  Value weightsSlice = arith::AddIOp::create(
+                      rewriter, tileConvOp.getLoc(), rewriter.getI64Type(),
+                      weights, offsetValue);
                   if (transWeight1203) {
                     offsetAttr = rewriter.getI64IntegerAttr(
                         ((kch * kernelDim * kernelDim + krow_ * kernelDim +
@@ -1792,11 +1796,11 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
                              outChannels +
                          poch) *
                         sizeOfElemT);
-                    offsetValue = rewriter.create<arith::ConstantOp>(
-                        tileConvOp.getLoc(), offsetAttr);
-                    weightsSlice = rewriter.create<arith::AddIOp>(
-                        tileConvOp.getLoc(), rewriter.getI64Type(), weights,
-                        offsetValue);
+                    offsetValue = arith::ConstantOp::create(
+                        rewriter, tileConvOp.getLoc(), offsetAttr);
+                    weightsSlice = arith::AddIOp::create(
+                        rewriter, tileConvOp.getLoc(), rewriter.getI64Type(),
+                        weights, offsetValue);
                   } else if (transWeight0132) {
                     offsetAttr = rewriter.getI64IntegerAttr(
                         ((krow_ * kernelDim * outChannels +
@@ -1804,11 +1808,11 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
                              inChannels +
                          kch) *
                         sizeOfElemT);
-                    offsetValue = rewriter.create<arith::ConstantOp>(
-                        tileConvOp.getLoc(), offsetAttr);
-                    weightsSlice = rewriter.create<arith::AddIOp>(
-                        tileConvOp.getLoc(), rewriter.getI64Type(), weights,
-                        offsetValue);
+                    offsetValue = arith::ConstantOp::create(
+                        rewriter, tileConvOp.getLoc(), offsetAttr);
+                    weightsSlice = arith::AddIOp::create(
+                        rewriter, tileConvOp.getLoc(), rewriter.getI64Type(),
+                        weights, offsetValue);
                   }
                   offsetAttr = rewriter.getI64IntegerAttr(
                       ((b * inRowDim * inColDim +
@@ -1817,11 +1821,11 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
                            inChannels +
                        kch) *
                       sizeOfElemT);
-                  offsetValue = rewriter.create<arith::ConstantOp>(
-                      tileConvOp.getLoc(), offsetAttr);
-                  Value in = rewriter.create<arith::AddIOp>(
-                      tileConvOp.getLoc(), rewriter.getI64Type(), input,
-                      offsetValue);
+                  offsetValue = arith::ConstantOp::create(
+                      rewriter, tileConvOp.getLoc(), offsetAttr);
+                  Value in = arith::AddIOp::create(
+                      rewriter, tileConvOp.getLoc(), rewriter.getI64Type(),
+                      input, offsetValue);
                   if (transInput3120) {
                     offsetAttr = rewriter.getI64IntegerAttr(
                         ((kch * inRowDim * inColDim +
@@ -1830,9 +1834,9 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
                              batchSize +
                          b) *
                         sizeOfElemT);
-                    in = rewriter.create<arith::AddIOp>(tileConvOp.getLoc(),
-                                                        rewriter.getI64Type(),
-                                                        input, offsetValue);
+                    in = arith::AddIOp::create(rewriter, tileConvOp.getLoc(),
+                                               rewriter.getI64Type(), input,
+                                               offsetValue);
                   }
 
                   spTiledConv(
@@ -1854,8 +1858,8 @@ class GemminiTileConvLowering : public ConvertOpToLLVMPattern<TileConvOp> {
       }
     }
     IntegerAttr flushAttr = rewriter.getI64IntegerAttr(0);
-    Value flushValue = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getI64Type(), flushAttr);
+    Value flushValue = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getI64Type(), flushAttr);
     rewriter.replaceOpWithNewOp<Flush_IntrOp>(tileConvOp, flushValue,
                                               flushValue);
   }
@@ -1948,21 +1952,21 @@ public:
     Location loc = tileConvOp.getLoc();
     IntegerType i64Type = rewriter.getI64Type();
     Value inputExtractOp =
-        rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, input);
+        memref::ExtractAlignedPointerAsIndexOp::create(rewriter, loc, input);
     Value inputIndexCastOp =
-        rewriter.create<arith::IndexCastOp>(loc, i64Type, inputExtractOp);
+        arith::IndexCastOp::create(rewriter, loc, i64Type, inputExtractOp);
     Value outputExtractOp =
-        rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, output);
+        memref::ExtractAlignedPointerAsIndexOp::create(rewriter, loc, output);
     Value outputIndexCastOp =
-        rewriter.create<arith::IndexCastOp>(loc, i64Type, outputExtractOp);
+        arith::IndexCastOp::create(rewriter, loc, i64Type, outputExtractOp);
     Value biasExtractOp =
-        rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, bias);
+        memref::ExtractAlignedPointerAsIndexOp::create(rewriter, loc, bias);
     Value biasIndexCastOp =
-        rewriter.create<arith::IndexCastOp>(loc, i64Type, biasExtractOp);
+        arith::IndexCastOp::create(rewriter, loc, i64Type, biasExtractOp);
     Value weightsExtractOp =
-        rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, weights);
+        memref::ExtractAlignedPointerAsIndexOp::create(rewriter, loc, weights);
     Value weightsIndexCastOp =
-        rewriter.create<arith::IndexCastOp>(loc, i64Type, weightsExtractOp);
+        arith::IndexCastOp::create(rewriter, loc, i64Type, weightsExtractOp);
     const bool noPool = poolSize == 0;
     if (noPool) {
       poolSize = 1;

--- a/midend/lib/Dialect/IME/Transforms/LegalizeForLLVMExport.cpp
+++ b/midend/lib/Dialect/IME/Transforms/LegalizeForLLVMExport.cpp
@@ -37,24 +37,24 @@ namespace {
 
 /// Enumeration of supported IME data types
 enum class IMEDataType {
-  Int8,   // 8-bit integer (signed/unsigned)
-  Int16,  // 16-bit integer (signed/unsigned)
-  FP16    // 16-bit floating point
+  Int8,  // 8-bit integer (signed/unsigned)
+  Int16, // 16-bit integer (signed/unsigned)
+  FP16   // 16-bit floating point
 };
 
 /// Configuration structure for IME operations based on data type
 struct IMETypeConfig {
-  int64_t targetVL;        // Vector length
-  int64_t sew;             // SEW encoding: 0=e8, 1=e16, 2=e32, 3=e64
-  int64_t lmul;            // LMUL encoding: 0=m1, 1=m2, 2=m4, 3=m8
-  int64_t extendedVL;      // Extended VL for sliding operations (2x targetVL)
-  Type elementType;        // Element type for input vectors
-  Type outputElementType;  // Element type for output vectors
-  VectorType inputVecType; // Input vector type (e.g., nxv32i8)
-  VectorType outputVecType;// Output vector type (e.g., nxv8i32)
-  VectorType extendedInputVecType; // Extended input vector for sliding ops
-  std::string inputVecSuffix;  // e.g., "nxv32i8"
-  std::string outputVecSuffix; // e.g., "nxv8i32"
+  int64_t targetVL;         // Vector length
+  int64_t sew;              // SEW encoding: 0=e8, 1=e16, 2=e32, 3=e64
+  int64_t lmul;             // LMUL encoding: 0=m1, 1=m2, 2=m4, 3=m8
+  int64_t extendedVL;       // Extended VL for sliding operations (2x targetVL)
+  Type elementType;         // Element type for input vectors
+  Type outputElementType;   // Element type for output vectors
+  VectorType inputVecType;  // Input vector type (e.g., nxv32i8)
+  VectorType outputVecType; // Output vector type (e.g., nxv8i32)
+  VectorType extendedInputVecType;    // Extended input vector for sliding ops
+  std::string inputVecSuffix;         // e.g., "nxv32i8"
+  std::string outputVecSuffix;        // e.g., "nxv8i32"
   std::string extendedInputVecSuffix; // e.g., "nxv64i8"
 };
 
@@ -66,39 +66,48 @@ static IMETypeConfig getIMETypeConfig(MLIRContext *ctx, Type elementType) {
   if (elementType.isInteger(8)) {
     // int8: SEW=e8, VL=32, MAC unit 4x4x8
     config.targetVL = 32;
-    config.sew = 0;  // e8
+    config.sew = 0; // e8
     config.extendedVL = 64;
     config.elementType = IntegerType::get(ctx, 8);
     config.outputElementType = IntegerType::get(ctx, 32);
-    config.inputVecType = VectorType::get({32}, config.elementType, /*scalableDims=*/true);
-    config.outputVecType = VectorType::get({8}, config.outputElementType, /*scalableDims=*/true);
-    config.extendedInputVecType = VectorType::get({64}, config.elementType, /*scalableDims=*/true);
+    config.inputVecType =
+        VectorType::get({32}, config.elementType, /*scalableDims=*/true);
+    config.outputVecType =
+        VectorType::get({8}, config.outputElementType, /*scalableDims=*/true);
+    config.extendedInputVecType =
+        VectorType::get({64}, config.elementType, /*scalableDims=*/true);
     config.inputVecSuffix = "nxv32i8";
     config.outputVecSuffix = "nxv8i32";
     config.extendedInputVecSuffix = "nxv64i8";
   } else if (elementType.isInteger(16)) {
     // int16: SEW=e16, VL=16, MAC unit 4x4x4
     config.targetVL = 16;
-    config.sew = 1;  // e16
+    config.sew = 1; // e16
     config.extendedVL = 32;
     config.elementType = IntegerType::get(ctx, 16);
     config.outputElementType = IntegerType::get(ctx, 32);
-    config.inputVecType = VectorType::get({16}, config.elementType, /*scalableDims=*/true);
-    config.outputVecType = VectorType::get({8}, config.outputElementType, /*scalableDims=*/true);
-    config.extendedInputVecType = VectorType::get({32}, config.elementType, /*scalableDims=*/true);
+    config.inputVecType =
+        VectorType::get({16}, config.elementType, /*scalableDims=*/true);
+    config.outputVecType =
+        VectorType::get({8}, config.outputElementType, /*scalableDims=*/true);
+    config.extendedInputVecType =
+        VectorType::get({32}, config.elementType, /*scalableDims=*/true);
     config.inputVecSuffix = "nxv16i16";
     config.outputVecSuffix = "nxv8i32";
     config.extendedInputVecSuffix = "nxv32i16";
   } else if (elementType.isF16()) {
     // fp16: SEW=e16, VL=16, MAC unit 4x4x4
     config.targetVL = 16;
-    config.sew = 1;  // e16
+    config.sew = 1; // e16
     config.extendedVL = 32;
     config.elementType = Float16Type::get(ctx);
     config.outputElementType = Float16Type::get(ctx); // fp16 output is also f16
-    config.inputVecType = VectorType::get({16}, config.elementType, /*scalableDims=*/true);
-    config.outputVecType = VectorType::get({16}, config.outputElementType, /*scalableDims=*/true);
-    config.extendedInputVecType = VectorType::get({32}, config.elementType, /*scalableDims=*/true);
+    config.inputVecType =
+        VectorType::get({16}, config.elementType, /*scalableDims=*/true);
+    config.outputVecType =
+        VectorType::get({16}, config.outputElementType, /*scalableDims=*/true);
+    config.extendedInputVecType =
+        VectorType::get({32}, config.elementType, /*scalableDims=*/true);
     config.inputVecSuffix = "nxv16f16";
     config.outputVecSuffix = "nxv16f16";
     config.extendedInputVecSuffix = "nxv32f16";
@@ -109,9 +118,12 @@ static IMETypeConfig getIMETypeConfig(MLIRContext *ctx, Type elementType) {
     config.extendedVL = 64;
     config.elementType = IntegerType::get(ctx, 8);
     config.outputElementType = IntegerType::get(ctx, 32);
-    config.inputVecType = VectorType::get({32}, config.elementType, /*scalableDims=*/true);
-    config.outputVecType = VectorType::get({8}, config.outputElementType, /*scalableDims=*/true);
-    config.extendedInputVecType = VectorType::get({64}, config.elementType, /*scalableDims=*/true);
+    config.inputVecType =
+        VectorType::get({32}, config.elementType, /*scalableDims=*/true);
+    config.outputVecType =
+        VectorType::get({8}, config.outputElementType, /*scalableDims=*/true);
+    config.extendedInputVecType =
+        VectorType::get({64}, config.elementType, /*scalableDims=*/true);
     config.inputVecSuffix = "nxv32i8";
     config.outputVecSuffix = "nxv8i32";
     config.extendedInputVecSuffix = "nxv64i8";
@@ -141,9 +153,8 @@ getOrInsertIntrinsic(ConversionPatternRewriter &rewriter, ModuleOp module,
 
   auto savedInsertionPoint = rewriter.saveInsertionPoint();
   rewriter.setInsertionPointToEnd(module.getBody());
-  rewriter.create<LLVM::LLVMFuncOp>(module.getLoc(), intrinsicName, funcType,
-                                    LLVM::Linkage::External, false,
-                                    LLVM::CConv::C);
+  LLVM::LLVMFuncOp::create(rewriter, module.getLoc(), intrinsicName, funcType,
+                           LLVM::Linkage::External, false, LLVM::CConv::C);
   rewriter.restoreInsertionPoint(savedInsertionPoint);
   return FlatSymbolRefAttr::get(ctx, intrinsicName);
 }
@@ -160,18 +171,18 @@ static Value createVsetvli(ConversionPatternRewriter &rewriter, Location loc,
   // vsetvli intrinsic: i64 @llvm.riscv.vsetvli.i64(i64 avl, i64 sew, i64 lmul)
   auto funcType =
       LLVM::LLVMFunctionType::get(i64Type, {i64Type, i64Type, i64Type}, false);
-  auto funcRef =
-      getOrInsertIntrinsic(rewriter, module, "llvm.riscv.vsetvli.i64", funcType);
+  auto funcRef = getOrInsertIntrinsic(rewriter, module,
+                                      "llvm.riscv.vsetvli.i64", funcType);
 
-  auto avlVal = rewriter.create<LLVM::ConstantOp>(
-      loc, i64Type, rewriter.getI64IntegerAttr(avl));
-  auto sewVal = rewriter.create<LLVM::ConstantOp>(
-      loc, i64Type, rewriter.getI64IntegerAttr(sew));
-  auto lmulVal = rewriter.create<LLVM::ConstantOp>(
-      loc, i64Type, rewriter.getI64IntegerAttr(lmul));
+  auto avlVal = LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                         rewriter.getI64IntegerAttr(avl));
+  auto sewVal = LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                         rewriter.getI64IntegerAttr(sew));
+  auto lmulVal = LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                          rewriter.getI64IntegerAttr(lmul));
 
-  auto call = rewriter.create<LLVM::CallOp>(loc, TypeRange{i64Type}, funcRef,
-                                            ValueRange{avlVal, sewVal, lmulVal});
+  auto call = LLVM::CallOp::create(rewriter, loc, TypeRange{i64Type}, funcRef,
+                                   ValueRange{avlVal, sewVal, lmulVal});
   return call.getResult();
 }
 
@@ -186,10 +197,10 @@ static Value createRVVVectorLoad(ConversionPatternRewriter &rewriter,
   auto funcType = LLVM::LLVMFunctionType::get(
       vectorType, {vectorType, ptrType, i64Type}, false);
   auto funcRef = getOrInsertIntrinsic(rewriter, module, mangledName, funcType);
-  auto undefPassthru = rewriter.create<LLVM::UndefOp>(loc, vectorType);
+  auto undefPassthru = LLVM::UndefOp::create(rewriter, loc, vectorType);
   auto call =
-      rewriter.create<LLVM::CallOp>(loc, TypeRange{vectorType}, funcRef,
-                                    ValueRange{undefPassthru, pointer, vl});
+      LLVM::CallOp::create(rewriter, loc, TypeRange{vectorType}, funcRef,
+                           ValueRange{undefPassthru, pointer, vl});
   return call.getResult();
 }
 
@@ -206,8 +217,8 @@ static void createRVVVectorStore(ConversionPatternRewriter &rewriter,
   auto funcType = LLVM::LLVMFunctionType::get(
       voidType, {vectorType, ptrType, i64Type}, false);
   auto funcRef = getOrInsertIntrinsic(rewriter, module, mangledName, funcType);
-  rewriter.create<LLVM::CallOp>(loc, TypeRange{}, funcRef,
-                                ValueRange{vector, pointer, vl});
+  LLVM::CallOp::create(rewriter, loc, TypeRange{}, funcRef,
+                       ValueRange{vector, pointer, vl});
 }
 
 static Value createIMEVmadotIntrinsic(ConversionPatternRewriter &rewriter,
@@ -223,9 +234,8 @@ static Value createIMEVmadotIntrinsic(ConversionPatternRewriter &rewriter,
   auto funcType =
       LLVM::LLVMFunctionType::get(vdType, {vdType, vs1Type, vs2Type}, false);
   auto funcRef = getOrInsertIntrinsic(rewriter, module, mangledName, funcType);
-  auto call =
-      rewriter.create<LLVM::CallOp>(loc, TypeRange{vdType}, funcRef,
-                                    ValueRange{vdVector, vs1Vector, vs2Vector});
+  auto call = LLVM::CallOp::create(rewriter, loc, TypeRange{vdType}, funcRef,
+                                   ValueRange{vdVector, vs1Vector, vs2Vector});
   return call.getResult();
 }
 
@@ -244,8 +254,8 @@ static Value createIMEVmadotnIntrinsic(ConversionPatternRewriter &rewriter,
   auto funcType = LLVM::LLVMFunctionType::get(
       vdType, {vdType, vs1Type, vs2Type, i64Type}, false);
   auto funcRef = getOrInsertIntrinsic(rewriter, module, mangledName, funcType);
-  auto call = rewriter.create<LLVM::CallOp>(
-      loc, TypeRange{vdType}, funcRef,
+  auto call = LLVM::CallOp::create(
+      rewriter, loc, TypeRange{vdType}, funcRef,
       ValueRange{vdVector, vs1Vector, vs2Vector, slideVal});
   return call.getResult();
 }
@@ -256,9 +266,9 @@ static Value extractPointerFromMemref(ConversionPatternRewriter &rewriter,
   auto ptrType = LLVM::LLVMPointerType::get(ctx);
   auto i64Type = IntegerType::get(ctx, 64);
   Value idx =
-      rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, memref);
-  Value i64Val = rewriter.create<arith::IndexCastOp>(loc, i64Type, idx);
-  Value ptr = rewriter.create<LLVM::IntToPtrOp>(loc, ptrType, i64Val);
+      memref::ExtractAlignedPointerAsIndexOp::create(rewriter, loc, memref);
+  Value i64Val = arith::IndexCastOp::create(rewriter, loc, i64Type, idx);
+  Value ptr = LLVM::IntToPtrOp::create(rewriter, loc, ptrType, i64Val);
   return ptr;
 }
 
@@ -283,31 +293,37 @@ struct IMEVmadotLowering : public ConvertOpToLLVMPattern<VmadotOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.inputVecSuffix + "." + config.inputVecSuffix;
+                             config.inputVecSuffix + "." +
+                             config.inputVecSuffix;
 
-    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot",
-        typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+    Value vs1Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs1Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vmadot", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -334,31 +350,37 @@ struct IMEVmadotuLowering : public ConvertOpToLLVMPattern<VmadotuOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.inputVecSuffix + "." + config.inputVecSuffix;
+                             config.inputVecSuffix + "." +
+                             config.inputVecSuffix;
 
-    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadotu",
-        typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+    Value vs1Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs1Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vmadotu", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -385,31 +407,37 @@ struct IMEVmadotsuLowering : public ConvertOpToLLVMPattern<VmadotsuOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.inputVecSuffix + "." + config.inputVecSuffix;
+                             config.inputVecSuffix + "." +
+                             config.inputVecSuffix;
 
-    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadotsu",
-        typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+    Value vs1Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs1Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vmadotsu", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -436,31 +464,37 @@ struct IMEVmadotusLowering : public ConvertOpToLLVMPattern<VmadotusOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.inputVecSuffix + "." + config.inputVecSuffix;
+                             config.inputVecSuffix + "." +
+                             config.inputVecSuffix;
 
-    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadotus",
-        typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+    Value vs1Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs1Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vmadotus", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -487,31 +521,37 @@ struct IMEVfmadotLowering : public ConvertOpToLLVMPattern<VfmadotOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type (fp16: vl=16, SEW=e16, LMUL=m1)
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.inputVecSuffix + "." + config.inputVecSuffix;
+                             config.inputVecSuffix + "." +
+                             config.inputVecSuffix;
 
-    Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vfmadot",
-        typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+    Value vs1Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs1Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vfmadot", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -538,36 +578,43 @@ struct IMEVmadot1Lowering : public ConvertOpToLLVMPattern<Vmadot1Op> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
     // For extended loads (2x elements for vs1)
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     // Load extended elements for VS1 (two consecutive vector registers)
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot1",
-        typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vmadot1", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -594,34 +641,41 @@ struct IMEVmadot1uLowering : public ConvertOpToLLVMPattern<Vmadot1uOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot1u",
-        typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vmadot1u", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -648,34 +702,41 @@ struct IMEVmadot1suLowering : public ConvertOpToLLVMPattern<Vmadot1suOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
-        "llvm.riscv.ime.vmadot1su", typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vmadot1su", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -702,34 +763,41 @@ struct IMEVmadot1usLowering : public ConvertOpToLLVMPattern<Vmadot1usOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
-        "llvm.riscv.ime.vmadot1us", typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vmadot1us", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -756,34 +824,41 @@ struct IMEVmadot2Lowering : public ConvertOpToLLVMPattern<Vmadot2Op> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot2",
-        typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vmadot2", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -810,34 +885,41 @@ struct IMEVmadot2uLowering : public ConvertOpToLLVMPattern<Vmadot2uOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot2u",
-        typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vmadot2u", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -864,34 +946,41 @@ struct IMEVmadot2suLowering : public ConvertOpToLLVMPattern<Vmadot2suOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
-        "llvm.riscv.ime.vmadot2su", typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vmadot2su", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -918,34 +1007,41 @@ struct IMEVmadot2usLowering : public ConvertOpToLLVMPattern<Vmadot2usOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
-        "llvm.riscv.ime.vmadot2us", typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vmadot2us", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -972,34 +1068,41 @@ struct IMEVmadot3Lowering : public ConvertOpToLLVMPattern<Vmadot3Op> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot3",
-        typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vmadot3", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -1026,34 +1129,41 @@ struct IMEVmadot3uLowering : public ConvertOpToLLVMPattern<Vmadot3uOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vmadot3u",
-        typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vmadot3u", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -1080,34 +1190,41 @@ struct IMEVmadot3suLowering : public ConvertOpToLLVMPattern<Vmadot3suOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
-        "llvm.riscv.ime.vmadot3su", typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vmadot3su", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -1134,34 +1251,41 @@ struct IMEVmadot3usLowering : public ConvertOpToLLVMPattern<Vmadot3usOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
-        "llvm.riscv.ime.vmadot3us", typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vmadot3us", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -1188,34 +1312,41 @@ struct IMEVfmadot1Lowering : public ConvertOpToLLVMPattern<Vfmadot1Op> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type (fp16: vl=16, SEW=e16, LMUL=m1)
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vfmadot1",
-        typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vfmadot1", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -1242,34 +1373,41 @@ struct IMEVfmadot2Lowering : public ConvertOpToLLVMPattern<Vfmadot2Op> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type (fp16: vl=16, SEW=e16, LMUL=m1)
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vfmadot2",
-        typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vfmadot2", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -1296,34 +1434,41 @@ struct IMEVfmadot3Lowering : public ConvertOpToLLVMPattern<Vfmadot3Op> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type (fp16: vl=16, SEW=e16, LMUL=m1)
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
-    Value result = createIMEVmadotIntrinsic(
-        rewriter, loc, module, vdVec, vs1Vec, vs2Vec, "llvm.riscv.ime.vfmadot3",
-        typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
+    Value result =
+        createIMEVmadotIntrinsic(rewriter, loc, module, vdVec, vs1Vec, vs2Vec,
+                                 "llvm.riscv.ime.vfmadot3", typeSuffix);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -1350,35 +1495,42 @@ struct IMEVmadotnLowering : public ConvertOpToLLVMPattern<VmadotnOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
     Value slideVal = op.getSlide();
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotnIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, slideVal,
         "llvm.riscv.ime.vmadotn", typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -1405,35 +1557,42 @@ struct IMEVmadotnuLowering : public ConvertOpToLLVMPattern<VmadotnuOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
     Value slideVal = op.getSlide();
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotnIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, slideVal,
         "llvm.riscv.ime.vmadotnu", typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -1460,35 +1619,42 @@ struct IMEVmadotnsuLowering : public ConvertOpToLLVMPattern<VmadotnsuOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
     Value slideVal = op.getSlide();
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotnIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, slideVal,
         "llvm.riscv.ime.vmadotnsu", typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -1515,35 +1681,42 @@ struct IMEVmadotnusLowering : public ConvertOpToLLVMPattern<VmadotnusOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
     Value slideVal = op.getSlide();
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
-    std::string outputLoadIntrinsic = "llvm.riscv.vle." + config.outputVecSuffix;
+    std::string outputLoadIntrinsic =
+        "llvm.riscv.vle." + config.outputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, outputLoadIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            outputLoadIntrinsic, vlValue);
     Value result = createIMEVmadotnIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, slideVal,
         "llvm.riscv.ime.vmadotnus", typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }
@@ -1570,34 +1743,40 @@ struct IMEVfmadotnLowering : public ConvertOpToLLVMPattern<VfmadotnOp> {
     auto i64Type = IntegerType::get(ctx, 64);
 
     // Configure vtype based on element type
-    createVsetvli(rewriter, loc, module, config.targetVL, config.sew, config.lmul);
-    Value vlValue = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
-    Value vlValueExtended = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
+    createVsetvli(rewriter, loc, module, config.targetVL, config.sew,
+                  config.lmul);
+    Value vlValue = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.targetVL));
+    Value vlValueExtended = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(config.extendedVL));
 
     Value vdPtr = extractPointerFromMemref(rewriter, loc, op.getVd());
     Value vs1Ptr = extractPointerFromMemref(rewriter, loc, op.getVs1());
     Value vs2Ptr = extractPointerFromMemref(rewriter, loc, op.getVs2());
     Value slideVal = op.getSlide();
 
-    std::string extLoadIntrinsic = "llvm.riscv.vle." + config.extendedInputVecSuffix;
+    std::string extLoadIntrinsic =
+        "llvm.riscv.vle." + config.extendedInputVecSuffix;
     std::string loadIntrinsic = "llvm.riscv.vle." + config.inputVecSuffix;
     std::string storeIntrinsic = "llvm.riscv.vse." + config.outputVecSuffix;
     std::string typeSuffix = "." + config.outputVecSuffix + "." +
-                             config.extendedInputVecSuffix + "." + config.inputVecSuffix;
+                             config.extendedInputVecSuffix + "." +
+                             config.inputVecSuffix;
 
     Value vs1Vec = createRVVVectorLoad(rewriter, loc, module, vs1Ptr,
-                                       config.extendedInputVecType, extLoadIntrinsic, vlValueExtended);
-    Value vs2Vec = createRVVVectorLoad(rewriter, loc, module, vs2Ptr,
-                                       config.inputVecType, loadIntrinsic, vlValue);
-    Value vdVec = createRVVVectorLoad(rewriter, loc, module, vdPtr,
-                                      config.outputVecType, loadIntrinsic, vlValue);
+                                       config.extendedInputVecType,
+                                       extLoadIntrinsic, vlValueExtended);
+    Value vs2Vec =
+        createRVVVectorLoad(rewriter, loc, module, vs2Ptr, config.inputVecType,
+                            loadIntrinsic, vlValue);
+    Value vdVec =
+        createRVVVectorLoad(rewriter, loc, module, vdPtr, config.outputVecType,
+                            loadIntrinsic, vlValue);
     Value result = createIMEVmadotnIntrinsic(
         rewriter, loc, module, vdVec, vs1Vec, vs2Vec, slideVal,
         "llvm.riscv.ime.vfmadotn", typeSuffix);
-    createRVVVectorStore(rewriter, loc, module, result, vdPtr,
-                         storeIntrinsic, vlValue);
+    createRVVVectorStore(rewriter, loc, module, result, vdPtr, storeIntrinsic,
+                         vlValue);
     rewriter.eraseOp(op);
     return success();
   }

--- a/midend/lib/Dialect/RVV/Transforms/LegalizeForLLVMExport.cpp
+++ b/midend/lib/Dialect/RVV/Transforms/LegalizeForLLVMExport.cpp
@@ -53,14 +53,13 @@ public:
     Value src1 = op.getOperand(0);
     Value src2 = op.getOperand(1);
     Value vl = op.getOperand(2);
-    Value vlCast = rewriter
-                       .create<UnrealizedConversionCastOp>(
-                           op.getLoc(),
-                           rewriter.getIntegerType(RVVTargetIndexBitwidth), vl)
+    Value vlCast = UnrealizedConversionCastOp::create(
+                       rewriter, op.getLoc(),
+                       rewriter.getIntegerType(RVVTargetIndexBitwidth), vl)
                        .getResult(0);
     SmallVector<Value, 6> operandsVector({src1, src2, vlCast});
 
-    Value passthru = rewriter.create<LLVM::UndefOp>(loc, resultType[0]);
+    Value passthru = LLVM::UndefOp::create(rewriter, loc, resultType[0]);
     operandsVector.insert(operandsVector.begin(), passthru);
 
     const LLVMTypeConverter *typeConverter = this->getTypeConverter();
@@ -116,26 +115,20 @@ struct RVVSetVlOpLowering : public ConvertOpToLLVMPattern<RVVSetVlOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto resultType = rewriter.getIntegerType(RVVTargetIndexBitwidth);
     Value avl = op.getOperand(0);
-    Value avlCast =
-        rewriter
-            .create<UnrealizedConversionCastOp>(
-                op.getLoc(), rewriter.getIntegerType(RVVTargetIndexBitwidth),
-                avl)
-            .getResult(0);
+    Value avlCast = UnrealizedConversionCastOp::create(
+                        rewriter, op.getLoc(),
+                        rewriter.getIntegerType(RVVTargetIndexBitwidth), avl)
+                        .getResult(0);
     Value sew = op.getOperand(1);
-    Value sewCast =
-        rewriter
-            .create<UnrealizedConversionCastOp>(
-                op.getLoc(), rewriter.getIntegerType(RVVTargetIndexBitwidth),
-                sew)
-            .getResult(0);
+    Value sewCast = UnrealizedConversionCastOp::create(
+                        rewriter, op.getLoc(),
+                        rewriter.getIntegerType(RVVTargetIndexBitwidth), sew)
+                        .getResult(0);
     Value lmul = op.getOperand(2);
-    Value lmulCast =
-        rewriter
-            .create<UnrealizedConversionCastOp>(
-                op.getLoc(), rewriter.getIntegerType(RVVTargetIndexBitwidth),
-                lmul)
-            .getResult(0);
+    Value lmulCast = UnrealizedConversionCastOp::create(
+                         rewriter, op.getLoc(),
+                         rewriter.getIntegerType(RVVTargetIndexBitwidth), lmul)
+                         .getResult(0);
     rewriter.replaceOpWithNewOp<RVVIntrSetVlIOp>(op, resultType, avlCast,
                                                  sewCast, lmulCast);
     return success();
@@ -157,17 +150,16 @@ struct RVVLoadOpLowering : public ConvertOpToLLVMPattern<RVVLoadOp> {
     auto resultType = loadOp.getResult().getType();
     auto context = loadOp.getContext();
     Value passthru =
-        rewriter.create<LLVM::UndefOp>(loadOp.getLoc(), resultType);
+        LLVM::UndefOp::create(rewriter, loadOp.getLoc(), resultType);
     LLVM::LLVMPointerType llvmDataTypePtr = LLVM::LLVMPointerType::get(context);
     Value dataPtr = getStridedElementPtr(rewriter, loadOp.getLoc(), type,
                                          adaptor.getBase(), adaptor.getIndex());
-    Value bitCastedPtr = rewriter.create<LLVM::BitcastOp>(
-        loadOp.getLoc(), llvmDataTypePtr, dataPtr);
+    Value bitCastedPtr = LLVM::BitcastOp::create(rewriter, loadOp.getLoc(),
+                                                 llvmDataTypePtr, dataPtr);
     Value vl = loadOp.getOperand(2);
-    Value vlCast = rewriter
-                       .create<UnrealizedConversionCastOp>(
-                           loadOp.getLoc(),
-                           rewriter.getIntegerType(RVVTargetIndexBitwidth), vl)
+    Value vlCast = UnrealizedConversionCastOp::create(
+                       rewriter, loadOp.getLoc(),
+                       rewriter.getIntegerType(RVVTargetIndexBitwidth), vl)
                        .getResult(0);
     rewriter.replaceOpWithNewOp<RVVIntrLoadEleOp>(loadOp, resultType, passthru,
                                                   bitCastedPtr, vlCast);
@@ -192,13 +184,12 @@ struct RVVStoreOpLowering : public ConvertOpToLLVMPattern<RVVStoreOp> {
     LLVM::LLVMPointerType llvmDataTypePtr = LLVM::LLVMPointerType::get(context);
     Value dataPtr = getStridedElementPtr(rewriter, storeOp.getLoc(), type,
                                          adaptor.getBase(), adaptor.getIndex());
-    Value bitCastedPtr = rewriter.create<LLVM::BitcastOp>(
-        storeOp.getLoc(), llvmDataTypePtr, dataPtr);
+    Value bitCastedPtr = LLVM::BitcastOp::create(rewriter, storeOp.getLoc(),
+                                                 llvmDataTypePtr, dataPtr);
     Value vl = storeOp.getOperand(3);
-    Value vlCast = rewriter
-                       .create<UnrealizedConversionCastOp>(
-                           storeOp.getLoc(),
-                           rewriter.getIntegerType(RVVTargetIndexBitwidth), vl)
+    Value vlCast = UnrealizedConversionCastOp::create(
+                       rewriter, storeOp.getLoc(),
+                       rewriter.getIntegerType(RVVTargetIndexBitwidth), vl)
                        .getResult(0);
     rewriter.replaceOpWithNewOp<RVVIntrStoreEleOp>(storeOp, adaptor.getValue(),
                                                    bitCastedPtr, vlCast);
@@ -219,13 +210,12 @@ struct RsqrtOpLowering : public ConvertOpToLLVMPattern<RsqrtOp> {
                   ConversionPatternRewriter &rewriter) const override {
 
     auto resultType = op.getResult().getType();
-    Value passthru = rewriter.create<LLVM::UndefOp>(op.getLoc(), resultType);
+    Value passthru = LLVM::UndefOp::create(rewriter, op.getLoc(), resultType);
     Value src = op.getOperand(0);
     Value vl = op.getOperand(1);
-    Value vlCast = rewriter
-                       .create<UnrealizedConversionCastOp>(
-                           op.getLoc(),
-                           rewriter.getIntegerType(RVVTargetIndexBitwidth), vl)
+    Value vlCast = UnrealizedConversionCastOp::create(
+                       rewriter, op.getLoc(),
+                       rewriter.getIntegerType(RVVTargetIndexBitwidth), vl)
                        .getResult(0);
     rewriter.replaceOpWithNewOp<IntrFrsqrt7Op>(op, resultType, passthru, src,
                                                vlCast);

--- a/midend/lib/Dialect/XTAME/Transforms/LegalizeForLLVMExport.cpp
+++ b/midend/lib/Dialect/XTAME/Transforms/LegalizeForLLVMExport.cpp
@@ -43,9 +43,8 @@ getOrInsertIntrinsic(ConversionPatternRewriter &rewriter, ModuleOp module,
 
   auto savedInsertionPoint = rewriter.saveInsertionPoint();
   rewriter.setInsertionPointToEnd(module.getBody());
-  rewriter.create<LLVM::LLVMFuncOp>(module.getLoc(), intrinsicName, funcType,
-                                    LLVM::Linkage::External, false,
-                                    LLVM::CConv::C);
+  LLVM::LLVMFuncOp::create(rewriter, module.getLoc(), intrinsicName, funcType,
+                           LLVM::Linkage::External, false, LLVM::CConv::C);
   rewriter.restoreInsertionPoint(savedInsertionPoint);
   return FlatSymbolRefAttr::get(ctx, intrinsicName);
 }
@@ -56,9 +55,9 @@ static Value extractPointerFromMemref(ConversionPatternRewriter &rewriter,
   auto ptrType = LLVM::LLVMPointerType::get(ctx);
   auto i64Type = IntegerType::get(ctx, 64);
   Value idx =
-      rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(loc, memref);
-  Value i64Val = rewriter.create<arith::IndexCastOp>(loc, i64Type, idx);
-  Value ptr = rewriter.create<LLVM::IntToPtrOp>(loc, ptrType, i64Val);
+      memref::ExtractAlignedPointerAsIndexOp::create(rewriter, loc, memref);
+  Value i64Val = arith::IndexCastOp::create(rewriter, loc, i64Type, idx);
+  Value ptr = LLVM::IntToPtrOp::create(rewriter, loc, ptrType, i64Val);
   return ptr;
 }
 
@@ -90,11 +89,11 @@ struct XTAMEThMcfgmiLowering : public ConvertOpToLLVMPattern<ThMcfgmiOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mcfgmi", funcType);
 
-    Value tilemVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getTilem()));
+    Value tilemVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getTilem()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{tilemVal});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{tilemVal});
     rewriter.eraseOp(op);
     return success();
   }
@@ -120,11 +119,11 @@ struct XTAMEThMcfgniLowering : public ConvertOpToLLVMPattern<ThMcfgniOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mcfgni", funcType);
 
-    Value tilenVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getTilen()));
+    Value tilenVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getTilen()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{tilenVal});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{tilenVal});
     rewriter.eraseOp(op);
     return success();
   }
@@ -150,11 +149,11 @@ struct XTAMEThMcfgkiLowering : public ConvertOpToLLVMPattern<ThMcfgkiOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mcfgki", funcType);
 
-    Value tilekVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getTilek()));
+    Value tilekVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getTilek()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{tilekVal});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{tilekVal});
     rewriter.eraseOp(op);
     return success();
   }
@@ -180,11 +179,11 @@ struct XTAMEThMzeroLowering : public ConvertOpToLLVMPattern<ThMzeroOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mzero", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal});
     rewriter.eraseOp(op);
     return success();
   }
@@ -217,13 +216,12 @@ struct XTAMEThMlde8Lowering : public ConvertOpToLLVMPattern<ThMlde8Op> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mlde8", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{}, intrinsicName,
-        ValueRange{mdVal, adaptor.getStride(), basePtr});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, adaptor.getStride(), basePtr});
     rewriter.eraseOp(op);
     return success();
   }
@@ -251,13 +249,12 @@ struct XTAMEThMlde16Lowering : public ConvertOpToLLVMPattern<ThMlde16Op> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mlde16", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{}, intrinsicName,
-        ValueRange{mdVal, adaptor.getStride(), basePtr});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, adaptor.getStride(), basePtr});
     rewriter.eraseOp(op);
     return success();
   }
@@ -285,13 +282,12 @@ struct XTAMEThMlde32Lowering : public ConvertOpToLLVMPattern<ThMlde32Op> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mlde32", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{}, intrinsicName,
-        ValueRange{mdVal, adaptor.getStride(), basePtr});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, adaptor.getStride(), basePtr});
     rewriter.eraseOp(op);
     return success();
   }
@@ -319,13 +315,12 @@ struct XTAMEThMlde64Lowering : public ConvertOpToLLVMPattern<ThMlde64Op> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mlde64", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{}, intrinsicName,
-        ValueRange{mdVal, adaptor.getStride(), basePtr});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, adaptor.getStride(), basePtr});
     rewriter.eraseOp(op);
     return success();
   }
@@ -353,13 +348,12 @@ struct XTAMEThMldte8Lowering : public ConvertOpToLLVMPattern<ThMldte8Op> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mldte8", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{}, intrinsicName,
-        ValueRange{mdVal, adaptor.getStride(), basePtr});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, adaptor.getStride(), basePtr});
     rewriter.eraseOp(op);
     return success();
   }
@@ -388,13 +382,12 @@ struct XTAMEThMldte16Lowering : public ConvertOpToLLVMPattern<ThMldte16Op> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mldte16", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{}, intrinsicName,
-        ValueRange{mdVal, adaptor.getStride(), basePtr});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, adaptor.getStride(), basePtr});
     rewriter.eraseOp(op);
     return success();
   }
@@ -423,13 +416,12 @@ struct XTAMEThMldte32Lowering : public ConvertOpToLLVMPattern<ThMldte32Op> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mldte32", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{}, intrinsicName,
-        ValueRange{mdVal, adaptor.getStride(), basePtr});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, adaptor.getStride(), basePtr});
     rewriter.eraseOp(op);
     return success();
   }
@@ -458,13 +450,12 @@ struct XTAMEThMldte64Lowering : public ConvertOpToLLVMPattern<ThMldte64Op> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mldte64", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{}, intrinsicName,
-        ValueRange{mdVal, adaptor.getStride(), basePtr});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, adaptor.getStride(), basePtr});
     rewriter.eraseOp(op);
     return success();
   }
@@ -496,13 +487,12 @@ struct XTAMEThMste8Lowering : public ConvertOpToLLVMPattern<ThMste8Op> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mste8", funcType);
 
-    Value ms3Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs3()));
+    Value ms3Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs3()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{}, intrinsicName,
-        ValueRange{ms3Val, adaptor.getStride(), basePtr});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{ms3Val, adaptor.getStride(), basePtr});
     rewriter.eraseOp(op);
     return success();
   }
@@ -530,13 +520,12 @@ struct XTAMEThMste16Lowering : public ConvertOpToLLVMPattern<ThMste16Op> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mste16", funcType);
 
-    Value ms3Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs3()));
+    Value ms3Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs3()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{}, intrinsicName,
-        ValueRange{ms3Val, adaptor.getStride(), basePtr});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{ms3Val, adaptor.getStride(), basePtr});
     rewriter.eraseOp(op);
     return success();
   }
@@ -564,13 +553,12 @@ struct XTAMEThMste32Lowering : public ConvertOpToLLVMPattern<ThMste32Op> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mste32", funcType);
 
-    Value ms3Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs3()));
+    Value ms3Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs3()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{}, intrinsicName,
-        ValueRange{ms3Val, adaptor.getStride(), basePtr});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{ms3Val, adaptor.getStride(), basePtr});
     rewriter.eraseOp(op);
     return success();
   }
@@ -598,13 +586,12 @@ struct XTAMEThMste64Lowering : public ConvertOpToLLVMPattern<ThMste64Op> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mste64", funcType);
 
-    Value ms3Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs3()));
+    Value ms3Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs3()));
     Value basePtr = extractPointerFromMemref(rewriter, loc, op.getBase());
 
-    rewriter.create<LLVM::CallOp>(
-        loc, TypeRange{}, intrinsicName,
-        ValueRange{ms3Val, adaptor.getStride(), basePtr});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{ms3Val, adaptor.getStride(), basePtr});
     rewriter.eraseOp(op);
     return success();
   }
@@ -634,15 +621,15 @@ struct XTAMEThMmaccWBLowering : public ConvertOpToLLVMPattern<ThMmaccWBOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mmacc.w.b", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms2Val, ms1Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms2Val, ms1Val});
     rewriter.eraseOp(op);
     return success();
   }
@@ -669,15 +656,15 @@ struct XTAMEThMmaccuWBLowering : public ConvertOpToLLVMPattern<ThMmaccuWBOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mmaccu.w.b", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms2Val, ms1Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms2Val, ms1Val});
     rewriter.eraseOp(op);
     return success();
   }
@@ -704,15 +691,15 @@ struct XTAMEThMmaccusWBLowering : public ConvertOpToLLVMPattern<ThMmaccusWBOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mmaccus.w.b", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms2Val, ms1Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms2Val, ms1Val});
     rewriter.eraseOp(op);
     return success();
   }
@@ -739,15 +726,15 @@ struct XTAMEThMmaccsuWBLowering : public ConvertOpToLLVMPattern<ThMmaccsuWBOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mmaccsu.w.b", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms2Val, ms1Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms2Val, ms1Val});
     rewriter.eraseOp(op);
     return success();
   }
@@ -777,15 +764,15 @@ struct XTAMEThMfmaccHLowering : public ConvertOpToLLVMPattern<ThMfmaccHOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mfmacc.h", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms2Val, ms1Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms2Val, ms1Val});
     rewriter.eraseOp(op);
     return success();
   }
@@ -812,15 +799,15 @@ struct XTAMEThMfmaccBf16Lowering
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mfmacc.bf16", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms2Val, ms1Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms2Val, ms1Val});
     rewriter.eraseOp(op);
     return success();
   }
@@ -846,15 +833,15 @@ struct XTAMEThMfmaccSLowering : public ConvertOpToLLVMPattern<ThMfmaccSOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mfmacc.s", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms2Val, ms1Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms2Val, ms1Val});
     rewriter.eraseOp(op);
     return success();
   }
@@ -880,15 +867,15 @@ struct XTAMEThMfmaccDLowering : public ConvertOpToLLVMPattern<ThMfmaccDOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mfmacc.d", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms2Val, ms1Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms2Val, ms1Val});
     rewriter.eraseOp(op);
     return success();
   }
@@ -916,15 +903,15 @@ struct XTAMEThMfmaccHE4m3Lowering
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mfmacc.h.e4m3", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms2Val, ms1Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms2Val, ms1Val});
     rewriter.eraseOp(op);
     return success();
   }
@@ -952,15 +939,15 @@ struct XTAMEThMfmaccHE5m2Lowering
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mfmacc.h.e5m2", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms2Val, ms1Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms2Val, ms1Val});
     rewriter.eraseOp(op);
     return success();
   }
@@ -988,15 +975,15 @@ struct XTAMEThMfmaccBf16E4m3Lowering
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mfmacc.bf16.e4m3", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms2Val, ms1Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms2Val, ms1Val});
     rewriter.eraseOp(op);
     return success();
   }
@@ -1024,15 +1011,15 @@ struct XTAMEThMfmaccBf16E5m2Lowering
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mfmacc.bf16.e5m2", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms2Val, ms1Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms2Val, ms1Val});
     rewriter.eraseOp(op);
     return success();
   }
@@ -1059,15 +1046,15 @@ struct XTAMEThMfmaccSHLowering : public ConvertOpToLLVMPattern<ThMfmaccSHOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mfmacc.s.h", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms2Val, ms1Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms2Val, ms1Val});
     rewriter.eraseOp(op);
     return success();
   }
@@ -1095,15 +1082,15 @@ struct XTAMEThMfmaccSBf16Lowering
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mfmacc.s.bf16", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms2Val, ms1Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms2Val, ms1Val});
     rewriter.eraseOp(op);
     return success();
   }
@@ -1130,15 +1117,15 @@ struct XTAMEThMfmaccDSLowering : public ConvertOpToLLVMPattern<ThMfmaccDSOp> {
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mfmacc.d.s", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms2Val, ms1Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms2Val, ms1Val});
     rewriter.eraseOp(op);
     return success();
   }
@@ -1166,15 +1153,15 @@ struct XTAMEThMfmaccSE4m3Lowering
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mfmacc.s.e4m3", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms2Val, ms1Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms2Val, ms1Val});
     rewriter.eraseOp(op);
     return success();
   }
@@ -1202,15 +1189,15 @@ struct XTAMEThMfmaccSE5m2Lowering
     auto intrinsicName = getOrInsertIntrinsic(
         rewriter, module, "llvm.riscv.buddy.th.mfmacc.s.e5m2", funcType);
 
-    Value mdVal = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
-    Value ms2Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
-    Value ms1Val = rewriter.create<LLVM::ConstantOp>(
-        loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
+    Value mdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMd()));
+    Value ms2Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs2()));
+    Value ms1Val = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(op.getMs1()));
 
-    rewriter.create<LLVM::CallOp>(loc, TypeRange{}, intrinsicName,
-                                  ValueRange{mdVal, ms2Val, ms1Val});
+    LLVM::CallOp::create(rewriter, loc, TypeRange{}, intrinsicName,
+                         ValueRange{mdVal, ms2Val, ms1Val});
     rewriter.eraseOp(op);
     return success();
   }

--- a/midend/lib/Utils/AffineTransformUtils.cpp
+++ b/midend/lib/Utils/AffineTransformUtils.cpp
@@ -50,63 +50,64 @@ void affineTransformCoreTiled(OpBuilder &builder, Location loc,
   VectorType vectorTyI16 =
       VectorType::get({stride}, IntegerType::get(builder.getContext(), 16));
 
-  builder.create<scf::ForOp>(
-      loc, yStart, yEnd, c1, ValueRange{},
+  scf::ForOp::create(
+      builder, loc, yStart, yEnd, c1, ValueRange{},
       [&](OpBuilder &yBuilder, Location yLoc, Value yiv, ValueRange) {
-        Value yOffset = yBuilder.create<arith::SubIOp>(yLoc, yiv, yStart);
+        Value yOffset = arith::SubIOp::create(yBuilder, yLoc, yiv, yStart);
 
         Value yF32 = indexToF32(yBuilder, yLoc, yiv);
-        Value yF32_0 = yBuilder.create<arith::MulFOp>(yLoc, yF32, m1);
-        Value yF32_1 = yBuilder.create<arith::MulFOp>(yLoc, yF32, m4);
-        Value yF32_0_rsv = yBuilder.create<arith::MulFOp>(yLoc, yF32_0, c_rsv);
-        Value yF32_1_rsv = yBuilder.create<arith::MulFOp>(yLoc, yF32_1, c_rsv);
-        Value y0 = yBuilder.create<arith::FPToSIOp>(yLoc, yBuilder.getI32Type(),
-                                                    yF32_0_rsv);
-        Value y1 = yBuilder.create<arith::FPToSIOp>(yLoc, yBuilder.getI32Type(),
-                                                    yF32_1_rsv);
+        Value yF32_0 = arith::MulFOp::create(yBuilder, yLoc, yF32, m1);
+        Value yF32_1 = arith::MulFOp::create(yBuilder, yLoc, yF32, m4);
+        Value yF32_0_rsv = arith::MulFOp::create(yBuilder, yLoc, yF32_0, c_rsv);
+        Value yF32_1_rsv = arith::MulFOp::create(yBuilder, yLoc, yF32_1, c_rsv);
+        Value y0 = arith::FPToSIOp::create(yBuilder, yLoc,
+                                           yBuilder.getI32Type(), yF32_0_rsv);
+        Value y1 = arith::FPToSIOp::create(yBuilder, yLoc,
+                                           yBuilder.getI32Type(), yF32_1_rsv);
 
         Value y0Vec =
-            yBuilder.create<vector::BroadcastOp>(yLoc, vectorTyI32, y0);
+            vector::BroadcastOp::create(yBuilder, yLoc, vectorTyI32, y0);
         Value y1Vec =
-            yBuilder.create<vector::BroadcastOp>(yLoc, vectorTyI32, y1);
+            vector::BroadcastOp::create(yBuilder, yLoc, vectorTyI32, y1);
 
-        yBuilder.create<scf::ForOp>(
-            yLoc, xStart, xEnd, strideVal, ValueRange{},
+        scf::ForOp::create(
+            yBuilder, yLoc, xStart, xEnd, strideVal, ValueRange{},
             [&](OpBuilder &xBuilder, Location xLoc, Value xiv, ValueRange) {
-              Value xOffset = xBuilder.create<arith::SubIOp>(xLoc, xiv, xStart);
-              Value x0Vec = xBuilder.create<vector::LoadOp>(xLoc, vectorTyI32,
-                                                            xAddr1, xiv);
-              Value x1Vec = xBuilder.create<vector::LoadOp>(xLoc, vectorTyI32,
-                                                            xAddr2, xiv);
+              Value xOffset =
+                  arith::SubIOp::create(xBuilder, xLoc, xiv, xStart);
+              Value x0Vec = vector::LoadOp::create(xBuilder, xLoc, vectorTyI32,
+                                                   xAddr1, xiv);
+              Value x1Vec = vector::LoadOp::create(xBuilder, xLoc, vectorTyI32,
+                                                   xAddr2, xiv);
 
               Value srcXVec =
-                  xBuilder.create<arith::AddIOp>(xLoc, x0Vec, y0Vec);
+                  arith::AddIOp::create(xBuilder, xLoc, x0Vec, y0Vec);
               Value srcYVec =
-                  xBuilder.create<arith::AddIOp>(xLoc, x1Vec, y1Vec);
+                  arith::AddIOp::create(xBuilder, xLoc, x1Vec, y1Vec);
 
               Value srcXVecShifted =
-                  xBuilder.create<arith::ShRSIOp>(xLoc, srcXVec, rsvValVec);
+                  arith::ShRSIOp::create(xBuilder, xLoc, srcXVec, rsvValVec);
               Value srcYVecShifted =
-                  xBuilder.create<arith::ShRSIOp>(xLoc, srcYVec, rsvValVec);
-              Value srcXVecInt = xBuilder.create<arith::TruncIOp>(
-                  xLoc, vectorTyI16, srcXVecShifted);
-              Value srcYVecInt = xBuilder.create<arith::TruncIOp>(
-                  xLoc, vectorTyI16, srcYVecShifted);
+                  arith::ShRSIOp::create(xBuilder, xLoc, srcYVec, rsvValVec);
+              Value srcXVecInt = arith::TruncIOp::create(
+                  xBuilder, xLoc, vectorTyI16, srcXVecShifted);
+              Value srcYVecInt = arith::TruncIOp::create(
+                  xBuilder, xLoc, vectorTyI16, srcYVecShifted);
 
               SmallVector<int64_t> maskVec;
               for (int i = 0; i < stride; i++) {
                 maskVec.push_back(i);
                 maskVec.push_back(i + stride);
               }
-              Value res2Store = xBuilder.create<vector::ShuffleOp>(
-                  loc, srcXVecInt, srcYVecInt, maskVec);
-              xBuilder.create<vector::StoreOp>(
-                  loc, res2Store, resIntPart, ValueRange{yOffset, xOffset, c0});
+              Value res2Store = vector::ShuffleOp::create(
+                  xBuilder, loc, srcXVecInt, srcYVecInt, maskVec);
+              vector::StoreOp::create(xBuilder, loc, res2Store, resIntPart,
+                                      ValueRange{yOffset, xOffset, c0});
 
-              xBuilder.create<scf::YieldOp>(xLoc);
+              scf::YieldOp::create(xBuilder, xLoc);
             });
 
-        yBuilder.create<scf::YieldOp>(yLoc);
+        scf::YieldOp::create(yBuilder, yLoc);
       });
 }
 
@@ -116,17 +117,17 @@ void affineTransformCore(OpBuilder &builder, Location loc, MLIRContext *ctx,
                          Value xAddr1, Value xAddr2, int64_t stride,
                          const int &RSV_BITS, int interp_type,
                          dip::ImageFormat format) {
-  Value c0 = builder.create<arith::ConstantIndexOp>(loc, 0);
-  Value c1 = builder.create<arith::ConstantIndexOp>(loc, 1);
-  Value c_rsv = builder.create<arith::ConstantOp>(
-      loc, builder.getF32FloatAttr((float)(1 << RSV_BITS)));
-  Value rsvVal = builder.create<arith::ConstantOp>(
-      loc, builder.getI32IntegerAttr(RSV_BITS));
-  Value strideVal = builder.create<arith::ConstantIndexOp>(loc, stride);
+  Value c0 = arith::ConstantIndexOp::create(builder, loc, 0);
+  Value c1 = arith::ConstantIndexOp::create(builder, loc, 1);
+  Value c_rsv = arith::ConstantOp::create(
+      builder, loc, builder.getF32FloatAttr((float)(1 << RSV_BITS)));
+  Value rsvVal = arith::ConstantOp::create(builder, loc,
+                                           builder.getI32IntegerAttr(RSV_BITS));
+  Value strideVal = arith::ConstantIndexOp::create(builder, loc, stride);
   VectorType vectorTyI32 =
       VectorType::get({stride}, IntegerType::get(builder.getContext(), 32));
   Value rsvValVec =
-      builder.create<vector::BroadcastOp>(loc, vectorTyI32, rsvVal);
+      vector::BroadcastOp::create(builder, loc, vectorTyI32, rsvVal);
 
   // create memref to store compute result for remap use
   // TODO: auto config BLOCK_SZ by input type. float->32, uchar->64
@@ -135,27 +136,28 @@ void affineTransformCore(OpBuilder &builder, Location loc, MLIRContext *ctx,
       MemRefType::get({BLOCK_SZ / 2, BLOCK_SZ * 2, 2},
                       IntegerType::get(builder.getContext(), 16));
 
-  Value resIntPart = builder.create<memref::AllocOp>(loc, resIntPartType);
-  Value rowStride = builder.create<arith::ConstantIndexOp>(loc, BLOCK_SZ / 2);
-  Value colStride = builder.create<arith::ConstantIndexOp>(loc, BLOCK_SZ * 2);
+  Value resIntPart = memref::AllocOp::create(builder, loc, resIntPartType);
+  Value rowStride = arith::ConstantIndexOp::create(builder, loc, BLOCK_SZ / 2);
+  Value colStride = arith::ConstantIndexOp::create(builder, loc, BLOCK_SZ * 2);
 #undef BLOCK_SZ
 
   if (format == dip::ImageFormat::HW) {
-    builder.create<scf::ForOp>(
-        loc, yStart, yEnd, rowStride, ValueRange{},
+    scf::ForOp::create(
+        builder, loc, yStart, yEnd, rowStride, ValueRange{},
         [&](OpBuilder &yBuilder, Location yLoc, Value yiv, ValueRange) {
-          Value realYEnd = yBuilder.create<arith::MinUIOp>(
-              yLoc, yEnd, yBuilder.create<arith::AddIOp>(yLoc, yiv, rowStride));
-          Value rows = yBuilder.create<arith::SubIOp>(yLoc, realYEnd, yiv);
+          Value realYEnd = arith::MinUIOp::create(
+              yBuilder, yLoc, yEnd,
+              arith::AddIOp::create(yBuilder, yLoc, yiv, rowStride));
+          Value rows = arith::SubIOp::create(yBuilder, yLoc, realYEnd, yiv);
 
-          yBuilder.create<scf::ForOp>(
-              yLoc, xStart, xEnd, colStride, ValueRange{},
+          scf::ForOp::create(
+              yBuilder, yLoc, xStart, xEnd, colStride, ValueRange{},
               [&](OpBuilder &xBuilder, Location xLoc, Value xiv, ValueRange) {
-                Value realXEnd = xBuilder.create<arith::MinUIOp>(
-                    xLoc, xEnd,
-                    xBuilder.create<arith::AddIOp>(xLoc, xiv, colStride));
+                Value realXEnd = arith::MinUIOp::create(
+                    xBuilder, xLoc, xEnd,
+                    arith::AddIOp::create(xBuilder, xLoc, xiv, colStride));
                 Value cols =
-                    xBuilder.create<arith::SubIOp>(xLoc, realXEnd, xiv);
+                    arith::SubIOp::create(xBuilder, xLoc, realXEnd, xiv);
 
                 affineTransformCoreTiled(xBuilder, xLoc, resIntPart, yiv,
                                          realYEnd, xiv, realXEnd, m1, m4,
@@ -165,35 +167,36 @@ void affineTransformCore(OpBuilder &builder, Location loc, MLIRContext *ctx,
                 remapNearest2D(xBuilder, xLoc, ctx, input, output, resIntPart,
                                yiv, xiv, rows, cols);
 
-                xBuilder.create<scf::YieldOp>(xLoc);
+                scf::YieldOp::create(xBuilder, xLoc);
               });
-          yBuilder.create<scf::YieldOp>(yLoc);
+          scf::YieldOp::create(yBuilder, yLoc);
         });
 
   } else if (format == dip::ImageFormat::NCHW ||
              format == dip::ImageFormat::NHWC) {
-    Value inputBatch = builder.create<memref::DimOp>(loc, input, c0);
-    builder.create<scf::ForOp>(
-        loc, c0, inputBatch, c1, ValueRange{},
+    Value inputBatch = memref::DimOp::create(builder, loc, input, c0);
+    scf::ForOp::create(
+        builder, loc, c0, inputBatch, c1, ValueRange{},
         [&](OpBuilder &nBuilder, Location nLoc, Value niv, ValueRange) {
-          nBuilder.create<scf::ForOp>(
-              loc, yStart, yEnd, rowStride, ValueRange{},
+          scf::ForOp::create(
+              nBuilder, loc, yStart, yEnd, rowStride, ValueRange{},
               [&](OpBuilder &yBuilder, Location yLoc, Value yiv, ValueRange) {
-                Value realYEnd = yBuilder.create<arith::MinUIOp>(
-                    yLoc, yEnd,
-                    yBuilder.create<arith::AddIOp>(yLoc, yiv, rowStride));
+                Value realYEnd = arith::MinUIOp::create(
+                    yBuilder, yLoc, yEnd,
+                    arith::AddIOp::create(yBuilder, yLoc, yiv, rowStride));
                 Value rows =
-                    yBuilder.create<arith::SubIOp>(yLoc, realYEnd, yiv);
+                    arith::SubIOp::create(yBuilder, yLoc, realYEnd, yiv);
 
-                yBuilder.create<scf::ForOp>(
-                    yLoc, xStart, xEnd, colStride, ValueRange{},
+                scf::ForOp::create(
+                    yBuilder, yLoc, xStart, xEnd, colStride, ValueRange{},
                     [&](OpBuilder &xBuilder, Location xLoc, Value xiv,
                         ValueRange) {
-                      Value realXEnd = xBuilder.create<arith::MinUIOp>(
-                          xLoc, xEnd,
-                          xBuilder.create<arith::AddIOp>(xLoc, xiv, colStride));
+                      Value realXEnd = arith::MinUIOp::create(
+                          xBuilder, xLoc, xEnd,
+                          arith::AddIOp::create(xBuilder, xLoc, xiv,
+                                                colStride));
                       Value cols =
-                          xBuilder.create<arith::SubIOp>(xLoc, realXEnd, xiv);
+                          arith::SubIOp::create(xBuilder, xLoc, realXEnd, xiv);
 
                       affineTransformCoreTiled(
                           xBuilder, xLoc, resIntPart, yiv, realYEnd, xiv,
@@ -204,54 +207,56 @@ void affineTransformCore(OpBuilder &builder, Location loc, MLIRContext *ctx,
                                      resIntPart, yiv, xiv, rows, cols, format,
                                      niv);
 
-                      xBuilder.create<scf::YieldOp>(xLoc);
+                      scf::YieldOp::create(xBuilder, xLoc);
                     });
-                yBuilder.create<scf::YieldOp>(yLoc);
+                scf::YieldOp::create(yBuilder, yLoc);
               });
-          nBuilder.create<scf::YieldOp>(nLoc);
+          scf::YieldOp::create(nBuilder, nLoc);
         });
   }
 
-  builder.create<memref::DeallocOp>(loc, resIntPart);
+  memref::DeallocOp::create(builder, loc, resIntPart);
 }
 
 void remapNearest2D(OpBuilder &builder, Location loc, MLIRContext *ctx,
                     Value input, Value output, Value mapInt, Value yStart,
                     Value xStart, Value rows, Value cols) {
-  Value c0 = builder.create<arith::ConstantIndexOp>(loc, 0);
-  Value c1 = builder.create<arith::ConstantIndexOp>(loc, 1);
-  Value inputRow = builder.create<memref::DimOp>(loc, input, c0);
-  Value inputCol = builder.create<memref::DimOp>(loc, input, c1);
-  builder.create<scf::ForOp>(
-      loc, c0, rows, c1, ValueRange{},
+  Value c0 = arith::ConstantIndexOp::create(builder, loc, 0);
+  Value c1 = arith::ConstantIndexOp::create(builder, loc, 1);
+  Value inputRow = memref::DimOp::create(builder, loc, input, c0);
+  Value inputCol = memref::DimOp::create(builder, loc, input, c1);
+  scf::ForOp::create(
+      builder, loc, c0, rows, c1, ValueRange{},
       [&](OpBuilder &yBuilder, Location yLoc, Value yiv, ValueRange) {
-        Value dstY = yBuilder.create<arith::AddIOp>(yLoc, yiv, yStart);
+        Value dstY = arith::AddIOp::create(yBuilder, yLoc, yiv, yStart);
 
-        yBuilder.create<scf::ForOp>(
-            yLoc, c0, cols, c1, ValueRange{},
+        scf::ForOp::create(
+            yBuilder, yLoc, c0, cols, c1, ValueRange{},
             [&](OpBuilder &xBuilder, Location xLoc, Value xiv, ValueRange) {
-              Value dstX = xBuilder.create<arith::AddIOp>(xLoc, xiv, xStart);
-              Value srcXI16 = xBuilder.create<memref::LoadOp>(
-                  xLoc, mapInt, ValueRange{yiv, xiv, c0});
-              Value srcYI16 = xBuilder.create<memref::LoadOp>(
-                  xLoc, mapInt, ValueRange{yiv, xiv, c1});
+              Value dstX = arith::AddIOp::create(xBuilder, xLoc, xiv, xStart);
+              Value srcXI16 = memref::LoadOp::create(xBuilder, xLoc, mapInt,
+                                                     ValueRange{yiv, xiv, c0});
+              Value srcYI16 = memref::LoadOp::create(xBuilder, xLoc, mapInt,
+                                                     ValueRange{yiv, xiv, c1});
 
-              Value srcX = xBuilder.create<arith::IndexCastOp>(
-                  xLoc, IndexType::get(xBuilder.getContext()), srcXI16);
-              Value srcY = xBuilder.create<arith::IndexCastOp>(
-                  xLoc, IndexType::get(xBuilder.getContext()), srcYI16);
+              Value srcX = arith::IndexCastOp::create(
+                  xBuilder, xLoc, IndexType::get(xBuilder.getContext()),
+                  srcXI16);
+              Value srcY = arith::IndexCastOp::create(
+                  xBuilder, xLoc, IndexType::get(xBuilder.getContext()),
+                  srcYI16);
               Value xInBound = inBound(xBuilder, xLoc, srcX, c0, inputCol);
               Value yInBound = inBound(xBuilder, xLoc, srcY, c0, inputRow);
               Value pixelInBound =
-                  xBuilder.create<arith::AndIOp>(xLoc, xInBound, yInBound);
-              xBuilder.create<scf::IfOp>(
-                  xLoc, pixelInBound,
+                  arith::AndIOp::create(xBuilder, xLoc, xInBound, yInBound);
+              scf::IfOp::create(
+                  xBuilder, xLoc, pixelInBound,
                   [&](OpBuilder &thenBuilder, Location thenLoc) {
-                    Value pixel = thenBuilder.create<memref::LoadOp>(
-                        thenLoc, input, ValueRange{srcY, srcX});
-                    thenBuilder.create<memref::StoreOp>(thenLoc, pixel, output,
-                                                        ValueRange{dstY, dstX});
-                    thenBuilder.create<scf::YieldOp>(thenLoc);
+                    Value pixel = memref::LoadOp::create(
+                        thenBuilder, thenLoc, input, ValueRange{srcY, srcX});
+                    memref::StoreOp::create(thenBuilder, thenLoc, pixel, output,
+                                            ValueRange{dstY, dstX});
+                    scf::YieldOp::create(thenBuilder, thenLoc);
                   },
                   [&](OpBuilder &elseBuilder, Location elseLoc) {
                     auto inElemTy =
@@ -259,15 +264,15 @@ void remapNearest2D(OpBuilder &builder, Location loc, MLIRContext *ctx,
                             .getElementType();
                     Value pixel = insertZeroConstantOp(ctx, elseBuilder,
                                                        elseLoc, inElemTy);
-                    elseBuilder.create<memref::StoreOp>(elseLoc, pixel, output,
-                                                        ValueRange{dstY, dstX});
-                    elseBuilder.create<scf::YieldOp>(elseLoc);
+                    memref::StoreOp::create(elseBuilder, elseLoc, pixel, output,
+                                            ValueRange{dstY, dstX});
+                    scf::YieldOp::create(elseBuilder, elseLoc);
                   });
 
-              xBuilder.create<scf::YieldOp>(xLoc);
+              scf::YieldOp::create(xBuilder, xLoc);
             });
 
-        yBuilder.create<scf::YieldOp>(yLoc);
+        scf::YieldOp::create(yBuilder, yLoc);
       });
 }
 
@@ -275,97 +280,99 @@ void remapNearest3D(OpBuilder &builder, Location loc, MLIRContext *ctx,
                     Value input, Value output, Value mapInt, Value yStart,
                     Value xStart, Value rows, Value cols,
                     dip::ImageFormat format, Value niv) {
-  Value c0 = builder.create<arith::ConstantIndexOp>(loc, 0);
-  Value c1 = builder.create<arith::ConstantIndexOp>(loc, 1);
-  Value c2 = builder.create<arith::ConstantIndexOp>(loc, 2);
-  Value c3 = builder.create<arith::ConstantIndexOp>(loc, 3);
+  Value c0 = arith::ConstantIndexOp::create(builder, loc, 0);
+  Value c1 = arith::ConstantIndexOp::create(builder, loc, 1);
+  Value c2 = arith::ConstantIndexOp::create(builder, loc, 2);
+  Value c3 = arith::ConstantIndexOp::create(builder, loc, 3);
 
   Value inputRow, inputCol, inputChannel;
   if (format == dip::ImageFormat::NHWC) {
-    inputRow = builder.create<memref::DimOp>(loc, input, c1);
-    inputCol = builder.create<memref::DimOp>(loc, input, c2);
-    inputChannel = builder.create<memref::DimOp>(loc, input, c3);
+    inputRow = memref::DimOp::create(builder, loc, input, c1);
+    inputCol = memref::DimOp::create(builder, loc, input, c2);
+    inputChannel = memref::DimOp::create(builder, loc, input, c3);
   } else if (format == dip::ImageFormat::NCHW) {
-    inputRow = builder.create<memref::DimOp>(loc, input, c2);
-    inputCol = builder.create<memref::DimOp>(loc, input, c3);
-    inputChannel = builder.create<memref::DimOp>(loc, input, c1);
+    inputRow = memref::DimOp::create(builder, loc, input, c2);
+    inputCol = memref::DimOp::create(builder, loc, input, c3);
+    inputChannel = memref::DimOp::create(builder, loc, input, c1);
   }
-  Value is3Channel = builder.create<arith::CmpIOp>(
-      loc, arith::CmpIPredicate::eq, inputChannel, c3);
+  Value is3Channel = arith::CmpIOp::create(
+      builder, loc, arith::CmpIPredicate::eq, inputChannel, c3);
 
-  builder.create<scf::ForOp>(
-      loc, c0, rows, c1, ValueRange{},
+  scf::ForOp::create(
+      builder, loc, c0, rows, c1, ValueRange{},
       [&](OpBuilder &yBuilder, Location yLoc, Value yiv, ValueRange) {
-        Value dstY = yBuilder.create<arith::AddIOp>(yLoc, yiv, yStart);
+        Value dstY = arith::AddIOp::create(yBuilder, yLoc, yiv, yStart);
 
-        yBuilder.create<scf::IfOp>(
-            yLoc, is3Channel,
+        scf::IfOp::create(
+            yBuilder, yLoc, is3Channel,
             [&](OpBuilder &thenBuilder, Location thenLoc) {
               //  3 channels, make common case fast
-              thenBuilder.create<scf::ForOp>(
-                  thenLoc, c0, cols, c1, ValueRange{},
+              scf::ForOp::create(
+                  thenBuilder, thenLoc, c0, cols, c1, ValueRange{},
                   [&](OpBuilder &xBuilder, Location xLoc, Value xiv,
                       ValueRange) {
                     Value dstX =
-                        xBuilder.create<arith::AddIOp>(xLoc, xiv, xStart);
-                    Value srcXI16 = xBuilder.create<memref::LoadOp>(
-                        xLoc, mapInt, ValueRange{yiv, xiv, c0});
-                    Value srcYI16 = xBuilder.create<memref::LoadOp>(
-                        xLoc, mapInt, ValueRange{yiv, xiv, c1});
+                        arith::AddIOp::create(xBuilder, xLoc, xiv, xStart);
+                    Value srcXI16 = memref::LoadOp::create(
+                        xBuilder, xLoc, mapInt, ValueRange{yiv, xiv, c0});
+                    Value srcYI16 = memref::LoadOp::create(
+                        xBuilder, xLoc, mapInt, ValueRange{yiv, xiv, c1});
 
-                    Value srcX = xBuilder.create<arith::IndexCastOp>(
-                        xLoc, IndexType::get(xBuilder.getContext()), srcXI16);
-                    Value srcY = xBuilder.create<arith::IndexCastOp>(
-                        xLoc, IndexType::get(xBuilder.getContext()), srcYI16);
+                    Value srcX = arith::IndexCastOp::create(
+                        xBuilder, xLoc, IndexType::get(xBuilder.getContext()),
+                        srcXI16);
+                    Value srcY = arith::IndexCastOp::create(
+                        xBuilder, xLoc, IndexType::get(xBuilder.getContext()),
+                        srcYI16);
                     Value xInBound =
                         inBound(xBuilder, xLoc, srcX, c0, inputCol);
                     Value yInBound =
                         inBound(xBuilder, xLoc, srcY, c0, inputRow);
-                    Value pixelInBound = xBuilder.create<arith::AndIOp>(
-                        xLoc, xInBound, yInBound);
-                    xBuilder.create<scf::IfOp>(
-                        xLoc, pixelInBound,
+                    Value pixelInBound = arith::AndIOp::create(
+                        xBuilder, xLoc, xInBound, yInBound);
+                    scf::IfOp::create(
+                        xBuilder, xLoc, pixelInBound,
                         [&](OpBuilder &thenBuilder, Location thenLoc) {
                           if (format == dip::ImageFormat::NCHW) {
-                            Value srcC0 = thenBuilder.create<memref::LoadOp>(
-                                thenLoc, input,
+                            Value srcC0 = memref::LoadOp::create(
+                                thenBuilder, thenLoc, input,
                                 ValueRange{niv, c0, srcY, srcX});
-                            Value srcC1 = thenBuilder.create<memref::LoadOp>(
-                                thenLoc, input,
+                            Value srcC1 = memref::LoadOp::create(
+                                thenBuilder, thenLoc, input,
                                 ValueRange{niv, c1, srcY, srcX});
-                            Value srcC2 = thenBuilder.create<memref::LoadOp>(
-                                thenLoc, input,
+                            Value srcC2 = memref::LoadOp::create(
+                                thenBuilder, thenLoc, input,
                                 ValueRange{niv, c2, srcY, srcX});
-                            thenBuilder.create<memref::StoreOp>(
-                                thenLoc, srcC0, output,
+                            memref::StoreOp::create(
+                                thenBuilder, thenLoc, srcC0, output,
                                 ValueRange{niv, c0, dstY, dstX});
-                            thenBuilder.create<memref::StoreOp>(
-                                thenLoc, srcC1, output,
+                            memref::StoreOp::create(
+                                thenBuilder, thenLoc, srcC1, output,
                                 ValueRange{niv, c1, dstY, dstX});
-                            thenBuilder.create<memref::StoreOp>(
-                                thenLoc, srcC2, output,
+                            memref::StoreOp::create(
+                                thenBuilder, thenLoc, srcC2, output,
                                 ValueRange{niv, c2, dstY, dstX});
                           } else if (format == dip::ImageFormat::NHWC) {
-                            Value srcC0 = thenBuilder.create<memref::LoadOp>(
-                                thenLoc, input,
+                            Value srcC0 = memref::LoadOp::create(
+                                thenBuilder, thenLoc, input,
                                 ValueRange{niv, srcY, srcX, c0});
-                            Value srcC1 = thenBuilder.create<memref::LoadOp>(
-                                thenLoc, input,
+                            Value srcC1 = memref::LoadOp::create(
+                                thenBuilder, thenLoc, input,
                                 ValueRange{niv, srcY, srcX, c1});
-                            Value srcC2 = thenBuilder.create<memref::LoadOp>(
-                                thenLoc, input,
+                            Value srcC2 = memref::LoadOp::create(
+                                thenBuilder, thenLoc, input,
                                 ValueRange{niv, srcY, srcX, c2});
-                            thenBuilder.create<memref::StoreOp>(
-                                thenLoc, srcC0, output,
+                            memref::StoreOp::create(
+                                thenBuilder, thenLoc, srcC0, output,
                                 ValueRange{niv, dstY, dstX, c0});
-                            thenBuilder.create<memref::StoreOp>(
-                                thenLoc, srcC1, output,
+                            memref::StoreOp::create(
+                                thenBuilder, thenLoc, srcC1, output,
                                 ValueRange{niv, dstY, dstX, c1});
-                            thenBuilder.create<memref::StoreOp>(
-                                thenLoc, srcC2, output,
+                            memref::StoreOp::create(
+                                thenBuilder, thenLoc, srcC2, output,
                                 ValueRange{niv, dstY, dstX, c2});
                           }
-                          thenBuilder.create<scf::YieldOp>(thenLoc);
+                          scf::YieldOp::create(thenBuilder, thenLoc);
                         },
                         [&](OpBuilder &elseBuilder, Location elseLoc) {
                           auto inElemTy =
@@ -374,79 +381,82 @@ void remapNearest3D(OpBuilder &builder, Location loc, MLIRContext *ctx,
                           Value pixel = insertZeroConstantOp(ctx, elseBuilder,
                                                              elseLoc, inElemTy);
                           if (format == dip::ImageFormat::NCHW) {
-                            elseBuilder.create<memref::StoreOp>(
-                                elseLoc, pixel, output,
+                            memref::StoreOp::create(
+                                elseBuilder, elseLoc, pixel, output,
                                 ValueRange{niv, c0, dstY, dstX});
-                            elseBuilder.create<memref::StoreOp>(
-                                elseLoc, pixel, output,
+                            memref::StoreOp::create(
+                                elseBuilder, elseLoc, pixel, output,
                                 ValueRange{niv, c1, dstY, dstX});
-                            elseBuilder.create<memref::StoreOp>(
-                                elseLoc, pixel, output,
+                            memref::StoreOp::create(
+                                elseBuilder, elseLoc, pixel, output,
                                 ValueRange{niv, c2, dstY, dstX});
                           } else if (format == dip::ImageFormat::NHWC) {
-                            elseBuilder.create<memref::StoreOp>(
-                                elseLoc, pixel, output,
+                            memref::StoreOp::create(
+                                elseBuilder, elseLoc, pixel, output,
                                 ValueRange{niv, dstY, dstX, c0});
-                            elseBuilder.create<memref::StoreOp>(
-                                elseLoc, pixel, output,
+                            memref::StoreOp::create(
+                                elseBuilder, elseLoc, pixel, output,
                                 ValueRange{niv, dstY, dstX, c1});
-                            elseBuilder.create<memref::StoreOp>(
-                                elseLoc, pixel, output,
+                            memref::StoreOp::create(
+                                elseBuilder, elseLoc, pixel, output,
                                 ValueRange{niv, dstY, dstX, c2});
                           }
-                          elseBuilder.create<scf::YieldOp>(elseLoc);
+                          scf::YieldOp::create(elseBuilder, elseLoc);
                         });
-                    thenBuilder.create<scf::YieldOp>(thenLoc);
+                    scf::YieldOp::create(thenBuilder, thenLoc);
                   });
-              thenBuilder.create<scf::YieldOp>(thenLoc);
+              scf::YieldOp::create(thenBuilder, thenLoc);
             },
             [&](OpBuilder &elseBuilder, Location elseLoc) {
-              elseBuilder.create<scf::ForOp>(
-                  elseLoc, c0, cols, c1, ValueRange{},
+              scf::ForOp::create(
+                  elseBuilder, elseLoc, c0, cols, c1, ValueRange{},
                   [&](OpBuilder &xBuilder, Location xLoc, Value xiv,
                       ValueRange) {
                     Value dstX =
-                        xBuilder.create<arith::AddIOp>(xLoc, xiv, xStart);
-                    Value srcXI16 = xBuilder.create<memref::LoadOp>(
-                        xLoc, mapInt, ValueRange{yiv, xiv, c0});
-                    Value srcYI16 = xBuilder.create<memref::LoadOp>(
-                        xLoc, mapInt, ValueRange{yiv, xiv, c1});
+                        arith::AddIOp::create(xBuilder, xLoc, xiv, xStart);
+                    Value srcXI16 = memref::LoadOp::create(
+                        xBuilder, xLoc, mapInt, ValueRange{yiv, xiv, c0});
+                    Value srcYI16 = memref::LoadOp::create(
+                        xBuilder, xLoc, mapInt, ValueRange{yiv, xiv, c1});
 
-                    Value srcX = xBuilder.create<arith::IndexCastOp>(
-                        xLoc, IndexType::get(xBuilder.getContext()), srcXI16);
-                    Value srcY = xBuilder.create<arith::IndexCastOp>(
-                        xLoc, IndexType::get(xBuilder.getContext()), srcYI16);
+                    Value srcX = arith::IndexCastOp::create(
+                        xBuilder, xLoc, IndexType::get(xBuilder.getContext()),
+                        srcXI16);
+                    Value srcY = arith::IndexCastOp::create(
+                        xBuilder, xLoc, IndexType::get(xBuilder.getContext()),
+                        srcYI16);
                     Value xInBound =
                         inBound(xBuilder, xLoc, srcX, c0, inputCol);
                     Value yInBound =
                         inBound(xBuilder, xLoc, srcY, c0, inputRow);
-                    Value pixelInBound = xBuilder.create<arith::AndIOp>(
-                        xLoc, xInBound, yInBound);
-                    xBuilder.create<scf::IfOp>(
-                        xLoc, pixelInBound,
+                    Value pixelInBound = arith::AndIOp::create(
+                        xBuilder, xLoc, xInBound, yInBound);
+                    scf::IfOp::create(
+                        xBuilder, xLoc, pixelInBound,
                         [&](OpBuilder &thenBuilder, Location thenLoc) {
-                          thenBuilder.create<scf::ForOp>(
-                              thenLoc, c0, inputChannel, c1, ValueRange{},
+                          scf::ForOp::create(
+                              thenBuilder, thenLoc, c0, inputChannel, c1,
+                              ValueRange{},
                               [&](OpBuilder &cBuilder, Location cLoc, Value civ,
                                   ValueRange) {
                                 if (format == dip::ImageFormat::NCHW) {
-                                  Value srcC = cBuilder.create<memref::LoadOp>(
-                                      cLoc, input,
+                                  Value srcC = memref::LoadOp::create(
+                                      cBuilder, cLoc, input,
                                       ValueRange{niv, civ, srcY, srcX});
-                                  cBuilder.create<memref::StoreOp>(
-                                      cLoc, srcC, output,
+                                  memref::StoreOp::create(
+                                      cBuilder, cLoc, srcC, output,
                                       ValueRange{niv, civ, dstY, dstX});
                                 } else if (format == dip::ImageFormat::NHWC) {
-                                  Value srcC = cBuilder.create<memref::LoadOp>(
-                                      cLoc, input,
+                                  Value srcC = memref::LoadOp::create(
+                                      cBuilder, cLoc, input,
                                       ValueRange{niv, srcY, srcX, civ});
-                                  cBuilder.create<memref::StoreOp>(
-                                      cLoc, srcC, output,
+                                  memref::StoreOp::create(
+                                      cBuilder, cLoc, srcC, output,
                                       ValueRange{niv, dstY, dstX, civ});
                                 }
-                                cBuilder.create<scf::YieldOp>(cLoc);
+                                scf::YieldOp::create(cBuilder, cLoc);
                               });
-                          thenBuilder.create<scf::YieldOp>(elseLoc);
+                          scf::YieldOp::create(thenBuilder, elseLoc);
                         },
                         [&](OpBuilder &elseBuilder, Location elseLoc) {
                           auto inElemTy =
@@ -454,29 +464,30 @@ void remapNearest3D(OpBuilder &builder, Location loc, MLIRContext *ctx,
                                   .getElementType();
                           Value pixel = insertZeroConstantOp(ctx, elseBuilder,
                                                              elseLoc, inElemTy);
-                          elseBuilder.create<scf::ForOp>(
-                              elseLoc, c0, inputChannel, c1, ValueRange{},
+                          scf::ForOp::create(
+                              elseBuilder, elseLoc, c0, inputChannel, c1,
+                              ValueRange{},
                               [&](OpBuilder &cBuilder, Location cLoc, Value civ,
                                   ValueRange) {
                                 if (format == dip::ImageFormat::NCHW) {
-                                  cBuilder.create<memref::StoreOp>(
-                                      cLoc, pixel, output,
+                                  memref::StoreOp::create(
+                                      cBuilder, cLoc, pixel, output,
                                       ValueRange{niv, civ, dstY, dstX});
                                 } else if (format == dip::ImageFormat::NHWC) {
-                                  cBuilder.create<memref::StoreOp>(
-                                      cLoc, pixel, output,
+                                  memref::StoreOp::create(
+                                      cBuilder, cLoc, pixel, output,
                                       ValueRange{niv, dstY, dstX, civ});
                                 }
-                                cBuilder.create<scf::YieldOp>(cLoc);
+                                scf::YieldOp::create(cBuilder, cLoc);
                               });
-                          elseBuilder.create<scf::YieldOp>(elseLoc);
+                          scf::YieldOp::create(elseBuilder, elseLoc);
                         });
-                    xBuilder.create<scf::YieldOp>(xLoc);
+                    scf::YieldOp::create(xBuilder, xLoc);
                   });
-              elseBuilder.create<scf::YieldOp>(elseLoc);
+              scf::YieldOp::create(elseBuilder, elseLoc);
             });
 
-        yBuilder.create<scf::YieldOp>(yLoc);
+        scf::YieldOp::create(yBuilder, yLoc);
       });
 }
 

--- a/midend/lib/Utils/DAPUtils.cpp
+++ b/midend/lib/Utils/DAPUtils.cpp
@@ -48,27 +48,27 @@ SmallVector<Value, 5> generateSOSParams(OpBuilder &rewriter, Location loc,
                                         Value c0, Value c1, Value c2, Value c4,
                                         Value c5, Value filterSize,
                                         Value kernel) {
-  Value initB0 = rewriter.create<vector::BroadcastOp>(loc, vectorTy, f1);
-  Value initB1 = rewriter.create<vector::BroadcastOp>(loc, vectorTy, f0);
-  Value initB2 = rewriter.create<vector::BroadcastOp>(loc, vectorTy, f0);
-  Value initA1 = rewriter.create<vector::BroadcastOp>(loc, vectorTy, f0);
-  Value initA2 = rewriter.create<vector::BroadcastOp>(loc, vectorTy, f0);
+  Value initB0 = vector::BroadcastOp::create(rewriter, loc, vectorTy, f1);
+  Value initB1 = vector::BroadcastOp::create(rewriter, loc, vectorTy, f0);
+  Value initB2 = vector::BroadcastOp::create(rewriter, loc, vectorTy, f0);
+  Value initA1 = vector::BroadcastOp::create(rewriter, loc, vectorTy, f0);
+  Value initA2 = vector::BroadcastOp::create(rewriter, loc, vectorTy, f0);
 
   // Distribute all params into 5 param vectors
-  auto vecDistribute = rewriter.create<scf::ForOp>(
-      loc, c0, filterSize, c1,
+  auto vecDistribute = scf::ForOp::create(
+      rewriter, loc, c0, filterSize, c1,
       ValueRange{initB0, initB1, initB2, initA1, initA2},
       [&](OpBuilder &builder, Location loc, Value iv, ValueRange iargs) {
         Value b0 =
-            builder.create<memref::LoadOp>(loc, kernel, ValueRange{iv, c0});
+            memref::LoadOp::create(builder, loc, kernel, ValueRange{iv, c0});
         Value b1 =
-            builder.create<memref::LoadOp>(loc, kernel, ValueRange{iv, c1});
+            memref::LoadOp::create(builder, loc, kernel, ValueRange{iv, c1});
         Value b2 =
-            builder.create<memref::LoadOp>(loc, kernel, ValueRange{iv, c2});
+            memref::LoadOp::create(builder, loc, kernel, ValueRange{iv, c2});
         Value a1 =
-            builder.create<memref::LoadOp>(loc, kernel, ValueRange{iv, c4});
+            memref::LoadOp::create(builder, loc, kernel, ValueRange{iv, c4});
         Value a2 =
-            builder.create<memref::LoadOp>(loc, kernel, ValueRange{iv, c5});
+            memref::LoadOp::create(builder, loc, kernel, ValueRange{iv, c5});
 
         Value b0Next = vector::InsertOp::create(builder, loc, b0, iargs[0], iv);
         Value b1Next = vector::InsertOp::create(builder, loc, b0, iargs[1], iv);
@@ -76,8 +76,9 @@ SmallVector<Value, 5> generateSOSParams(OpBuilder &rewriter, Location loc,
         Value a1Next = vector::InsertOp::create(builder, loc, b0, iargs[3], iv);
         Value a2Next = vector::InsertOp::create(builder, loc, b0, iargs[4], iv);
 
-        builder.create<scf::YieldOp>(
-            loc, std::vector<Value>{b0Next, b1Next, b2Next, a1Next, a2Next});
+        scf::YieldOp::create(
+            builder, loc,
+            std::vector<Value>{b0Next, b1Next, b2Next, a1Next, a2Next});
       });
 
   return SmallVector<Value, 5>{vecDistribute.getResults()};
@@ -94,97 +95,98 @@ void biquadProcess(OpBuilder &rewriter, Location loc, VectorType vectorTy,
   Value vecA1 = SOSParams[3];
   Value vecA2 = SOSParams[4];
 
-  Value vecOut = rewriter.create<vector::BroadcastOp>(loc, vectorTy, f0);
-  Value vecS1 = rewriter.create<vector::BroadcastOp>(loc, vectorTy, f0);
-  Value vecS2 = rewriter.create<vector::BroadcastOp>(loc, vectorTy, f0);
+  Value vecOut = vector::BroadcastOp::create(rewriter, loc, vectorTy, f0);
+  Value vecS1 = vector::BroadcastOp::create(rewriter, loc, vectorTy, f0);
+  Value vecS2 = vector::BroadcastOp::create(rewriter, loc, vectorTy, f0);
 
   // Injection stage for iir operation, no output produced
-  auto injectionResult = rewriter.create<scf::ForOp>(
-      loc, c0, cUpperBound, c1, ValueRange{vecOut, vecS1, vecS2},
+  auto injectionResult = scf::ForOp::create(
+      rewriter, loc, c0, cUpperBound, c1, ValueRange{vecOut, vecS1, vecS2},
       [&](OpBuilder &builder, Location loc, Value iv, ValueRange iargs) {
-        Value inElem = builder.create<memref::LoadOp>(loc, input, iv);
-        Value vecInMoveRight = builder.create<vector::ShuffleOp>(
-            loc, iargs[0], iargs[0], arrayRef);
+        Value inElem = memref::LoadOp::create(builder, loc, input, iv);
+        Value vecInMoveRight = vector::ShuffleOp::create(builder, loc, iargs[0],
+                                                         iargs[0], arrayRef);
         Value vecInNext =
             vector::InsertOp::create(builder, loc, inElem, vecInMoveRight, c0);
         Value vecOutNext =
-            builder.create<vector::FMAOp>(loc, vecB0, vecInNext, iargs[1]);
+            vector::FMAOp::create(builder, loc, vecB0, vecInNext, iargs[1]);
 
         Value vecS1Lhs =
-            builder.create<vector::FMAOp>(loc, vecB1, vecInNext, iargs[2]);
-        Value vecS1Rhs = builder.create<arith::MulFOp>(loc, vecA1, vecOutNext);
+            vector::FMAOp::create(builder, loc, vecB1, vecInNext, iargs[2]);
+        Value vecS1Rhs = arith::MulFOp::create(builder, loc, vecA1, vecOutNext);
         Value vecS1Next =
-            builder.create<arith::SubFOp>(loc, vecS1Lhs, vecS1Rhs);
+            arith::SubFOp::create(builder, loc, vecS1Lhs, vecS1Rhs);
 
-        Value vecS2Lhs = builder.create<arith::MulFOp>(loc, vecB2, vecInNext);
-        Value vecS2Rhs = builder.create<arith::MulFOp>(loc, vecA2, vecOutNext);
+        Value vecS2Lhs = arith::MulFOp::create(builder, loc, vecB2, vecInNext);
+        Value vecS2Rhs = arith::MulFOp::create(builder, loc, vecA2, vecOutNext);
         Value vecS2Next =
-            builder.create<arith::SubFOp>(loc, vecS2Lhs, vecS2Rhs);
+            arith::SubFOp::create(builder, loc, vecS2Lhs, vecS2Rhs);
 
-        builder.create<scf::YieldOp>(
-            loc, std::vector<Value>{vecOutNext, vecS1Next, vecS2Next});
+        scf::YieldOp::create(
+            builder, loc, std::vector<Value>{vecOutNext, vecS1Next, vecS2Next});
       });
 
-  Value upperBound = rewriter.create<arith::SubIOp>(loc, N, cUpperBound);
+  Value upperBound = arith::SubIOp::create(rewriter, loc, N, cUpperBound);
 
   // Processing stage for iir operation, start to produce ouput
-  auto processResult = rewriter.create<scf::ForOp>(
-      loc, c0, upperBound, c1, ValueRange{injectionResult.getResults()},
+  auto processResult = scf::ForOp::create(
+      rewriter, loc, c0, upperBound, c1,
+      ValueRange{injectionResult.getResults()},
       [&](OpBuilder &builder, Location loc, Value iv, ValueRange iargs) {
-        Value index = builder.create<arith::AddIOp>(loc, iv, cUpperBound);
-        Value inElem = builder.create<memref::LoadOp>(loc, input, index);
-        Value vecInMoveRight = builder.create<vector::ShuffleOp>(
-            loc, iargs[0], iargs[0], arrayRef);
+        Value index = arith::AddIOp::create(builder, loc, iv, cUpperBound);
+        Value inElem = memref::LoadOp::create(builder, loc, input, index);
+        Value vecInMoveRight = vector::ShuffleOp::create(builder, loc, iargs[0],
+                                                         iargs[0], arrayRef);
         Value vecInNext =
             vector::InsertOp::create(builder, loc, inElem, vecInMoveRight, c0);
         Value vecOutNext =
-            builder.create<vector::FMAOp>(loc, vecB0, vecInNext, iargs[1]);
+            vector::FMAOp::create(builder, loc, vecB0, vecInNext, iargs[1]);
         Value outElem =
             vector::ExtractOp::create(builder, loc, vecOutNext, cUpperBound);
-        builder.create<memref::StoreOp>(loc, outElem, output, iv);
+        memref::StoreOp::create(builder, loc, outElem, output, iv);
 
         Value vecS1Lhs =
-            builder.create<vector::FMAOp>(loc, vecB1, vecInNext, iargs[2]);
-        Value vecS1Rhs = builder.create<arith::MulFOp>(loc, vecA1, vecOutNext);
+            vector::FMAOp::create(builder, loc, vecB1, vecInNext, iargs[2]);
+        Value vecS1Rhs = arith::MulFOp::create(builder, loc, vecA1, vecOutNext);
         Value vecS1Next =
-            builder.create<arith::SubFOp>(loc, vecS1Lhs, vecS1Rhs);
+            arith::SubFOp::create(builder, loc, vecS1Lhs, vecS1Rhs);
 
-        Value vecS2Lhs = builder.create<arith::MulFOp>(loc, vecB2, vecInNext);
-        Value vecS2Rhs = builder.create<arith::MulFOp>(loc, vecA2, vecOutNext);
+        Value vecS2Lhs = arith::MulFOp::create(builder, loc, vecB2, vecInNext);
+        Value vecS2Rhs = arith::MulFOp::create(builder, loc, vecA2, vecOutNext);
         Value vecS2Next =
-            builder.create<arith::SubFOp>(loc, vecS2Lhs, vecS2Rhs);
+            arith::SubFOp::create(builder, loc, vecS2Lhs, vecS2Rhs);
 
-        builder.create<scf::YieldOp>(
-            loc, std::vector<Value>{vecOutNext, vecS1Next, vecS2Next});
+        scf::YieldOp::create(
+            builder, loc, std::vector<Value>{vecOutNext, vecS1Next, vecS2Next});
       });
 
   // Tail ending stafe for iir operation, generate rest ouput
-  rewriter.create<scf::ForOp>(
-      loc, upperBound, N, c1, ValueRange{processResult.getResults()},
+  scf::ForOp::create(
+      rewriter, loc, upperBound, N, c1, ValueRange{processResult.getResults()},
       [&](OpBuilder &builder, Location loc, Value iv, ValueRange iargs) {
-        Value vecInMoveRight = builder.create<vector::ShuffleOp>(
-            loc, iargs[0], iargs[0], arrayRef);
+        Value vecInMoveRight = vector::ShuffleOp::create(builder, loc, iargs[0],
+                                                         iargs[0], arrayRef);
         Value vecInNext =
             vector::InsertOp::create(builder, loc, f0, vecInMoveRight, c0);
         Value vecOutNext =
-            builder.create<vector::FMAOp>(loc, vecB0, vecInNext, iargs[1]);
+            vector::FMAOp::create(builder, loc, vecB0, vecInNext, iargs[1]);
         Value outElem =
             vector::ExtractOp::create(builder, loc, vecOutNext, cUpperBound);
-        builder.create<memref::StoreOp>(loc, outElem, output, iv);
+        memref::StoreOp::create(builder, loc, outElem, output, iv);
 
         Value vecS1Lhs =
-            builder.create<vector::FMAOp>(loc, vecB1, vecInNext, iargs[2]);
-        Value vecS1Rhs = builder.create<arith::MulFOp>(loc, vecA1, vecOutNext);
+            vector::FMAOp::create(builder, loc, vecB1, vecInNext, iargs[2]);
+        Value vecS1Rhs = arith::MulFOp::create(builder, loc, vecA1, vecOutNext);
         Value vecS1Next =
-            builder.create<arith::SubFOp>(loc, vecS1Lhs, vecS1Rhs);
+            arith::SubFOp::create(builder, loc, vecS1Lhs, vecS1Rhs);
 
-        Value vecS2Lhs = builder.create<arith::MulFOp>(loc, vecB2, vecInNext);
-        Value vecS2Rhs = builder.create<arith::MulFOp>(loc, vecA2, vecOutNext);
+        Value vecS2Lhs = arith::MulFOp::create(builder, loc, vecB2, vecInNext);
+        Value vecS2Rhs = arith::MulFOp::create(builder, loc, vecA2, vecOutNext);
         Value vecS2Next =
-            builder.create<arith::SubFOp>(loc, vecS2Lhs, vecS2Rhs);
+            arith::SubFOp::create(builder, loc, vecS2Lhs, vecS2Rhs);
 
-        builder.create<scf::YieldOp>(
-            loc, std::vector<Value>{vecOutNext, vecS1Next, vecS2Next});
+        scf::YieldOp::create(
+            builder, loc, std::vector<Value>{vecOutNext, vecS1Next, vecS2Next});
       });
 }
 
@@ -198,7 +200,7 @@ void iirVectorizationProcess(OpBuilder &rewriter, Location loc, uint64_t vecLen,
   VectorType vectorTy = VectorType::get(vecLen, floatType);
   uint64_t vecLenMinusOne = vecLen - 1;
   Value cUpperBound =
-      rewriter.create<arith::ConstantIndexOp>(loc, vecLenMinusOne);
+      arith::ConstantIndexOp::create(rewriter, loc, vecLenMinusOne);
 
   auto SOSParams = dap::generateSOSParams(rewriter, loc, vectorTy, f0, f1, c0,
                                           c1, c2, c4, c5, filterSize, kernel);

--- a/midend/lib/Utils/DIPUtils.cpp
+++ b/midend/lib/Utils/DIPUtils.cpp
@@ -211,10 +211,10 @@ Value insertFMAOp(OpBuilder &builder, Location loc, VectorType type,
   auto elemTy = type.getElementType();
   auto bitWidth = elemTy.getIntOrFloatBitWidth();
   if (elemTy.isF32() || elemTy.isF64()) {
-    res = builder.create<vector::FMAOp>(loc, inputVec, kernelVec, outputVec);
+    res = vector::FMAOp::create(builder, loc, inputVec, kernelVec, outputVec);
   } else if (elemTy.isInteger(bitWidth)) {
-    Value mul = builder.create<arith::MulIOp>(loc, inputVec, kernelVec);
-    res = builder.create<arith::AddIOp>(loc, mul, outputVec);
+    Value mul = arith::MulIOp::create(builder, loc, inputVec, kernelVec);
+    res = arith::AddIOp::create(builder, loc, mul, outputVec);
   }
 
   return res;
@@ -226,12 +226,12 @@ void calcAndStoreFMAwoTailProcessing(OpBuilder &builder, Location loc,
                                      VectorType vecType, Value inputVec,
                                      Value kernelVec, Value output,
                                      Value beginIdx, Value endIdx) {
-  Value outputVec = builder.create<vector::LoadOp>(
-      loc, vecType, output, ValueRange{beginIdx, endIdx});
+  Value outputVec = vector::LoadOp::create(builder, loc, vecType, output,
+                                           ValueRange{beginIdx, endIdx});
   Value resVec =
       insertFMAOp(builder, loc, vecType, inputVec, kernelVec, outputVec);
-  builder.create<vector::StoreOp>(loc, resVec, output,
-                                  ValueRange{beginIdx, endIdx});
+  vector::StoreOp::create(builder, loc, resVec, output,
+                          ValueRange{beginIdx, endIdx});
 }
 
 // Checks if we encountered a tail (columns remaining after processing in
@@ -239,21 +239,22 @@ void calcAndStoreFMAwoTailProcessing(OpBuilder &builder, Location loc,
 Value tailChecker(OpBuilder &builder, Location loc, AffineMap calcHelper,
                   Value strideVal, Value kernelSize, Value c1, Value pseudoCol,
                   Value colPivot) {
-  Value tailChecker = builder.create<affine::AffineApplyOp>(
-      loc, calcHelper, ValueRange{strideVal, kernelSize, c1});
+  Value tailChecker = affine::AffineApplyOp::create(
+      builder, loc, calcHelper, ValueRange{strideVal, kernelSize, c1});
   Value colEndDistance =
-      builder.create<arith::SubIOp>(loc, pseudoCol, colPivot);
-  Value tailCond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sge,
-                                                 colEndDistance, tailChecker);
+      arith::SubIOp::create(builder, loc, pseudoCol, colPivot);
+  Value tailCond = arith::CmpIOp::create(
+      builder, loc, arith::CmpIPredicate::sge, colEndDistance, tailChecker);
   return tailCond;
 }
 
 // Creates the required mask which is to be used for tail processing.
 Value tailMaskCreator(OpBuilder &builder, Location loc, Value inputCol,
                       Value colPivot, VectorType vectorMaskTy) {
-  Value extraElemCount = builder.create<arith::SubIOp>(loc, inputCol, colPivot);
+  Value extraElemCount =
+      arith::SubIOp::create(builder, loc, inputCol, colPivot);
   Value tailMask =
-      builder.create<vector::CreateMaskOp>(loc, vectorMaskTy, extraElemCount);
+      vector::CreateMaskOp::create(builder, loc, vectorMaskTy, extraElemCount);
   return tailMask;
 }
 
@@ -265,30 +266,31 @@ void calcAndStoreFMAwTailProcessing(OpBuilder &builder, Location loc,
                                     Value beginIdx, Value endIdx,
                                     Value tailCond, Value zeroPadding,
                                     Value inputCol, VectorType vectorMaskTy) {
-  builder.create<scf::IfOp>(
-      loc, tailCond,
+  scf::IfOp::create(
+      builder, loc, tailCond,
       [&](OpBuilder &builder, Location loc) {
-        Value outputVec = builder.create<vector::LoadOp>(
-            loc, vecType, output, ValueRange{beginIdx, endIdx});
+        Value outputVec = vector::LoadOp::create(builder, loc, vecType, output,
+                                                 ValueRange{beginIdx, endIdx});
         Value resVec =
             insertFMAOp(builder, loc, vecType, inputVec, kernelVec, outputVec);
-        builder.create<vector::StoreOp>(loc, resVec, output,
-                                        ValueRange{beginIdx, endIdx});
+        vector::StoreOp::create(builder, loc, resVec, output,
+                                ValueRange{beginIdx, endIdx});
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       },
       [&](OpBuilder &builder, Location loc) {
         Value extraElemMask =
             tailMaskCreator(builder, loc, inputCol, endIdx, vectorMaskTy);
-        Value outputVec = builder.create<vector::MaskedLoadOp>(
-            loc, vecType, output, ValueRange{beginIdx, endIdx}, extraElemMask,
-            zeroPadding);
+        Value outputVec = vector::MaskedLoadOp::create(
+            builder, loc, vecType, output, ValueRange{beginIdx, endIdx},
+            extraElemMask, zeroPadding);
         Value resVec =
             insertFMAOp(builder, loc, vecType, inputVec, kernelVec, outputVec);
-        builder.create<vector::MaskedStoreOp>(
-            loc, output, ValueRange{beginIdx, endIdx}, extraElemMask, resVec);
+        vector::MaskedStoreOp::create(builder, loc, output,
+                                      ValueRange{beginIdx, endIdx},
+                                      extraElemMask, resVec);
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 }
 
@@ -296,16 +298,16 @@ void calcAndStoreFMAwTailProcessing(OpBuilder &builder, Location loc,
 std::vector<Value> shearTransform(OpBuilder &builder, Location loc,
                                   Value originalX, Value originalY,
                                   Value sinVec, Value tanVec) {
-  Value yTan1 = builder.create<arith::MulFOp>(loc, tanVec, originalY);
-  Value xIntermediate1 = builder.create<arith::SubFOp>(loc, originalX, yTan1);
+  Value yTan1 = arith::MulFOp::create(builder, loc, tanVec, originalY);
+  Value xIntermediate1 = arith::SubFOp::create(builder, loc, originalX, yTan1);
   Value xIntermediate = roundOff(builder, loc, xIntermediate1);
 
-  Value xSin = builder.create<arith::MulFOp>(loc, xIntermediate, sinVec);
-  Value newY1 = builder.create<arith::AddFOp>(loc, xSin, originalY);
+  Value xSin = arith::MulFOp::create(builder, loc, xIntermediate, sinVec);
+  Value newY1 = arith::AddFOp::create(builder, loc, xSin, originalY);
   Value newY = roundOff(builder, loc, newY1);
 
-  Value yTan2 = builder.create<arith::MulFOp>(loc, newY, tanVec);
-  Value newX1 = builder.create<arith::SubFOp>(loc, xIntermediate, yTan2);
+  Value yTan2 = arith::MulFOp::create(builder, loc, newY, tanVec);
+  Value newX1 = arith::SubFOp::create(builder, loc, xIntermediate, yTan2);
   Value newX = roundOff(builder, loc, newX1);
 
   return {newY, newX};
@@ -315,14 +317,14 @@ std::vector<Value> shearTransform(OpBuilder &builder, Location loc,
 std::vector<Value> standardRotate(OpBuilder &builder, Location loc,
                                   Value originalX, Value originalY,
                                   Value sinVec, Value cosVec) {
-  Value ySin = builder.create<arith::MulFOp>(loc, originalY, sinVec);
-  Value yCos = builder.create<arith::MulFOp>(loc, originalY, cosVec);
+  Value ySin = arith::MulFOp::create(builder, loc, originalY, sinVec);
+  Value yCos = arith::MulFOp::create(builder, loc, originalY, cosVec);
 
-  Value xSin = builder.create<arith::MulFOp>(loc, originalX, sinVec);
-  Value xCos = builder.create<arith::MulFOp>(loc, originalX, cosVec);
+  Value xSin = arith::MulFOp::create(builder, loc, originalX, sinVec);
+  Value xCos = arith::MulFOp::create(builder, loc, originalX, cosVec);
 
-  Value newY1 = builder.create<arith::SubFOp>(loc, yCos, xSin);
-  Value newX1 = builder.create<arith::AddFOp>(loc, ySin, xCos);
+  Value newY1 = arith::SubFOp::create(builder, loc, yCos, xSin);
+  Value newX1 = arith::AddFOp::create(builder, loc, ySin, xCos);
 
   return {roundOff(builder, loc, newY1), roundOff(builder, loc, newX1)};
 }
@@ -330,14 +332,14 @@ std::vector<Value> standardRotate(OpBuilder &builder, Location loc,
 // Get center co-ordinates w.r.t given dimension.
 Value getCenter(OpBuilder &builder, Location loc, MLIRContext *ctx, Value dim) {
   Value dimF32 = indexToF32(builder, loc, dim);
-  Value c1f = builder.create<arith::ConstantFloatOp>(loc, builder.getF32Type(),
-                                                     (llvm::APFloat)1.0f);
-  Value c2f = builder.create<arith::ConstantFloatOp>(loc, builder.getF32Type(),
-                                                     (llvm::APFloat)2.0f);
+  Value c1f = arith::ConstantFloatOp::create(builder, loc, builder.getF32Type(),
+                                             (llvm::APFloat)1.0f);
+  Value c2f = arith::ConstantFloatOp::create(builder, loc, builder.getF32Type(),
+                                             (llvm::APFloat)2.0f);
 
-  Value temp1 = builder.create<arith::AddFOp>(loc, dimF32, c1f);
-  Value temp2 = builder.create<arith::DivFOp>(loc, temp1, c2f);
-  Value center = builder.create<arith::SubFOp>(loc, temp2, c1f);
+  Value temp1 = arith::AddFOp::create(builder, loc, dimF32, c1f);
+  Value temp2 = arith::DivFOp::create(builder, loc, temp1, c2f);
+  Value center = arith::SubFOp::create(builder, loc, temp2, c1f);
   Value centerRound = roundOff(builder, loc, center);
 
   return F32ToIndex(builder, loc, centerRound);
@@ -347,11 +349,11 @@ Value getCenter(OpBuilder &builder, Location loc, MLIRContext *ctx, Value dim) {
 // position(s).
 Value pixelScaling(OpBuilder &builder, Location loc, Value imageDImF32Vec,
                    Value coordVec, Value imageCenterF32Vec, Value c1F32Vec) {
-  Value interm1 = builder.create<arith::SubFOp>(loc, imageDImF32Vec, coordVec);
+  Value interm1 = arith::SubFOp::create(builder, loc, imageDImF32Vec, coordVec);
   Value interm2 =
-      builder.create<arith::SubFOp>(loc, interm1, imageCenterF32Vec);
+      arith::SubFOp::create(builder, loc, interm1, imageCenterF32Vec);
 
-  return builder.create<arith::SubFOp>(loc, interm2, c1F32Vec);
+  return arith::SubFOp::create(builder, loc, interm2, c1F32Vec);
 }
 
 // Extract values present at a particular index in two vectors for using
@@ -376,9 +378,10 @@ void fillPixels(OpBuilder &builder, Location loc, Value resXVec, Value resYVec,
                 Value strideVal, Value outputRowLastElemF32,
                 Value outputColLastElemF32, Value inputRowLastElemF32,
                 Value inputColLastElemF32, Value c0F32) {
-  builder.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, builder.getDimIdentityMap(), ValueRange{strideVal},
-      builder.getDimIdentityMap(), /*step*/ 1, ValueRange{},
+  affine::AffineForOp::create(
+      builder, loc, ValueRange{c0}, builder.getDimIdentityMap(),
+      ValueRange{strideVal}, builder.getDimIdentityMap(), /*step*/ 1,
+      ValueRange{},
       [&](OpBuilder &builder, Location loc, ValueRange ivs,
           ValueRange iterArg) {
         std::vector<Value> origIndices =
@@ -388,13 +391,13 @@ void fillPixels(OpBuilder &builder, Location loc, Value resXVec, Value resYVec,
             extractIndices(builder, loc, resXVec, resYVec, ivs[0],
                            outputColLastElemF32, outputRowLastElemF32, c0F32);
 
-        Value pixelVal = builder.create<memref::LoadOp>(
-            loc, builder.getF32Type(), input,
-            ValueRange{origIndices[1], origIndices[0]});
-        builder.create<memref::StoreOp>(
-            loc, pixelVal, output, ValueRange{resIndices[1], resIndices[0]});
+        Value pixelVal =
+            memref::LoadOp::create(builder, loc, builder.getF32Type(), input,
+                                   ValueRange{origIndices[1], origIndices[0]});
+        memref::StoreOp::create(builder, loc, pixelVal, output,
+                                ValueRange{resIndices[1], resIndices[0]});
 
-        builder.create<affine::AffineYieldOp>(loc);
+        affine::AffineYieldOp::create(builder, loc);
       });
 }
 
@@ -406,9 +409,10 @@ void fillPixelsNearestNeighbour4D(
     Value strideVal, Value outputRowLastElemF32, Value outputColLastElemF32,
     Value inputRowLastElemF32, Value inputColLastElemF32, Value c0F32,
     Value dataCondition) {
-  builder.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, builder.getDimIdentityMap(), ValueRange{strideVal},
-      builder.getDimIdentityMap(), /*step*/ 1, ValueRange{},
+  affine::AffineForOp::create(
+      builder, loc, ValueRange{c0}, builder.getDimIdentityMap(),
+      ValueRange{strideVal}, builder.getDimIdentityMap(), /*step*/ 1,
+      ValueRange{},
       [&](OpBuilder &builder, Location loc, ValueRange ivs,
           ValueRange iterArg) {
         std::vector<Value> origIndices =
@@ -418,51 +422,51 @@ void fillPixelsNearestNeighbour4D(
             extractIndices(builder, loc, resXVec, resYVec, ivs[0],
                            outputColLastElemF32, outputRowLastElemF32, c0F32);
 
-        auto ifop = builder.create<scf::IfOp>(
-            loc, dataCondition,
+        auto ifop = scf::IfOp::create(
+            builder, loc, dataCondition,
             [&](OpBuilder &builder, Location loc) {
-              Value pixelVal = builder.create<memref::LoadOp>(
-                  loc, builder.getF32Type(), input,
+              Value pixelVal = memref::LoadOp::create(
+                  builder, loc, builder.getF32Type(), input,
                   ValueRange{ivs0, origIndices[1], origIndices[0], ivs1});
-              builder.create<scf::YieldOp>(loc, pixelVal);
+              scf::YieldOp::create(builder, loc, pixelVal);
             },
             [&](OpBuilder &builder, Location loc) {
-              Value pixelVal = builder.create<memref::LoadOp>(
-                  loc, builder.getF32Type(), input,
+              Value pixelVal = memref::LoadOp::create(
+                  builder, loc, builder.getF32Type(), input,
                   ValueRange{ivs0, ivs1, origIndices[1], origIndices[0]});
-              builder.create<scf::YieldOp>(loc, pixelVal);
+              scf::YieldOp::create(builder, loc, pixelVal);
             });
         Value pixelVal = ifop.getResult(0);
 
-        builder.create<scf::IfOp>(
-            loc, dataCondition,
+        scf::IfOp::create(
+            builder, loc, dataCondition,
             [&](OpBuilder &builder, Location loc) {
-              builder.create<memref::StoreOp>(
-                  loc, pixelVal, output,
+              memref::StoreOp::create(
+                  builder, loc, pixelVal, output,
                   ValueRange{ivs0, resIndices[1], resIndices[0], ivs1});
-              builder.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(builder, loc);
             },
             [&](OpBuilder &builder, Location loc) {
-              builder.create<memref::StoreOp>(
-                  loc, pixelVal, output,
+              memref::StoreOp::create(
+                  builder, loc, pixelVal, output,
                   ValueRange{ivs0, ivs1, resIndices[1], resIndices[0]});
-              builder.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(builder, loc);
             });
 
-        builder.create<affine::AffineYieldOp>(loc);
+        affine::AffineYieldOp::create(builder, loc);
       });
 }
 
 // Calculate tan(angle / 2) where angle is a function parameter.
 Value customTanVal(OpBuilder &builder, Location loc, Value angleVal) {
-  Value c2F32 = builder.create<arith::ConstantFloatOp>(
-      loc, builder.getF32Type(), (llvm::APFloat)2.0f);
-  Value angleVal_2 = builder.create<arith::DivFOp>(loc, angleVal, c2F32);
+  Value c2F32 = arith::ConstantFloatOp::create(
+      builder, loc, builder.getF32Type(), (llvm::APFloat)2.0f);
+  Value angleVal_2 = arith::DivFOp::create(builder, loc, angleVal, c2F32);
 
-  Value sinVal = builder.create<math::SinOp>(loc, angleVal_2);
-  Value cosVal = builder.create<math::CosOp>(loc, angleVal_2);
+  Value sinVal = math::SinOp::create(builder, loc, angleVal_2);
+  Value cosVal = math::CosOp::create(builder, loc, angleVal_2);
 
-  return builder.create<arith::DivFOp>(loc, sinVal, cosVal);
+  return arith::DivFOp::create(builder, loc, sinVal, cosVal);
 }
 
 // Calculate the real affine matrix for rotation by
@@ -472,14 +476,14 @@ SmallVector<Value, 6> calculateRotationMatrix(OpBuilder &builder, Location loc,
                                               Value inputCol, Value inputRow,
                                               Value outputCol, Value outputRow,
                                               Value angleVal) {
-  Value c1 = builder.create<arith::ConstantIndexOp>(loc, 1);
+  Value c1 = arith::ConstantIndexOp::create(builder, loc, 1);
 
   // let alpha = scale * cos(angle), beta = scale * sin(angle)
   // the affine matrix would be as follow:
   // [[alpha, beta, (1 - alpha) * centerx - beta * centery],
   //  [-beta, alpha, beta * centerx + (1 - alpha) * centery]]
-  Value centerX = builder.create<arith::ShRSIOp>(loc, inputCol, c1);
-  Value centerY = builder.create<arith::ShRSIOp>(loc, inputRow, c1);
+  Value centerX = arith::ShRSIOp::create(builder, loc, inputCol, c1);
+  Value centerY = arith::ShRSIOp::create(builder, loc, inputRow, c1);
   Value centerXF32 = indexToF32(builder, loc, centerX);
   Value centerYF32 = indexToF32(builder, loc, centerY);
 
@@ -491,17 +495,17 @@ SmallVector<Value, 6> calculateRotationMatrix(OpBuilder &builder, Location loc,
 
   //  modify the affine matrix to preserve the full original
   //  image after rotation
-  Value deltaXI = builder.create<arith::SubIOp>(loc, outputCol, inputCol);
-  Value deltaYI = builder.create<arith::SubIOp>(loc, outputRow, inputRow);
-  Value deltaXIDiv2 = builder.create<arith::ShRSIOp>(loc, deltaXI, c1);
-  Value deltaYIDiv2 = builder.create<arith::ShRSIOp>(loc, deltaYI, c1);
+  Value deltaXI = arith::SubIOp::create(builder, loc, outputCol, inputCol);
+  Value deltaYI = arith::SubIOp::create(builder, loc, outputRow, inputRow);
+  Value deltaXIDiv2 = arith::ShRSIOp::create(builder, loc, deltaXI, c1);
+  Value deltaYIDiv2 = arith::ShRSIOp::create(builder, loc, deltaYI, c1);
   Value deltaXFDiv2 = indexToF32(builder, loc, deltaXIDiv2);
   Value deltaYFDiv2 = indexToF32(builder, loc, deltaYIDiv2);
 
   affineMatrix[2] =
-      builder.create<arith::AddFOp>(loc, affineMatrix[2], deltaXFDiv2);
+      arith::AddFOp::create(builder, loc, affineMatrix[2], deltaXFDiv2);
   affineMatrix[5] =
-      builder.create<arith::AddFOp>(loc, affineMatrix[5], deltaYFDiv2);
+      arith::AddFOp::create(builder, loc, affineMatrix[5], deltaYFDiv2);
 
   return affineMatrix;
 }
@@ -516,25 +520,25 @@ SmallVector<Value, 6> getRotationMatrix(OpBuilder &builder, Location loc,
   // and the rotation will be calculated as
   // x = m0 * x_new + m1 * y_new + m2
   // y_new = m3 * x_new + m4 * y_new + m
-  Value alpha0 = builder.create<math::CosOp>(loc, angle);
-  Value alpha = builder.create<arith::MulFOp>(loc, alpha0, scale);
-  Value beta0 = builder.create<math::SinOp>(loc, angle);
-  Value beta = builder.create<arith::MulFOp>(loc, beta0, scale);
-  Value oneMinusAlpha = builder.create<arith::SubFOp>(
-      loc,
-      builder.create<arith::ConstantOp>(loc,
-                                        builder.getF32FloatAttr((float)1.)),
+  Value alpha0 = math::CosOp::create(builder, loc, angle);
+  Value alpha = arith::MulFOp::create(builder, loc, alpha0, scale);
+  Value beta0 = math::SinOp::create(builder, loc, angle);
+  Value beta = arith::MulFOp::create(builder, loc, beta0, scale);
+  Value oneMinusAlpha = arith::SubFOp::create(
+      builder, loc,
+      arith::ConstantOp::create(builder, loc,
+                                builder.getF32FloatAttr((float)1.)),
       alpha);
-  Value m20 = builder.create<arith::MulFOp>(loc, oneMinusAlpha, centerX);
-  Value m21 = builder.create<arith::MulFOp>(loc, beta, centerY);
-  Value m50 = builder.create<arith::MulFOp>(loc, beta, centerX);
-  Value m51 = builder.create<arith::MulFOp>(loc, oneMinusAlpha, centerY);
+  Value m20 = arith::MulFOp::create(builder, loc, oneMinusAlpha, centerX);
+  Value m21 = arith::MulFOp::create(builder, loc, beta, centerY);
+  Value m50 = arith::MulFOp::create(builder, loc, beta, centerX);
+  Value m51 = arith::MulFOp::create(builder, loc, oneMinusAlpha, centerY);
   Value m0 = alpha;
   Value m1 = beta;
-  Value m2 = builder.create<arith::SubFOp>(loc, m20, m21);
-  Value m3 = builder.create<arith::NegFOp>(loc, beta);
+  Value m2 = arith::SubFOp::create(builder, loc, m20, m21);
+  Value m3 = arith::NegFOp::create(builder, loc, beta);
   Value m4 = alpha;
-  Value m5 = builder.create<arith::AddFOp>(loc, m50, m51);
+  Value m5 = arith::AddFOp::create(builder, loc, m50, m51);
 
   return SmallVector<Value, 6>{m0, m1, m2, m3, m4, m5};
 }
@@ -545,46 +549,46 @@ SmallVector<Value, 6> getRotationMatrix(OpBuilder &builder, Location loc,
 // m5
 inline void inverseAffineMatrix(OpBuilder &builder, Location loc,
                                 SmallVector<Value, 6> &affineMatrix) {
-  Value c0F32 = builder.create<arith::ConstantOp>(
-      loc, builder.getF32FloatAttr((float).0));
+  Value c0F32 = arith::ConstantOp::create(builder, loc,
+                                          builder.getF32FloatAttr((float).0));
   Value m0pm4 =
-      builder.create<arith::MulFOp>(loc, affineMatrix[0], affineMatrix[4]);
+      arith::MulFOp::create(builder, loc, affineMatrix[0], affineMatrix[4]);
   Value m1pm3 =
-      builder.create<arith::MulFOp>(loc, affineMatrix[1], affineMatrix[3]);
-  Value D = builder.create<arith::SubFOp>(loc, m0pm4, m1pm3);
+      arith::MulFOp::create(builder, loc, affineMatrix[1], affineMatrix[3]);
+  Value D = arith::SubFOp::create(builder, loc, m0pm4, m1pm3);
   Value dEq0 =
-      builder.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OEQ, D, c0F32);
-  auto scfRes = builder.create<scf::IfOp>(
-      loc, dEq0,
+      arith::CmpFOp::create(builder, loc, arith::CmpFPredicate::OEQ, D, c0F32);
+  auto scfRes = scf::IfOp::create(
+      builder, loc, dEq0,
       [&](OpBuilder &thenBuilder, Location thenLoc) {
-        thenBuilder.create<scf::YieldOp>(thenLoc, ValueRange{c0F32});
+        scf::YieldOp::create(thenBuilder, thenLoc, ValueRange{c0F32});
       },
       [&](OpBuilder &elseBuilder, Location elseLoc) {
-        Value c1F32 = elseBuilder.create<arith::ConstantOp>(
-            elseLoc, builder.getF32FloatAttr((float)1.));
-        Value res = elseBuilder.create<arith::DivFOp>(elseLoc, c1F32, D);
-        elseBuilder.create<scf::YieldOp>(elseLoc, ValueRange{res});
+        Value c1F32 = arith::ConstantOp::create(
+            elseBuilder, elseLoc, builder.getF32FloatAttr((float)1.));
+        Value res = arith::DivFOp::create(elseBuilder, elseLoc, c1F32, D);
+        scf::YieldOp::create(elseBuilder, elseLoc, ValueRange{res});
       });
   D = scfRes.getResult(0);
-  Value negD = builder.create<arith::NegFOp>(loc, D);
-  Value a0 = builder.create<arith::MulFOp>(loc, affineMatrix[4], D);
-  Value a4 = builder.create<arith::MulFOp>(loc, affineMatrix[0], D);
+  Value negD = arith::NegFOp::create(builder, loc, D);
+  Value a0 = arith::MulFOp::create(builder, loc, affineMatrix[4], D);
+  Value a4 = arith::MulFOp::create(builder, loc, affineMatrix[0], D);
   affineMatrix[0] = a0;
-  affineMatrix[1] = builder.create<arith::MulFOp>(loc, affineMatrix[1], negD);
-  affineMatrix[3] = builder.create<arith::MulFOp>(loc, affineMatrix[3], negD);
+  affineMatrix[1] = arith::MulFOp::create(builder, loc, affineMatrix[1], negD);
+  affineMatrix[3] = arith::MulFOp::create(builder, loc, affineMatrix[3], negD);
   affineMatrix[4] = a4;
   Value m0pm2 =
-      builder.create<arith::MulFOp>(loc, affineMatrix[0], affineMatrix[2]);
+      arith::MulFOp::create(builder, loc, affineMatrix[0], affineMatrix[2]);
   Value m1pm5 =
-      builder.create<arith::MulFOp>(loc, affineMatrix[1], affineMatrix[5]);
-  Value negB1 = builder.create<arith::AddFOp>(loc, m0pm2, m1pm5);
+      arith::MulFOp::create(builder, loc, affineMatrix[1], affineMatrix[5]);
+  Value negB1 = arith::AddFOp::create(builder, loc, m0pm2, m1pm5);
   Value m2pm3 =
-      builder.create<arith::MulFOp>(loc, affineMatrix[2], affineMatrix[3]);
+      arith::MulFOp::create(builder, loc, affineMatrix[2], affineMatrix[3]);
   Value m4pm5 =
-      builder.create<arith::MulFOp>(loc, affineMatrix[4], affineMatrix[5]);
-  Value negB2 = builder.create<arith::AddFOp>(loc, m2pm3, m4pm5);
-  affineMatrix[2] = builder.create<arith::NegFOp>(loc, negB1);
-  affineMatrix[5] = builder.create<arith::NegFOp>(loc, negB2);
+      arith::MulFOp::create(builder, loc, affineMatrix[4], affineMatrix[5]);
+  Value negB2 = arith::AddFOp::create(builder, loc, m2pm3, m4pm5);
+  affineMatrix[2] = arith::NegFOp::create(builder, loc, negB1);
+  affineMatrix[5] = arith::NegFOp::create(builder, loc, negB2);
 }
 
 // Controls affine transform application.
@@ -595,19 +599,19 @@ void affineTransformController(OpBuilder &builder, Location loc,
   VectorType vectorTyF32 = VectorType::get({stride}, Float32Type::get(ctx));
   VectorType vectorTyI32 = VectorType::get({stride}, IntegerType::get(ctx, 32));
 
-  Value c0Index = builder.create<arith::ConstantIndexOp>(loc, 0);
-  Value c1Index = builder.create<arith::ConstantIndexOp>(loc, 1);
+  Value c0Index = arith::ConstantIndexOp::create(builder, loc, 0);
+  Value c1Index = arith::ConstantIndexOp::create(builder, loc, 1);
 
   inverseAffineMatrix(builder, loc, affineMatrix);
 
   Value m0Vec =
-      builder.create<vector::BroadcastOp>(loc, vectorTyF32, affineMatrix[0]);
+      vector::BroadcastOp::create(builder, loc, vectorTyF32, affineMatrix[0]);
   Value m2Vec =
-      builder.create<vector::BroadcastOp>(loc, vectorTyF32, affineMatrix[2]);
+      vector::BroadcastOp::create(builder, loc, vectorTyF32, affineMatrix[2]);
   Value m3Vec =
-      builder.create<vector::BroadcastOp>(loc, vectorTyF32, affineMatrix[3]);
+      vector::BroadcastOp::create(builder, loc, vectorTyF32, affineMatrix[3]);
   Value m5Vec =
-      builder.create<vector::BroadcastOp>(loc, vectorTyF32, affineMatrix[5]);
+      vector::BroadcastOp::create(builder, loc, vectorTyF32, affineMatrix[5]);
 
   //  get the output image dimensions
   int dimIndex = -1;
@@ -618,16 +622,17 @@ void affineTransformController(OpBuilder &builder, Location loc,
   } else if (format == dip::ImageFormat::NCHW) {
     dimIndex = 2;
   }
-  Value rowIndex = builder.create<arith::ConstantIndexOp>(loc, dimIndex);
-  Value colIndex = builder.create<arith::ConstantIndexOp>(loc, dimIndex + 1);
-  Value outputRow = builder.create<memref::DimOp>(loc, output, rowIndex);
-  Value outputCol = builder.create<memref::DimOp>(loc, output, colIndex);
+  Value rowIndex = arith::ConstantIndexOp::create(builder, loc, dimIndex);
+  Value colIndex = arith::ConstantIndexOp::create(builder, loc, dimIndex + 1);
+  Value outputRow = memref::DimOp::create(builder, loc, output, rowIndex);
+  Value outputCol = memref::DimOp::create(builder, loc, output, colIndex);
 
-  Value strideVal = builder.create<arith::ConstantIndexOp>(loc, stride);
+  Value strideVal = arith::ConstantIndexOp::create(builder, loc, stride);
   Value outputColStrideRatio =
-      builder.create<arith::DivUIOp>(loc, outputCol, strideVal);
-  Value outputColMultiple = builder.create<arith::MulIOp>(
-      loc, builder.create<arith::AddIOp>(loc, outputColStrideRatio, c1Index),
+      arith::DivUIOp::create(builder, loc, outputCol, strideVal);
+  Value outputColMultiple = arith::MulIOp::create(
+      builder, loc,
+      arith::AddIOp::create(builder, loc, outputColStrideRatio, c1Index),
       strideVal);
 
   Value xVecInitial = iotaVec0F32(builder, loc, stride);
@@ -637,63 +642,65 @@ void affineTransformController(OpBuilder &builder, Location loc,
 
   // compute x*m0+m2 and x*m3+m5 and store the results into xMm0 and xMm3
   Value xMm0 =
-      builder.create<memref::AllocOp>(loc, dynamicTypeI32, outputColMultiple);
+      memref::AllocOp::create(builder, loc, dynamicTypeI32, outputColMultiple);
   Value xMm3 =
-      builder.create<memref::AllocOp>(loc, dynamicTypeI32, outputColMultiple);
+      memref::AllocOp::create(builder, loc, dynamicTypeI32, outputColMultiple);
 
   // RSV_BITS = reserved bits, how many bits should be reserved for fraction
   // part
   // TODO: make reserved bits configurable
   const int RSV_BITS = 5;
-  Value c_rsv = builder.create<arith::ConstantOp>(
-      loc, builder.getF32FloatAttr((float)(1 << RSV_BITS)));
-  Value rsv_delta = builder.create<arith::ConstantOp>(
-      loc, builder.getI32IntegerAttr(1 << (RSV_BITS - 1)));
-  Value c_rsvVec = builder.create<vector::BroadcastOp>(loc, vectorTyF32, c_rsv);
+  Value c_rsv = arith::ConstantOp::create(
+      builder, loc, builder.getF32FloatAttr((float)(1 << RSV_BITS)));
+  Value rsv_delta = arith::ConstantOp::create(
+      builder, loc, builder.getI32IntegerAttr(1 << (RSV_BITS - 1)));
+  Value c_rsvVec =
+      vector::BroadcastOp::create(builder, loc, vectorTyF32, c_rsv);
   Value rsv_deltaVec =
-      builder.create<vector::BroadcastOp>(loc, vectorTyI32, rsv_delta);
+      vector::BroadcastOp::create(builder, loc, vectorTyI32, rsv_delta);
 
-  builder.create<affine::AffineForOp>(
-      loc, ValueRange{c0Index}, builder.getDimIdentityMap(),
+  affine::AffineForOp::create(
+      builder, loc, ValueRange{c0Index}, builder.getDimIdentityMap(),
       ValueRange{outputColMultiple}, builder.getDimIdentityMap(), stride,
       ValueRange{},
       [&](OpBuilder &builderFor, Location locFor, ValueRange ivsFor,
           ValueRange iterArg) {
-        Value delta = builderFor.create<vector::BroadcastOp>(
-            locFor, vectorTyF32, indexToF32(builderFor, locFor, ivsFor[0]));
+        Value delta = vector::BroadcastOp::create(
+            builderFor, locFor, vectorTyF32,
+            indexToF32(builderFor, locFor, ivsFor[0]));
         Value xVec =
-            builderFor.create<arith::AddFOp>(locFor, xVecInitial, delta);
-        Value x0xM0 = builderFor.create<arith::MulFOp>(locFor, xVec, m0Vec);
-        Value x1xM3 = builderFor.create<arith::MulFOp>(locFor, xVec, m3Vec);
+            arith::AddFOp::create(builderFor, locFor, xVecInitial, delta);
+        Value x0xM0 = arith::MulFOp::create(builderFor, locFor, xVec, m0Vec);
+        Value x1xM3 = arith::MulFOp::create(builderFor, locFor, xVec, m3Vec);
         Value x0xM0addM2 =
-            builderFor.create<arith::AddFOp>(locFor, x0xM0, m2Vec);
+            arith::AddFOp::create(builderFor, locFor, x0xM0, m2Vec);
         Value x1xM3addM5 =
-            builderFor.create<arith::AddFOp>(locFor, x1xM3, m5Vec);
+            arith::AddFOp::create(builderFor, locFor, x1xM3, m5Vec);
         Value x0xM0addM2xrsv =
-            builderFor.create<arith::MulFOp>(locFor, x0xM0addM2, c_rsvVec);
+            arith::MulFOp::create(builderFor, locFor, x0xM0addM2, c_rsvVec);
         Value x1xM3addM5xrsv =
-            builderFor.create<arith::MulFOp>(locFor, x1xM3addM5, c_rsvVec);
-        Value x0 = builderFor.create<arith::FPToSIOp>(locFor, vectorTyI32,
-                                                      x0xM0addM2xrsv);
-        Value x1 = builderFor.create<arith::FPToSIOp>(locFor, vectorTyI32,
-                                                      x1xM3addM5xrsv);
+            arith::MulFOp::create(builderFor, locFor, x1xM3addM5, c_rsvVec);
+        Value x0 = arith::FPToSIOp::create(builderFor, locFor, vectorTyI32,
+                                           x0xM0addM2xrsv);
+        Value x1 = arith::FPToSIOp::create(builderFor, locFor, vectorTyI32,
+                                           x1xM3addM5xrsv);
         Value x0addrsv_delta =
-            builderFor.create<arith::AddIOp>(locFor, x0, rsv_deltaVec);
+            arith::AddIOp::create(builderFor, locFor, x0, rsv_deltaVec);
         Value x1addrsv_delta =
-            builderFor.create<arith::AddIOp>(locFor, x1, rsv_deltaVec);
-        builderFor.create<vector::StoreOp>(locFor, x0addrsv_delta, xMm0,
-                                           ValueRange{ivsFor[0]});
-        builderFor.create<vector::StoreOp>(locFor, x1addrsv_delta, xMm3,
-                                           ValueRange{ivsFor[0]});
-        builderFor.create<affine::AffineYieldOp>(locFor);
+            arith::AddIOp::create(builderFor, locFor, x1, rsv_deltaVec);
+        vector::StoreOp::create(builderFor, locFor, x0addrsv_delta, xMm0,
+                                ValueRange{ivsFor[0]});
+        vector::StoreOp::create(builderFor, locFor, x1addrsv_delta, xMm3,
+                                ValueRange{ivsFor[0]});
+        affine::AffineYieldOp::create(builderFor, locFor);
       });
 
   affineTransformCore(builder, loc, ctx, input, output, c0Index, outputRow,
                       c0Index, outputCol, affineMatrix[1], affineMatrix[4],
                       xMm0, xMm3, stride, RSV_BITS, 0, format);
 
-  builder.create<memref::DeallocOp>(loc, xMm0);
-  builder.create<memref::DeallocOp>(loc, xMm3);
+  memref::DeallocOp::create(builder, loc, xMm0);
+  memref::DeallocOp::create(builder, loc, xMm3);
 }
 
 // Controls shear transform application.
@@ -712,7 +719,7 @@ void shearTransformController(
       [&](OpBuilder &builder, Location loc, ValueRange ivs) {
         Value ivs0F32 = indexToF32(builder, loc, ivs[0]);
         Value yVec =
-            builder.create<vector::BroadcastOp>(loc, vectorTy32, ivs0F32);
+            vector::BroadcastOp::create(builder, loc, vectorTy32, ivs0F32);
         Value xVec = iotaVec(builder, loc, ctx, ivs[1], strideVal, vectorTy32,
                              c0, stride);
 
@@ -723,10 +730,10 @@ void shearTransformController(
 
         std::vector<Value> resIndices = shearTransform(
             builder, loc, xVecModified, yVecModified, sinVec, tanVec);
-        Value resYVec = builder.create<arith::SubFOp>(loc, outputCenterYF32Vec,
-                                                      resIndices[0]);
-        Value resXVec = builder.create<arith::SubFOp>(loc, outputCenterXF32Vec,
-                                                      resIndices[1]);
+        Value resYVec = arith::SubFOp::create(builder, loc, outputCenterYF32Vec,
+                                              resIndices[0]);
+        Value resXVec = arith::SubFOp::create(builder, loc, outputCenterXF32Vec,
+                                              resIndices[1]);
 
         fillPixels(builder, loc, resXVec, resYVec, xVec, yVec, input, output,
                    c0, strideVal, outputRowLastElemF32, outputColLastElemF32,
@@ -745,15 +752,15 @@ void standardRotateController(
     Value outputRowLastElemF32, Value outputColLastElemF32,
     Value inputRowLastElemF32, Value inputColLastElemF32, Value c0, Value c0F32,
     Value c1F32Vec, VectorType vectorTy32, int64_t stride, FloatType f32) {
-  Value cosVal = builder.create<math::CosOp>(loc, angleVal);
-  Value cosVec = builder.create<vector::BroadcastOp>(loc, vectorTy32, cosVal);
+  Value cosVal = math::CosOp::create(builder, loc, angleVal);
+  Value cosVec = vector::BroadcastOp::create(builder, loc, vectorTy32, cosVal);
 
   affine::buildAffineLoopNest(
       builder, loc, lowerBounds, upperBounds, steps,
       [&](OpBuilder &builder, Location loc, ValueRange ivs) {
         Value ivs0F32 = indexToF32(builder, loc, ivs[0]);
         Value yVec =
-            builder.create<vector::BroadcastOp>(loc, vectorTy32, ivs0F32);
+            vector::BroadcastOp::create(builder, loc, vectorTy32, ivs0F32);
         Value xVec = iotaVec(builder, loc, ctx, ivs[1], strideVal, vectorTy32,
                              c0, stride);
 
@@ -764,10 +771,10 @@ void standardRotateController(
 
         std::vector<Value> resIndices = standardRotate(
             builder, loc, xVecModified, yVecModified, sinVec, cosVec);
-        Value resYVec = builder.create<arith::SubFOp>(loc, outputCenterYF32Vec,
-                                                      resIndices[0]);
-        Value resXVec = builder.create<arith::SubFOp>(loc, outputCenterXF32Vec,
-                                                      resIndices[1]);
+        Value resYVec = arith::SubFOp::create(builder, loc, outputCenterYF32Vec,
+                                              resIndices[0]);
+        Value resXVec = arith::SubFOp::create(builder, loc, outputCenterXF32Vec,
+                                              resIndices[1]);
 
         fillPixels(builder, loc, resXVec, resYVec, xVec, yVec, input, output,
                    c0, strideVal, inputRowLastElemF32, inputColLastElemF32,
@@ -783,9 +790,10 @@ void fillPixelsBilinearInterpolate(
     Value outputRowLastElemF32, Value outputColLastElemF32,
     Value inputRowLastElemF32, Value inputColLastElemF32, Value c0F32,
     Value c1F32) {
-  builder.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, builder.getDimIdentityMap(), ValueRange{strideVal},
-      builder.getDimIdentityMap(), /*step*/ 1, ValueRange{},
+  affine::AffineForOp::create(
+      builder, loc, ValueRange{c0}, builder.getDimIdentityMap(),
+      ValueRange{strideVal}, builder.getDimIdentityMap(), /*step*/ 1,
+      ValueRange{},
       [&](OpBuilder &builder, Location loc, ValueRange ivs,
           ValueRange iterArg) {
         std::vector<Value> resIndices =
@@ -811,54 +819,54 @@ void fillPixelsBilinearInterpolate(
             valBound(builder, loc, yPos_temp, inputRowLastElemF32, c0F32));
 
         std::vector<Value> indexWeights_UnitComplements = {
-            builder.create<arith::SubFOp>(loc, c1F32, indexWeights[0]),
-            builder.create<arith::SubFOp>(loc, c1F32, indexWeights[1])};
+            arith::SubFOp::create(builder, loc, c1F32, indexWeights[0]),
+            arith::SubFOp::create(builder, loc, c1F32, indexWeights[1])};
 
-        Value pixelVal_a = builder.create<memref::LoadOp>(
-            loc, builder.getF32Type(), input,
+        Value pixelVal_a = memref::LoadOp::create(
+            builder, loc, builder.getF32Type(), input,
             ValueRange{inputIndices_L[1], inputIndices_L[0]});
-        Value pixelVal_b = builder.create<memref::LoadOp>(
-            loc, builder.getF32Type(), input,
+        Value pixelVal_b = memref::LoadOp::create(
+            builder, loc, builder.getF32Type(), input,
             ValueRange{inputIndices_H[1], inputIndices_L[0]});
-        Value pixelVal_c = builder.create<memref::LoadOp>(
-            loc, builder.getF32Type(), input,
+        Value pixelVal_c = memref::LoadOp::create(
+            builder, loc, builder.getF32Type(), input,
             ValueRange{inputIndices_L[1], inputIndices_H[0]});
-        Value pixelVal_d = builder.create<memref::LoadOp>(
-            loc, builder.getF32Type(), input,
+        Value pixelVal_d = memref::LoadOp::create(
+            builder, loc, builder.getF32Type(), input,
             ValueRange{inputIndices_H[1], inputIndices_H[0]});
 
         Value weightVal1 =
-            builder.create<arith::MulFOp>(loc, indexWeights_UnitComplements[0],
-                                          indexWeights_UnitComplements[1]);
-        Value weightVal2 = builder.create<arith::MulFOp>(
-            loc, indexWeights[0], indexWeights_UnitComplements[1]);
-        Value weightVal3 = builder.create<arith::MulFOp>(
-            loc, indexWeights[1], indexWeights_UnitComplements[0]);
-        Value weightVal4 = builder.create<arith::MulFOp>(loc, indexWeights[0],
-                                                         indexWeights[1]);
+            arith::MulFOp::create(builder, loc, indexWeights_UnitComplements[0],
+                                  indexWeights_UnitComplements[1]);
+        Value weightVal2 = arith::MulFOp::create(
+            builder, loc, indexWeights[0], indexWeights_UnitComplements[1]);
+        Value weightVal3 = arith::MulFOp::create(
+            builder, loc, indexWeights[1], indexWeights_UnitComplements[0]);
+        Value weightVal4 = arith::MulFOp::create(builder, loc, indexWeights[0],
+                                                 indexWeights[1]);
 
         Value interm1 =
-            builder.create<arith::MulFOp>(loc, pixelVal_a, weightVal1);
+            arith::MulFOp::create(builder, loc, pixelVal_a, weightVal1);
         Value interm2 =
-            builder.create<arith::MulFOp>(loc, pixelVal_b, weightVal2);
+            arith::MulFOp::create(builder, loc, pixelVal_b, weightVal2);
         Value interm3 =
-            builder.create<arith::MulFOp>(loc, pixelVal_c, weightVal3);
+            arith::MulFOp::create(builder, loc, pixelVal_c, weightVal3);
         Value interm4 =
-            builder.create<arith::MulFOp>(loc, pixelVal_d, weightVal4);
+            arith::MulFOp::create(builder, loc, pixelVal_d, weightVal4);
 
         Value pixel_interm1 =
-            builder.create<arith::AddFOp>(loc, interm1, interm2);
+            arith::AddFOp::create(builder, loc, interm1, interm2);
         Value pixel_interm2 =
-            builder.create<arith::AddFOp>(loc, interm3, interm4);
+            arith::AddFOp::create(builder, loc, interm3, interm4);
         Value pixel_interm3 =
-            builder.create<arith::AddFOp>(loc, pixel_interm1, pixel_interm2);
+            arith::AddFOp::create(builder, loc, pixel_interm1, pixel_interm2);
 
         Value pixelVal = roundOff(builder, loc, pixel_interm3);
 
-        builder.create<memref::StoreOp>(
-            loc, pixelVal, output, ValueRange{resIndices[1], resIndices[0]});
+        memref::StoreOp::create(builder, loc, pixelVal, output,
+                                ValueRange{resIndices[1], resIndices[0]});
 
-        builder.create<affine::AffineYieldOp>(loc);
+        affine::AffineYieldOp::create(builder, loc);
       });
 }
 
@@ -870,9 +878,10 @@ void fillPixelsBilinearInterpolate4D(
     Value yVecWeight, Value outputRowLastElemF32, Value outputColLastElemF32,
     Value inputRowLastElemF32, Value inputColLastElemF32, Value c0F32,
     Value c1F32, Value dataCondition) {
-  builder.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, builder.getDimIdentityMap(), ValueRange{strideVal},
-      builder.getDimIdentityMap(), /*step*/ 1, ValueRange{},
+  affine::AffineForOp::create(
+      builder, loc, ValueRange{c0}, builder.getDimIdentityMap(),
+      ValueRange{strideVal}, builder.getDimIdentityMap(), /*step*/ 1,
+      ValueRange{},
       [&](OpBuilder &builder, Location loc, ValueRange ivs,
           ValueRange iterArg) {
         std::vector<Value> resIndices =
@@ -898,43 +907,43 @@ void fillPixelsBilinearInterpolate4D(
             valBound(builder, loc, yPos_temp, inputRowLastElemF32, c0F32));
 
         std::vector<Value> indexWeights_UnitComplements = {
-            builder.create<arith::SubFOp>(loc, c1F32, indexWeights[0]),
-            builder.create<arith::SubFOp>(loc, c1F32, indexWeights[1])};
+            arith::SubFOp::create(builder, loc, c1F32, indexWeights[0]),
+            arith::SubFOp::create(builder, loc, c1F32, indexWeights[1])};
 
-        auto ifop = builder.create<scf::IfOp>(
-            loc, dataCondition,
+        auto ifop = scf::IfOp::create(
+            builder, loc, dataCondition,
             [&](OpBuilder &builder, Location loc) {
-              Value pixelVal_a = builder.create<memref::LoadOp>(
-                  loc, builder.getF32Type(), input,
+              Value pixelVal_a = memref::LoadOp::create(
+                  builder, loc, builder.getF32Type(), input,
                   ValueRange{ivs0, inputIndices_L[1], inputIndices_L[0], ivs1});
-              Value pixelVal_b = builder.create<memref::LoadOp>(
-                  loc, builder.getF32Type(), input,
+              Value pixelVal_b = memref::LoadOp::create(
+                  builder, loc, builder.getF32Type(), input,
                   ValueRange{ivs0, inputIndices_H[1], inputIndices_L[0], ivs1});
-              Value pixelVal_c = builder.create<memref::LoadOp>(
-                  loc, builder.getF32Type(), input,
+              Value pixelVal_c = memref::LoadOp::create(
+                  builder, loc, builder.getF32Type(), input,
                   ValueRange{ivs0, inputIndices_L[1], inputIndices_H[0], ivs1});
-              Value pixelVal_d = builder.create<memref::LoadOp>(
-                  loc, builder.getF32Type(), input,
+              Value pixelVal_d = memref::LoadOp::create(
+                  builder, loc, builder.getF32Type(), input,
                   ValueRange{ivs0, inputIndices_H[1], inputIndices_H[0], ivs1});
-              builder.create<scf::YieldOp>(
-                  loc,
+              scf::YieldOp::create(
+                  builder, loc,
                   ValueRange{pixelVal_a, pixelVal_b, pixelVal_c, pixelVal_d});
             },
             [&](OpBuilder &builder, Location loc) {
-              Value pixelVal_a = builder.create<memref::LoadOp>(
-                  loc, builder.getF32Type(), input,
+              Value pixelVal_a = memref::LoadOp::create(
+                  builder, loc, builder.getF32Type(), input,
                   ValueRange{ivs0, ivs1, inputIndices_L[1], inputIndices_L[0]});
-              Value pixelVal_b = builder.create<memref::LoadOp>(
-                  loc, builder.getF32Type(), input,
+              Value pixelVal_b = memref::LoadOp::create(
+                  builder, loc, builder.getF32Type(), input,
                   ValueRange{ivs0, ivs1, inputIndices_H[1], inputIndices_L[0]});
-              Value pixelVal_c = builder.create<memref::LoadOp>(
-                  loc, builder.getF32Type(), input,
+              Value pixelVal_c = memref::LoadOp::create(
+                  builder, loc, builder.getF32Type(), input,
                   ValueRange{ivs0, ivs1, inputIndices_L[1], inputIndices_H[0]});
-              Value pixelVal_d = builder.create<memref::LoadOp>(
-                  loc, builder.getF32Type(), input,
+              Value pixelVal_d = memref::LoadOp::create(
+                  builder, loc, builder.getF32Type(), input,
                   ValueRange{ivs0, ivs1, inputIndices_H[1], inputIndices_H[0]});
-              builder.create<scf::YieldOp>(
-                  loc,
+              scf::YieldOp::create(
+                  builder, loc,
                   ValueRange{pixelVal_a, pixelVal_b, pixelVal_c, pixelVal_d});
             });
         Value pixelVal_a = ifop.getResult(0);
@@ -943,49 +952,49 @@ void fillPixelsBilinearInterpolate4D(
         Value pixelVal_d = ifop.getResult(3);
 
         Value weightVal1 =
-            builder.create<arith::MulFOp>(loc, indexWeights_UnitComplements[0],
-                                          indexWeights_UnitComplements[1]);
-        Value weightVal2 = builder.create<arith::MulFOp>(
-            loc, indexWeights[0], indexWeights_UnitComplements[1]);
-        Value weightVal3 = builder.create<arith::MulFOp>(
-            loc, indexWeights[1], indexWeights_UnitComplements[0]);
-        Value weightVal4 = builder.create<arith::MulFOp>(loc, indexWeights[0],
-                                                         indexWeights[1]);
+            arith::MulFOp::create(builder, loc, indexWeights_UnitComplements[0],
+                                  indexWeights_UnitComplements[1]);
+        Value weightVal2 = arith::MulFOp::create(
+            builder, loc, indexWeights[0], indexWeights_UnitComplements[1]);
+        Value weightVal3 = arith::MulFOp::create(
+            builder, loc, indexWeights[1], indexWeights_UnitComplements[0]);
+        Value weightVal4 = arith::MulFOp::create(builder, loc, indexWeights[0],
+                                                 indexWeights[1]);
 
         Value interm1 =
-            builder.create<arith::MulFOp>(loc, pixelVal_a, weightVal1);
+            arith::MulFOp::create(builder, loc, pixelVal_a, weightVal1);
         Value interm2 =
-            builder.create<arith::MulFOp>(loc, pixelVal_b, weightVal2);
+            arith::MulFOp::create(builder, loc, pixelVal_b, weightVal2);
         Value interm3 =
-            builder.create<arith::MulFOp>(loc, pixelVal_c, weightVal3);
+            arith::MulFOp::create(builder, loc, pixelVal_c, weightVal3);
         Value interm4 =
-            builder.create<arith::MulFOp>(loc, pixelVal_d, weightVal4);
+            arith::MulFOp::create(builder, loc, pixelVal_d, weightVal4);
 
         Value pixel_interm1 =
-            builder.create<arith::AddFOp>(loc, interm1, interm2);
+            arith::AddFOp::create(builder, loc, interm1, interm2);
         Value pixel_interm2 =
-            builder.create<arith::AddFOp>(loc, interm3, interm4);
+            arith::AddFOp::create(builder, loc, interm3, interm4);
         Value pixelVal =
-            builder.create<arith::AddFOp>(loc, pixel_interm1, pixel_interm2);
+            arith::AddFOp::create(builder, loc, pixel_interm1, pixel_interm2);
 
         // Value pixelVal = roundOff(builder, loc, pixel_interm3);
 
-        builder.create<scf::IfOp>(
-            loc, dataCondition,
+        scf::IfOp::create(
+            builder, loc, dataCondition,
             [&](OpBuilder &builder, Location loc) {
-              builder.create<memref::StoreOp>(
-                  loc, pixelVal, output,
+              memref::StoreOp::create(
+                  builder, loc, pixelVal, output,
                   ValueRange{ivs0, resIndices[1], resIndices[0], ivs1});
-              builder.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(builder, loc);
             },
             [&](OpBuilder &builder, Location loc) {
-              builder.create<memref::StoreOp>(
-                  loc, pixelVal, output,
+              memref::StoreOp::create(
+                  builder, loc, pixelVal, output,
                   ValueRange{ivs0, ivs1, resIndices[1], resIndices[0]});
-              builder.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(builder, loc);
             });
 
-        builder.create<affine::AffineYieldOp>(loc);
+        affine::AffineYieldOp::create(builder, loc);
       });
 }
 
@@ -1004,14 +1013,14 @@ void NearestNeighbourInterpolationResizing(
       [&](OpBuilder &builder, Location loc, ValueRange ivs) {
         Value ivs0F32 = indexToF32(builder, loc, ivs[0]);
         Value yVec =
-            builder.create<vector::BroadcastOp>(loc, vectorTy32, ivs0F32);
+            vector::BroadcastOp::create(builder, loc, vectorTy32, ivs0F32);
         Value xVec = iotaVec(builder, loc, ctx, ivs[1], strideVal, vectorTy32,
                              c0, stride);
 
-        Value resXVecInterm = builder.create<arith::MulFOp>(
-            loc, xVec, horizontalScalingFactorVec);
+        Value resXVecInterm = arith::MulFOp::create(builder, loc, xVec,
+                                                    horizontalScalingFactorVec);
         Value resYVecInterm =
-            builder.create<arith::MulFOp>(loc, yVec, verticalScalingFactorVec);
+            arith::MulFOp::create(builder, loc, yVec, verticalScalingFactorVec);
 
         Value resXVec = roundOff(builder, loc, resXVecInterm);
         Value resYVec = roundOff(builder, loc, resYVecInterm);
@@ -1037,14 +1046,14 @@ void NearestNeighbourInterpolationResizing4D(
       [&](OpBuilder &builder, Location loc, ValueRange ivs) {
         Value ivs2F32 = indexToF32(builder, loc, ivs[2]);
         Value yVec =
-            builder.create<vector::BroadcastOp>(loc, vectorTy32, ivs2F32);
+            vector::BroadcastOp::create(builder, loc, vectorTy32, ivs2F32);
         Value xVec = iotaVec(builder, loc, ctx, ivs[3], strideVal, vectorTy32,
                              c0, stride);
 
         Value resXVecInterm =
-            builder.create<arith::MulFOp>(loc, xVec, verticalScalingFactorVec);
-        Value resYVecInterm = builder.create<arith::MulFOp>(
-            loc, yVec, horizontalScalingFactorVec);
+            arith::MulFOp::create(builder, loc, xVec, verticalScalingFactorVec);
+        Value resYVecInterm = arith::MulFOp::create(builder, loc, yVec,
+                                                    horizontalScalingFactorVec);
 
         Value resXVec = roundOff(builder, loc, resXVecInterm);
         Value resYVec = roundOff(builder, loc, resYVecInterm);
@@ -1070,25 +1079,25 @@ void BilinearInterpolationResizing(
       [&](OpBuilder &builder, Location loc, ValueRange ivs) {
         Value ivs0F32 = indexToF32(builder, loc, ivs[0]);
         Value yVec =
-            builder.create<vector::BroadcastOp>(loc, vectorTy32, ivs0F32);
+            vector::BroadcastOp::create(builder, loc, vectorTy32, ivs0F32);
         Value xVec = iotaVec(builder, loc, ctx, ivs[1], strideVal, vectorTy32,
                              c0, stride);
 
-        Value xVecInterm = builder.create<arith::MulFOp>(
-            loc, xVec, horizontalScalingFactorVec);
+        Value xVecInterm = arith::MulFOp::create(builder, loc, xVec,
+                                                 horizontalScalingFactorVec);
         Value yVecInterm =
-            builder.create<arith::MulFOp>(loc, yVec, verticalScalingFactorVec);
+            arith::MulFOp::create(builder, loc, yVec, verticalScalingFactorVec);
 
-        Value xVecInterm_L = builder.create<math::FloorOp>(loc, xVecInterm);
-        Value xVecInterm_H = builder.create<math::CeilOp>(loc, xVecInterm);
+        Value xVecInterm_L = math::FloorOp::create(builder, loc, xVecInterm);
+        Value xVecInterm_H = math::CeilOp::create(builder, loc, xVecInterm);
 
-        Value yVecInterm_L = builder.create<math::FloorOp>(loc, yVecInterm);
-        Value yVecInterm_H = builder.create<math::CeilOp>(loc, yVecInterm);
+        Value yVecInterm_L = math::FloorOp::create(builder, loc, yVecInterm);
+        Value yVecInterm_H = math::CeilOp::create(builder, loc, yVecInterm);
 
         Value xVecWeight =
-            builder.create<arith::SubFOp>(loc, xVecInterm, xVecInterm_L);
+            arith::SubFOp::create(builder, loc, xVecInterm, xVecInterm_L);
         Value yVecWeight =
-            builder.create<arith::SubFOp>(loc, yVecInterm, yVecInterm_L);
+            arith::SubFOp::create(builder, loc, yVecInterm, yVecInterm_L);
 
         fillPixelsBilinearInterpolate(
             builder, loc, xVec, yVec, xVecInterm_L, yVecInterm_L, xVecInterm_H,
@@ -1113,25 +1122,25 @@ void BilinearInterpolationResizing4D(
       [&](OpBuilder &builder, Location loc, ValueRange ivs) {
         Value ivs0F32 = indexToF32(builder, loc, ivs[2]);
         Value yVec =
-            builder.create<vector::BroadcastOp>(loc, vectorTy32, ivs0F32);
+            vector::BroadcastOp::create(builder, loc, vectorTy32, ivs0F32);
         Value xVec = iotaVec(builder, loc, ctx, ivs[3], strideVal, vectorTy32,
                              c0, stride);
 
         Value xVecInterm =
-            builder.create<arith::MulFOp>(loc, xVec, verticalScalingFactorVec);
-        Value yVecInterm = builder.create<arith::MulFOp>(
-            loc, yVec, horizontalScalingFactorVec);
+            arith::MulFOp::create(builder, loc, xVec, verticalScalingFactorVec);
+        Value yVecInterm = arith::MulFOp::create(builder, loc, yVec,
+                                                 horizontalScalingFactorVec);
 
-        Value xVecInterm_L = builder.create<math::FloorOp>(loc, xVecInterm);
-        Value xVecInterm_H = builder.create<math::CeilOp>(loc, xVecInterm);
+        Value xVecInterm_L = math::FloorOp::create(builder, loc, xVecInterm);
+        Value xVecInterm_H = math::CeilOp::create(builder, loc, xVecInterm);
 
-        Value yVecInterm_L = builder.create<math::FloorOp>(loc, yVecInterm);
-        Value yVecInterm_H = builder.create<math::CeilOp>(loc, yVecInterm);
+        Value yVecInterm_L = math::FloorOp::create(builder, loc, yVecInterm);
+        Value yVecInterm_H = math::CeilOp::create(builder, loc, yVecInterm);
 
         Value xVecWeight =
-            builder.create<arith::SubFOp>(loc, xVecInterm, xVecInterm_L);
+            arith::SubFOp::create(builder, loc, xVecInterm, xVecInterm_L);
         Value yVecWeight =
-            builder.create<arith::SubFOp>(loc, yVecInterm, yVecInterm_L);
+            arith::SubFOp::create(builder, loc, yVecInterm, yVecInterm_L);
 
         fillPixelsBilinearInterpolate4D(
             builder, loc, ivs[0], ivs[1], xVec, yVec, xVecInterm_L,
@@ -1148,11 +1157,11 @@ Value zeroCond(OpBuilder &builder, Location loc, Type elemType, Value value,
   Value cond;
   auto bitWidth = elemType.getIntOrFloatBitWidth();
   if (elemType.isF32() || elemType.isF64()) {
-    cond = builder.create<arith::CmpFOp>(loc, arith::CmpFPredicate::ONE, value,
-                                         zeroElem);
+    cond = arith::CmpFOp::create(builder, loc, arith::CmpFPredicate::ONE, value,
+                                 zeroElem);
   } else if (elemType.isInteger(bitWidth)) {
-    cond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne, value,
-                                         zeroElem);
+    cond = arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::ne, value,
+                                 zeroElem);
   }
   return cond;
 }
@@ -1166,19 +1175,19 @@ Value createCompVecMorph(OpBuilder &builder, Location loc, VectorType type,
   auto bitWidth = elemTy.getIntOrFloatBitWidth();
   if (elemTy.isF32() || elemTy.isF64()) {
     if (op == DIP_OP::EROSION_2D) {
-      compVec = builder.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OGE,
-                                              inputVec, outputVec);
+      compVec = arith::CmpFOp::create(builder, loc, arith::CmpFPredicate::OGE,
+                                      inputVec, outputVec);
     } else if (op == DIP_OP::DILATION_2D) {
-      compVec = builder.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OLE,
-                                              inputVec, outputVec);
+      compVec = arith::CmpFOp::create(builder, loc, arith::CmpFPredicate::OLE,
+                                      inputVec, outputVec);
     }
   } else if (elemTy.isInteger(bitWidth)) {
     if (op == DIP_OP::EROSION_2D) {
-      compVec = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sge,
-                                              inputVec, outputVec);
+      compVec = arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::sge,
+                                      inputVec, outputVec);
     } else if (op == DIP_OP::DILATION_2D) {
-      compVec = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sle,
-                                              inputVec, outputVec);
+      compVec = arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::sle,
+                                      inputVec, outputVec);
     }
   }
   return compVec;
@@ -1190,8 +1199,8 @@ void calcAndStorewoTailProcessingMorph(
     Value kernelVec, Value output, Value beginIdx, Value endIdx,
     Value zeroPadding, Value inputCol, VectorType vectorMaskTy, Type elemTy,
     Value kernelValue, Value zeroPaddingElem, DIP_OP op) {
-  Value outputVec = builder.create<vector::LoadOp>(
-      loc, vecType, output, ValueRange{beginIdx, endIdx});
+  Value outputVec = vector::LoadOp::create(builder, loc, vecType, output,
+                                           ValueRange{beginIdx, endIdx});
   Value compVec = {};
   if (op == DIP_OP::EROSION_2D) {
     compVec = createCompVecMorph(builder, loc, vecType, inputVec, outputVec,
@@ -1201,11 +1210,12 @@ void calcAndStorewoTailProcessingMorph(
                                  DIP_OP::DILATION_2D);
   }
 
-  Value resVec = builder.create<vector::MaskedLoadOp>(
-      loc, vecType, output, ValueRange{beginIdx, endIdx}, compVec, inputVec);
+  Value resVec = vector::MaskedLoadOp::create(builder, loc, vecType, output,
+                                              ValueRange{beginIdx, endIdx},
+                                              compVec, inputVec);
 
-  builder.create<vector::StoreOp>(loc, resVec, output,
-                                  ValueRange{beginIdx, endIdx});
+  vector::StoreOp::create(builder, loc, resVec, output,
+                          ValueRange{beginIdx, endIdx});
 }
 
 // Utility function for morphological transformations, can handle tail
@@ -1215,11 +1225,11 @@ void calcAndStorewTailProcessingMorph(
     Value kernelVec, Value output, Value beginIdx, Value endIdx, Value tailCond,
     Value zeroPadding, Value inputCol, VectorType vectorMaskTy, Type elemTy,
     Value kernelValue, Value zeroPaddingElem, DIP_OP op) {
-  builder.create<scf::IfOp>(
-      loc, tailCond,
+  scf::IfOp::create(
+      builder, loc, tailCond,
       [&](OpBuilder &builder, Location loc) {
-        Value outputVec = builder.create<vector::LoadOp>(
-            loc, vecType, output, ValueRange{beginIdx, endIdx});
+        Value outputVec = vector::LoadOp::create(builder, loc, vecType, output,
+                                                 ValueRange{beginIdx, endIdx});
 
         Value compVec = {};
         if (op == DIP_OP::EROSION_2D) {
@@ -1230,22 +1240,22 @@ void calcAndStorewTailProcessingMorph(
                                        outputVec, DIP_OP::DILATION_2D);
         }
 
-        Value resVec = builder.create<vector::MaskedLoadOp>(
-            loc, vecType, output, ValueRange{beginIdx, endIdx}, compVec,
-            inputVec);
+        Value resVec = vector::MaskedLoadOp::create(
+            builder, loc, vecType, output, ValueRange{beginIdx, endIdx},
+            compVec, inputVec);
 
-        builder.create<vector::StoreOp>(loc, resVec, output,
-                                        ValueRange{beginIdx, endIdx});
+        vector::StoreOp::create(builder, loc, resVec, output,
+                                ValueRange{beginIdx, endIdx});
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       },
       [&](OpBuilder &builder, Location loc) {
         Value extraElemMask =
             tailMaskCreator(builder, loc, inputCol, endIdx, vectorMaskTy);
 
-        Value outputVec = builder.create<vector::MaskedLoadOp>(
-            loc, vecType, output, ValueRange{beginIdx, endIdx}, extraElemMask,
-            zeroPadding);
+        Value outputVec = vector::MaskedLoadOp::create(
+            builder, loc, vecType, output, ValueRange{beginIdx, endIdx},
+            extraElemMask, zeroPadding);
 
         Value compVec;
         if (op == DIP_OP::EROSION_2D) {
@@ -1256,14 +1266,15 @@ void calcAndStorewTailProcessingMorph(
                                        outputVec, DIP_OP::DILATION_2D);
         }
 
-        Value resVec = builder.create<vector::MaskedLoadOp>(
-            loc, vecType, output, ValueRange{beginIdx, endIdx}, compVec,
-            inputVec);
+        Value resVec = vector::MaskedLoadOp::create(
+            builder, loc, vecType, output, ValueRange{beginIdx, endIdx},
+            compVec, inputVec);
 
-        builder.create<vector::MaskedStoreOp>(
-            loc, output, ValueRange{beginIdx, endIdx}, extraElemMask, resVec);
+        vector::MaskedStoreOp::create(builder, loc, output,
+                                      ValueRange{beginIdx, endIdx},
+                                      extraElemMask, resVec);
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 }
 
@@ -1273,21 +1284,21 @@ void traverseImagewBoundaryExtrapolation(
     Value constantValue, Value strideVal, Type elemTy,
     buddy::dip::BoundaryOption boundaryOptionAttr, int64_t stride, DIP_OP op) {
   // Create constant indices.
-  Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-  Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+  Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+  Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
 
   IntegerType i1 = IntegerType::get(ctx, 1);
 
   // Create DimOp.
-  Value inputRow = rewriter.create<memref::DimOp>(loc, input, c0);
-  Value inputCol = rewriter.create<memref::DimOp>(loc, input, c1);
-  Value kernelRow = rewriter.create<memref::DimOp>(loc, kernel, c0);
-  Value kernelCol = rewriter.create<memref::DimOp>(loc, kernel, c1);
+  Value inputRow = memref::DimOp::create(rewriter, loc, input, c0);
+  Value inputCol = memref::DimOp::create(rewriter, loc, input, c1);
+  Value kernelRow = memref::DimOp::create(rewriter, loc, kernel, c0);
+  Value kernelCol = memref::DimOp::create(rewriter, loc, kernel, c1);
 
   // Variables used for detecting rowMid, rowDown, colMid and colRight
   // regions.
-  Value rowMidHelper = rewriter.create<arith::AddIOp>(loc, inputRow, centerY);
-  Value colMidHelper = rewriter.create<arith::AddIOp>(loc, inputCol, centerX);
+  Value rowMidHelper = arith::AddIOp::create(rewriter, loc, inputRow, centerY);
+  Value colMidHelper = arith::AddIOp::create(rewriter, loc, inputCol, centerX);
 
   SmallVector<Value, 8> lowerBounds(4, c0);
   SmallVector<Value, 8> uperBounds{inputRow, kernelRow, inputCol, kernelCol};
@@ -1298,52 +1309,53 @@ void traverseImagewBoundaryExtrapolation(
 
   Value zeroPaddingElem = insertZeroConstantOp(ctx, rewriter, loc, elemTy);
   Value zeroPadding =
-      rewriter.create<vector::BroadcastOp>(loc, vectorTy32, zeroPaddingElem);
+      vector::BroadcastOp::create(rewriter, loc, vectorTy32, zeroPaddingElem);
 
   AffineExpr a, b, c;
   bindDims(ctx, a, b, c);
   AffineMap calcHelper = AffineMap::get(3, 0, {a + b - c}, ctx);
 
-  Value pseudoCol = rewriter.create<affine::AffineApplyOp>(
-      loc, calcHelper, ValueRange{inputCol, kernelCol, c1});
+  Value pseudoCol = affine::AffineApplyOp::create(
+      rewriter, loc, calcHelper, ValueRange{inputCol, kernelCol, c1});
 
   affine::buildAffineLoopNest(
       rewriter, loc, lowerBounds, uperBounds, steps,
       [&](OpBuilder &builder, Location loc, ValueRange ivs) {
         // Indices of current pixel with respect to pseudo image containing
         // extrapolated boundaries.
-        Value currRow = builder.create<arith::AddIOp>(loc, ivs[0], ivs[1]);
-        Value currCol = builder.create<arith::AddIOp>(loc, ivs[2], ivs[3]);
+        Value currRow = arith::AddIOp::create(builder, loc, ivs[0], ivs[1]);
+        Value currCol = arith::AddIOp::create(builder, loc, ivs[2], ivs[3]);
 
-        Value kernelValue = builder.create<memref::LoadOp>(
-            loc, kernel, ValueRange{ivs[1], ivs[3]});
+        Value kernelValue = memref::LoadOp::create(builder, loc, kernel,
+                                                   ValueRange{ivs[1], ivs[3]});
         Value kernelVec =
-            builder.create<vector::BroadcastOp>(loc, vectorTy32, kernelValue);
+            vector::BroadcastOp::create(builder, loc, vectorTy32, kernelValue);
 
         // Pixel indices with respect to the actual image.
-        Value imRow = builder.create<arith::SubIOp>(loc, currRow, centerY);
-        Value imCol = builder.create<arith::SubIOp>(loc, currCol, centerX);
+        Value imRow = arith::SubIOp::create(builder, loc, currRow, centerY);
+        Value imCol = arith::SubIOp::create(builder, loc, currCol, centerX);
 
         // Index of pixel used for determining right region.
         Value colLastElem =
-            builder.create<arith::AddIOp>(loc, currCol, strideVal);
+            arith::AddIOp::create(builder, loc, currCol, strideVal);
 
-        Value rowUpCond = builder.create<arith::CmpIOp>(
-            loc, arith::CmpIPredicate::slt, currRow, centerY);
+        Value rowUpCond = arith::CmpIOp::create(
+            builder, loc, arith::CmpIPredicate::slt, currRow, centerY);
 
         // Condition to check if the kernel value is a non-zero number.
         Value kernelNonZeroCond =
             zeroCond(builder, loc, elemTy, kernelValue, zeroPaddingElem);
-        builder.create<scf::IfOp>(
-            loc, kernelNonZeroCond, [&](OpBuilder &builder, Location loc) {
-              builder.create<scf::IfOp>(
-                  loc, rowUpCond,
+        scf::IfOp::create(
+            builder, loc, kernelNonZeroCond,
+            [&](OpBuilder &builder, Location loc) {
+              scf::IfOp::create(
+                  builder, loc, rowUpCond,
                   [&](OpBuilder &builder, Location loc) {
                     // rowUp
                     if (boundaryOptionAttr ==
                         buddy::dip::BoundaryOption::ConstantPadding) {
-                      Value inputVec = builder.create<vector::BroadcastOp>(
-                          loc, vectorTy32, constantValue);
+                      Value inputVec = vector::BroadcastOp::create(
+                          builder, loc, vectorTy32, constantValue);
                       if (op == DIP_OP::CORRELATION_2D) {
                         calcAndStoreFMAwoTailProcessing(
                             builder, loc, vectorTy32, inputVec, kernelVec,
@@ -1370,33 +1382,32 @@ void traverseImagewBoundaryExtrapolation(
                             zeroPaddingElem, DIP_OP::EROSION_2D);
                       }
                     } else {
-                      Value colLeftCond = builder.create<arith::CmpIOp>(
-                          loc, arith::CmpIPredicate::slt, currCol, centerX);
+                      Value colLeftCond = arith::CmpIOp::create(
+                          builder, loc, arith::CmpIPredicate::slt, currCol,
+                          centerX);
 
-                      builder.create<scf::IfOp>(
-                          loc, colLeftCond,
+                      scf::IfOp::create(
+                          builder, loc, colLeftCond,
                           [&](OpBuilder &builder, Location loc) {
                             // colLeft & rowUp
                             Value inputVec;
-                            Value leftMaskElem = builder.create<arith::SubIOp>(
-                                loc, centerX, currCol);
+                            Value leftMaskElem = arith::SubIOp::create(
+                                builder, loc, centerX, currCol);
                             Value leftMask =
                                 createInvertedMask(builder, loc, strideVal,
                                                    vectorMaskTy, leftMaskElem);
 
                             if (boundaryOptionAttr ==
                                 buddy::dip::BoundaryOption::ReplicatePadding) {
-                              Value paddingVal = builder.create<memref::LoadOp>(
-                                  loc, input, ValueRange{c0, c0});
-                              Value padding =
-                                  builder.create<vector::BroadcastOp>(
-                                      loc, vectorTy32, paddingVal);
+                              Value paddingVal = memref::LoadOp::create(
+                                  builder, loc, input, ValueRange{c0, c0});
+                              Value padding = vector::BroadcastOp::create(
+                                  builder, loc, vectorTy32, paddingVal);
 
-                              Value leftPaddingOffset =
-                                  builder.create<arith::SubIOp>(loc, c0,
-                                                                leftMaskElem);
-                              inputVec = builder.create<vector::MaskedLoadOp>(
-                                  loc, vectorTy32, input,
+                              Value leftPaddingOffset = arith::SubIOp::create(
+                                  builder, loc, c0, leftMaskElem);
+                              inputVec = vector::MaskedLoadOp::create(
+                                  builder, loc, vectorTy32, input,
                                   ValueRange{c0, leftPaddingOffset}, leftMask,
                                   padding);
                             }
@@ -1419,24 +1430,24 @@ void traverseImagewBoundaryExtrapolation(
                                   zeroPaddingElem, DIP_OP::DILATION_2D);
                             }
 
-                            builder.create<scf::YieldOp>(loc);
+                            scf::YieldOp::create(builder, loc);
                           },
                           [&](OpBuilder &builder, Location loc) {
                             // (colMid or colRight) & rowUp
-                            Value colMidCond = builder.create<arith::CmpIOp>(
-                                loc, arith::CmpIPredicate::slt, colLastElem,
-                                colMidHelper);
+                            Value colMidCond = arith::CmpIOp::create(
+                                builder, loc, arith::CmpIPredicate::slt,
+                                colLastElem, colMidHelper);
 
-                            builder.create<scf::IfOp>(
-                                loc, colMidCond,
+                            scf::IfOp::create(
+                                builder, loc, colMidCond,
                                 [&](OpBuilder &builder, Location loc) {
                                   // colMid & rowUp
                                   Value inputVec;
                                   if (boundaryOptionAttr ==
                                       buddy::dip::BoundaryOption::
                                           ReplicatePadding) {
-                                    inputVec = builder.create<vector::LoadOp>(
-                                        loc, vectorTy32, input,
+                                    inputVec = vector::LoadOp::create(
+                                        builder, loc, vectorTy32, input,
                                         ValueRange{c0, imCol});
                                   }
 
@@ -1459,40 +1470,35 @@ void traverseImagewBoundaryExtrapolation(
                                         elemTy, kernelValue, zeroPaddingElem,
                                         DIP_OP::DILATION_2D);
                                   }
-                                  builder.create<scf::YieldOp>(loc);
+                                  scf::YieldOp::create(builder, loc);
                                 },
                                 [&](OpBuilder &builder, Location loc) {
                                   // colRight & rowUp
                                   Value inputVec;
-                                  Value rightMaskHelper =
-                                      builder.create<arith::SubIOp>(
-                                          loc, colLastElem, colMidHelper);
-                                  Value rightMaskElem =
-                                      builder.create<arith::SubIOp>(
-                                          loc, strideVal, rightMaskHelper);
+                                  Value rightMaskHelper = arith::SubIOp::create(
+                                      builder, loc, colLastElem, colMidHelper);
+                                  Value rightMaskElem = arith::SubIOp::create(
+                                      builder, loc, strideVal, rightMaskHelper);
                                   Value rightMask =
-                                      builder.create<vector::CreateMaskOp>(
-                                          loc, vectorMaskTy, rightMaskElem);
+                                      vector::CreateMaskOp::create(
+                                          builder, loc, vectorMaskTy,
+                                          rightMaskElem);
 
                                   if (boundaryOptionAttr ==
                                       buddy::dip::BoundaryOption::
                                           ReplicatePadding) {
-                                    Value rightRange =
-                                        builder.create<arith::SubIOp>(
-                                            loc, inputCol, c1);
-                                    Value paddingVal =
-                                        builder.create<memref::LoadOp>(
-                                            loc, input,
-                                            ValueRange{c0, rightRange});
-                                    Value padding =
-                                        builder.create<vector::BroadcastOp>(
-                                            loc, vectorTy32, paddingVal);
+                                    Value rightRange = arith::SubIOp::create(
+                                        builder, loc, inputCol, c1);
+                                    Value paddingVal = memref::LoadOp::create(
+                                        builder, loc, input,
+                                        ValueRange{c0, rightRange});
+                                    Value padding = vector::BroadcastOp::create(
+                                        builder, loc, vectorTy32, paddingVal);
 
-                                    inputVec =
-                                        builder.create<vector::MaskedLoadOp>(
-                                            loc, vectorTy32, input,
-                                            ValueRange{c0, imCol}, rightMask,
-                                            padding);
+                                    inputVec = vector::MaskedLoadOp::create(
+                                        builder, loc, vectorTy32, input,
+                                        ValueRange{c0, imCol}, rightMask,
+                                        padding);
                                   }
                                   Value tailCond = tailChecker(
                                       builder, loc, calcHelper, strideVal,
@@ -1520,33 +1526,34 @@ void traverseImagewBoundaryExtrapolation(
                                         zeroPaddingElem, DIP_OP::EROSION_2D);
                                   }
 
-                                  builder.create<scf::YieldOp>(loc);
+                                  scf::YieldOp::create(builder, loc);
                                 });
-                            builder.create<scf::YieldOp>(loc);
+                            scf::YieldOp::create(builder, loc);
                           });
                     }
-                    builder.create<scf::YieldOp>(loc);
+                    scf::YieldOp::create(builder, loc);
                   },
                   [&](OpBuilder &builder, Location loc) {
                     // rowMid or rowDown
-                    Value rowMidCond = builder.create<arith::CmpIOp>(
-                        loc, arith::CmpIPredicate::slt, currRow, rowMidHelper);
+                    Value rowMidCond = arith::CmpIOp::create(
+                        builder, loc, arith::CmpIPredicate::slt, currRow,
+                        rowMidHelper);
 
-                    builder.create<scf::IfOp>(
-                        loc, rowMidCond,
+                    scf::IfOp::create(
+                        builder, loc, rowMidCond,
                         [&](OpBuilder &builder, Location loc) {
                           // rowMid
-                          Value colLeftCond = builder.create<arith::CmpIOp>(
-                              loc, arith::CmpIPredicate::slt, currCol, centerX);
+                          Value colLeftCond = arith::CmpIOp::create(
+                              builder, loc, arith::CmpIPredicate::slt, currCol,
+                              centerX);
 
-                          builder.create<scf::IfOp>(
-                              loc, colLeftCond,
+                          scf::IfOp::create(
+                              builder, loc, colLeftCond,
                               [&](OpBuilder &builder, Location loc) {
                                 // colLeft & rowMid
                                 Value inputVec;
-                                Value leftMaskElem =
-                                    builder.create<arith::SubIOp>(loc, centerX,
-                                                                  currCol);
+                                Value leftMaskElem = arith::SubIOp::create(
+                                    builder, loc, centerX, currCol);
                                 Value leftMask = createInvertedMask(
                                     builder, loc, strideVal, vectorMaskTy,
                                     leftMaskElem);
@@ -1554,36 +1561,32 @@ void traverseImagewBoundaryExtrapolation(
                                 if (boundaryOptionAttr ==
                                     buddy::dip::BoundaryOption::
                                         ConstantPadding) {
-                                  Value padding =
-                                      builder.create<vector::BroadcastOp>(
-                                          loc, vectorTy32, constantValue);
+                                  Value padding = vector::BroadcastOp::create(
+                                      builder, loc, vectorTy32, constantValue);
 
                                   Value leftPaddingOffset =
-                                      builder.create<arith::SubIOp>(
-                                          loc, c0, leftMaskElem);
-                                  inputVec =
-                                      builder.create<vector::MaskedLoadOp>(
-                                          loc, vectorTy32, input,
-                                          ValueRange{imRow, leftPaddingOffset},
-                                          leftMask, padding);
+                                      arith::SubIOp::create(builder, loc, c0,
+                                                            leftMaskElem);
+                                  inputVec = vector::MaskedLoadOp::create(
+                                      builder, loc, vectorTy32, input,
+                                      ValueRange{imRow, leftPaddingOffset},
+                                      leftMask, padding);
                                 } else if (boundaryOptionAttr ==
                                            buddy::dip::BoundaryOption::
                                                ReplicatePadding) {
-                                  Value paddingVal =
-                                      builder.create<memref::LoadOp>(
-                                          loc, input, ValueRange{imRow, c0});
-                                  Value padding =
-                                      builder.create<vector::BroadcastOp>(
-                                          loc, vectorTy32, paddingVal);
+                                  Value paddingVal = memref::LoadOp::create(
+                                      builder, loc, input,
+                                      ValueRange{imRow, c0});
+                                  Value padding = vector::BroadcastOp::create(
+                                      builder, loc, vectorTy32, paddingVal);
 
                                   Value leftPaddingOffset =
-                                      builder.create<arith::SubIOp>(
-                                          loc, c0, leftMaskElem);
-                                  inputVec =
-                                      builder.create<vector::MaskedLoadOp>(
-                                          loc, vectorTy32, input,
-                                          ValueRange{imRow, leftPaddingOffset},
-                                          leftMask, padding);
+                                      arith::SubIOp::create(builder, loc, c0,
+                                                            leftMaskElem);
+                                  inputVec = vector::MaskedLoadOp::create(
+                                      builder, loc, vectorTy32, input,
+                                      ValueRange{imRow, leftPaddingOffset},
+                                      leftMask, padding);
                                 }
 
                                 if (op == DIP_OP::CORRELATION_2D) {
@@ -1606,23 +1609,21 @@ void traverseImagewBoundaryExtrapolation(
                                       DIP_OP::DILATION_2D);
                                 }
 
-                                builder.create<scf::YieldOp>(loc);
+                                scf::YieldOp::create(builder, loc);
                               },
                               [&](OpBuilder &builder, Location loc) {
                                 // (colMid or colRight) & rowMid
-                                Value colMidCond =
-                                    builder.create<arith::CmpIOp>(
-                                        loc, arith::CmpIPredicate::slt,
-                                        colLastElem, colMidHelper);
+                                Value colMidCond = arith::CmpIOp::create(
+                                    builder, loc, arith::CmpIPredicate::slt,
+                                    colLastElem, colMidHelper);
 
-                                builder.create<scf::IfOp>(
-                                    loc, colMidCond,
+                                scf::IfOp::create(
+                                    builder, loc, colMidCond,
                                     [&](OpBuilder &builder, Location loc) {
                                       // colMid & rowMid
-                                      Value inputVec =
-                                          builder.create<vector::LoadOp>(
-                                              loc, vectorTy32, input,
-                                              ValueRange{imRow, imCol});
+                                      Value inputVec = vector::LoadOp::create(
+                                          builder, loc, vectorTy32, input,
+                                          ValueRange{imRow, imCol});
 
                                       if (op == DIP_OP::CORRELATION_2D) {
                                         calcAndStoreFMAwoTailProcessing(
@@ -1646,54 +1647,55 @@ void traverseImagewBoundaryExtrapolation(
                                             DIP_OP::DILATION_2D);
                                       }
 
-                                      builder.create<scf::YieldOp>(loc);
+                                      scf::YieldOp::create(builder, loc);
                                     },
                                     [&](OpBuilder &builder, Location loc) {
                                       // colRight & rowMid
                                       Value inputVec;
                                       Value rightMaskHelper =
-                                          builder.create<arith::SubIOp>(
-                                              loc, colLastElem, colMidHelper);
+                                          arith::SubIOp::create(builder, loc,
+                                                                colLastElem,
+                                                                colMidHelper);
                                       Value rightMaskElem =
-                                          builder.create<arith::SubIOp>(
-                                              loc, strideVal, rightMaskHelper);
+                                          arith::SubIOp::create(
+                                              builder, loc, strideVal,
+                                              rightMaskHelper);
                                       Value rightMask =
-                                          builder.create<vector::CreateMaskOp>(
-                                              loc, vectorMaskTy, rightMaskElem);
+                                          vector::CreateMaskOp::create(
+                                              builder, loc, vectorMaskTy,
+                                              rightMaskElem);
 
                                       if (boundaryOptionAttr ==
                                           buddy::dip::BoundaryOption::
                                               ConstantPadding) {
                                         Value padding =
-                                            builder.create<vector::BroadcastOp>(
-                                                loc, vectorTy32, constantValue);
+                                            vector::BroadcastOp::create(
+                                                builder, loc, vectorTy32,
+                                                constantValue);
 
-                                        inputVec =
-                                            builder
-                                                .create<vector::MaskedLoadOp>(
-                                                    loc, vectorTy32, input,
-                                                    ValueRange{imRow, imCol},
-                                                    rightMask, padding);
+                                        inputVec = vector::MaskedLoadOp::create(
+                                            builder, loc, vectorTy32, input,
+                                            ValueRange{imRow, imCol}, rightMask,
+                                            padding);
                                       } else if (boundaryOptionAttr ==
                                                  buddy::dip::BoundaryOption::
                                                      ReplicatePadding) {
                                         Value rightRange =
-                                            builder.create<arith::SubIOp>(
-                                                loc, inputCol, c1);
+                                            arith::SubIOp::create(builder, loc,
+                                                                  inputCol, c1);
                                         Value paddingVal =
-                                            builder.create<memref::LoadOp>(
-                                                loc, input,
+                                            memref::LoadOp::create(
+                                                builder, loc, input,
                                                 ValueRange{imRow, rightRange});
                                         Value padding =
-                                            builder.create<vector::BroadcastOp>(
-                                                loc, vectorTy32, paddingVal);
+                                            vector::BroadcastOp::create(
+                                                builder, loc, vectorTy32,
+                                                paddingVal);
 
-                                        inputVec =
-                                            builder
-                                                .create<vector::MaskedLoadOp>(
-                                                    loc, vectorTy32, input,
-                                                    ValueRange{imRow, imCol},
-                                                    rightMask, padding);
+                                        inputVec = vector::MaskedLoadOp::create(
+                                            builder, loc, vectorTy32, input,
+                                            ValueRange{imRow, imCol}, rightMask,
+                                            padding);
                                       }
                                       Value tailCond = tailChecker(
                                           builder, loc, calcHelper, strideVal,
@@ -1722,19 +1724,18 @@ void traverseImagewBoundaryExtrapolation(
                                             zeroPaddingElem,
                                             DIP_OP::EROSION_2D);
                                       }
-                                      builder.create<scf::YieldOp>(loc);
+                                      scf::YieldOp::create(builder, loc);
                                     });
-                                builder.create<scf::YieldOp>(loc);
+                                scf::YieldOp::create(builder, loc);
                               });
-                          builder.create<scf::YieldOp>(loc);
+                          scf::YieldOp::create(builder, loc);
                         },
                         [&](OpBuilder &builder, Location loc) {
                           // rowDown
                           if (boundaryOptionAttr ==
                               buddy::dip::BoundaryOption::ConstantPadding) {
-                            Value inputVec =
-                                builder.create<vector::BroadcastOp>(
-                                    loc, vectorTy32, constantValue);
+                            Value inputVec = vector::BroadcastOp::create(
+                                builder, loc, vectorTy32, constantValue);
 
                             if (op == DIP_OP::CORRELATION_2D) {
                               calcAndStoreFMAwoTailProcessing(
@@ -1754,21 +1755,19 @@ void traverseImagewBoundaryExtrapolation(
                                   zeroPaddingElem, DIP_OP::DILATION_2D);
                             }
                           } else {
-                            Value colLeftCond = builder.create<arith::CmpIOp>(
-                                loc, arith::CmpIPredicate::slt, currCol,
-                                centerX);
+                            Value colLeftCond = arith::CmpIOp::create(
+                                builder, loc, arith::CmpIPredicate::slt,
+                                currCol, centerX);
 
-                            builder.create<scf::IfOp>(
-                                loc, colLeftCond,
+                            scf::IfOp::create(
+                                builder, loc, colLeftCond,
                                 [&](OpBuilder &builder, Location loc) {
                                   // colLeft & rowDown
                                   Value inputVec;
-                                  Value downRange =
-                                      builder.create<arith::SubIOp>(
-                                          loc, inputRow, c1);
-                                  Value leftMaskElem =
-                                      builder.create<arith::SubIOp>(
-                                          loc, centerX, currCol);
+                                  Value downRange = arith::SubIOp::create(
+                                      builder, loc, inputRow, c1);
+                                  Value leftMaskElem = arith::SubIOp::create(
+                                      builder, loc, centerX, currCol);
                                   Value leftMask = createInvertedMask(
                                       builder, loc, strideVal, vectorMaskTy,
                                       leftMaskElem);
@@ -1776,23 +1775,20 @@ void traverseImagewBoundaryExtrapolation(
                                   if (boundaryOptionAttr ==
                                       buddy::dip::BoundaryOption::
                                           ReplicatePadding) {
-                                    Value paddingVal =
-                                        builder.create<memref::LoadOp>(
-                                            loc, input,
-                                            ValueRange{downRange, c0});
-                                    Value padding =
-                                        builder.create<vector::BroadcastOp>(
-                                            loc, vectorTy32, paddingVal);
+                                    Value paddingVal = memref::LoadOp::create(
+                                        builder, loc, input,
+                                        ValueRange{downRange, c0});
+                                    Value padding = vector::BroadcastOp::create(
+                                        builder, loc, vectorTy32, paddingVal);
 
                                     Value leftPaddingOffset =
-                                        builder.create<arith::SubIOp>(
-                                            loc, c0, leftMaskElem);
-                                    inputVec =
-                                        builder.create<vector::MaskedLoadOp>(
-                                            loc, vectorTy32, input,
-                                            ValueRange{downRange,
-                                                       leftPaddingOffset},
-                                            leftMask, padding);
+                                        arith::SubIOp::create(builder, loc, c0,
+                                                              leftMaskElem);
+                                    inputVec = vector::MaskedLoadOp::create(
+                                        builder, loc, vectorTy32, input,
+                                        ValueRange{downRange,
+                                                   leftPaddingOffset},
+                                        leftMask, padding);
                                   }
 
                                   if (op == DIP_OP::CORRELATION_2D) {
@@ -1815,30 +1811,27 @@ void traverseImagewBoundaryExtrapolation(
                                         DIP_OP::DILATION_2D);
                                   }
 
-                                  builder.create<scf::YieldOp>(loc);
+                                  scf::YieldOp::create(builder, loc);
                                 },
                                 [&](OpBuilder &builder, Location loc) {
                                   // (colMid or colRight) & rowDown
-                                  Value colMidCond =
-                                      builder.create<arith::CmpIOp>(
-                                          loc, arith::CmpIPredicate::slt,
-                                          colLastElem, colMidHelper);
+                                  Value colMidCond = arith::CmpIOp::create(
+                                      builder, loc, arith::CmpIPredicate::slt,
+                                      colLastElem, colMidHelper);
 
-                                  builder.create<scf::IfOp>(
-                                      loc, colMidCond,
+                                  scf::IfOp::create(
+                                      builder, loc, colMidCond,
                                       [&](OpBuilder &builder, Location loc) {
                                         // colMid & rowDown
                                         Value inputVec;
-                                        Value downRange =
-                                            builder.create<arith::SubIOp>(
-                                                loc, inputRow, c1);
+                                        Value downRange = arith::SubIOp::create(
+                                            builder, loc, inputRow, c1);
                                         if (boundaryOptionAttr ==
                                             buddy::dip::BoundaryOption::
                                                 ReplicatePadding) {
-                                          inputVec =
-                                              builder.create<vector::LoadOp>(
-                                                  loc, vectorTy32, input,
-                                                  ValueRange{downRange, imCol});
+                                          inputVec = vector::LoadOp::create(
+                                              builder, loc, vectorTy32, input,
+                                              ValueRange{downRange, imCol});
                                         }
 
                                         if (op == DIP_OP::CORRELATION_2D) {
@@ -1864,53 +1857,50 @@ void traverseImagewBoundaryExtrapolation(
                                               DIP_OP::DILATION_2D);
                                         }
 
-                                        builder.create<scf::YieldOp>(loc);
+                                        scf::YieldOp::create(builder, loc);
                                       },
                                       [&](OpBuilder &builder, Location loc) {
                                         // colRight & rowDown
                                         Value inputVec;
                                         Value rightMaskHelper =
-                                            builder.create<arith::SubIOp>(
-                                                loc, colLastElem, colMidHelper);
+                                            arith::SubIOp::create(builder, loc,
+                                                                  colLastElem,
+                                                                  colMidHelper);
                                         Value rightMaskElem =
-                                            builder.create<arith::SubIOp>(
-                                                loc, strideVal,
+                                            arith::SubIOp::create(
+                                                builder, loc, strideVal,
                                                 rightMaskHelper);
                                         Value rightMask =
-                                            builder
-                                                .create<vector::CreateMaskOp>(
-                                                    loc, vectorMaskTy,
-                                                    rightMaskElem);
+                                            vector::CreateMaskOp::create(
+                                                builder, loc, vectorMaskTy,
+                                                rightMaskElem);
 
-                                        Value downRange =
-                                            builder.create<arith::SubIOp>(
-                                                loc, inputRow, c1);
+                                        Value downRange = arith::SubIOp::create(
+                                            builder, loc, inputRow, c1);
                                         Value rightRange =
-                                            builder.create<arith::SubIOp>(
-                                                loc, inputCol, c1);
+                                            arith::SubIOp::create(builder, loc,
+                                                                  inputCol, c1);
 
                                         if (boundaryOptionAttr ==
                                             buddy::dip::BoundaryOption::
                                                 ReplicatePadding) {
 
                                           Value paddingVal =
-                                              builder.create<memref::LoadOp>(
-                                                  loc, input,
+                                              memref::LoadOp::create(
+                                                  builder, loc, input,
                                                   ValueRange{downRange,
                                                              rightRange});
                                           Value padding =
-                                              builder
-                                                  .create<vector::BroadcastOp>(
-                                                      loc, vectorTy32,
-                                                      paddingVal);
+                                              vector::BroadcastOp::create(
+                                                  builder, loc, vectorTy32,
+                                                  paddingVal);
 
                                           inputVec =
-                                              builder
-                                                  .create<vector::MaskedLoadOp>(
-                                                      loc, vectorTy32, input,
-                                                      ValueRange{downRange,
-                                                                 imCol},
-                                                      rightMask, padding);
+                                              vector::MaskedLoadOp::create(
+                                                  builder, loc, vectorTy32,
+                                                  input,
+                                                  ValueRange{downRange, imCol},
+                                                  rightMask, padding);
                                         }
                                         Value tailCond = tailChecker(
                                             builder, loc, calcHelper, strideVal,
@@ -1942,17 +1932,17 @@ void traverseImagewBoundaryExtrapolation(
                                               zeroPaddingElem,
                                               DIP_OP::EROSION_2D);
                                         }
-                                        builder.create<scf::YieldOp>(loc);
+                                        scf::YieldOp::create(builder, loc);
                                       });
-                                  builder.create<scf::YieldOp>(loc);
+                                  scf::YieldOp::create(builder, loc);
                                 });
                           }
-                          builder.create<scf::YieldOp>(loc);
+                          scf::YieldOp::create(builder, loc);
                         });
-                    builder.create<scf::YieldOp>(loc);
+                    scf::YieldOp::create(builder, loc);
                   });
 
-              builder.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(builder, loc);
             });
       });
 }

--- a/midend/lib/Utils/GPUUtils.cpp
+++ b/midend/lib/Utils/GPUUtils.cpp
@@ -108,7 +108,7 @@ static Value promoteElementToVector(Location loc, OpBuilder &builder,
                                     Value input) {
   VectorType vectorTypeBroadcast = VectorType::get({1}, input.getType());
   Value vectorInput =
-      builder.create<vector::BroadcastOp>(loc, vectorTypeBroadcast, input);
+      vector::BroadcastOp::create(builder, loc, vectorTypeBroadcast, input);
   return vectorInput;
 }
 
@@ -125,8 +125,9 @@ Value packVectorToSupportedWidth(Location loc, OpBuilder &builder,
   });
   VectorType packed32Type = VectorType::get({1}, builder.getI32Type());
   Value packedInputVec =
-      builder.create<vector::BitCastOp>(loc, packed32Type, input);
-  Value packedInput = builder.create<vector::ExtractOp>(loc, packedInputVec, 0);
+      vector::BitCastOp::create(builder, loc, packed32Type, input);
+  Value packedInput =
+      vector::ExtractOp::create(builder, loc, packedInputVec, 0);
   return packedInput;
 }
 
@@ -142,7 +143,7 @@ Value unpackToVector(Location loc, OpBuilder &builder, Value packedInput,
   });
   Value packedVector = promoteElementToVector(loc, builder, packedInput);
   Value unpackedVector =
-      builder.create<vector::BitCastOp>(loc, targetVecType, packedVector);
+      vector::BitCastOp::create(builder, loc, targetVecType, packedVector);
   return unpackedVector;
 }
 
@@ -374,10 +375,10 @@ hoistOneStaticallyBoundAllocation(func::FuncOp funcOp, OpBuilder &builder,
     OpBuilder::InsertionGuard g(builder);
     builder.setInsertionPointToStart(&funcOp.getBody().front());
     Value allocation =
-        builder.create<AllocLikeOpType>(loc, allocLikeType, alignmentAttr);
+        AllocLikeOpType::create(builder, loc, allocLikeType, alignmentAttr);
     if (std::is_same<AllocLikeOpType, memref::AllocOp>::value) {
       builder.setInsertionPoint(funcOp.getBody().front().getTerminator());
-      builder.create<memref::DeallocOp>(loc, allocation);
+      memref::DeallocOp::create(builder, loc, allocation);
     }
     return allocation;
   }
@@ -415,15 +416,15 @@ hoistOneStaticallyBoundAllocation(func::FuncOp funcOp, OpBuilder &builder,
     auto allocationType =
         MemRefType::get(staticShape, allocLikeType.getElementType());
     allocation =
-        builder.create<AllocLikeOpType>(loc, allocationType, alignmentAttr);
+        AllocLikeOpType::create(builder, loc, allocationType, alignmentAttr);
   }
 
-  Value subviewOp = builder.create<memref::SubViewOp>(loc, allocation, offsets,
-                                                      subviewSizes, strides);
+  Value subviewOp = memref::SubViewOp::create(builder, loc, allocation, offsets,
+                                              subviewSizes, strides);
 
   if (std::is_same<AllocLikeOpType, memref::AllocOp>::value) {
     builder.setInsertionPoint(funcOp.getBody().front().getTerminator());
-    builder.create<memref::DeallocOp>(loc, allocation);
+    memref::DeallocOp::create(builder, loc, allocation);
   }
   return subviewOp;
 }

--- a/midend/lib/Utils/Utils.cpp
+++ b/midend/lib/Utils/Utils.cpp
@@ -51,10 +51,10 @@ Value insertZeroConstantOp(MLIRContext *ctx, OpBuilder &builder, Location loc,
                               ? static_cast<FloatType>(Float32Type::get(ctx))
                               : static_cast<FloatType>(Float64Type::get(ctx));
     auto zero = APFloat::getZero(floatType.getFloatSemantics());
-    op = builder.create<arith::ConstantFloatOp>(loc, floatType, zero);
+    op = arith::ConstantFloatOp::create(builder, loc, floatType, zero);
   } else if (elemTy.isInteger(bitWidth)) {
     IntegerType type = IntegerType::get(ctx, bitWidth);
-    op = builder.create<arith::ConstantIntOp>(loc, type, 0);
+    op = arith::ConstantIntOp::create(builder, loc, type, 0);
   }
 
   return op;
@@ -66,11 +66,11 @@ Value zeroCond(OpBuilder &builder, Location loc, Type elemType, Value value,
   Value cond;
   auto bitWidth = elemType.getIntOrFloatBitWidth();
   if (elemType.isF32() || elemType.isF64()) {
-    cond = builder.create<arith::CmpFOp>(loc, arith::CmpFPredicate::ONE, value,
-                                         zeroElem);
+    cond = arith::CmpFOp::create(builder, loc, arith::CmpFPredicate::ONE, value,
+                                 zeroElem);
   } else if (elemType.isInteger(bitWidth)) {
-    cond = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ne, value,
-                                         zeroElem);
+    cond = arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::ne, value,
+                                 zeroElem);
   }
   return cond;
 }
@@ -79,56 +79,56 @@ Value zeroCond(OpBuilder &builder, Location loc, Type elemType, Value value,
 Value createInvertedMask(OpBuilder &builder, Location loc, Value strideVal,
                          VectorType vectorMaskTy, Value leftIndex) {
   Value leftMask =
-      builder.create<vector::CreateMaskOp>(loc, vectorMaskTy, leftIndex);
+      vector::CreateMaskOp::create(builder, loc, vectorMaskTy, leftIndex);
   Value maskInverter =
-      builder.create<vector::CreateMaskOp>(loc, vectorMaskTy, strideVal);
-  Value rightMask = builder.create<arith::SubIOp>(loc, maskInverter, leftMask);
+      vector::CreateMaskOp::create(builder, loc, vectorMaskTy, strideVal);
+  Value rightMask = arith::SubIOp::create(builder, loc, maskInverter, leftMask);
   return rightMask;
 }
 
 // Cast a value from index type to f32 type.
 Value indexToF32(OpBuilder &builder, Location loc, Value val) {
   Value interm1 =
-      builder.create<arith::IndexCastOp>(loc, builder.getI32Type(), val);
-  return builder.create<arith::SIToFPOp>(loc, builder.getF32Type(), interm1);
+      arith::IndexCastOp::create(builder, loc, builder.getI32Type(), val);
+  return arith::SIToFPOp::create(builder, loc, builder.getF32Type(), interm1);
 }
 
 // Cast a value from f32 type to index type.
 Value F32ToIndex(OpBuilder &builder, Location loc, Value val) {
   Value interm1 =
-      builder.create<arith::FPToUIOp>(loc, builder.getI32Type(), val);
-  return builder.create<arith::IndexCastOp>(loc, builder.getIndexType(),
-                                            interm1);
+      arith::FPToUIOp::create(builder, loc, builder.getI32Type(), val);
+  return arith::IndexCastOp::create(builder, loc, builder.getIndexType(),
+                                    interm1);
 }
 
 // Round off floating point value to nearest integer type value.
 Value roundOff(OpBuilder &builder, Location loc, Value val) {
-  Value ceilVal = builder.create<math::CeilOp>(loc, val);
-  Value floorVal = builder.create<math::FloorOp>(loc, val);
+  Value ceilVal = math::CeilOp::create(builder, loc, val);
+  Value floorVal = math::FloorOp::create(builder, loc, val);
 
-  Value diffCeil = builder.create<arith::SubFOp>(loc, ceilVal, val);
-  Value diffFloor = builder.create<arith::SubFOp>(loc, val, floorVal);
+  Value diffCeil = arith::SubFOp::create(builder, loc, ceilVal, val);
+  Value diffFloor = arith::SubFOp::create(builder, loc, val, floorVal);
 
-  Value diffCond = builder.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OGT,
-                                                 diffCeil, diffFloor);
+  Value diffCond = arith::CmpFOp::create(
+      builder, loc, arith::CmpFPredicate::OGT, diffCeil, diffFloor);
 
-  return builder.create<arith::SelectOp>(loc, diffCond, floorVal, ceilVal);
+  return arith::SelectOp::create(builder, loc, diffCond, floorVal, ceilVal);
 }
 
 // Bound values to permissible range of allocatable values w.r.t output image.
 Value valBound(OpBuilder &builder, Location loc, Value val, Value lastElemF32,
                Value c0F32) {
-  Value interm1 = builder.create<arith::MaximumFOp>(loc, val, c0F32);
-  return builder.create<arith::MinimumFOp>(loc, interm1, lastElemF32);
+  Value interm1 = arith::MaximumFOp::create(builder, loc, val, c0F32);
+  return arith::MinimumFOp::create(builder, loc, interm1, lastElemF32);
 }
 
 // check if lb <= val < ub and returns Value 0 or 1
 Value inBound(OpBuilder &builder, Location loc, Value val, Value lb, Value ub) {
   Value greaterThanLb =
-      builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sle, lb, val);
+      arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::sle, lb, val);
   Value lowerThanUb =
-      builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt, val, ub);
-  return builder.create<arith::AndIOp>(loc, greaterThanLb, lowerThanUb);
+      arith::CmpIOp::create(builder, loc, arith::CmpIPredicate::slt, val, ub);
+  return arith::AndIOp::create(builder, loc, greaterThanLb, lowerThanUb);
 }
 
 // Equivalent of std::iota.
@@ -138,20 +138,21 @@ Value iotaVec(OpBuilder &builder, Location loc, MLIRContext *ctx,
   // ToDo : Try to get rid of memref load/store, find less expensive ways of
   // implementing this function.
   MemRefType memTy = MemRefType::get({stride}, builder.getF32Type());
-  Value tempMem = builder.create<memref::AllocOp>(loc, memTy);
+  Value tempMem = memref::AllocOp::create(builder, loc, memTy);
 
-  builder.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, builder.getDimIdentityMap(), ValueRange{strideVal},
-      builder.getDimIdentityMap(), 1, ValueRange{},
+  affine::AffineForOp::create(
+      builder, loc, ValueRange{c0}, builder.getDimIdentityMap(),
+      ValueRange{strideVal}, builder.getDimIdentityMap(), 1, ValueRange{},
       [&](OpBuilder &builder, Location loc, Value iv, ValueRange iterArg) {
-        Value iotaValIndex = builder.create<arith::AddIOp>(loc, iv, indexStart);
+        Value iotaValIndex =
+            arith::AddIOp::create(builder, loc, iv, indexStart);
         Value iotaVal = indexToF32(builder, loc, iotaValIndex);
 
-        builder.create<memref::StoreOp>(loc, iotaVal, tempMem, ValueRange{iv});
-        builder.create<affine::AffineYieldOp>(loc);
+        memref::StoreOp::create(builder, loc, iotaVal, tempMem, ValueRange{iv});
+        affine::AffineYieldOp::create(builder, loc);
       });
 
-  return builder.create<vector::LoadOp>(loc, vecType, tempMem, ValueRange{c0});
+  return vector::LoadOp::create(builder, loc, vecType, tempMem, ValueRange{c0});
 }
 
 // Generate vector[0, 1, ..., length - 1] with f32 type
@@ -159,8 +160,8 @@ Value iotaVec0F32(OpBuilder &builder, Location loc, int64_t length) {
   MLIRContext *ctx = builder.getContext();
   std::vector<float> vec(length);
   std::iota(vec.begin(), vec.end(), .0);
-  Value res = builder.create<arith::ConstantOp>(
-      loc,
+  Value res = arith::ConstantOp::create(
+      builder, loc,
       DenseFPElementsAttr::get(VectorType::get(length, Float32Type::get(ctx)),
                                ArrayRef<float>(vec)));
   return res;
@@ -170,7 +171,7 @@ Value iotaVec0F32(OpBuilder &builder, Location loc, int64_t length) {
 Value castAndExpand(OpBuilder &builder, Location loc, Value val,
                     VectorType vecType) {
   Value interm1 = indexToF32(builder, loc, val);
-  return builder.create<vector::BroadcastOp>(loc, vecType, interm1);
+  return vector::BroadcastOp::create(builder, loc, vecType, interm1);
 }
 
 // print values(for debug use)
@@ -180,18 +181,18 @@ void printValues(OpBuilder &builder, Location loc,
     return;
   Type valueTy = values.begin()->getType();
   VectorType vecTy = VectorType::get({(long)values.size()}, valueTy);
-  Value vec = builder.create<vector::BroadcastOp>(loc, vecTy, *values.begin());
+  Value vec = vector::BroadcastOp::create(builder, loc, vecTy, *values.begin());
   int idx = 0;
   for (auto value : values) {
     if (idx != 0) {
       // all values should have same type
       assert(value.getType() == valueTy);
-      Value idxVal = builder.create<arith::ConstantIndexOp>(loc, idx);
+      Value idxVal = arith::ConstantIndexOp::create(builder, loc, idx);
       vec = vector::InsertOp::create(builder, loc, value, vec, idxVal);
     }
     idx++;
   }
-  builder.create<vector::PrintOp>(loc, vec);
+  vector::PrintOp::create(builder, loc, vec);
 }
 
 // Function for calculating complex addition of 2 input 1D complex vectors.
@@ -199,8 +200,8 @@ void printValues(OpBuilder &builder, Location loc,
 inline std::vector<Value> complexVecAddI(OpBuilder &builder, Location loc,
                                          Value vec1Real, Value vec1Imag,
                                          Value vec2Real, Value vec2Imag) {
-  return {builder.create<arith::AddFOp>(loc, vec1Real, vec2Real),
-          builder.create<arith::AddFOp>(loc, vec1Imag, vec2Imag)};
+  return {arith::AddFOp::create(builder, loc, vec1Real, vec2Real),
+          arith::AddFOp::create(builder, loc, vec1Imag, vec2Imag)};
 }
 
 // Function for calculating complex subtraction of 2 input 1D complex vectors.
@@ -208,8 +209,8 @@ inline std::vector<Value> complexVecAddI(OpBuilder &builder, Location loc,
 inline std::vector<Value> complexVecSubI(OpBuilder &builder, Location loc,
                                          Value vec1Real, Value vec1Imag,
                                          Value vec2Real, Value vec2Imag) {
-  return {builder.create<arith::SubFOp>(loc, vec1Real, vec2Real),
-          builder.create<arith::SubFOp>(loc, vec1Imag, vec2Imag)};
+  return {arith::SubFOp::create(builder, loc, vec1Real, vec2Real),
+          arith::SubFOp::create(builder, loc, vec1Imag, vec2Imag)};
 }
 
 // Function for calculating complex product of 2 input 1D complex vectors.
@@ -217,13 +218,13 @@ inline std::vector<Value> complexVecSubI(OpBuilder &builder, Location loc,
 std::vector<Value> complexVecMulI(OpBuilder &builder, Location loc,
                                   Value vec1Real, Value vec1Imag,
                                   Value vec2Real, Value vec2Imag) {
-  Value int1 = builder.create<arith::MulFOp>(loc, vec1Real, vec2Real);
-  Value int2 = builder.create<arith::MulFOp>(loc, vec1Imag, vec2Imag);
-  Value int3 = builder.create<arith::MulFOp>(loc, vec1Real, vec2Imag);
-  Value int4 = builder.create<arith::MulFOp>(loc, vec1Imag, vec2Real);
+  Value int1 = arith::MulFOp::create(builder, loc, vec1Real, vec2Real);
+  Value int2 = arith::MulFOp::create(builder, loc, vec1Imag, vec2Imag);
+  Value int3 = arith::MulFOp::create(builder, loc, vec1Real, vec2Imag);
+  Value int4 = arith::MulFOp::create(builder, loc, vec1Imag, vec2Real);
 
-  return {builder.create<arith::SubFOp>(loc, int1, int2),
-          builder.create<arith::AddFOp>(loc, int3, int4)};
+  return {arith::SubFOp::create(builder, loc, int1, int2),
+          arith::AddFOp::create(builder, loc, int3, int4)};
 }
 
 // Function for calculating Transpose of 2D input MemRef.
@@ -238,11 +239,12 @@ void scalar2DMemRefTranspose(OpBuilder &builder, Location loc, Value memref1,
   affine::buildAffineLoopNest(
       builder, loc, lowerBounds, upperBounds, steps,
       [&](OpBuilder &builder, Location loc, ValueRange ivs) {
-        Value pixelVal = builder.create<memref::LoadOp>(
-            loc, builder.getF32Type(), memref1, ValueRange{ivs[0], ivs[1]});
+        Value pixelVal =
+            memref::LoadOp::create(builder, loc, builder.getF32Type(), memref1,
+                                   ValueRange{ivs[0], ivs[1]});
 
-        builder.create<memref::StoreOp>(loc, pixelVal, memref2,
-                                        ValueRange{ivs[1], ivs[0]});
+        memref::StoreOp::create(builder, loc, pixelVal, memref2,
+                                ValueRange{ivs[1], ivs[0]});
       });
 }
 
@@ -260,24 +262,24 @@ void vector2DMemRefMultiply(OpBuilder &builder, Location loc, Value memRef1Real,
   affine::buildAffineLoopNest(
       builder, loc, lowerBounds, upperBounds, steps,
       [&](OpBuilder &builder, Location loc, ValueRange ivs) {
-        Value pixelVal1Real = builder.create<vector::LoadOp>(
-            loc, vecType, memRef1Real, ValueRange{ivs[0], ivs[1]});
-        Value pixelVal1Imag = builder.create<vector::LoadOp>(
-            loc, vecType, memRef1Imag, ValueRange{ivs[0], ivs[1]});
+        Value pixelVal1Real = vector::LoadOp::create(
+            builder, loc, vecType, memRef1Real, ValueRange{ivs[0], ivs[1]});
+        Value pixelVal1Imag = vector::LoadOp::create(
+            builder, loc, vecType, memRef1Imag, ValueRange{ivs[0], ivs[1]});
 
-        Value pixelVal2Real = builder.create<vector::LoadOp>(
-            loc, vecType, memRef2Real, ValueRange{ivs[0], ivs[1]});
-        Value pixelVal2Imag = builder.create<vector::LoadOp>(
-            loc, vecType, memRef2Imag, ValueRange{ivs[0], ivs[1]});
+        Value pixelVal2Real = vector::LoadOp::create(
+            builder, loc, vecType, memRef2Real, ValueRange{ivs[0], ivs[1]});
+        Value pixelVal2Imag = vector::LoadOp::create(
+            builder, loc, vecType, memRef2Imag, ValueRange{ivs[0], ivs[1]});
 
         std::vector<Value> resVecs =
             complexVecMulI(builder, loc, pixelVal1Real, pixelVal1Imag,
                            pixelVal2Real, pixelVal2Imag);
 
-        builder.create<vector::StoreOp>(loc, resVecs[0], memRef3Real,
-                                        ValueRange{ivs[0], ivs[1]});
-        builder.create<vector::StoreOp>(loc, resVecs[1], memRef3Imag,
-                                        ValueRange{ivs[0], ivs[1]});
+        vector::StoreOp::create(builder, loc, resVecs[0], memRef3Real,
+                                ValueRange{ivs[0], ivs[1]});
+        vector::StoreOp::create(builder, loc, resVecs[1], memRef3Imag,
+                                ValueRange{ivs[0], ivs[1]});
       });
 }
 
@@ -290,7 +292,7 @@ void idft1DCooleyTukeyButterfly(OpBuilder &builder, Location loc,
                                 VectorType vecType, Value rowIndex, Value c0,
                                 Value c1, int64_t step) {
   // Cooley Tukey Butterfly algorithm implementation.
-  Value subProbs = builder.create<arith::ShRSIOp>(loc, memRefLength, c1);
+  Value subProbs = arith::ShRSIOp::create(builder, loc, memRefLength, c1);
   Value subProbSize, half = c1, i, jBegin, jEnd, j, angle;
   Value wStepReal, wStepImag, wReal, wImag, tmp1Real, tmp1Imag, tmp2Real,
       tmp2Imag;
@@ -299,62 +301,64 @@ void idft1DCooleyTukeyButterfly(OpBuilder &builder, Location loc,
 
   Value upperBound =
       F32ToIndex(builder, loc,
-                 builder.create<math::Log2Op>(
-                     loc, indexToF32(builder, loc, memRefLength)));
-  Value pos2MPI = builder.create<arith::ConstantFloatOp>(
-      loc, builder.getF32Type(), (llvm::APFloat)(float)(2.0 * M_PI));
+                 math::Log2Op::create(builder, loc,
+                                      indexToF32(builder, loc, memRefLength)));
+  Value pos2MPI = arith::ConstantFloatOp::create(
+      builder, loc, builder.getF32Type(), (llvm::APFloat)(float)(2.0 * M_PI));
 
-  builder.create<scf::ForOp>(
-      loc, c0, upperBound, c1, ValueRange{subProbs, half},
+  scf::ForOp::create(
+      builder, loc, c0, upperBound, c1, ValueRange{subProbs, half},
       [&](OpBuilder &builder, Location loc, ValueRange iv,
           ValueRange outerIterVR) {
-        subProbSize = builder.create<arith::ShLIOp>(loc, outerIterVR[1], c1);
-        angle = builder.create<arith::DivFOp>(
-            loc, pos2MPI, indexToF32(builder, loc, subProbSize));
+        subProbSize = arith::ShLIOp::create(builder, loc, outerIterVR[1], c1);
+        angle = arith::DivFOp::create(builder, loc, pos2MPI,
+                                      indexToF32(builder, loc, subProbSize));
 
-        wStepReal = builder.create<math::CosOp>(loc, angle);
+        wStepReal = math::CosOp::create(builder, loc, angle);
         wStepRealVec =
-            builder.create<vector::BroadcastOp>(loc, vecType, wStepReal);
+            vector::BroadcastOp::create(builder, loc, vecType, wStepReal);
 
-        wStepImag = builder.create<math::SinOp>(loc, angle);
+        wStepImag = math::SinOp::create(builder, loc, angle);
         wStepImagVec =
-            builder.create<vector::BroadcastOp>(loc, vecType, wStepImag);
+            vector::BroadcastOp::create(builder, loc, vecType, wStepImag);
 
-        builder.create<scf::ForOp>(
-            loc, c0, outerIterVR[0], c1, ValueRange{},
+        scf::ForOp::create(
+            builder, loc, c0, outerIterVR[0], c1, ValueRange{},
             [&](OpBuilder &builder, Location loc, ValueRange iv1, ValueRange) {
-              jBegin = builder.create<arith::MulIOp>(loc, iv1[0], subProbSize);
-              jEnd = builder.create<arith::AddIOp>(loc, jBegin, outerIterVR[1]);
-              wReal = builder.create<arith::ConstantFloatOp>(
-                  loc, builder.getF32Type(), (llvm::APFloat)1.0f);
-              wImag = builder.create<arith::ConstantFloatOp>(
-                  loc, builder.getF32Type(), (llvm::APFloat)0.0f);
+              jBegin = arith::MulIOp::create(builder, loc, iv1[0], subProbSize);
+              jEnd =
+                  arith::AddIOp::create(builder, loc, jBegin, outerIterVR[1]);
+              wReal = arith::ConstantFloatOp::create(
+                  builder, loc, builder.getF32Type(), (llvm::APFloat)1.0f);
+              wImag = arith::ConstantFloatOp::create(
+                  builder, loc, builder.getF32Type(), (llvm::APFloat)0.0f);
 
               wRealVec =
-                  builder.create<vector::BroadcastOp>(loc, vecType, wReal);
+                  vector::BroadcastOp::create(builder, loc, vecType, wReal);
               wImagVec =
-                  builder.create<vector::BroadcastOp>(loc, vecType, wImag);
+                  vector::BroadcastOp::create(builder, loc, vecType, wImag);
 
               // Vectorize stuff inside this loop (take care of tail processing
               // as well)
-              builder.create<scf::ForOp>(
-                  loc, jBegin, jEnd, strideVal, ValueRange{wRealVec, wImagVec},
+              scf::ForOp::create(
+                  builder, loc, jBegin, jEnd, strideVal,
+                  ValueRange{wRealVec, wImagVec},
                   [&](OpBuilder &builder, Location loc, ValueRange iv2,
                       ValueRange wVR) {
-                    tmp1Real = builder.create<vector::LoadOp>(
-                        loc, vecType, memRefReal2D,
+                    tmp1Real = vector::LoadOp::create(
+                        builder, loc, vecType, memRefReal2D,
                         ValueRange{rowIndex, iv2[0]});
-                    tmp1Imag = builder.create<vector::LoadOp>(
-                        loc, vecType, memRefImag2D,
+                    tmp1Imag = vector::LoadOp::create(
+                        builder, loc, vecType, memRefImag2D,
                         ValueRange{rowIndex, iv2[0]});
 
-                    Value secondIndex = builder.create<arith::AddIOp>(
-                        loc, iv2[0], outerIterVR[1]);
-                    tmp2RealTemp = builder.create<vector::LoadOp>(
-                        loc, vecType, memRefReal2D,
+                    Value secondIndex = arith::AddIOp::create(
+                        builder, loc, iv2[0], outerIterVR[1]);
+                    tmp2RealTemp = vector::LoadOp::create(
+                        builder, loc, vecType, memRefReal2D,
                         ValueRange{rowIndex, secondIndex});
-                    tmp2ImagTemp = builder.create<vector::LoadOp>(
-                        loc, vecType, memRefImag2D,
+                    tmp2ImagTemp = vector::LoadOp::create(
+                        builder, loc, vecType, memRefImag2D,
                         ValueRange{rowIndex, secondIndex});
 
                     std::vector<Value> tmp2Vec =
@@ -364,61 +368,61 @@ void idft1DCooleyTukeyButterfly(OpBuilder &builder, Location loc,
                     std::vector<Value> int1Vec =
                         complexVecAddI(builder, loc, tmp1Real, tmp1Imag,
                                        tmp2Vec[0], tmp2Vec[1]);
-                    builder.create<vector::StoreOp>(
-                        loc, int1Vec[0], memRefReal2D,
-                        ValueRange{rowIndex, iv2[0]});
-                    builder.create<vector::StoreOp>(
-                        loc, int1Vec[1], memRefImag2D,
-                        ValueRange{rowIndex, iv2[0]});
+                    vector::StoreOp::create(builder, loc, int1Vec[0],
+                                            memRefReal2D,
+                                            ValueRange{rowIndex, iv2[0]});
+                    vector::StoreOp::create(builder, loc, int1Vec[1],
+                                            memRefImag2D,
+                                            ValueRange{rowIndex, iv2[0]});
 
                     std::vector<Value> int2Vec =
                         complexVecSubI(builder, loc, tmp1Real, tmp1Imag,
                                        tmp2Vec[0], tmp2Vec[1]);
-                    builder.create<vector::StoreOp>(
-                        loc, int2Vec[0], memRefReal2D,
-                        ValueRange{rowIndex, secondIndex});
-                    builder.create<vector::StoreOp>(
-                        loc, int2Vec[1], memRefImag2D,
-                        ValueRange{rowIndex, secondIndex});
+                    vector::StoreOp::create(builder, loc, int2Vec[0],
+                                            memRefReal2D,
+                                            ValueRange{rowIndex, secondIndex});
+                    vector::StoreOp::create(builder, loc, int2Vec[1],
+                                            memRefImag2D,
+                                            ValueRange{rowIndex, secondIndex});
 
                     std::vector<Value> wUpdate =
                         complexVecMulI(builder, loc, wVR[0], wVR[1],
                                        wStepRealVec, wStepImagVec);
 
-                    builder.create<scf::YieldOp>(
-                        loc, ValueRange{wUpdate[0], wUpdate[1]});
+                    scf::YieldOp::create(builder, loc,
+                                         ValueRange{wUpdate[0], wUpdate[1]});
                   });
 
-              builder.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(builder, loc);
             });
         Value updatedSubProbs =
-            builder.create<arith::ShRSIOp>(loc, outerIterVR[0], c1);
+            arith::ShRSIOp::create(builder, loc, outerIterVR[0], c1);
 
-        builder.create<scf::YieldOp>(loc,
-                                     ValueRange{updatedSubProbs, subProbSize});
+        scf::YieldOp::create(builder, loc,
+                             ValueRange{updatedSubProbs, subProbSize});
       });
 
-  Value memRefLengthVec = builder.create<vector::BroadcastOp>(
-      loc, vecType, indexToF32(builder, loc, memRefLength));
+  Value memRefLengthVec = vector::BroadcastOp::create(
+      builder, loc, vecType, indexToF32(builder, loc, memRefLength));
 
-  builder.create<scf::ForOp>(
-      loc, c0, memRefLength, strideVal, ValueRange{},
+  scf::ForOp::create(
+      builder, loc, c0, memRefLength, strideVal, ValueRange{},
       [&](OpBuilder &builder, Location loc, ValueRange iv, ValueRange) {
-        Value tempVecReal = builder.create<vector::LoadOp>(
-            loc, vecType, memRefReal2D, ValueRange{rowIndex, iv[0]});
+        Value tempVecReal = vector::LoadOp::create(
+            builder, loc, vecType, memRefReal2D, ValueRange{rowIndex, iv[0]});
         Value tempResVecReal =
-            builder.create<arith::DivFOp>(loc, tempVecReal, memRefLengthVec);
-        builder.create<vector::StoreOp>(loc, tempResVecReal, memRefReal2D,
-                                        ValueRange{rowIndex, iv[0]});
+            arith::DivFOp::create(builder, loc, tempVecReal, memRefLengthVec);
+        vector::StoreOp::create(builder, loc, tempResVecReal, memRefReal2D,
+                                ValueRange{rowIndex, iv[0]});
 
-        Value tempVecImag = builder.create<vector::LoadOp>(
-            loc, vecType, memRefImag2D, ValueRange{rowIndex, iv[0]});
+        Value tempVecImag = vector::LoadOp::create(
+            builder, loc, vecType, memRefImag2D, ValueRange{rowIndex, iv[0]});
         Value tempResVecImag =
-            builder.create<arith::DivFOp>(loc, tempVecImag, memRefLengthVec);
-        builder.create<vector::StoreOp>(loc, tempResVecImag, memRefImag2D,
-                                        ValueRange{rowIndex, iv[0]});
+            arith::DivFOp::create(builder, loc, tempVecImag, memRefLengthVec);
+        vector::StoreOp::create(builder, loc, tempResVecImag, memRefImag2D,
+                                ValueRange{rowIndex, iv[0]});
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 }
 
@@ -439,100 +443,101 @@ void dft1DGentlemanSandeButterfly(OpBuilder &builder, Location loc,
 
   Value upperBound =
       F32ToIndex(builder, loc,
-                 builder.create<math::Log2Op>(
-                     loc, indexToF32(builder, loc, memRefLength)));
-  Value neg2MPI = builder.create<arith::ConstantFloatOp>(
-      loc, builder.getF32Type(), (llvm::APFloat)(float)(-2.0 * M_PI));
+                 math::Log2Op::create(builder, loc,
+                                      indexToF32(builder, loc, memRefLength)));
+  Value neg2MPI = arith::ConstantFloatOp::create(
+      builder, loc, builder.getF32Type(), (llvm::APFloat)(float)(-2.0 * M_PI));
 
-  builder.create<scf::ForOp>(
-      loc, c0, upperBound, c1, ValueRange{subProbs, subProbSize},
+  scf::ForOp::create(
+      builder, loc, c0, upperBound, c1, ValueRange{subProbs, subProbSize},
       [&](OpBuilder &builder, Location loc, ValueRange iv,
           ValueRange outerIterVR) {
-        half = builder.create<arith::ShRSIOp>(loc, outerIterVR[1], c1);
-        angle = builder.create<arith::DivFOp>(
-            loc, neg2MPI, indexToF32(builder, loc, outerIterVR[1]));
+        half = arith::ShRSIOp::create(builder, loc, outerIterVR[1], c1);
+        angle = arith::DivFOp::create(builder, loc, neg2MPI,
+                                      indexToF32(builder, loc, outerIterVR[1]));
 
-        wStepReal = builder.create<math::CosOp>(loc, angle);
+        wStepReal = math::CosOp::create(builder, loc, angle);
         wStepRealVec =
-            builder.create<vector::BroadcastOp>(loc, vecType, wStepReal);
+            vector::BroadcastOp::create(builder, loc, vecType, wStepReal);
 
-        wStepImag = builder.create<math::SinOp>(loc, angle);
+        wStepImag = math::SinOp::create(builder, loc, angle);
         wStepImagVec =
-            builder.create<vector::BroadcastOp>(loc, vecType, wStepImag);
+            vector::BroadcastOp::create(builder, loc, vecType, wStepImag);
 
-        builder.create<scf::ForOp>(
-            loc, c0, outerIterVR[0], c1, ValueRange{},
+        scf::ForOp::create(
+            builder, loc, c0, outerIterVR[0], c1, ValueRange{},
             [&](OpBuilder &builder, Location loc, ValueRange iv1, ValueRange) {
               jBegin =
-                  builder.create<arith::MulIOp>(loc, iv1[0], outerIterVR[1]);
-              jEnd = builder.create<arith::AddIOp>(loc, jBegin, half);
-              wReal = builder.create<arith::ConstantFloatOp>(
-                  loc, builder.getF32Type(), (llvm::APFloat)1.0f);
-              wImag = builder.create<arith::ConstantFloatOp>(
-                  loc, builder.getF32Type(), (llvm::APFloat)0.0f);
+                  arith::MulIOp::create(builder, loc, iv1[0], outerIterVR[1]);
+              jEnd = arith::AddIOp::create(builder, loc, jBegin, half);
+              wReal = arith::ConstantFloatOp::create(
+                  builder, loc, builder.getF32Type(), (llvm::APFloat)1.0f);
+              wImag = arith::ConstantFloatOp::create(
+                  builder, loc, builder.getF32Type(), (llvm::APFloat)0.0f);
 
               wRealVec =
-                  builder.create<vector::BroadcastOp>(loc, vecType, wReal);
+                  vector::BroadcastOp::create(builder, loc, vecType, wReal);
               wImagVec =
-                  builder.create<vector::BroadcastOp>(loc, vecType, wImag);
+                  vector::BroadcastOp::create(builder, loc, vecType, wImag);
 
               // Vectorize stuff inside this loop (take care of tail processing
               // as well)
-              builder.create<scf::ForOp>(
-                  loc, jBegin, jEnd, strideVal, ValueRange{wRealVec, wImagVec},
+              scf::ForOp::create(
+                  builder, loc, jBegin, jEnd, strideVal,
+                  ValueRange{wRealVec, wImagVec},
                   [&](OpBuilder &builder, Location loc, ValueRange iv2,
                       ValueRange wVR) {
-                    tmp1Real = builder.create<vector::LoadOp>(
-                        loc, vecType, memRefReal2D,
+                    tmp1Real = vector::LoadOp::create(
+                        builder, loc, vecType, memRefReal2D,
                         ValueRange{rowIndex, iv2[0]});
-                    tmp1Imag = builder.create<vector::LoadOp>(
-                        loc, vecType, memRefImag2D,
+                    tmp1Imag = vector::LoadOp::create(
+                        builder, loc, vecType, memRefImag2D,
                         ValueRange{rowIndex, iv2[0]});
 
                     Value secondIndex =
-                        builder.create<arith::AddIOp>(loc, iv2[0], half);
-                    tmp2Real = builder.create<vector::LoadOp>(
-                        loc, vecType, memRefReal2D,
+                        arith::AddIOp::create(builder, loc, iv2[0], half);
+                    tmp2Real = vector::LoadOp::create(
+                        builder, loc, vecType, memRefReal2D,
                         ValueRange{rowIndex, secondIndex});
-                    tmp2Imag = builder.create<vector::LoadOp>(
-                        loc, vecType, memRefImag2D,
+                    tmp2Imag = vector::LoadOp::create(
+                        builder, loc, vecType, memRefImag2D,
                         ValueRange{rowIndex, secondIndex});
 
                     std::vector<Value> int1Vec = complexVecAddI(
                         builder, loc, tmp1Real, tmp1Imag, tmp2Real, tmp2Imag);
-                    builder.create<vector::StoreOp>(
-                        loc, int1Vec[0], memRefReal2D,
-                        ValueRange{rowIndex, iv2[0]});
-                    builder.create<vector::StoreOp>(
-                        loc, int1Vec[1], memRefImag2D,
-                        ValueRange{rowIndex, iv2[0]});
+                    vector::StoreOp::create(builder, loc, int1Vec[0],
+                                            memRefReal2D,
+                                            ValueRange{rowIndex, iv2[0]});
+                    vector::StoreOp::create(builder, loc, int1Vec[1],
+                                            memRefImag2D,
+                                            ValueRange{rowIndex, iv2[0]});
 
                     std::vector<Value> int2Vec = complexVecSubI(
                         builder, loc, tmp1Real, tmp1Imag, tmp2Real, tmp2Imag);
                     std::vector<Value> int3Vec = complexVecMulI(
                         builder, loc, int2Vec[0], int2Vec[1], wVR[0], wVR[1]);
 
-                    builder.create<vector::StoreOp>(
-                        loc, int3Vec[0], memRefReal2D,
-                        ValueRange{rowIndex, secondIndex});
-                    builder.create<vector::StoreOp>(
-                        loc, int3Vec[1], memRefImag2D,
-                        ValueRange{rowIndex, secondIndex});
+                    vector::StoreOp::create(builder, loc, int3Vec[0],
+                                            memRefReal2D,
+                                            ValueRange{rowIndex, secondIndex});
+                    vector::StoreOp::create(builder, loc, int3Vec[1],
+                                            memRefImag2D,
+                                            ValueRange{rowIndex, secondIndex});
 
                     std::vector<Value> wUpdate =
                         complexVecMulI(builder, loc, wVR[0], wVR[1],
                                        wStepRealVec, wStepImagVec);
 
-                    builder.create<scf::YieldOp>(
-                        loc, ValueRange{wUpdate[0], wUpdate[1]});
+                    scf::YieldOp::create(builder, loc,
+                                         ValueRange{wUpdate[0], wUpdate[1]});
                   });
 
-              builder.create<scf::YieldOp>(loc);
+              scf::YieldOp::create(builder, loc);
             });
         Value updatedSubProbs =
-            builder.create<arith::ShLIOp>(loc, outerIterVR[0], c1);
+            arith::ShLIOp::create(builder, loc, outerIterVR[0], c1);
 
-        builder.create<scf::YieldOp>(loc, ValueRange{updatedSubProbs, half});
+        scf::YieldOp::create(builder, loc, ValueRange{updatedSubProbs, half});
       });
 }
 
@@ -542,8 +547,8 @@ void idft2D(OpBuilder &builder, Location loc, Value container2DReal,
             Value container2DImag, Value container2DRows, Value container2DCols,
             Value intermediateReal, Value intermediateImag, Value c0, Value c1,
             Value strideVal, VectorType vecType) {
-  builder.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, builder.getDimIdentityMap(),
+  affine::AffineForOp::create(
+      builder, loc, ValueRange{c0}, builder.getDimIdentityMap(),
       ValueRange{container2DRows}, builder.getDimIdentityMap(), 1, ValueRange{},
       [&](OpBuilder &nestedBuilder, Location nestedLoc, Value iv,
           ValueRange itrArg) {
@@ -551,7 +556,7 @@ void idft2D(OpBuilder &builder, Location loc, Value container2DReal,
                                    container2DImag, container2DCols, strideVal,
                                    vecType, iv, c0, c1, 1);
 
-        nestedBuilder.create<affine::AffineYieldOp>(nestedLoc);
+        affine::AffineYieldOp::create(nestedBuilder, nestedLoc);
       });
 
   scalar2DMemRefTranspose(builder, loc, container2DReal, intermediateReal,
@@ -561,8 +566,8 @@ void idft2D(OpBuilder &builder, Location loc, Value container2DReal,
                           container2DRows, container2DCols, container2DCols,
                           container2DRows, c0);
 
-  builder.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, builder.getDimIdentityMap(),
+  affine::AffineForOp::create(
+      builder, loc, ValueRange{c0}, builder.getDimIdentityMap(),
       ValueRange{container2DCols}, builder.getDimIdentityMap(), 1, ValueRange{},
       [&](OpBuilder &nestedBuilder, Location nestedLoc, Value iv,
           ValueRange itrArg) {
@@ -570,13 +575,13 @@ void idft2D(OpBuilder &builder, Location loc, Value container2DReal,
                                    intermediateImag, container2DRows, strideVal,
                                    vecType, iv, c0, c1, 1);
 
-        nestedBuilder.create<affine::AffineYieldOp>(nestedLoc);
+        affine::AffineYieldOp::create(nestedBuilder, nestedLoc);
       });
 
-  Value transposeCond = builder.create<arith::CmpIOp>(
-      loc, arith::CmpIPredicate::ne, container2DRows, container2DCols);
-  builder.create<scf::IfOp>(
-      loc, transposeCond,
+  Value transposeCond = arith::CmpIOp::create(
+      builder, loc, arith::CmpIPredicate::ne, container2DRows, container2DCols);
+  scf::IfOp::create(
+      builder, loc, transposeCond,
       [&](OpBuilder &builder, Location loc) {
         scalar2DMemRefTranspose(builder, loc, intermediateReal, container2DReal,
                                 container2DCols, container2DRows,
@@ -585,13 +590,13 @@ void idft2D(OpBuilder &builder, Location loc, Value container2DReal,
                                 container2DCols, container2DRows,
                                 container2DRows, container2DCols, c0);
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       },
       [&](OpBuilder &builder, Location loc) {
-        builder.create<memref::CopyOp>(loc, intermediateReal, container2DReal);
-        builder.create<memref::CopyOp>(loc, intermediateImag, container2DImag);
+        memref::CopyOp::create(builder, loc, intermediateReal, container2DReal);
+        memref::CopyOp::create(builder, loc, intermediateImag, container2DImag);
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 }
 
@@ -601,8 +606,8 @@ void dft2D(OpBuilder &builder, Location loc, Value container2DReal,
            Value container2DImag, Value container2DRows, Value container2DCols,
            Value intermediateReal, Value intermediateImag, Value c0, Value c1,
            Value strideVal, VectorType vecType) {
-  builder.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, builder.getDimIdentityMap(),
+  affine::AffineForOp::create(
+      builder, loc, ValueRange{c0}, builder.getDimIdentityMap(),
       ValueRange{container2DRows}, builder.getDimIdentityMap(), 1, ValueRange{},
       [&](OpBuilder &nestedBuilder, Location nestedLoc, Value iv,
           ValueRange itrArg) {
@@ -610,7 +615,7 @@ void dft2D(OpBuilder &builder, Location loc, Value container2DReal,
                                      container2DImag, container2DCols,
                                      strideVal, vecType, iv, c0, c1, 1);
 
-        nestedBuilder.create<affine::AffineYieldOp>(nestedLoc);
+        affine::AffineYieldOp::create(nestedBuilder, nestedLoc);
       });
 
   scalar2DMemRefTranspose(builder, loc, container2DReal, intermediateReal,
@@ -620,8 +625,8 @@ void dft2D(OpBuilder &builder, Location loc, Value container2DReal,
                           container2DRows, container2DCols, container2DCols,
                           container2DRows, c0);
 
-  builder.create<affine::AffineForOp>(
-      loc, ValueRange{c0}, builder.getDimIdentityMap(),
+  affine::AffineForOp::create(
+      builder, loc, ValueRange{c0}, builder.getDimIdentityMap(),
       ValueRange{container2DCols}, builder.getDimIdentityMap(), 1, ValueRange{},
       [&](OpBuilder &nestedBuilder, Location nestedLoc, Value iv,
           ValueRange itrArg) {
@@ -629,13 +634,13 @@ void dft2D(OpBuilder &builder, Location loc, Value container2DReal,
                                      intermediateImag, container2DRows,
                                      strideVal, vecType, iv, c0, c1, 1);
 
-        nestedBuilder.create<affine::AffineYieldOp>(nestedLoc);
+        affine::AffineYieldOp::create(nestedBuilder, nestedLoc);
       });
 
-  Value transposeCond = builder.create<arith::CmpIOp>(
-      loc, arith::CmpIPredicate::ne, container2DRows, container2DCols);
-  builder.create<scf::IfOp>(
-      loc, transposeCond,
+  Value transposeCond = arith::CmpIOp::create(
+      builder, loc, arith::CmpIPredicate::ne, container2DRows, container2DCols);
+  scf::IfOp::create(
+      builder, loc, transposeCond,
       [&](OpBuilder &builder, Location loc) {
         scalar2DMemRefTranspose(builder, loc, intermediateReal, container2DReal,
                                 container2DCols, container2DRows,
@@ -644,13 +649,13 @@ void dft2D(OpBuilder &builder, Location loc, Value container2DReal,
                                 container2DCols, container2DRows,
                                 container2DRows, container2DCols, c0);
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       },
       [&](OpBuilder &builder, Location loc) {
-        builder.create<memref::CopyOp>(loc, intermediateReal, container2DReal);
-        builder.create<memref::CopyOp>(loc, intermediateImag, container2DImag);
+        memref::CopyOp::create(builder, loc, intermediateReal, container2DReal);
+        memref::CopyOp::create(builder, loc, intermediateImag, container2DImag);
 
-        builder.create<scf::YieldOp>(loc);
+        scf::YieldOp::create(builder, loc);
       });
 }
 


### PR DESCRIPTION
## Summary

- OpBuilder::create is deprecated now (see llvm/llvm-project#164649), this cause a lot of warning in CI now, we should fix it.
- Add a extra `grep` based ci check so that `OpBuilder::create` won't happen again.

## Checklist

- [x] The code builds successfully
- [x] Existing tests pass
- [x] New ci are added where appropriate
- [x] Code follows the project coding style
- [x] Documentation is updated if needed
