### PR TITLE
Fix the issue of decoding inference segment errors in the deepseek_r1…

### DIFF
--- a/tools/buddy-codegen/gen_session.py
+++ b/tools/buddy-codegen/gen_session.py
@@ -324,6 +324,7 @@ def gen_impl_tiered(config: dict) -> str:
 
     cache_count = len(cache_sizes)
     cache_size_list = ", ".join(str(x) for x in cache_sizes)
+    dummy_groups = kv_layers // 2 - 1
     weight_ptr_types = ", ".join(
         f"MemRef<{w['cpp_type']}, 1> *" for w in weights
     )
@@ -377,8 +378,25 @@ def gen_impl_tiered(config: dict) -> str:
     p("} // namespace")
     p()
 
+    p("using Dummy1Ref = MemRef<long long, 1>;")
     p(f"using KV4Ref = {kv_memref};")
     p(f"using Logits3Ref = {logits_memref};")
+    p()
+    p("struct DecodeKVGroup {")
+    p("  alignas(Dummy1Ref) char dummy_[sizeof(Dummy1Ref)];")
+    p("  alignas(KV4Ref) char kv0_[sizeof(KV4Ref)];")
+    p("  alignas(KV4Ref) char kv1_[sizeof(KV4Ref)];")
+    p()
+    p("  Dummy1Ref &dummy() {")
+    p("    return *std::launder(reinterpret_cast<Dummy1Ref *>(dummy_));")
+    p("  }")
+    p("  KV4Ref &kv0() {")
+    p("    return *std::launder(reinterpret_cast<KV4Ref *>(kv0_));")
+    p("  }")
+    p("  KV4Ref &kv1() {")
+    p("    return *std::launder(reinterpret_cast<KV4Ref *>(kv1_));")
+    p("  }")
+    p("};")
     p()
     p("struct PrefillABI {")
     p(f"  alignas({kv_memref}) char kv_[sizeof({kv_memref}) *")
@@ -396,12 +414,28 @@ def gen_impl_tiered(config: dict) -> str:
     p("};")
     p()
     p("struct DecodeABI {")
-    p(f"  alignas(KV4Ref) char kv_[sizeof(KV4Ref) * {mp}_KV_LAYERS];")
+    p("  alignas(Dummy1Ref) char cache_position_out_[sizeof(Dummy1Ref)];")
+    p("  alignas(KV4Ref) char kv0_[sizeof(KV4Ref)];")
+    p("  alignas(KV4Ref) char kv1_[sizeof(KV4Ref)];")
+    p(f"  DecodeKVGroup groups_[{dummy_groups}];")
     p("  alignas(Logits3Ref) char logits_[sizeof(Logits3Ref)];")
     p()
+    p("  Dummy1Ref &cachePositionOut() {")
+    p(
+        "    return *std::launder("
+        "reinterpret_cast<Dummy1Ref *>(cache_position_out_));"
+    )
+    p("  }")
+    p("  Dummy1Ref &dummy(int i) { return groups_[i].dummy(); }")
     p("  KV4Ref &kv(int i) {")
-    p("    return *std::launder(reinterpret_cast<KV4Ref *>(")
-    p("        kv_ + i * sizeof(KV4Ref)));")
+    p("    if (i == 0)")
+    p("      return *std::launder(reinterpret_cast<KV4Ref *>(kv0_));")
+    p("    if (i == 1)")
+    p("      return *std::launder(reinterpret_cast<KV4Ref *>(kv1_));")
+    p("    int group = (i - 2) / 2;")
+    p(
+        "    return ((i - 2) % 2 == 0) ? groups_[group].kv0() : groups_[group].kv1();"
+    )
     p("  }")
     p("  Logits3Ref &logits() {")
     p("    return *std::launder(reinterpret_cast<Logits3Ref *>(logits_));")
@@ -412,13 +446,17 @@ def gen_impl_tiered(config: dict) -> str:
         f"using PrefillFn = void (*)(PrefillABI *, {weight_ptr_types}, Text<size_t, 2> *);"
     )
     p("using KV4 = KV4Ref *;")
+    p("using Dummy1 = Dummy1Ref *;")
     decode_sig_parts = [
         "DecodeABI *",
         *[f"MemRef<{w['cpp_type']}, 1> *" for w in weights],
         "MemRef<long long, 2> *",
         "MemRef<long long, 1> *",
+        "KV4",
+        "KV4",
     ]
-    decode_sig_parts.extend(["KV4" for _i in range(kv_layers)])
+    for _i in range(dummy_groups):
+        decode_sig_parts.extend(["Dummy1", "KV4", "KV4"])
     p("using DecodeFn = void (*)(")
     line = "    "
     for idx, part in enumerate(decode_sig_parts):
@@ -464,7 +502,11 @@ def gen_impl_tiered(config: dict) -> str:
         call_parts.append(w["tag"])
     call_parts.append("decodeTokenInput")
     call_parts.append("cachePosition")
-    call_parts.extend(f"&a.kv({i})" for i in range(kv_layers))
+    call_parts.extend(["&a.kv(0)", "&a.kv(1)"])
+    for i in range(dummy_groups):
+        call_parts.extend(
+            [f"&a.dummy({i})", f"&a.kv({2 + i * 2})", f"&a.kv({3 + i * 2})"]
+        )
     p("  fn(")
     line = "      "
     for idx, part in enumerate(call_parts):
@@ -497,6 +539,9 @@ def gen_impl_tiered(config: dict) -> str:
     p(f"        for (int i = 0; i < {mp}_KV_LAYERS; ++i)")
     p("          prefillAbi[slot].kv(i).~KV4Ref();")
     p("        prefillAbi[slot].logits().~Logits3Ref();")
+    p("        decodeAbi[slot].cachePositionOut().~Dummy1Ref();")
+    p(f"        for (int i = 0; i < {dummy_groups}; ++i)")
+    p("          decodeAbi[slot].dummy(i).~Dummy1Ref();")
     p(f"        for (int i = 0; i < {mp}_KV_LAYERS; ++i)")
     p("          decodeAbi[slot].kv(i).~KV4Ref();")
     p("        decodeAbi[slot].logits().~Logits3Ref();")
@@ -582,9 +627,17 @@ def gen_impl_tiered(config: dict) -> str:
     p("  for (int slot = 0; slot < kTieredCacheCount; ++slot) {")
     p("    int cacheLen = kTieredCacheSizes[slot];")
     p("    intptr_t kvShape[4] = {1, cfg_.headNum, cacheLen, cfg_.hiddenSize};")
+    p(
+        "    new (&impl_->decodeAbi[slot].cachePositionOut()) Dummy1Ref(pshape, 0LL);"
+    )
+    p("    impl_->decodeAbi[slot].cachePositionOut().getData()[0] = 0LL;")
     p(f"    for (int i = 0; i < {mp}_KV_LAYERS; ++i) {{")
     p("      new (&impl_->prefillAbi[slot].kv(i)) KV4Ref(kvShape, 0.0f);")
     p("      new (&impl_->decodeAbi[slot].kv(i)) KV4Ref(kvShape, 0.0f);")
+    p("    }")
+    p(f"    for (int i = 0; i < {dummy_groups}; ++i) {{")
+    p("      new (&impl_->decodeAbi[slot].dummy(i)) Dummy1Ref(pshape, 0LL);")
+    p("      impl_->decodeAbi[slot].dummy(i).getData()[0] = 0LL;")
     p("    }")
     p("    intptr_t prefillLogitsShape[3] = {1, cacheLen, cfg_.vocabSize};")
     p("    new (&impl_->prefillAbi[slot].logits())")
@@ -672,6 +725,8 @@ def gen_impl_tiered(config: dict) -> str:
     p("  decodeTokenInput_->getData()[0] = (long long)tokenId;")
     p("  cachePosition_->getData()[0] = (long long)position_;")
     p("  auto &a = impl_->decodeAbi[impl_->activeSlot];")
+    p(f"  for (int i = 0; i < {dummy_groups}; ++i)")
+    p("    a.dummy(i).getData()[0] = (long long)position_;")
     p(
         f"  callDecodeFn(impl_->decodeFns[impl_->activeSlot], a, {weight_addrs_internal},"
     )
@@ -832,8 +887,11 @@ def gen_impl(config: dict) -> str:
     )
     p("//")
     p("// _mlir_ciface_forward_decode writes:")
-    p(f"//   [kv0..kv{kv_layers - 1} : {kv_memref} x {kv_layers}]")
-    p(f"//   [logits : {logits_memref}]")
+    p("//   [cache_position_out : MemRef<long long, 1>]")
+    p(
+        f"//   [kv0][kv1][dummy0][kv2][kv3][dummy1] ... "
+        f"[kv{kv_layers - 2}][kv{kv_layers - 1}][logits]"
+    )
     p("//")
     p(
         "// Because MemRef<T,N>() is protected, we store these objects in char arrays"
@@ -849,6 +907,22 @@ def gen_impl(config: dict) -> str:
     p("using Dummy1Ref = MemRef<long long, 1>;")
     p(f"using KV4Ref = {kv_memref};")
     p(f"using Logits3Ref = {logits_memref};")
+    p()
+    p("struct DecodeKVGroup {")
+    p("  alignas(Dummy1Ref) char dummy_[sizeof(Dummy1Ref)];")
+    p("  alignas(KV4Ref) char kv0_[sizeof(KV4Ref)];")
+    p("  alignas(KV4Ref) char kv1_[sizeof(KV4Ref)];")
+    p()
+    p("  Dummy1Ref &dummy() {")
+    p("    return *std::launder(reinterpret_cast<Dummy1Ref *>(dummy_));")
+    p("  }")
+    p("  KV4Ref &kv0() {")
+    p("    return *std::launder(reinterpret_cast<KV4Ref *>(kv0_));")
+    p("  }")
+    p("  KV4Ref &kv1() {")
+    p("    return *std::launder(reinterpret_cast<KV4Ref *>(kv1_));")
+    p("  }")
+    p("};")
     p()
     p("struct PrefillABI {")
     p(f"  alignas({kv_memref}) char kv_[sizeof({kv_memref}) *")
@@ -867,12 +941,28 @@ def gen_impl(config: dict) -> str:
     p("};")
     p()
     p("struct DecodeABI {")
-    p(f"  alignas(KV4Ref) char kv_[sizeof(KV4Ref) * {mp}_KV_LAYERS];")
+    p("  alignas(Dummy1Ref) char cache_position_out_[sizeof(Dummy1Ref)];")
+    p("  alignas(KV4Ref) char kv0_[sizeof(KV4Ref)];")
+    p("  alignas(KV4Ref) char kv1_[sizeof(KV4Ref)];")
+    p(f"  DecodeKVGroup groups_[{dummy_groups}];")
     p("  alignas(Logits3Ref) char logits_[sizeof(Logits3Ref)];")
     p()
+    p("  Dummy1Ref &cachePositionOut() {")
+    p(
+        "    return *std::launder("
+        "reinterpret_cast<Dummy1Ref *>(cache_position_out_));"
+    )
+    p("  }")
+    p("  Dummy1Ref &dummy(int i) { return groups_[i].dummy(); }")
     p("  KV4Ref &kv(int i) {")
-    p("    return *std::launder(reinterpret_cast<KV4Ref *>(")
-    p("        kv_ + i * sizeof(KV4Ref)));")
+    p("    if (i == 0)")
+    p("      return *std::launder(reinterpret_cast<KV4Ref *>(kv0_));")
+    p("    if (i == 1)")
+    p("      return *std::launder(reinterpret_cast<KV4Ref *>(kv1_));")
+    p("    int group = (i - 2) / 2;")
+    p(
+        "    return ((i - 2) % 2 == 0) ? groups_[group].kv0() : groups_[group].kv1();"
+    )
     p("  }")
     p("  Logits3Ref &logits() {")
     p("    return *std::launder(reinterpret_cast<Logits3Ref *>(logits_));")
@@ -899,15 +989,20 @@ def gen_impl(config: dict) -> str:
     p()
 
     kv4 = "KV4Ref *"
+    dummy1 = "Dummy1Ref *"
     p(f"using KV4 = {kv4};")
+    p(f"using Dummy1 = {dummy1};")
     p()
     decode_sig_parts = [
         "DecodeABI *",
         *[f"MemRef<{w['cpp_type']}, 1> *" for w in weights],
         "MemRef<long long, 2> *",
         "MemRef<long long, 1> *",
+        "KV4",
+        "KV4",
     ]
-    decode_sig_parts.extend(["KV4" for _i in range(kv_layers)])
+    for _i in range(dummy_groups):
+        decode_sig_parts.extend(["Dummy1", "KV4", "KV4"])
     p("using DecodeFn = void (*)(")
     line = "    "
     for idx, part in enumerate(decode_sig_parts):


### PR DESCRIPTION
… model

Assisted-by : OpenAI Codex

## Summary
In the actual signature of forward_decode.mlir, many memref<1xi64> dummy/cache_position parameters are interleaved among the KV parameters, but the currently generated ModelSession.cpp defines DecodeFn and its call with 27 intermediate MemRef<long long, 1> dummy parameters missing.

## Checklist

- [x] The code builds successfully
- [x] Code follows the project coding style
