### PR TITLE
[TASK]BuddyStableDiffusion Output Correctness Fix

### DIFF
--- a/.github/scripts/test_examples.sh
+++ b/.github/scripts/test_examples.sh
@@ -25,6 +25,7 @@ else
     -DBUDDY_MOBILENETV3_EXAMPLES=ON \
     -DBUDDY_QWEN3_EXAMPLES=ON \
     -DBUDDY_RESNET_EXAMPLES=ON \
+    -DBUDDY_STABLE_DIFFUSION_EXAMPLES=ON \
     -DBUDDY_TRANSFORMER_EXAMPLES=ON \
     -DBUDDY_ENABLE_PNG=ON
 
@@ -35,6 +36,7 @@ else
     transformer-runner \
     buddy-bert-run \
     buddy-lenet-run \
+    buddy-stable-diffusion-run \
     buddy-mobilenetv3-run \
     buddy-resnet-run
   ccache -s

--- a/examples/BuddyStableDiffusion/CMakeLists.txt
+++ b/examples/BuddyStableDiffusion/CMakeLists.txt
@@ -72,7 +72,7 @@ add_custom_command(
             -bufferization-lower-deallocations
             -conv-nhwc-fhwc-optimize
             -matmul-parallel-vectorization-optimize
-            # -batchmatmul-optimize
+            -batchmatmul-optimize
             -convert-linalg-to-affine-loops
             -affine-loop-fusion
             -affine-parallelize
@@ -284,13 +284,25 @@ add_custom_command(
     VERBATIM)
 
 
-add_library(TEXTENCODER STATIC forward_text_encoder.o subgraph0_text_encoder.o)
-add_library(UNET STATIC forward_unet.o subgraph0_unet.o)
-add_library(VAE STATIC forward_vae.o subgraph0_vae.o)
+set(BUDDY_STABLE_DIFFUSION_LIBRARY_TYPE STATIC)
+
+add_library(TEXTENCODER ${BUDDY_STABLE_DIFFUSION_LIBRARY_TYPE}
+  forward_text_encoder.o subgraph0_text_encoder.o)
+add_library(UNET ${BUDDY_STABLE_DIFFUSION_LIBRARY_TYPE}
+  forward_unet.o subgraph0_unet.o)
+add_library(VAE ${BUDDY_STABLE_DIFFUSION_LIBRARY_TYPE}
+  forward_vae.o subgraph0_vae.o)
 
 SET_TARGET_PROPERTIES(TEXTENCODER PROPERTIES LINKER_LANGUAGE C)
 SET_TARGET_PROPERTIES(UNET PROPERTIES LINKER_LANGUAGE C)
 SET_TARGET_PROPERTIES(VAE PROPERTIES LINKER_LANGUAGE C)
+
+target_link_directories(TEXTENCODER PRIVATE ${LLVM_LIBRARY_DIR})
+target_link_directories(UNET PRIVATE ${LLVM_LIBRARY_DIR})
+target_link_directories(VAE PRIVATE ${LLVM_LIBRARY_DIR})
+target_link_libraries(TEXTENCODER PRIVATE mlir_c_runner_utils omp)
+target_link_libraries(UNET PRIVATE mlir_c_runner_utils omp)
+target_link_libraries(VAE PRIVATE mlir_c_runner_utils omp)
 
 add_executable(buddy-stable-diffusion-run buddy-stable-diffusion-main.cpp)
 

--- a/examples/BuddyStableDiffusion/CMakeLists.txt
+++ b/examples/BuddyStableDiffusion/CMakeLists.txt
@@ -297,13 +297,6 @@ SET_TARGET_PROPERTIES(TEXTENCODER PROPERTIES LINKER_LANGUAGE C)
 SET_TARGET_PROPERTIES(UNET PROPERTIES LINKER_LANGUAGE C)
 SET_TARGET_PROPERTIES(VAE PROPERTIES LINKER_LANGUAGE C)
 
-target_link_directories(TEXTENCODER PRIVATE ${LLVM_LIBRARY_DIR})
-target_link_directories(UNET PRIVATE ${LLVM_LIBRARY_DIR})
-target_link_directories(VAE PRIVATE ${LLVM_LIBRARY_DIR})
-target_link_libraries(TEXTENCODER PRIVATE mlir_c_runner_utils omp)
-target_link_libraries(UNET PRIVATE mlir_c_runner_utils omp)
-target_link_libraries(VAE PRIVATE mlir_c_runner_utils omp)
-
 add_executable(buddy-stable-diffusion-run buddy-stable-diffusion-main.cpp)
 
 target_compile_options(buddy-stable-diffusion-run PRIVATE -mcmodel=large)

--- a/frontend/Python/ops/tosa.py
+++ b/frontend/Python/ops/tosa.py
@@ -13850,8 +13850,10 @@ def gqa_attention_fused_op(node: GQAAttentionFusedOp, symbol_table):
     value_shape = v_cache.type.shape
 
     # All intermediate constants use compute_dtype (f32)
-    scale_val = 1 / numpy.sqrt(query.type.shape[-1]) if scale is None else scale
-    scale_val = arith.ConstantOp(compute_dtype, float(scale_val)).result
+    scale_factor = (
+        1 / numpy.sqrt(query.type.shape[-1]) if scale is None else scale
+    )
+    scale_val = arith.ConstantOp(compute_dtype, float(scale_factor)).result
 
     neg_inf = arith.ConstantOp(compute_dtype, -1.0e30, loc=loc).result
     zero_compute = arith.ConstantOp(compute_dtype, 0.0, loc=loc).result

--- a/frontend/Python/ops/tosa.py
+++ b/frontend/Python/ops/tosa.py
@@ -375,10 +375,7 @@ def _scalar_to_tensor(
         element = ir.FloatAttr.get(element_type, float(scalar))
     else:
         element = ir.IntegerAttr.get(element_type, int(scalar))
-    attr = ir.DenseElementsAttr.get_splat(
-        ir.RankedTensorType.get(shape, element_type), element
-    )
-    return tosa.ConstOp(attr).results[0]
+    return splat_tensor_value(list(shape), element_type, element)
 
 
 def _normalize_binary_operator_args(arg1, arg2):
@@ -4098,9 +4095,8 @@ def scaled_dot_product_flash_attention_for_cpu_op(
     dtype = node.tensor_meta["dtype"][0]
     attn_bias_shape = [L, S]
     mlir_dtype = mlir_element_type_get(dtype)
-    attn_bias_type = ir.RankedTensorType.get(attn_bias_shape, mlir_dtype)
-    zero_constant = arith.ConstantOp(mlir_dtype, 0.0)
-    attn_bias = tensor.SplatOp(attn_bias_type, zero_constant, [])
+    zero_attr = mlir_element_attr_get(dtype, 0.0)
+    attn_bias = splat_tensor_value(attn_bias_shape, mlir_dtype, zero_attr)
     if attn_mask is not None:
         attn_mask = symbol_table.get((str(attn_mask), 0), attn_mask)
         if attn_mask.type.element_type == ir.IntegerType.get_signless(1):
@@ -4122,14 +4118,16 @@ def scaled_dot_product_flash_attention_for_cpu_op(
                     ir.FloatAttr.get(ir.F32Type.get(), float("-inf")),
                 ),
             )
-            attn_bias = tensor.SelectOp(attn_mask, minus_inf_tensor, attn_bias)
+            attn_bias = tensor.SelectOp(
+                attn_mask, minus_inf_tensor, attn_bias
+            ).result
         else:
-            if attn_mask.type.shape != attn_bias.result.type.shape:
+            if attn_mask.type.shape != attn_bias.type.shape:
                 attn_mask_operand = _create_shape_operand(
-                    list(attn_bias.result.type.shape)
+                    list(attn_bias.type.shape)
                 )
                 attn_mask = tosa.ReshapeOp(attn_mask, attn_mask_operand)
-            attn_bias = tosa.AddOp(attn_bias.result.type, attn_bias, attn_mask)
+            attn_bias = tosa.AddOp(attn_bias.type, attn_bias, attn_mask).result
 
     # Matrix multiplication of query and key
     query_reshape_operand = _create_shape_operand(
@@ -4155,8 +4153,9 @@ def scaled_dot_product_flash_attention_for_cpu_op(
     ]
     matmul_result_type = ir.RankedTensorType.get(matmul_result_shp, mlir_dtype)
     element = mlir_element_attr_get(dtype, 0.0)
-    attr = ir.DenseElementsAttr.get_splat(matmul_result_type, element)
-    matmul_result_buffer = arith.ConstantOp(matmul_result_type, attr).result
+    matmul_result_buffer = splat_tensor_value(
+        matmul_result_shp, mlir_dtype, element
+    )
     generic_map = ir.AffineMap.get_permutation([0, 1, 2, 3])
     matmul_op = linalg.BatchMatmulOp(
         result_tensors=[matmul_result_type],
@@ -4196,13 +4195,15 @@ def scaled_dot_product_flash_attention_for_cpu_op(
             max_fp_attr,
         )
     # Multiply result by scale factor
-    scale_factor_constant = arith.ConstantOp(mlir_dtype, scale_factor)
-    scale_factor = tensor.SplatOp(matmul_result_type, scale_factor_constant, [])
+    scale_factor_attr = mlir_element_attr_get(dtype, scale_factor)
+    scale_factor = splat_tensor_value(
+        matmul_result_shp, mlir_dtype, scale_factor_attr
+    )
     shift = _create_mul_shift_operand()
     mul_op = tosa.MulOp(matmul_result_type, matmul_op, scale_factor, shift)
 
     # Add attention bias to the result
-    add_op = _gen_arith_binary_op(mul_op.result, attn_bias.result, tosa.AddOp)
+    add_op = _gen_arith_binary_op(mul_op.result, attn_bias, tosa.AddOp)
     # add_op = tosa.AddOp(matmul_result_type, mul_op.result, attn_bias)
     # Apply softmax to the result
     softmax_output_shape = list(add_op.result.type.shape)
@@ -4310,8 +4311,10 @@ def flash_attention_for_cpu_prefill_op(
     output_shape = list(query_shape)
 
     # scale = 1/sqrt(H)
-    scale_val = 1 / numpy.sqrt(query.type.shape[-1]) if scale is None else scale
-    scale_val = arith.ConstantOp(dtype, float(scale_val)).result
+    scale_factor = (
+        1 / numpy.sqrt(query.type.shape[-1]) if scale is None else scale
+    )
+    scale_val = arith.ConstantOp(dtype, float(scale_factor)).result
 
     zero = arith.ConstantOp(dtype, 0.0, loc=loc).result
     neg_inf = arith.ConstantOp(dtype, -1.0e30, loc=loc).result
@@ -4841,15 +4844,11 @@ def zeros_op(node: ZerosOp, symbol_table):
     result_type = ir.RankedTensorType.get(output_shape, result_element_type)
 
     if str(result_element_type).find("f") != -1:
-        zero_attr = ir.DenseElementsAttr.get_splat(
-            result_type, ir.FloatAttr.get(result_element_type, 0.0)
-        )
+        zero_attr = ir.FloatAttr.get(result_element_type, 0.0)
     else:
-        zero_attr = ir.DenseElementsAttr.get_splat(
-            result_type, ir.IntegerAttr.get(result_element_type, 0)
-        )
+        zero_attr = ir.IntegerAttr.get(result_element_type, 0)
 
-    return tosa.ConstOp(zero_attr)
+    return splat_tensor_value(output_shape, result_element_type, zero_attr)
 
 
 def zeros_like_op(node: ZerosLikeOp, symbol_table):
@@ -4863,15 +4862,11 @@ def zeros_like_op(node: ZerosLikeOp, symbol_table):
     result_type = ir.RankedTensorType.get(input_shape, input_dtype)
 
     if str(input_dtype).find("f") != -1:
-        zero_attr = ir.DenseElementsAttr.get_splat(
-            result_type, ir.FloatAttr.get(input_dtype, 0.0)
-        )
+        zero_attr = ir.FloatAttr.get(input_dtype, 0.0)
     else:
-        zero_attr = ir.DenseElementsAttr.get_splat(
-            result_type, ir.IntegerAttr.get(input_dtype, 0)
-        )
+        zero_attr = ir.IntegerAttr.get(input_dtype, 0)
 
-    return tosa.ConstOp(zero_attr)
+    return splat_tensor_value(input_shape, input_dtype, zero_attr)
 
 
 def ones_like_op(node: OnesLikeOp, symbol_table):
@@ -4885,15 +4880,11 @@ def ones_like_op(node: OnesLikeOp, symbol_table):
     result_type = ir.RankedTensorType.get(input_shape, input_dtype)
 
     if str(input_dtype).find("f") != -1:
-        one_attr = ir.DenseElementsAttr.get_splat(
-            result_type, ir.FloatAttr.get(input_dtype, 1.0)
-        )
+        one_attr = ir.FloatAttr.get(input_dtype, 1.0)
     else:
-        one_attr = ir.DenseElementsAttr.get_splat(
-            result_type, ir.IntegerAttr.get(input_dtype, 1)
-        )
+        one_attr = ir.IntegerAttr.get(input_dtype, 1)
 
-    return tosa.ConstOp(one_attr)
+    return splat_tensor_value(input_shape, input_dtype, one_attr)
 
 
 def full_like_op(node: FullLikeOp, symbol_table):
@@ -4908,15 +4899,11 @@ def full_like_op(node: FullLikeOp, symbol_table):
     result_type = ir.RankedTensorType.get(input_shape, input_dtype)
 
     if str(input_dtype).find("f") != -1:
-        value_attr = ir.DenseElementsAttr.get_splat(
-            result_type, ir.FloatAttr.get(input_dtype, float(fill_value))
-        )
+        value_attr = ir.FloatAttr.get(input_dtype, float(fill_value))
     else:
-        value_attr = ir.DenseElementsAttr.get_splat(
-            result_type, ir.IntegerAttr.get(input_dtype, int(fill_value))
-        )
+        value_attr = ir.IntegerAttr.get(input_dtype, int(fill_value))
 
-    return tosa.ConstOp(value_attr)
+    return splat_tensor_value(input_shape, input_dtype, value_attr)
 
 
 def all_op(node: AllOp, symbol_table):
@@ -14002,11 +13989,11 @@ def gqa_attention_fused_op(node: GQAAttentionFusedOp, symbol_table):
     )
 
     # ========= scale + mask =========
-    scale_splat = tensor.SplatOp(
-        score_tensor_shape,
-        scale_val,
-        [],
-    ).result
+    scale_splat = splat_tensor_value(
+        [query_shape[0], query_shape[1], query_shape[2], key_shape[2]],
+        compute_dtype,
+        ir.FloatAttr.get(compute_dtype, float(scale_factor)),
+    )
 
     shift = _create_mul_shift_operand()
     scaled = tosa.MulOp(

--- a/frontend/Python/ops/utils.py
+++ b/frontend/Python/ops/utils.py
@@ -23,7 +23,8 @@ from buddy_mlir.dialects import arith, linalg, tensor
 
 from ..graph import TensorDType
 
-LARGE_ZERO_TENSOR_ELEMENT_THRESHOLD = 1_000_000
+LARGE_SPLAT_TENSOR_ELEMENT_THRESHOLD = 10_000
+LARGE_ZERO_TENSOR_ELEMENT_THRESHOLD = LARGE_SPLAT_TENSOR_ELEMENT_THRESHOLD
 
 
 def _static_element_count(shape: list[int]) -> int | None:
@@ -48,6 +49,16 @@ def zero_tensor_value(
     element_threshold: int = LARGE_ZERO_TENSOR_ELEMENT_THRESHOLD,
 ) -> ir.Value:
     """Create a zero tensor value without materializing huge f32 literals."""
+    return splat_tensor_value(shape, element_type, zero_attr, element_threshold)
+
+
+def splat_tensor_value(
+    shape: list[int],
+    element_type: ir.Type,
+    element_attr: ir.Attribute,
+    element_threshold: int = LARGE_SPLAT_TENSOR_ELEMENT_THRESHOLD,
+) -> ir.Value:
+    """Create a splat tensor without materializing huge f32 literals."""
     tensor_type = ir.RankedTensorType.get(shape, element_type)
     element_count = _static_element_count(shape)
     if (
@@ -55,11 +66,11 @@ def zero_tensor_value(
         and element_count >= element_threshold
         and isinstance(element_type, ir.F32Type)
     ):
-        zero = arith.ConstantOp(element_type, zero_attr).result
+        scalar = arith.ConstantOp(element_type, element_attr).result
         empty = tensor.EmptyOp(shape, element_type).result
-        return linalg.fill(zero, outs=[empty])
+        return linalg.fill(scalar, outs=[empty])
 
-    attr = ir.DenseElementsAttr.get_splat(tensor_type, zero_attr)
+    attr = ir.DenseElementsAttr.get_splat(tensor_type, element_attr)
     return arith.ConstantOp(tensor_type, attr).result
 
 

--- a/midend/lib/Conversion/MatMulOptimization/BatchMatMulOptimize.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/BatchMatMulOptimize.cpp
@@ -18,6 +18,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/AffineMap.h"
@@ -42,6 +43,7 @@
 #include <mlir/IR/TypeUtilities.h>
 #include <mlir/IR/Value.h>
 #include <mlir/Pass/Pass.h>
+#include <mlir/Transforms/DialectConversion.h>
 
 using namespace mlir;
 using namespace vector;
@@ -52,6 +54,36 @@ using namespace affine;
 //===----------------------------------------------------------------------===//
 
 namespace {
+
+static bool hasDefaultBatchMatmulIndexingMaps(linalg::BatchMatmulOp op) {
+  return linalg::BatchMatmulOp::isDefaultIndexingMaps(
+      op->getAttr("indexing_maps"));
+}
+
+static bool isSupportedBatchMatmulOp(linalg::BatchMatmulOp op) {
+  if (!op.hasPureBufferSemantics())
+    return false;
+  if (!hasDefaultBatchMatmulIndexingMaps(op))
+    return false;
+
+  Value A = op.getInputs()[0];
+  Value B = op.getInputs()[1];
+  Value C = op.getOutputs()[0];
+  auto aType = dyn_cast<MemRefType>(A.getType());
+  auto bType = dyn_cast<MemRefType>(B.getType());
+  auto cType = dyn_cast<MemRefType>(C.getType());
+  if (!aType || !bType || !cType)
+    return false;
+  if (aType.getRank() != 3 || bType.getRank() != 3 || cType.getRank() != 3)
+    return false;
+
+  Type elementType = aType.getElementType();
+  if (bType.getElementType() != elementType ||
+      cType.getElementType() != elementType)
+    return false;
+
+  return isa<IntegerType, FloatType>(elementType);
+}
 
 class BatchMatMulOptimizePattern : public ConversionPattern {
 public:
@@ -65,17 +97,18 @@ public:
   LogicalResult
   matchAndRewrite(Operation *op, ArrayRef<Value> /*operands*/,
                   ConversionPatternRewriter &rewriter) const override {
+    auto batchMatmulOp = cast<linalg::BatchMatmulOp>(op);
+    if (!isSupportedBatchMatmulOp(batchMatmulOp))
+      return failure();
+
     auto loc = op->getLoc();
     auto ctx = op->getContext();
 
     // Retrieve input tensors A, B, and C.
-    Value A = op->getOperand(0);
-    Value B = op->getOperand(1);
-    Value C = op->getOperand(2);
+    Value A = batchMatmulOp.getInputs()[0];
+    Value B = batchMatmulOp.getInputs()[1];
+    Value C = batchMatmulOp.getOutputs()[0];
 
-    // Get i1 as the element type for mask vector.
-    IntegerType i1 = IntegerType::get(ctx, 1);
-    VectorType vectorMaskTy = mlir::VectorType::get({vecSize}, i1);
     // Acquire the element type of input tensors.
     Type elementType =
         mlir::cast<mlir::MemRefType>(A.getType()).getElementType();
@@ -120,8 +153,8 @@ public:
     auto createUnrollParallel = [&](int unrollSize, Value lowerBound,
                                     Value upperBound) {
       // Create the primary parallel batch level loop.
-      auto parOp = scf::ParallelOp::create(
-          rewriter, loc,
+      rewriter.create<scf::ParallelOp>(
+          loc,
           /*lowerBounds=*/ValueRange{constantVals[0], lowerBound},
           /*upperBounds=*/ValueRange{batch, upperBound},
           /*steps=*/ValueRange{constantVals[1], constantVals[unrollSize]},
@@ -162,9 +195,9 @@ public:
                             auto aVec = vector::BroadcastOp::create(
                                 rewriter, loc, vectorTy, aEle);
                             Value mulVec =
-                                arith::MulIOp::create(builder, loc, aVec, bVec);
-                            Value resSumVec = arith::AddIOp::create(
-                                builder, loc, mulVec, iterArgs1[0]);
+                                builder.create<arith::MulIOp>(loc, aVec, bVec);
+                            Value resSumVec = builder.create<arith::AddIOp>(
+                                loc, mulVec, iterArgs1[i]);
                             resSumVecs.push_back(resSumVec);
                           }
                         } else {
@@ -299,11 +332,12 @@ void BatchMatMulOptimizePass::runOnOperation() {
   ModuleOp module = getOperation();
 
   ConversionTarget target(*context);
-  target
-      .addLegalDialect<arith::ArithDialect, affine::AffineDialect,
-                       scf::SCFDialect, memref::MemRefDialect, VectorDialect>();
+  target.addLegalDialect<arith::ArithDialect, affine::AffineDialect,
+                         scf::SCFDialect, memref::MemRefDialect, VectorDialect,
+                         linalg::LinalgDialect>();
+  target.addDynamicallyLegalOp<linalg::BatchMatmulOp>(
+      [](linalg::BatchMatmulOp op) { return !isSupportedBatchMatmulOp(op); });
   target.addLegalOp<ModuleOp, func::FuncOp, func::ReturnOp>();
-  target.addLegalOp<linalg::FillOp>();
 
   RewritePatternSet patterns(context);
   patterns.add<BatchMatMulOptimizePattern>(context, vecSize);

--- a/midend/lib/Conversion/MatMulOptimization/BatchMatMulOptimize.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/BatchMatMulOptimize.cpp
@@ -153,8 +153,8 @@ public:
     auto createUnrollParallel = [&](int unrollSize, Value lowerBound,
                                     Value upperBound) {
       // Create the primary parallel batch level loop.
-      rewriter.create<scf::ParallelOp>(
-          loc,
+      scf::ParallelOp::create(
+          rewriter, loc,
           /*lowerBounds=*/ValueRange{constantVals[0], lowerBound},
           /*upperBounds=*/ValueRange{batch, upperBound},
           /*steps=*/ValueRange{constantVals[1], constantVals[unrollSize]},
@@ -195,9 +195,9 @@ public:
                             auto aVec = vector::BroadcastOp::create(
                                 rewriter, loc, vectorTy, aEle);
                             Value mulVec =
-                                builder.create<arith::MulIOp>(loc, aVec, bVec);
-                            Value resSumVec = builder.create<arith::AddIOp>(
-                                loc, mulVec, iterArgs1[i]);
+                                arith::MulIOp::create(builder, loc, aVec, bVec);
+                            Value resSumVec = arith::AddIOp::create(
+                                builder, loc, mulVec, iterArgs1[i]);
                             resSumVecs.push_back(resSumVec);
                           }
                         } else {

--- a/tests/Conversion/batchmatmul-optimize.mlir
+++ b/tests/Conversion/batchmatmul-optimize.mlir
@@ -1,0 +1,127 @@
+// RUN: buddy-opt %s -batchmatmul-optimize="vector-size=4" | FileCheck %s --check-prefix=CHECK-IR
+// RUN: buddy-opt %s -batchmatmul-optimize="vector-size=4" \
+// RUN:     -convert-linalg-to-loops -scf-parallel-for-to-nested-fors \
+// RUN:     -lower-affine -convert-scf-to-cf \
+// RUN:     -convert-vector-to-llvm -finalize-memref-to-llvm \
+// RUN:     -convert-arith-to-llvm -convert-cf-to-llvm \
+// RUN:     -convert-func-to-llvm -reconcile-unrealized-casts \
+// RUN: | mlir-runner -e main -entry-point-result=void \
+// RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_runner_utils%shlibext \
+// RUN:     -shared-libs=%mlir_runner_utils_dir/libmlir_c_runner_utils%shlibext \
+// RUN: | FileCheck %s --check-prefix=CHECK-OUT
+
+module {
+  func.func private @printMemrefF32(memref<*xf32>)
+  func.func private @printMemrefI32(memref<*xi32>)
+
+  func.func @batch_m_lt_8_f32(%A: memref<1x3x2xf32>,
+                              %B: memref<1x2x5xf32>,
+                              %C: memref<1x3x5xf32>) {
+    linalg.batch_matmul
+      ins(%A, %B : memref<1x3x2xf32>, memref<1x2x5xf32>)
+      outs(%C : memref<1x3x5xf32>)
+    return
+  }
+
+  func.func @batch_i32(%A: memref<1x9x2xi32>,
+                       %B: memref<1x2x5xi32>,
+                       %C: memref<1x9x5xi32>) {
+    linalg.batch_matmul
+      ins(%A, %B : memref<1x9x2xi32>, memref<1x2x5xi32>)
+      outs(%C : memref<1x9x5xi32>)
+    return
+  }
+
+  func.func @batch_transpose_b_kept(%A: memref<1x3x2xf32>,
+                                    %B: memref<1x5x2xf32>,
+                                    %C: memref<1x3x5xf32>) {
+    linalg.batch_matmul indexing_maps = [
+      affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>,
+      affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>,
+      affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+    ]
+      ins(%A, %B : memref<1x3x2xf32>, memref<1x5x2xf32>)
+      outs(%C : memref<1x3x5xf32>)
+    return
+  }
+
+  func.func @main() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c9 = arith.constant 9 : index
+
+    %f1 = arith.constant 1.0 : f32
+    %f2 = arith.constant 2.0 : f32
+    %f10 = arith.constant 10.0 : f32
+    %A_f32 = memref.alloc() : memref<1x3x2xf32>
+    %B_f32 = memref.alloc() : memref<1x2x5xf32>
+    %C_f32 = memref.alloc() : memref<1x3x5xf32>
+    linalg.fill ins(%f1 : f32) outs(%A_f32 : memref<1x3x2xf32>)
+    linalg.fill ins(%f2 : f32) outs(%B_f32 : memref<1x2x5xf32>)
+    linalg.fill ins(%f10 : f32) outs(%C_f32 : memref<1x3x5xf32>)
+    call @batch_m_lt_8_f32(%A_f32, %B_f32, %C_f32)
+      : (memref<1x3x2xf32>, memref<1x2x5xf32>, memref<1x3x5xf32>) -> ()
+
+    %print_f32 = memref.cast %C_f32 : memref<1x3x5xf32> to memref<*xf32>
+    call @printMemrefF32(%print_f32) : (memref<*xf32>) -> ()
+
+    %i0 = arith.constant 0 : i32
+    %i1 = arith.constant 1 : i32
+    %A_i32 = memref.alloc() : memref<1x9x2xi32>
+    %B_i32 = memref.alloc() : memref<1x2x5xi32>
+    %C_i32 = memref.alloc() : memref<1x9x5xi32>
+    linalg.fill ins(%i0 : i32) outs(%A_i32 : memref<1x9x2xi32>)
+    linalg.fill ins(%i1 : i32) outs(%B_i32 : memref<1x2x5xi32>)
+    linalg.fill ins(%i0 : i32) outs(%C_i32 : memref<1x9x5xi32>)
+
+    scf.for %m = %c0 to %c9 step %c1 {
+      %m_i32 = arith.index_cast %m : index to i32
+      %row_val = arith.addi %m_i32, %i1 : i32
+      memref.store %row_val, %A_i32[%c0, %m, %c0] : memref<1x9x2xi32>
+      memref.store %row_val, %A_i32[%c0, %m, %c1] : memref<1x9x2xi32>
+    }
+
+    call @batch_i32(%A_i32, %B_i32, %C_i32)
+      : (memref<1x9x2xi32>, memref<1x2x5xi32>, memref<1x9x5xi32>) -> ()
+
+    %print_i32 = memref.cast %C_i32 : memref<1x9x5xi32> to memref<*xi32>
+    call @printMemrefI32(%print_i32) : (memref<*xi32>) -> ()
+
+    memref.dealloc %C_i32 : memref<1x9x5xi32>
+    memref.dealloc %B_i32 : memref<1x2x5xi32>
+    memref.dealloc %A_i32 : memref<1x9x2xi32>
+    memref.dealloc %C_f32 : memref<1x3x5xf32>
+    memref.dealloc %B_f32 : memref<1x2x5xf32>
+    memref.dealloc %A_f32 : memref<1x3x2xf32>
+    return
+  }
+}
+
+// CHECK-IR-LABEL: func.func @batch_m_lt_8_f32
+// CHECK-IR:       scf.parallel
+// CHECK-IR:       vector.fma
+
+// CHECK-IR-LABEL: func.func @batch_i32
+// CHECK-IR:       scf.parallel
+// CHECK-IR:       arith.muli {{.*}} : vector<4xi32>
+// CHECK-IR:       arith.addi {{.*}} : vector<4xi32>
+
+// CHECK-IR-LABEL: func.func @batch_transpose_b_kept
+// CHECK-IR:       linalg.batch_matmul
+// CHECK-IR-SAME:  indexing_maps
+
+// CHECK-OUT: Unranked Memref base@ = {{.*}} rank = 3 offset = 0 sizes = [1, 3, 5] strides = [15, 5, 1] data =
+// CHECK-OUT: [14,   14,   14,   14,   14]
+// CHECK-OUT: [14,   14,   14,   14,   14]
+// CHECK-OUT: [14,   14,   14,   14,   14]
+// CHECK-OUT: Unranked Memref base@ = {{.*}} rank = 3 offset = 0 sizes = [1, 9, 5] strides = [45, 5, 1] data =
+// CHECK-OUT: [2,   2,   2,   2,   2]
+// CHECK-OUT: [4,   4,   4,   4,   4]
+// CHECK-OUT: [6,   6,   6,   6,   6]
+// CHECK-OUT: [8,   8,   8,   8,   8]
+// CHECK-OUT: [10,   10,   10,   10,   10]
+// CHECK-OUT: [12,   12,   12,   12,   12]
+// CHECK-OUT: [14,   14,   14,   14,   14]
+// CHECK-OUT: [16,   16,   16,   16,   16]
+// CHECK-OUT: [18,   18,   18,   18,   18]


### PR DESCRIPTION
## Summary
#800 

- Fix the -batchmatmul-optimize pass to make it compatible with the current LLVM/MLIR version, re-enable this pass in subgraph0_text_encoder, add dedicated lit tests, and fix a macOS crash caused by large splat constants in the frontend. 
- The end-to-end LeNet and Stable Diffusion pipeline is verified to run correctly and produce valid images.
<img width="350" height="337" alt="image" src="https://github.com/user-attachments/assets/12e2f755-fc2e-453d-97c9-b5f3d367d645" />

- Add a test file to tests/Conversion/batchmatmul-optimize.mlir




- Describe how reviewers can verify and test this change. Include command-line instructions if applicable.
```
# You can test BuddyStableDiffusion using this command.
$ cmake -G Ninja .. -DBUDDY_STABLE_DIFFUSION_EXAMPLES=ON
$ ninja buddy-stable-diffusion-run
$ cd bin
$ ./buddy-stable-diffusion-run
```
## Checklist

- [x] The code builds successfully
- [x] Existing tests pass
- [x] New tests are added where appropriate
- [x] Code follows the project coding style
- [x] Documentation is updated if needed
