### PR TITLE
[build] Fixed various dependency installation issues for riscv

### DIFF
--- a/.github/actions/ci-common/action.yml
+++ b/.github/actions/ci-common/action.yml
@@ -68,9 +68,6 @@ runs:
 
         ${{ inputs.venv_activate }}
         pip install -U pip setuptools wheel packaging
-        sed -i \
-          -e '1s/^/# /' \
-          requirements.txt
         pip install -r requirements.txt
         ${{ inputs.venv_deactivate }}
 

--- a/.github/scripts/test_examples.sh
+++ b/.github/scripts/test_examples.sh
@@ -6,10 +6,6 @@ arch="${1:?usage: .github/scripts/test_examples.sh <arch>}"
 export PYTHONPATH="$PWD/build/python_packages:${PYTHONPATH:-}"
 
 if [ "$arch" = "riscv64" ]; then
-  # The installed torchvision on riscv64 is outdated and causes compatibility
-  # issues with other modules.
-  pip uninstall torchvision -y
-
   cmake -S . -B build \
     -DBUDDY_QWEN3_EXAMPLES=ON \
     -DBUDDY_GEMMA4_EXAMPLES=ON \

--- a/.github/workflows/TestBuild.yml
+++ b/.github/workflows/TestBuild.yml
@@ -98,8 +98,8 @@ jobs:
               pip uninstall -y torchvision || true
             fi
             pip install --pre \
-              --index-url https://ruyirepo.ruyicommunity.cn/pypi/simple/ \
               --extra-index-url https://download.pytorch.org/whl/cpu \
+              --extra-index-url https://ruyirepo.ruyicommunity.cn/pypi/simple/ \
               --upgrade --force-reinstall \
               "${torch_packages[@]}"
             python -c 'import textwrap; exec(textwrap.dedent("""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,7 +257,7 @@ configure_package_config_file(
   INSTALL_DESTINATION ${BUDDY_MLIR_INSTALL_CMAKE_DIR}
 )
 
-option(BUDDY_PACKAGE_VERSION "Release VERSION" "0.0.0")
+set(BUDDY_PACKAGE_VERSION "0.0.0" CACHE STRING "Release VERSION")
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/BuddyMLIRConfigVersion.cmake
   VERSION ${BUDDY_PACKAGE_VERSION}

--- a/examples/BuddyNext/next-batchmatmul-sgemm-unroll-vec.mlir
+++ b/examples/BuddyNext/next-batchmatmul-sgemm-unroll-vec.mlir
@@ -177,7 +177,7 @@ module {
     %t_end = call @rtclock() : () -> f64
     %time = arith.subf %t_end, %t_start : f64
     vector.print %time : f64
-    // CHECK: {{[0-9]+\.[0-9]+}}
+    // CHECK: {{[0-9]+}}
     return
   }
 

--- a/examples/BuddyNext/next-blis-matmul.mlir
+++ b/examples/BuddyNext/next-blis-matmul.mlir
@@ -360,8 +360,8 @@ module {
     vector.print %time_ref : f64
     vector.print %time_vec : f64
 
-    // CHECK: {{[0-9]+\.[0-9]+}}
-    // CHECK: {{[0-9]+\.[0-9]+}}
+    // CHECK: {{[0-9]+}}
+    // CHECK: {{[0-9]+}}
 
     memref.dealloc %C_vec_large : memref<?x?xf32>
     memref.dealloc %B_large : memref<?x?xf32>

--- a/examples/BuddyNext/next-embedding.mlir
+++ b/examples/BuddyNext/next-embedding.mlir
@@ -55,7 +55,7 @@ func.func @kernel(%arg0: tensor<151936x1536xf32>, %arg1: tensor<1x1024xi64>) -> 
 
   // Print timings.
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
 
   return %3 : tensor<1x1024x1536xf32>
 }

--- a/examples/BuddyNext/next-ffn-no-reshape.mlir
+++ b/examples/BuddyNext/next-ffn-no-reshape.mlir
@@ -93,7 +93,7 @@ func.func @kernel(%arg0: tensor<8960x1536xf32>, %arg1: tensor<1024x1536xf32>, %a
 
   // Print timings.
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
 
   return %211 : tensor<1024x1536xf32>
 }

--- a/examples/BuddyNext/next-ffn-no-transpose.mlir
+++ b/examples/BuddyNext/next-ffn-no-transpose.mlir
@@ -90,7 +90,7 @@ func.func @kernel(%arg0: tensor<1536x8960xf32>, %arg1: tensor<1024x1536xf32>, %a
 
   // Print timings.
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
 
   return %211 : tensor<1024x1536xf32>
 }

--- a/examples/BuddyNext/next-ffn.mlir
+++ b/examples/BuddyNext/next-ffn.mlir
@@ -76,7 +76,7 @@ func.func @kernel(%arg0: tensor<1x1536xf32>, %arg1: tensor<1536x8960xf32>, %arg2
 
   // Print timings.
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
 
   return %284 : tensor<1x1x1536xf32>
 }

--- a/examples/BuddyNext/next-flash-attention-prefill.mlir
+++ b/examples/BuddyNext/next-flash-attention-prefill.mlir
@@ -241,7 +241,7 @@ func.func @main() {
   // call @printMemrefF32(%tensor_unranked_scores) : (tensor<*xf32>) -> ()
 
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
   return
 }
 func.func private @printMemrefF32(%ptr : tensor<*xf32>)

--- a/examples/BuddyNext/next-flash-attention.mlir
+++ b/examples/BuddyNext/next-flash-attention.mlir
@@ -212,7 +212,7 @@ func.func @main() {
 
   %time = arith.subf %t_end, %t_start : f64
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
 
   return
 }

--- a/examples/BuddyNext/next-gqa-attention-fusion.mlir
+++ b/examples/BuddyNext/next-gqa-attention-fusion.mlir
@@ -184,7 +184,7 @@ func.func @main() {
   %t_end = call @rtclock() : () -> f64
   %time = arith.subf %t_end, %t_start : f64
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
 
   %tensor_unranked = tensor.cast %result_out : tensor<1x12x1x128xf32> to tensor<*xf32>
   // call @printMemrefF32(%tensor_unranked) : (tensor<*xf32>) -> ()

--- a/examples/BuddyNext/next-gqa-attention.mlir
+++ b/examples/BuddyNext/next-gqa-attention.mlir
@@ -161,7 +161,7 @@ func.func @main() {
   %t_end = call @rtclock() : () -> f64
   %time = arith.subf %t_end, %t_start : f64
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
 
   %tensor_unranked = tensor.cast %result_out : tensor<1x12x1x128xf32> to tensor<*xf32>
   // call @printMemrefF32(%tensor_unranked) : (tensor<*xf32>) -> ()

--- a/examples/BuddyNext/next-linalg-matmul-decode.mlir
+++ b/examples/BuddyNext/next-linalg-matmul-decode.mlir
@@ -71,7 +71,7 @@ module {
     %5 = call @rtclock() : () -> f64
     %6 = arith.subf %5, %0 : f64
     vector.print %6 : f64
-    // CHECK: {{[0-9]+\.[0-9]+}}
+    // CHECK: {{[0-9]+}}
     return %c : memref<1x1536xf32>
   }
   func.func @main() {

--- a/examples/BuddyNext/next-linalg-matmul.mlir
+++ b/examples/BuddyNext/next-linalg-matmul.mlir
@@ -59,7 +59,7 @@ module {
     %t_end = call @rtclock() : () -> f64
     %time = arith.subf %t_end, %t_start : f64
     vector.print %time : f64
-    // CHECK: {{[0-9]+\.[0-9]+}}
+    // CHECK: {{[0-9]+}}
     return %273 : tensor<1x1536xf32>
   }
 

--- a/examples/BuddyNext/next-lm-head.mlir
+++ b/examples/BuddyNext/next-lm-head.mlir
@@ -94,7 +94,7 @@ func.func @main() {
   // call @printMemrefF32(%tensor_unranked) : (tensor<*xf32>) -> ()
 
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
   return
 }
 func.func private @printMemrefF32(%ptr : tensor<*xf32>)

--- a/examples/BuddyNext/next-matmul-transpose-op.mlir
+++ b/examples/BuddyNext/next-matmul-transpose-op.mlir
@@ -34,7 +34,7 @@ func.func @kernel(%a : tensor<1024x1536xf32>, %b : tensor<1536x1536xf32>, %c : t
   %time = arith.subf %t_end, %t_start : f64
   // Print timings.
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
   return %137 : tensor<1024x1536xf32>
 }
 

--- a/examples/BuddyNext/next-matmul-transpose.mlir
+++ b/examples/BuddyNext/next-matmul-transpose.mlir
@@ -33,7 +33,7 @@ func.func @kernel(%a : tensor<1024x1536xf32>, %b : tensor<1536x1536xf32>, %c : t
   %time = arith.subf %t_end, %t_start : f64
   // Print timings.
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
   return %52 : tensor<1024x1536xf32>
 }
 

--- a/examples/BuddyNext/next-mhsa-context.mlir
+++ b/examples/BuddyNext/next-mhsa-context.mlir
@@ -58,7 +58,7 @@ func.func @kernel(%arg0: tensor<1536x1536xf32>, %arg1: tensor<1x1024x1536xf32>, 
 
   // Print timings.
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
 
   return %160 : tensor<1x1024x1536xf32>
 }

--- a/examples/BuddyNext/next-mhsa-core.mlir
+++ b/examples/BuddyNext/next-mhsa-core.mlir
@@ -90,7 +90,7 @@ func.func @kernel(%arg0: tensor<1x1x1024x1024xf32>, %arg1: tensor<1x1x1024x1024x
 
   // Print timings.
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
 
   return %154 : tensor<1x1024x1536xf32>
 }

--- a/examples/BuddyNext/next-mhsa-qkv.mlir
+++ b/examples/BuddyNext/next-mhsa-qkv.mlir
@@ -139,7 +139,7 @@ func.func @kernel(%arg0: tensor<1x1024x1536xf32>, %arg1: tensor<1536xf32>, %arg2
 
   // Print timings.
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
 
   return %113, %124, %129 : tensor<1x12x1024x128xf32>, tensor<1x12x1024x128xf32>, tensor<1x12x1024x128xf32>
 }

--- a/examples/BuddyNext/next-mmtb-sgemm-unroll-vec.mlir
+++ b/examples/BuddyNext/next-mmtb-sgemm-unroll-vec.mlir
@@ -166,7 +166,7 @@ module {
     %t_end = call @rtclock() : () -> f64
     %time = arith.subf %t_end, %t_start : f64
     vector.print %time : f64
-    // CHECK: {{[0-9]+\.[0-9]+}}
+    // CHECK: {{[0-9]+}}
     return
   }
 

--- a/examples/BuddyNext/next-mmtb.mlir
+++ b/examples/BuddyNext/next-mmtb.mlir
@@ -29,7 +29,7 @@ module {
     %t_end = call @rtclock() : () -> f64
     %time = arith.subf %t_end, %t_start : f64
     vector.print %time : f64
-    // CHECK: {{[0-9]+\.[0-9]+}}
+    // CHECK: {{[0-9]+}}
     return
   }
 

--- a/examples/BuddyNext/next-no-reshape.mlir
+++ b/examples/BuddyNext/next-no-reshape.mlir
@@ -57,7 +57,7 @@ func.func @kernel(%arg0: tensor<1536x8960xf32>, %arg1: tensor<1024x1536xf32>, %a
 
   // Print timings.
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
 
   return %177 : tensor<1024x8960xf32>
 }

--- a/examples/BuddyNext/next-norm.mlir
+++ b/examples/BuddyNext/next-norm.mlir
@@ -74,7 +74,7 @@ func.func @kernel(%arg0: tensor<1x1x1536xf32>, %arg1: tensor<1x1x1536xf32>, %arg
 
   // Print timings.
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
 
   return %146 : tensor<1x1x1536xf32>
 }

--- a/examples/BuddyNext/next-output.mlir
+++ b/examples/BuddyNext/next-output.mlir
@@ -63,7 +63,7 @@ func.func @kernel(%arg0: tensor<151936x1536xf32>, %arg1: tensor<1x1024x1536xf32>
 
   // Print timings.
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
 
   return %3963 : tensor<1x1024x151936xf32>
 }

--- a/examples/BuddyNext/next-positional-encoding.mlir
+++ b/examples/BuddyNext/next-positional-encoding.mlir
@@ -161,7 +161,7 @@ func.func @kernel(%arg0 : tensor<1x1024xi64>, %arg1 : tensor<64xf32>) -> (tensor
 
   // Print timings.
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
 
   return %51, %53 : tensor<1x1024x128xf32>, tensor<1x1024x128xf32>
 }

--- a/examples/BuddyNext/next-reshape.mlir
+++ b/examples/BuddyNext/next-reshape.mlir
@@ -59,7 +59,7 @@ func.func @kernel(%arg0: tensor<1536x8960xf32>, %arg1: tensor<1x1024x1536xf32>, 
 
   // Print timings.
   vector.print %time : f64
-  // CHECK: {{[0-9]+\.[0-9]+}}
+  // CHECK: {{[0-9]+}}
 
   return %177 : tensor<1024x8960xf32>
 }

--- a/examples/BuddyNext/next-sgemm-unroll-vec-aligned.mlir
+++ b/examples/BuddyNext/next-sgemm-unroll-vec-aligned.mlir
@@ -185,7 +185,7 @@ module {
     %t_end = call @rtclock() : () -> f64
     %time = arith.subf %t_end, %t_start : f64
     vector.print %time : f64
-    // CHECK: {{[0-9]+\.[0-9]+}}
+    // CHECK: {{[0-9]+}}
     return
   }
 

--- a/examples/BuddyNext/next-sgemm-unroll-vec-fixed.mlir
+++ b/examples/BuddyNext/next-sgemm-unroll-vec-fixed.mlir
@@ -176,7 +176,7 @@ module {
     %t_end = call @rtclock() : () -> f64
     %time = arith.subf %t_end, %t_start : f64
     vector.print %time : f64
-    // CHECK: {{[0-9]+\.[0-9]+}}
+    // CHECK: {{[0-9]+}}
     return
   }
 

--- a/examples/BuddyNext/next-sgemm-unroll-vec-scalable.mlir
+++ b/examples/BuddyNext/next-sgemm-unroll-vec-scalable.mlir
@@ -180,7 +180,7 @@ module {
 
     %t_end = call @rtclock() : () -> f64
     %time = arith.subf %t_end, %t_start : f64
-    // CHECK: {{[0-9]+.[0-9]+}}
+    // CHECK: {{[0-9]+}}
     vector.print %time : f64
     return
   }

--- a/examples/BuddyNext/next-sgemm.mlir
+++ b/examples/BuddyNext/next-sgemm.mlir
@@ -30,7 +30,7 @@ module {
     %t_end = call @rtclock() : () -> f64
     %time = arith.subf %t_end, %t_start : f64
     vector.print %time : f64
-    // CHECK: {{[0-9]+\.[0-9]+}}
+    // CHECK: {{[0-9]+}}
     return
   }
 

--- a/examples/BuddyNext/next-tosa-matmul-manual.mlir
+++ b/examples/BuddyNext/next-tosa-matmul-manual.mlir
@@ -70,7 +70,7 @@ module {
     %4 = call @rtclock() : () -> f64
     %5 = arith.subf %4, %0 : f64
     vector.print %5 : f64
-    // CHECK: {{[0-9]+\.[0-9]+}}
+    // CHECK: {{[0-9]+}}
     return %output : memref<12x1x128xf32>
   }
   func.func @main() {

--- a/examples/BuddyNext/next-tosa-matmul.mlir
+++ b/examples/BuddyNext/next-tosa-matmul.mlir
@@ -51,7 +51,7 @@ module {
     %t_end = call @rtclock() : () -> f64
     %time = arith.subf %t_end, %t_start : f64
     vector.print %time : f64
-    // CHECK: {{[0-9]+\.[0-9]+}}
+    // CHECK: {{[0-9]+}}
     return %res : tensor<12x1x128xf32>
   }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,19 @@
---pre --extra-index-url https://download.pytorch.org/whl/cpu
+--extra-index-url https://download.pytorch.org/whl/cpu
+--extra-index-url https://ruyirepo.ruyicommunity.cn/pypi/simple/
 torch==2.10.0
-# The meson-python required by numpy==2.5 say:
-# "meson-python: error: The package requires Python version >=3.12, running on 3.11.6"
-# Maybe we should drop python<=3.11 support
-numpy>=2,<2.5
+# NumPy 2.3+ requires Python >=3.11, while release wheels still include cp310.
+numpy>=2,<2.3; python_version<"3.11"
+numpy>=2,<2.5; python_version>="3.11"
 transformers==5.5.0
 tokenizers>=0.20
-sentencepiece==0.2.0
+sentencepiece>=0.2
 accelerate
 protobuf
-torchvision
+torchvision; platform_machine != "riscv64"
 tabulate
-datasets
+datasets; platform_machine != "riscv64"
 soundfile
-librosa
+librosa; platform_machine != "riscv64"
 PyYAML
 certifi
 idna

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -154,7 +154,6 @@ if [ -z "${IN_DOCKER:-}" ]; then
     -e BUDDY_HASH="${BUDDY_HASH}" \
     -e LLVM_HASH="${LLVM_HASH}" \
     -e MANYLINUX_TAG="${MANYLINUX_TAG}" \
-    -e BUDDY_TORCH_SPEC="${BUDDY_TORCH_SPEC:-torch}" \
     \
     -v "${REPO_ROOT}:${WORKSPACE}" \
     -v "${HOST_LLVM_SRC}:${WORKSPACE_LLVM_SRC}:ro" \
@@ -179,8 +178,6 @@ else
     shopt -s globstar nullglob
     rm -rf "${WORKSPACE}"/**/__pycache__ "${WORKSPACE}"/**/*.py[co]
     shopt -u globstar nullglob
-    # TODO: move .py-stage to other place so that we can make ${WORKSPACE} read-only
-    [ -e "${WORKSPACE}/.py-stage" ] && chown -R "$HOST_UID":"$HOST_GID" "${WORKSPACE}"
     [ -e "${BUDDY_BUILD_ROOT}" ] && chown -R "$HOST_UID":"$HOST_GID" "${BUDDY_BUILD_ROOT}"
     [ -e "${LLVM_BUILD_ROOT}" ] && chown -R "$HOST_UID":"$HOST_GID" "${LLVM_BUILD_ROOT}"
   }
@@ -246,7 +243,7 @@ else
   # ---------------------------------------------------------------------------
 
   # Install image deps via dnf.
-  DNF_INSTALL_ARGS=(install -y)
+  DNF_INSTALL_ARGS=(--setopt=keepcache=1 install -y)
   if [ "${TARGET_ARCH}" = "riscv64" ]; then
     # Rocky 10 riscv64 metadata can briefly prefer a libpng-devel build before
     # every mirror has the matching libpng runtime package. --nobest lets dnf
@@ -257,33 +254,39 @@ else
   # Prepare serval necessary package for buddy-mlir
   dnf "${DNF_INSTALL_ARGS[@]}" cmake libpng-devel libjpeg-turbo-devel zlib-devel perl
 
-  # Prepare ccache if support, riscv doesn't support
-  if dnf install -y ccache; then
-    export CCACHE_BIN="/usr/bin/ccache"
-    CCACHE_LINK_DIR="/usr/lib64/ccache"
-    mkdir -p "$CCACHE_LINK_DIR"
-    # To help CMake use ccache, there are two methods:
-    # - One is to explicitly specify `-DCMAKE_CXX_COMPILER_LAUNCHER=ccache`
-    # - the other is to place the symbolic links `cc` and `c++` created by
-    #   ccache at the beginning of the path.
-    # Since the RISC-V image does not provide ccache, we now temporarily choose
-    # the second method.
-    CCACHE_COMPILERS=(gcc g++ cc c++)
-    case "${TARGET_ARCH}" in
-      x86_64)
-        CCACHE_COMPILERS+=(x86_64-redhat-linux-gcc x86_64-redhat-linux-g++)
-        ;;
-      riscv64)
-        CCACHE_COMPILERS+=(riscv64-redhat-linux-gcc riscv64-redhat-linux-g++)
-        ;;
-    esac
-    for cmd in "${CCACHE_COMPILERS[@]}"; do
-      ln -sf "$CCACHE_BIN" "$CCACHE_LINK_DIR/$cmd"
-    done
-    export PATH="$CCACHE_LINK_DIR:$PATH"
-    export CCACHE_DIR="${WORKSPACE_BUILD_DIR}/.ccache"
-    ccache -M 50G
-  fi
+  # Prepare ccache.
+  case "${TARGET_ARCH}" in
+    x86_64)
+      dnf "${DNF_INSTALL_ARGS[@]}" ccache
+      export CCACHE_BIN="/usr/bin/ccache"
+      ;;
+    riscv64)
+      CCACHE_VERSION="4.13.6"
+      CCACHE_ARCHIVE="ccache-${CCACHE_VERSION}-linux-riscv64-musl-static.tar.gz"
+      CCACHE_URL="https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/${CCACHE_ARCHIVE}"
+      curl -L --fail -o "/tmp/${CCACHE_ARCHIVE}" "${CCACHE_URL}"
+      tar -xzf "/tmp/${CCACHE_ARCHIVE}" -C /tmp
+      export CCACHE_BIN="/tmp/ccache-${CCACHE_VERSION}-linux-riscv64-musl-static/ccache"
+      ;;
+  esac
+  CCACHE_LINK_DIR="/usr/lib64/ccache"
+  mkdir -p "$CCACHE_LINK_DIR"
+  CCACHE_COMPILERS=(gcc g++ cc c++)
+  case "${TARGET_ARCH}" in
+    x86_64)
+      CCACHE_COMPILERS+=(x86_64-redhat-linux-gcc x86_64-redhat-linux-g++)
+      ;;
+    riscv64)
+      CCACHE_COMPILERS+=(riscv64-redhat-linux-gcc riscv64-redhat-linux-g++)
+      ;;
+  esac
+  for cmd in "${CCACHE_COMPILERS[@]}"; do
+    ln -sf "$CCACHE_BIN" "$CCACHE_LINK_DIR/$cmd"
+  done
+  ln -sf "$CCACHE_BIN" "$CCACHE_LINK_DIR/ccache"
+  export PATH="$CCACHE_LINK_DIR:$PATH"
+  export CCACHE_DIR="${WORKSPACE_BUILD_DIR}/.ccache"
+  ccache -M 50G
 
   # Flatbuffer doesn't exist in riscv image.
   FLATBUFFERS_VERSION="25.12.19"
@@ -292,6 +295,8 @@ else
     mkdir build && cd build
     cmake .. \
       -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       -DFLATBUFFERS_BUILD_TESTS=OFF \
       -DFLATBUFFERS_INSTALL=ON \
       -DCMAKE_POSITION_INDEPENDENT_CODE=ON
@@ -302,18 +307,11 @@ else
   # This is necessary, old pip versions fail to resolve the torch package correctly.
   "$PYBIN" -m pip install --upgrade pip
   "$PYBIN" -m pip --version
-  "$PYBIN" -m pip install build auditwheel ninja pybind11==2.10.* nanobind==2.9.* PyYAML tabulate
-  BUDDY_TORCH_SPEC="${BUDDY_TORCH_SPEC:-torch}"
   if [ "${TARGET_ARCH}" = "riscv64" ]; then
     # build transformers need rust toolchain.
-    dnf install -y rust cargo
-    # build transformers from source need torch
-    "$PYBIN" -m pip install -i https://ruyirepo.ruyicommunity.cn/pypi/simple/ numpy "${BUDDY_TORCH_SPEC}"
-  else
-    "$PYBIN" -m pip install numpy
-    "$PYBIN" -m pip install --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple "${BUDDY_TORCH_SPEC}"
+    dnf "${DNF_INSTALL_ARGS[@]}" rust cargo
   fi
-  "$PYBIN" -m pip install transformers==4.56.2
+  "$PYBIN" -m pip install build auditwheel ninja -r requirements.txt
   PYTHON_SOABI="$("$PYBIN" -c 'import sysconfig; print(sysconfig.get_config_var("SOABI") or "")')"
 
   LLVM_STAMP_FILE="${LLVM_BUILD_DIR}/.manylinux-llvm-ready"

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,10 @@ if not PYTHON_PACKAGES_DIR.exists():
         "before building the wheel (default build dir: ./build)."
     )
 
-# Stage into the repository because setuptools rejects absolute package_dir
-# paths here, so .py-stage cannot live in an arbitrary external build path.
-STAGING_ROOT = ROOT / ".py-stage"
+# Stage under the CMake build tree. Docker release builds run as root, so
+# staging inside the checked-out repository can leave root-owned files that the
+# next actions/checkout cannot clean up on self-hosted runners.
+STAGING_ROOT = CMAKE_BUILD / ".py-stage"
 if STAGING_ROOT.exists():
     shutil.rmtree(STAGING_ROOT)
 STAGING_ROOT.mkdir(parents=True, exist_ok=True)
@@ -147,11 +148,6 @@ ENTRY_POINTS = {
 }
 
 
-def _resolve_install_requires() -> list[str]:
-    """No hard pin from build env."""
-    return []
-
-
 class build(_build):
     def initialize_options(self):
         super().initialize_options()
@@ -181,7 +177,6 @@ setup(
     include_package_data=True,
     cmdclass={"build_py": build_py, "build": build, "bdist_wheel": bdist_wheel},
     distclass=BinaryDistribution,
-    install_requires=_resolve_install_requires(),
     entry_points=ENTRY_POINTS,
     zip_safe=False,
 )


### PR DESCRIPTION
## Summary

Fixed various dependency installation issues. Now, both x86 and riscv can install dependencies directly via `pip install -r requirements.txt`. Of course, using `uv pip` is also supported. Given that uv is faster and supports different Python versions (rather than being limited to the system Python), we might switch to uv for CI (uv also supports riscv!) in the future to maintain a unified Python version across platforms.

Regarding Python version support, the project will currently follow the officially supported Python versions. For instance, the version currently maintained by the core team is 3.10.
see https://devguide.python.org/versions/

## Checklist

- [x] The code builds successfully
- [x] Existing tests pass
- [x] New tests are added where appropriate
- [x] Code follows the project coding style
- [x] Documentation is updated if needed
