### PR TITLE
[ci] Use PR ref for triggered test-example workflows

### DIFF
--- a/.github/actions/ci-common/action.yml
+++ b/.github/actions/ci-common/action.yml
@@ -109,10 +109,7 @@ runs:
           -DPython_EXECUTABLE="$(which python)"
 
         ccache -z
-        ninja -C "$LLVM_BUILD_DIR" check-clang || true
-        ninja -C "$LLVM_BUILD_DIR" check-mlir || true
-        ninja -C "$LLVM_BUILD_DIR" check-openmp || true
-        ninja -C "$LLVM_BUILD_DIR" mlir-libraries
+        ninja -C "$LLVM_BUILD_DIR" check-clang check-mlir check-openmp mlir-libraries
         ccache -s
 
         ${{ inputs.venv_deactivate }}

--- a/.github/scripts/test_examples.sh
+++ b/.github/scripts/test_examples.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+arch="${1:?usage: .github/scripts/test_examples.sh <arch>}"
+
+export PYTHONPATH="$PWD/build/python_packages:${PYTHONPATH:-}"
+
+if [ "$arch" = "riscv64" ]; then
+  # The installed torchvision on riscv64 is outdated and causes compatibility
+  # issues with other modules.
+  pip uninstall torchvision -y
+
+  cmake -S . -B build \
+    -DBUDDY_DEEPSEEKR1_EXAMPLES=ON
+
+  ccache -z
+  ninja -C build -j1 \
+    buddy-deepseek-r1-cli
+  ccache -s
+else
+  cmake -S . -B build \
+    -DBUDDY_BERT_EXAMPLES=ON \
+    -DBUDDY_DEEPSEEKR1_EXAMPLES=ON \
+    -DBUDDY_LENET_EXAMPLES=ON \
+    -DBUDDY_MOBILENETV3_EXAMPLES=ON \
+    -DBUDDY_QWEN3_EXAMPLES=ON \
+    -DBUDDY_RESNET_EXAMPLES=ON \
+    -DBUDDY_TRANSFORMER_EXAMPLES=ON \
+    -DBUDDY_ENABLE_PNG=ON
+
+  ccache -z
+  ninja -C build -j1 \
+    buddy-deepseek-r1-cli \
+    buddy-qwen3-0.6b-run \
+    transformer-runner \
+    buddy-bert-run \
+    buddy-lenet-run \
+    buddy-mobilenetv3-run \
+    buddy-resnet-run
+  ccache -s
+fi
+
+ctest --test-dir "$PWD/build" \
+  -L example \
+  --output-on-failure \
+  --no-tests=error

--- a/.github/workflows/TestBuild.yml
+++ b/.github/workflows/TestBuild.yml
@@ -66,6 +66,7 @@ jobs:
           llvm-src: ${{ matrix.llvm_src }}
 
       - name: Build buddy-mlir
+        continue-on-error: ${{ matrix.arch == 'arm64' }}
         uses: ./.github/actions/ci-common
         with:
           arch: ${{ matrix.arch }}

--- a/.github/workflows/test-example.yml
+++ b/.github/workflows/test-example.yml
@@ -111,6 +111,7 @@ jobs:
           llvm-src: ${{ matrix.llvm_src }}
 
       - name: Build buddy-mlir
+        continue-on-error: ${{ matrix.arch == 'arm64' }}
         uses: ./.github/actions/ci-common
         with:
           arch: ${{ matrix.arch }}
@@ -119,68 +120,11 @@ jobs:
           llvm-src: ${{ matrix.llvm_src }}
           llvm-build-root: ${{ matrix.llvm_build_root }}
 
-      - name: Build examples
-        if: matrix.arch != 'riscv64'
+      - name: Run example tests
         continue-on-error: ${{ matrix.arch == 'arm64' }}
         run: |
           ${{ matrix.venv_activate }}
-
-          export PYTHONPATH=$PWD/build/python_packages:${PYTHONPATH}
-
-          cmake -S . -B build \
-            -DBUDDY_BERT_EXAMPLES=ON \
-            -DBUDDY_DEEPSEEKR1_EXAMPLES=ON \
-            -DBUDDY_LENET_EXAMPLES=ON \
-            -DBUDDY_MOBILENETV3_EXAMPLES=ON \
-            -DBUDDY_QWEN3_EXAMPLES=ON \
-            -DBUDDY_RESNET_EXAMPLES=ON \
-            -DBUDDY_TRANSFORMER_EXAMPLES=ON \
-            -DBUDDY_ENABLE_PNG=ON
-
-          ccache -z
-          ninja -C build -j1 \
-            buddy-deepseek-r1-cli \
-            buddy-qwen3-0.6b-run \
-            transformer-runner \
-            buddy-bert-run \
-            buddy-lenet-run \
-            buddy-mobilenetv3-run \
-            buddy-resnet-run
-          ccache -s
-
-          ${{ matrix.venv_deactivate }}
-
-      - name: Build examples (riscv64)
-        if: matrix.arch == 'riscv64'
-        run: |
-          ${{ matrix.venv_activate }}
-
-          export PYTHONPATH=$PWD/build/python_packages:${PYTHONPATH}
-
-          # The installed torchvision on riscv64 is outdated and causes
-          # compatibility issues with other modules.
-          pip uninstall torchvision -y
-
-          cmake -S . -B build \
-            -DBUDDY_DEEPSEEKR1_EXAMPLES=ON
-
-          ccache -z
-          ninja -C build -j1 \
-            buddy-deepseek-r1-cli
-          ccache -s
-
-          ${{ matrix.venv_deactivate }}
-
-      - name: Run examples
-        continue-on-error: ${{ matrix.arch == 'arm64' }}
-        run: |
-          ${{ matrix.venv_activate }}
-
-          ctest --test-dir "$PWD/build" \
-            -L example \
-            --output-on-failure \
-            --no-tests=error
-
+          bash .github/scripts/test_examples.sh "${{ matrix.arch }}"
           ${{ matrix.venv_deactivate }}
 
       - name: Report matrix status


### PR DESCRIPTION
## Summary

Currently, when triggering `test-example` using a label, it can only use `test-example.yml` from the upstream repository branch. This means that even if you add a new `example`, it still won't trigger. 

This PR fixes this and moves the specific test content into a bash script. Although it's not very elegant, I haven't found a better solution yet. In this respect, GitHub Actions is far inferior to other CI systems.

## Checklist

- [x] The code builds successfully
- [x] Existing tests pass
- [x] New tests are added where appropriate
- [x] Code follows the project coding style
- [x] Documentation is updated if needed
