### PR TITLE
[models] Add Whisper (encoder-decoder ASR) as a buddy-cli/.rax model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,13 @@ if(BUDDY_ENABLE_TENSTORRENT)
   endif()
 endif()
 
+# Whisper (buddy-codegen, encoder-decoder ASR): import → .so / .rax + runner
+# plugin loaded by buddy-cli. Off by default; enable with
+# -DBUDDY_BUILD_WHISPER_MODEL=ON (requires BUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON).
+option(BUDDY_BUILD_WHISPER_MODEL
+  "Build models/whisper (whisper_model.so, whisper.rax, whisper_runner.so)"
+  OFF)
+
 set(_buddy_require_jpeg OFF)
 set(_buddy_require_png OFF)
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ python3 tools/buddy-codegen/build_model.py \
   --build-dir build
 ```
 
+For Whisper, use the same build entry point with the Whisper spec:
+
+```bash
+python3 tools/buddy-codegen/build_model.py \
+  --spec models/whisper/specs/base.json \
+  --build-dir build
+```
+
 For supported models, the default build uses layer-partitioned model
 compilation to parallelize the slowest MLIR compile stages while preserving
 validated runtime correctness. See
@@ -140,6 +148,14 @@ python3 tools/buddy-codegen/build_model.py \
   --cpus 0-47 \
   --model ./build/models/deepseek_r1/deepseek_r1.rax \
   --prompt "Tell me a joke in 200 words."
+```
+
+Whisper uses the same `.rax` / `buddy-cli` deployment path, with an audio input:
+
+```bash
+./build/bin/buddy-cli \
+  --model ./build/models/whisper/whisper.rax \
+  --audio ./build/models/whisper/audio.wav
 ```
 
 ## Build Python Package

--- a/frontend/Python/ops/tosa.py
+++ b/frontend/Python/ops/tosa.py
@@ -3720,18 +3720,9 @@ def convolution2d_op(node: Conv2dOp, symbol_table):
                 result_element_type,
             )
 
-            pad_values = ir.DenseElementsAttr.get(
-                numpy.array(
-                    [0, 0, 0, 0, input_padding[0], input_padding[0]],
-                    dtype=numpy.int64,
-                )
+            pad_constant = _create_shape_operand(
+                [0, 0, 0, 0, input_padding[0], input_padding[0]]
             )
-            pad_tensor_type = ir.RankedTensorType.get([6], ir.IndexType.get())
-            pad_values_attr = ir.DenseElementsAttr.get(
-                pad_values, type=pad_tensor_type
-            )
-            shape_type = ir.Type.parse("!tosa.shape<6>")
-            pad_constant = tosa.const_shape(shape_type, pad_values_attr)
             ty = ir.Type.parse("tensor<1xf32>")
             pad_zp = tosa.ConstOp(
                 ir.DenseElementsAttr.get_splat(ty, ir.FloatAttr.get_f32(0.0))

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -1,6 +1,11 @@
 if(BUDDY_BUILD_DEEPSEEK_R1_MODEL)
   add_subdirectory(deepseek_r1)
 endif()
+
 if(BUDDY_BUILD_LLAMA31_TT_MODEL OR BUDDY_BUILD_LLAMA32_TT_MODEL)
   add_subdirectory(llama31_tt)
+endif()
+
+if(BUDDY_BUILD_WHISPER_MODEL)
+  add_subdirectory(whisper)
 endif()

--- a/models/whisper/CMakeLists.txt
+++ b/models/whisper/CMakeLists.txt
@@ -1,0 +1,221 @@
+# ══════════════════════════════════════════════════════════════════════════════
+# Whisper (encoder-decoder ASR) — buddy-cli / .rax integration
+#
+# Self-contained build (does NOT use tools/buddy-codegen/buddy_add_model, which is
+# specialized for LLM prefill/decode + KV cache).  Produces the same runtime
+# contract as models/deepseek_r1:
+#
+#   whisper_model.so   compiled MLIR kernels (exports _mlir_ciface_forward)
+#   whisper_runner.so  InferenceRunner plugin (dlopen'd by buddy-cli)
+#   whisper.rax        RHAL manifest (weights + model.so embedded as payload)
+#   vocab.txt          tokenizer vocab (resolved file: relative to the .rax)
+#   audio.wav          sample input (convenience; pass via --audio)
+#
+# Run:  buddy-cli --model whisper.rax --audio audio.wav
+# ══════════════════════════════════════════════════════════════════════════════
+
+set(WHISPER_DIR        "${CMAKE_CURRENT_SOURCE_DIR}")
+set(WHISPER_CODEGEN    "${WHISPER_DIR}/codegen")
+set(WHISPER_SPEC       "${WHISPER_DIR}/specs/base.json")
+set(WHISPER_EXAMPLE    "${CMAKE_SOURCE_DIR}/examples/BuddyWhisper")
+set(BIN                "${CMAKE_CURRENT_BINARY_DIR}")
+
+# OpenMP runtime (libomp.so) lives under the LLVM runtimes build tree, not in
+# ${LLVM_LIBRARY_DIR}. Mirror examples/CMakeLists.txt so -lomp resolves.
+get_filename_component(WHISPER_LLVM_BUILD_DIR "${LLVM_LIBRARY_DIR}" DIRECTORY)
+set(WHISPER_OMP_DIR
+  "${WHISPER_LLVM_BUILD_DIR}/runtimes/runtimes-bins/openmp/runtime/src")
+
+# Optional local HF snapshot; when set it is exported as WHISPER_MODEL_PATH so the
+# importer loads weights from disk instead of downloading openai/whisper-base.
+set(BUDDY_WHISPER_MODEL_PATH "" CACHE PATH
+  "Local HuggingFace whisper snapshot dir (sets WHISPER_MODEL_PATH for import)")
+
+if(NOT Python3_EXECUTABLE)
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+endif()
+
+# ── Stage 1: import PyTorch model → forward.mlir / subgraph0.mlir / arg0.data ──
+if(NOT BUDDY_MLIR_ENABLE_PYTHON_PACKAGES)
+  message(FATAL_ERROR
+    "models/whisper: PyTorch→MLIR import needs the Buddy Python package under "
+    "build/python_packages. Re-configure with -DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON.")
+endif()
+
+set(WHISPER_PY_PKG_ROOT "${CMAKE_BINARY_DIR}/python_packages")
+if(BUDDY_WHISPER_MODEL_PATH)
+  set(WHISPER_IMPORT_ENV ${CMAKE_COMMAND} -E env
+      "PYTHONPATH=${WHISPER_PY_PKG_ROOT}"
+      "WHISPER_MODEL_PATH=${BUDDY_WHISPER_MODEL_PATH}")
+else()
+  set(WHISPER_IMPORT_ENV ${CMAKE_COMMAND} -E env
+      "PYTHONPATH=${WHISPER_PY_PKG_ROOT}")
+endif()
+
+set(WHISPER_IMPORT_DEPS
+  "${WHISPER_CODEGEN}/import-whisper.py" "${WHISPER_SPEC}")
+if(TARGET python-package-buddy)
+  list(APPEND WHISPER_IMPORT_DEPS python-package-buddy)
+endif()
+
+add_custom_command(
+  OUTPUT  "${BIN}/forward.mlir" "${BIN}/subgraph0.mlir" "${BIN}/arg0.data"
+  COMMAND ${WHISPER_IMPORT_ENV}
+          "${Python3_EXECUTABLE}" "${WHISPER_CODEGEN}/import-whisper.py"
+          --spec "${WHISPER_SPEC}" --output-dir "${BIN}"
+  DEPENDS ${WHISPER_IMPORT_DEPS}
+  COMMENT "[whisper] Stage 1: importing model → forward/subgraph0.mlir + arg0.data"
+  VERBATIM)
+
+# ── Stage 2: forward.mlir → forward.o ─────────────────────────────────────────
+# (pass pipeline mirrors examples/BuddyWhisper/CMakeLists.txt exactly)
+add_custom_command(
+  OUTPUT "${BIN}/forward.o"
+  COMMAND ${LLVM_TOOLS_BINARY_DIR}/mlir-opt "${BIN}/forward.mlir"
+            -pass-pipeline "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith), empty-tensor-to-alloc-tensor, convert-elementwise-to-linalg)" |
+          ${BUDDY_BINARY_DIR}/buddy-opt
+            -pass-pipeline "builtin.module(func.func(buffer-deallocation-simplification, convert-linalg-to-loops),matmul-parallel-vectorization-optimize, batchmatmul-optimize, eliminate-empty-tensors, func.func(llvm-request-c-wrappers),convert-scf-to-openmp, convert-openmp-to-llvm, convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf,  convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, convert-func-to-llvm, reconcile-unrealized-casts)" |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+          ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+          ${LLVM_TOOLS_BINARY_DIR}/llc -filetype=obj -relocation-model=pic -O0 -o "${BIN}/forward.o"
+  DEPENDS "${BIN}/forward.mlir" buddy-opt
+  COMMENT "[whisper] Stage 2: forward.mlir → forward.o"
+  VERBATIM)
+
+# ── Stage 2: subgraph0.mlir → subgraph0.o ─────────────────────────────────────
+add_custom_command(
+  OUTPUT "${BIN}/subgraph0.o"
+  COMMAND ${LLVM_TOOLS_BINARY_DIR}/mlir-opt "${BIN}/subgraph0.mlir"
+            -pass-pipeline "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith))" |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+            -test-linalg-transform-patterns=test-decompose-pad-tensor |
+          ${BUDDY_BINARY_DIR}/buddy-opt
+            -arith-expand
+            -eliminate-empty-tensors
+            -convert-elementwise-to-linalg
+            -empty-tensor-to-alloc-tensor
+            -one-shot-bufferize=bufferize-function-boundaries
+            -ownership-based-buffer-deallocation
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -matmul-parallel-vectorization-optimize
+            -convert-linalg-to-affine-loops
+            -affine-loop-fusion
+            -affine-parallelize
+            -lower-affine
+            -convert-scf-to-openmp
+            -convert-linalg-to-loops
+            -convert-vector-to-scf
+            -expand-strided-metadata
+            -lower-affine
+            -cse
+            -convert-vector-to-llvm
+            -memref-expand
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -llvm-request-c-wrappers
+            -convert-openmp-to-llvm
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+          ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+          ${LLVM_TOOLS_BINARY_DIR}/llc -filetype=obj -relocation-model=pic -O3 -o "${BIN}/subgraph0.o"
+  DEPENDS "${BIN}/subgraph0.mlir" buddy-opt
+  COMMENT "[whisper] Stage 2: subgraph0.mlir → subgraph0.o"
+  VERBATIM)
+
+# ── Stage 3: link forward.o + subgraph0.o → whisper_model.so ──────────────────
+set(WHISPER_MODEL_SO "${BIN}/whisper_model.so")
+add_custom_command(
+  OUTPUT "${WHISPER_MODEL_SO}"
+  COMMAND ${CMAKE_CXX_COMPILER}
+            -shared -fPIC
+            -Wl,-soname,whisper_model.so
+            -Wl,--allow-multiple-definition
+            -o "${WHISPER_MODEL_SO}"
+            "${BIN}/forward.o" "${BIN}/subgraph0.o"
+            "-L${LLVM_LIBRARY_DIR}"
+            "-L${WHISPER_OMP_DIR}"
+            "-Wl,-rpath,${LLVM_LIBRARY_DIR}"
+            "-Wl,-rpath,${WHISPER_OMP_DIR}"
+            -lomp -lmlir_c_runner_utils -lm
+  DEPENDS "${BIN}/forward.o" "${BIN}/subgraph0.o"
+  COMMENT "[whisper] Stage 3: linking whisper_model.so"
+  VERBATIM)
+
+add_custom_target(whisper_model_so DEPENDS "${WHISPER_MODEL_SO}")
+
+# ── Runtime: runner static library + plugin shared library ────────────────────
+add_library(buddy_models_whisper STATIC WhisperRunner.cpp)
+target_include_directories(buddy_models_whisper PUBLIC
+  $<BUILD_INTERFACE:${WHISPER_DIR}/include>
+  $<BUILD_INTERFACE:${BUDDY_SOURCE_DIR}/frontend/Interfaces>
+  $<BUILD_INTERFACE:${BUDDY_BINARY_DIR}/frontend/Interfaces>)
+target_compile_features(buddy_models_whisper PUBLIC cxx_std_17)
+# The runner does not execute OpenMP itself (DAP preprocessing has no omp); the
+# model .so it dlopens carries its own libomp via rpath. So omp is not linked here.
+target_link_directories(buddy_models_whisper PUBLIC
+  "${LLVM_LIBRARY_DIR}" "${WHISPER_OMP_DIR}")
+target_link_libraries(buddy_models_whisper PUBLIC
+  buddy_runtime_core
+  BuddyLibDAP
+  mlir_c_runner_utils
+  LLVMSupport
+  ${CMAKE_DL_LIBS})
+
+add_library(buddy_models_whisper_runner SHARED WhisperRunnerPlugin.cpp)
+set_target_properties(buddy_models_whisper_runner PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY "${BIN}"
+  RUNTIME_OUTPUT_DIRECTORY "${BIN}"
+  OUTPUT_NAME "whisper_runner"
+  PREFIX "")
+target_link_libraries(buddy_models_whisper_runner PRIVATE buddy_models_whisper)
+target_compile_features(buddy_models_whisper_runner PRIVATE cxx_std_17)
+
+# ── Stage 4: RHAL manifest → whisper.rax ──────────────────────────────────────
+set(WHISPER_MANIFEST "${BIN}/whisper.mlir")
+add_custom_command(
+  OUTPUT  "${WHISPER_MANIFEST}"
+  COMMAND "${Python3_EXECUTABLE}" "${WHISPER_CODEGEN}/gen_whisper_manifest.py"
+          --spec "${WHISPER_SPEC}"
+          --runner-library "whisper_runner.so"
+          -o "${WHISPER_MANIFEST}"
+  DEPENDS "${WHISPER_CODEGEN}/gen_whisper_manifest.py" "${WHISPER_SPEC}"
+  COMMENT "[whisper] Stage 4: generating whisper.mlir (RHAL manifest)"
+  VERBATIM)
+
+# vocab.txt + audio.wav copied next to the .rax (vocab resolved file: at runtime).
+set(WHISPER_VOCAB_DST "${BIN}/vocab.txt")
+set(WHISPER_AUDIO_DST "${BIN}/audio.wav")
+add_custom_command(
+  OUTPUT  "${WHISPER_VOCAB_DST}" "${WHISPER_AUDIO_DST}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          "${WHISPER_EXAMPLE}/vocab.txt" "${WHISPER_VOCAB_DST}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          "${WHISPER_EXAMPLE}/audio.wav" "${WHISPER_AUDIO_DST}"
+  DEPENDS "${WHISPER_EXAMPLE}/vocab.txt" "${WHISPER_EXAMPLE}/audio.wav"
+  COMMENT "[whisper] Copying vocab.txt + audio.wav"
+  VERBATIM)
+
+set(WHISPER_RAX "${BIN}/whisper.rax")
+add_custom_command(
+  OUTPUT  "${WHISPER_RAX}"
+  COMMAND "${CMAKE_BINARY_DIR}/bin/rax-pack"
+          "${WHISPER_MANIFEST}" -o "${WHISPER_RAX}" --embed-payload
+  DEPENDS rax-pack
+          "${WHISPER_MANIFEST}"
+          "${WHISPER_MODEL_SO}"
+          "${BIN}/arg0.data"
+          buddy_models_whisper_runner
+          "${WHISPER_VOCAB_DST}"
+  COMMENT "[whisper] Stage 4: packing whisper.rax"
+  VERBATIM)
+
+add_custom_target(whisper_rax
+  DEPENDS "${WHISPER_RAX}" "${WHISPER_AUDIO_DST}"
+  COMMENT "whisper.rax + vocab.txt + audio.wav → ${BIN}")

--- a/models/whisper/CMakeLists.txt
+++ b/models/whisper/CMakeLists.txt
@@ -1,225 +1,34 @@
-# ══════════════════════════════════════════════════════════════════════════════
-# Whisper (encoder-decoder ASR) — buddy-cli / .rax integration
+# Whisper encoder-decoder ASR integration.
 #
-# Self-contained build (does NOT use tools/buddy-codegen/buddy_add_model, which is
-# specialized for LLM prefill/decode + KV cache).  Produces the same runtime
-# contract as models/deepseek_r1:
-#
-#   whisper_model.so   compiled MLIR kernels (exports _mlir_ciface_forward)
-#   whisper_runner.so  InferenceRunner plugin (dlopen'd by buddy-cli)
-#   whisper.rax        RHAL manifest (weights + model.so embedded as payload)
-#   vocab.txt          tokenizer vocab (resolved file: relative to the .rax)
-#   audio.wav          sample input (convenience; pass via --audio)
-#
-# Run:  buddy-cli --model whisper.rax --audio audio.wav
-# ══════════════════════════════════════════════════════════════════════════════
+# Uses the shared buddy-codegen model entry point with MODEL_KIND=single_forward.
+# Whisper keeps custom import and manifest generators because the generic
+# DeepSeek path is LLM prefill/decode + KV-cache specific.
 
-set(WHISPER_DIR        "${CMAKE_CURRENT_SOURCE_DIR}")
-set(WHISPER_CODEGEN    "${WHISPER_DIR}/codegen")
-set(WHISPER_EXAMPLE    "${CMAKE_SOURCE_DIR}/examples/BuddyWhisper")
-set(BIN                "${CMAKE_CURRENT_BINARY_DIR}")
+include(${CMAKE_SOURCE_DIR}/tools/buddy-codegen/cmake/buddy_model.cmake)
 
 set(BUDDY_WHISPER_SPEC
-  "${WHISPER_DIR}/specs/base.json"
+  "${CMAKE_CURRENT_SOURCE_DIR}/specs/base.json"
   CACHE FILEPATH "Whisper variant spec JSON, e.g. specs/base.json")
-set(WHISPER_SPEC "${BUDDY_WHISPER_SPEC}")
-
-# OpenMP runtime (libomp.so) lives under the LLVM runtimes build tree, not in
-# ${LLVM_LIBRARY_DIR}. Mirror examples/CMakeLists.txt so -lomp resolves.
-get_filename_component(WHISPER_LLVM_BUILD_DIR "${LLVM_LIBRARY_DIR}" DIRECTORY)
-set(WHISPER_OMP_DIR
-  "${WHISPER_LLVM_BUILD_DIR}/runtimes/runtimes-bins/openmp/runtime/src")
-
-# Optional local HF snapshot; when set it is exported as WHISPER_MODEL_PATH so the
-# importer loads weights from disk instead of downloading openai/whisper-base.
 set(BUDDY_WHISPER_MODEL_PATH "" CACHE PATH
-  "Local HuggingFace whisper snapshot dir (sets WHISPER_MODEL_PATH for import)")
+  "Local HuggingFace whisper snapshot dir")
 
-if(NOT Python3_EXECUTABLE)
-  find_package(Python3 COMPONENTS Interpreter REQUIRED)
-endif()
+set(WHISPER_EXAMPLE "${CMAKE_SOURCE_DIR}/examples/BuddyWhisper")
 
-# ── Stage 1: import PyTorch model → forward.mlir / subgraph0.mlir / arg0.data ──
-if(NOT BUDDY_MLIR_ENABLE_PYTHON_PACKAGES)
-  message(FATAL_ERROR
-    "models/whisper: PyTorch→MLIR import needs the Buddy Python package under "
-    "build/python_packages. Re-configure with -DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON.")
-endif()
-
-set(WHISPER_PY_PKG_ROOT "${CMAKE_BINARY_DIR}/python_packages")
-if(BUDDY_WHISPER_MODEL_PATH)
-  set(WHISPER_IMPORT_ENV ${CMAKE_COMMAND} -E env
-      "PYTHONPATH=${WHISPER_PY_PKG_ROOT}"
-      "WHISPER_MODEL_PATH=${BUDDY_WHISPER_MODEL_PATH}")
-else()
-  set(WHISPER_IMPORT_ENV ${CMAKE_COMMAND} -E env
-      "PYTHONPATH=${WHISPER_PY_PKG_ROOT}")
-endif()
-
-set(WHISPER_IMPORT_DEPS
-  "${WHISPER_CODEGEN}/import-whisper.py" "${WHISPER_SPEC}")
-if(TARGET python-package-buddy)
-  list(APPEND WHISPER_IMPORT_DEPS python-package-buddy)
-endif()
-
-add_custom_command(
-  OUTPUT  "${BIN}/forward.mlir" "${BIN}/subgraph0.mlir" "${BIN}/arg0.data"
-  COMMAND ${WHISPER_IMPORT_ENV}
-          "${Python3_EXECUTABLE}" "${WHISPER_CODEGEN}/import-whisper.py"
-          --spec "${WHISPER_SPEC}" --output-dir "${BIN}"
-  DEPENDS ${WHISPER_IMPORT_DEPS}
-  COMMENT "[whisper] Stage 1: importing model → forward/subgraph0.mlir + arg0.data"
-  VERBATIM)
-
-# ── Stage 2: forward.mlir → forward.o ─────────────────────────────────────────
-# (pass pipeline mirrors examples/BuddyWhisper/CMakeLists.txt exactly)
-add_custom_command(
-  OUTPUT "${BIN}/forward.o"
-  COMMAND ${LLVM_TOOLS_BINARY_DIR}/mlir-opt "${BIN}/forward.mlir"
-            -pass-pipeline "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith), empty-tensor-to-alloc-tensor, convert-elementwise-to-linalg)" |
-          ${BUDDY_BINARY_DIR}/buddy-opt
-            -pass-pipeline "builtin.module(func.func(buffer-deallocation-simplification, convert-linalg-to-loops),matmul-parallel-vectorization-optimize, batchmatmul-optimize, eliminate-empty-tensors, func.func(llvm-request-c-wrappers),convert-scf-to-openmp, convert-openmp-to-llvm, convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf,  convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, convert-func-to-llvm, reconcile-unrealized-casts)" |
-          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-          ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
-          ${LLVM_TOOLS_BINARY_DIR}/llc -filetype=obj -relocation-model=pic -O0 -o "${BIN}/forward.o"
-  DEPENDS "${BIN}/forward.mlir" buddy-opt
-  COMMENT "[whisper] Stage 2: forward.mlir → forward.o"
-  VERBATIM)
-
-# ── Stage 2: subgraph0.mlir → subgraph0.o ─────────────────────────────────────
-add_custom_command(
-  OUTPUT "${BIN}/subgraph0.o"
-  COMMAND ${LLVM_TOOLS_BINARY_DIR}/mlir-opt "${BIN}/subgraph0.mlir"
-            -pass-pipeline "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith))" |
-          ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
-            -test-linalg-transform-patterns=test-decompose-pad-tensor |
-          ${BUDDY_BINARY_DIR}/buddy-opt
-            -arith-expand
-            -eliminate-empty-tensors
-            -convert-elementwise-to-linalg
-            -empty-tensor-to-alloc-tensor
-            -one-shot-bufferize=bufferize-function-boundaries
-            -ownership-based-buffer-deallocation
-            -buffer-deallocation-simplification
-            -bufferization-lower-deallocations
-            -matmul-parallel-vectorization-optimize
-            -convert-linalg-to-affine-loops
-            -affine-loop-fusion
-            -affine-parallelize
-            -lower-affine
-            -convert-scf-to-openmp
-            -convert-linalg-to-loops
-            -convert-vector-to-scf
-            -expand-strided-metadata
-            -lower-affine
-            -cse
-            -convert-vector-to-llvm
-            -memref-expand
-            -convert-arith-to-llvm
-            -finalize-memref-to-llvm
-            -convert-scf-to-cf
-            -convert-cf-to-llvm
-            -llvm-request-c-wrappers
-            -convert-openmp-to-llvm
-            -convert-arith-to-llvm
-            -convert-math-to-llvm
-            -convert-math-to-libm
-            -convert-func-to-llvm
-            -reconcile-unrealized-casts |
-          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
-          ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
-          ${LLVM_TOOLS_BINARY_DIR}/llc -filetype=obj -relocation-model=pic -O3 -o "${BIN}/subgraph0.o"
-  DEPENDS "${BIN}/subgraph0.mlir" buddy-opt
-  COMMENT "[whisper] Stage 2: subgraph0.mlir → subgraph0.o"
-  VERBATIM)
-
-# ── Stage 3: link forward.o + subgraph0.o → whisper_model.so ──────────────────
-set(WHISPER_MODEL_SO "${BIN}/whisper_model.so")
-add_custom_command(
-  OUTPUT "${WHISPER_MODEL_SO}"
-  COMMAND ${CMAKE_CXX_COMPILER}
-            -shared -fPIC
-            -Wl,-soname,whisper_model.so
-            -Wl,--allow-multiple-definition
-            -o "${WHISPER_MODEL_SO}"
-            "${BIN}/forward.o" "${BIN}/subgraph0.o"
-            "-L${LLVM_LIBRARY_DIR}"
-            "-L${WHISPER_OMP_DIR}"
-            "-Wl,-rpath,${LLVM_LIBRARY_DIR}"
-            "-Wl,-rpath,${WHISPER_OMP_DIR}"
-            -lomp -lmlir_c_runner_utils -lm
-  DEPENDS "${BIN}/forward.o" "${BIN}/subgraph0.o"
-  COMMENT "[whisper] Stage 3: linking whisper_model.so"
-  VERBATIM)
-
-add_custom_target(whisper_model_so DEPENDS "${WHISPER_MODEL_SO}")
-
-# ── Runtime: runner static library + plugin shared library ────────────────────
-add_library(buddy_models_whisper STATIC WhisperRunner.cpp)
-target_include_directories(buddy_models_whisper PUBLIC
-  $<BUILD_INTERFACE:${WHISPER_DIR}/include>
-  $<BUILD_INTERFACE:${BUDDY_SOURCE_DIR}/frontend/Interfaces>
-  $<BUILD_INTERFACE:${BUDDY_BINARY_DIR}/frontend/Interfaces>)
-target_compile_features(buddy_models_whisper PUBLIC cxx_std_17)
-# The runner does not execute OpenMP itself (DAP preprocessing has no omp); the
-# model .so it dlopens carries its own libomp via rpath. So omp is not linked here.
-target_link_directories(buddy_models_whisper PUBLIC
-  "${LLVM_LIBRARY_DIR}" "${WHISPER_OMP_DIR}")
-target_link_libraries(buddy_models_whisper PUBLIC
-  buddy_runtime_core
-  BuddyLibDAP
-  mlir_c_runner_utils
-  LLVMSupport
-  ${CMAKE_DL_LIBS})
-
-add_library(buddy_models_whisper_runner SHARED WhisperRunnerPlugin.cpp)
-set_target_properties(buddy_models_whisper_runner PROPERTIES
-  LIBRARY_OUTPUT_DIRECTORY "${BIN}"
-  RUNTIME_OUTPUT_DIRECTORY "${BIN}"
-  OUTPUT_NAME "whisper_runner"
-  PREFIX "")
-target_link_libraries(buddy_models_whisper_runner PRIVATE buddy_models_whisper)
-target_compile_features(buddy_models_whisper_runner PRIVATE cxx_std_17)
-
-# ── Stage 4: RHAL manifest → whisper.rax ──────────────────────────────────────
-set(WHISPER_MANIFEST "${BIN}/whisper.mlir")
-add_custom_command(
-  OUTPUT  "${WHISPER_MANIFEST}"
-  COMMAND "${Python3_EXECUTABLE}" "${WHISPER_CODEGEN}/gen_whisper_manifest.py"
-          --spec "${WHISPER_SPEC}"
-          --runner-library "whisper_runner.so"
-          -o "${WHISPER_MANIFEST}"
-  DEPENDS "${WHISPER_CODEGEN}/gen_whisper_manifest.py" "${WHISPER_SPEC}"
-  COMMENT "[whisper] Stage 4: generating whisper.mlir (RHAL manifest)"
-  VERBATIM)
-
-# vocab.txt + audio.wav copied next to the .rax (vocab resolved file: at runtime).
-set(WHISPER_VOCAB_DST "${BIN}/vocab.txt")
-set(WHISPER_AUDIO_DST "${BIN}/audio.wav")
-add_custom_command(
-  OUTPUT  "${WHISPER_VOCAB_DST}" "${WHISPER_AUDIO_DST}"
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different
-          "${WHISPER_EXAMPLE}/vocab.txt" "${WHISPER_VOCAB_DST}"
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different
-          "${WHISPER_EXAMPLE}/audio.wav" "${WHISPER_AUDIO_DST}"
-  DEPENDS "${WHISPER_EXAMPLE}/vocab.txt" "${WHISPER_EXAMPLE}/audio.wav"
-  COMMENT "[whisper] Copying vocab.txt + audio.wav"
-  VERBATIM)
-
-set(WHISPER_RAX "${BIN}/whisper.rax")
-add_custom_command(
-  OUTPUT  "${WHISPER_RAX}"
-  COMMAND "${CMAKE_BINARY_DIR}/bin/rax-pack"
-          "${WHISPER_MANIFEST}" -o "${WHISPER_RAX}" --embed-payload
-  DEPENDS rax-pack
-          "${WHISPER_MANIFEST}"
-          "${WHISPER_MODEL_SO}"
-          "${BIN}/arg0.data"
-          buddy_models_whisper_runner
-          "${WHISPER_VOCAB_DST}"
-  COMMENT "[whisper] Stage 4: packing whisper.rax"
-  VERBATIM)
-
-add_custom_target(whisper_rax
-  DEPENDS "${WHISPER_RAX}" "${WHISPER_AUDIO_DST}"
-  COMMENT "whisper.rax + vocab.txt + audio.wav → ${BIN}")
+buddy_add_model(
+  NAME whisper
+  MODEL_KIND single_forward
+  SPEC "${BUDDY_WHISPER_SPEC}"
+  RUNNER_SRC WhisperRunner.cpp
+  RUNNER_PLUGIN_SRC WhisperRunnerPlugin.cpp
+  LOCAL_MODEL "${BUDDY_WHISPER_MODEL_PATH}"
+  LOCAL_MODEL_ENV WHISPER_MODEL_PATH
+  IMPORT_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/codegen/import-whisper.py"
+  MANIFEST_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_whisper_manifest.py"
+  MODEL_SO_NAME whisper_model.so
+  ASSET_FILES
+    "${WHISPER_EXAMPLE}/vocab.txt"
+    "${WHISPER_EXAMPLE}/audio.wav"
+  RUNTIME_LINK_LIBS
+    BuddyLibDAP
+    mlir_c_runner_utils
+)

--- a/models/whisper/CMakeLists.txt
+++ b/models/whisper/CMakeLists.txt
@@ -16,9 +16,13 @@
 
 set(WHISPER_DIR        "${CMAKE_CURRENT_SOURCE_DIR}")
 set(WHISPER_CODEGEN    "${WHISPER_DIR}/codegen")
-set(WHISPER_SPEC       "${WHISPER_DIR}/specs/base.json")
 set(WHISPER_EXAMPLE    "${CMAKE_SOURCE_DIR}/examples/BuddyWhisper")
 set(BIN                "${CMAKE_CURRENT_BINARY_DIR}")
+
+set(BUDDY_WHISPER_SPEC
+  "${WHISPER_DIR}/specs/base.json"
+  CACHE FILEPATH "Whisper variant spec JSON, e.g. specs/base.json")
+set(WHISPER_SPEC "${BUDDY_WHISPER_SPEC}")
 
 # OpenMP runtime (libomp.so) lives under the LLVM runtimes build tree, not in
 # ${LLVM_LIBRARY_DIR}. Mirror examples/CMakeLists.txt so -lomp resolves.

--- a/models/whisper/README.md
+++ b/models/whisper/README.md
@@ -14,19 +14,28 @@ manifest plus an `InferenceRunner` plugin that `buddy-cli` loads at run time.
 
 ## Build
 
-Configure with the Whisper model enabled, then build the `whisper_rax` target:
+Use the same `tools/buddy-codegen/build_model.py` entry point as the other
+packaged models:
 
 ```bash
 cd buddy-mlir
-cmake -G Ninja -S . -B build \
-    -DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON \
-    -DBUDDY_BUILD_WHISPER_MODEL=ON \
-    -DBUDDY_WHISPER_MODEL_PATH=/path/to/whisper-base
-ninja -C build whisper_rax buddy-cli
+python3 tools/buddy-codegen/build_model.py \
+  --spec models/whisper/specs/base.json \
+  --build-dir build
 ```
 
-`BUDDY_WHISPER_MODEL_PATH` is optional; if omitted the importer downloads
-`openai/whisper-base`. The build emits these artifacts under
+To import weights from a local HuggingFace snapshot directory, pass
+`--local-model`:
+
+```bash
+python3 tools/buddy-codegen/build_model.py \
+  --spec models/whisper/specs/base.json \
+  --build-dir build \
+  --local-model /path/to/whisper-base
+```
+
+If `--local-model` is omitted, the importer downloads `openai/whisper-base`.
+The build emits these artifacts under
 `build/models/whisper/`:
 
 | File | Description |

--- a/models/whisper/README.md
+++ b/models/whisper/README.md
@@ -1,0 +1,66 @@
+# Whisper
+
+Automatic speech recognition with [openai/whisper-base](https://huggingface.co/openai/whisper-base),
+served through the `buddy-cli` / `.rax` runtime. The build imports the PyTorch
+model, compiles it to MLIR, links `whisper_model.so`, and packs a `whisper.rax`
+manifest plus an `InferenceRunner` plugin that `buddy-cli` loads at run time.
+
+## Prerequisites
+
+- A built LLVM/MLIR and `buddy-mlir` (see the top-level [README](../../README.md)),
+  configured with `-DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON`.
+- A Python environment with `requirements.txt` installed (`transformers`, `torch`).
+- Optional: a local HuggingFace `whisper-base` snapshot directory (to avoid a download).
+
+## Build
+
+Configure with the Whisper model enabled, then build the `whisper_rax` target:
+
+```bash
+cd buddy-mlir
+cmake -G Ninja -S . -B build \
+    -DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON \
+    -DBUDDY_BUILD_WHISPER_MODEL=ON \
+    -DBUDDY_WHISPER_MODEL_PATH=/path/to/whisper-base
+ninja -C build whisper_rax buddy-cli
+```
+
+`BUDDY_WHISPER_MODEL_PATH` is optional; if omitted the importer downloads
+`openai/whisper-base`. The build emits these artifacts under
+`build/models/whisper/`:
+
+| File | Description |
+| --- | --- |
+| `whisper.rax` | Model manifest (embeds weights, `whisper_model.so`, vocab, runner) |
+| `whisper_model.so` | Compiled MLIR kernels (exports `_mlir_ciface_forward`) |
+| `whisper_runner.so` | `InferenceRunner` plugin loaded by `buddy-cli` |
+| `vocab.txt` / `audio.wav` | Tokenizer vocab / sample audio |
+
+## Run
+
+```bash
+./build/bin/buddy-cli \
+  --model ./build/models/whisper/whisper.rax \
+  --audio ./build/models/whisper/audio.wav
+```
+
+- `--audio <path.wav>` selects the input clip (16 kHz mono PCM). If omitted, it
+  falls back to `audio.wav` next to the `.rax`.
+- `--max-tokens N` caps the number of decode steps (~18 s per token on CPU); use
+  `--max-tokens 16` for a quick partial result.
+- `--no-stats` suppresses the per-token iteration log and prints only `[Output]`.
+
+Expected output for the sample clip:
+
+```
+[Output]  Nor is Mr. Quilter's manner less interesting than his matter.
+```
+
+## Notes
+
+- The `.rax` and other artifacts live in the **build** directory
+  (`build/models/whisper/`), not in the source tree. Use the `build/` prefix in
+  the `--model` / `--audio` paths.
+- The `.rax` embeds the runner plugin, so after editing the runner you must
+  re-run `ninja -C build whisper_rax` to repack. For quick iteration you can
+  override it at run time with `--runner-so <absolute-path>`.

--- a/models/whisper/WhisperRunner.cpp
+++ b/models/whisper/WhisperRunner.cpp
@@ -1,0 +1,242 @@
+//===- WhisperRunner.cpp - Whisper full inference loop -------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+//
+// Implements WhisperRunner::run(). This file owns the full ASR inference loop:
+//   - model .so loading (dlopen) and entrypoint resolution
+//   - weight file loading
+//   - audio preprocessing (DAP whisperPreprocess)
+//   - greedy autoregressive decode over `_mlir_ciface_forward`
+//   - detokenization (Text::revertWhisper)
+//
+// buddy-cli calls this through the generic InferenceRunner interface. Unlike
+// the LLM runners, Whisper uses a single forward entrypoint (no prefill/decode
+// KV cache) and takes an audio file rather than a text prompt.
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/models/WhisperRunner.h"
+#include "buddy/runtime/core/ModelManifest.h"
+
+#include "buddy/Core/Container.h"
+#include "buddy/DAP/DAP.h"
+#include "buddy/LLM/TextContainer.h"
+
+#include <algorithm>
+#include <chrono>
+#include <dlfcn.h>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+using buddy::Text;
+using dap::Audio;
+
+namespace buddy {
+namespace runtime {
+
+namespace {
+
+// Compile-time Whisper-base constants (mirror models/whisper/specs/base.json
+// and the shapes baked into the imported MLIR).
+constexpr size_t kParamsSize = 72593920;
+constexpr size_t kMaxVocabSize = 51865;
+constexpr size_t kMaxTokenLength = 448;
+constexpr size_t kEncSeq = 1500;
+constexpr size_t kEncDim = 512;
+constexpr size_t kMelBins = 80;
+constexpr size_t kAudioFrames = 3000;
+constexpr int kSotToken = 50258; // <|startoftranscript|>
+constexpr int kEotToken = 50257; // <|endoftext|>
+
+/// Whisper forward entrypoint exported by whisper_model.so.
+///   resultContainer[0] = encoder output {1, 1500, 512}
+///   resultContainer[1] = decoder logits  {1, 448, vocab}
+using ForwardFn = void (*)(MemRef<float, 3> *, MemRef<float, 1> *,
+                           MemRef<float, 3> *, MemRef<size_t, 2> *);
+
+void printLog(const std::string &msg, bool suppress) {
+  if (!suppress)
+    std::cerr << "\033[34;1m[Log] \033[0m" << msg << "\n";
+}
+
+int findMaxIndex(const float *start, const float *end) {
+  return static_cast<int>(std::distance(start, std::max_element(start, end)));
+}
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// WhisperRunner::run
+//===----------------------------------------------------------------------===//
+
+void WhisperRunner::run(const RunConfig &cfgIn) {
+  RunConfig cfg = cfgIn;
+  const bool suppress = cfg.suppressStats;
+
+  if (!suppress)
+    std::cerr
+        << "\033[33;1mWhisper Inference (buddy-cli / BuddyRuntime)\033[0m\n";
+
+  // ── Resolve model .so / weights / vocab ─────────────────────────────────
+  std::string soPath;
+  std::string weightsPath;
+  std::string vocabPath;
+  std::string baseDir;
+
+  if (!cfg.raxPath.empty()) {
+    printLog("Manifest: " + cfg.raxPath, suppress);
+    ModelManifest manifest = ModelManifest::loadFromRax(cfg.raxPath);
+    soPath = manifest.soPath;
+    if (manifest.weightPaths.empty())
+      throw std::runtime_error("WhisperRunner: manifest has no weight file.");
+    weightsPath = manifest.weightPaths.front();
+    vocabPath = manifest.vocabPath;
+    baseDir = std::filesystem::absolute(std::filesystem::path(cfg.raxPath))
+                  .parent_path()
+                  .string();
+  } else {
+    if (cfg.modelSoPath.empty())
+      throw std::runtime_error("WhisperRunner: Mode B requires --model-so.");
+    if (cfg.weightsPath.empty())
+      throw std::runtime_error("WhisperRunner: Mode B requires --weights.");
+    soPath = cfg.modelSoPath;
+    weightsPath = cfg.weightsPath;
+    vocabPath = cfg.vocabPath;
+    baseDir = std::filesystem::absolute(std::filesystem::path(cfg.modelSoPath))
+                  .parent_path()
+                  .string();
+  }
+
+  if (vocabPath.empty())
+    vocabPath = (std::filesystem::path(baseDir) / "vocab.txt").string();
+
+  // ── Resolve audio input (--audio, else audio.wav next to the model) ──────
+  std::string audioPath = cfg.audioPath;
+  if (audioPath.empty())
+    audioPath = (std::filesystem::path(baseDir) / "audio.wav").string();
+  if (!std::filesystem::exists(audioPath))
+    throw std::runtime_error("WhisperRunner: audio file not found: " +
+                             audioPath + " (pass --audio <path.wav>).");
+
+  printLog("Model .so : " + soPath, suppress);
+  printLog("Weights   : " + weightsPath, suppress);
+  printLog("Vocab     : " + vocabPath, suppress);
+  printLog("Audio     : " + audioPath, suppress);
+
+  // ── Load model .so and resolve entrypoint ───────────────────────────────
+  void *handle = dlopen(soPath.c_str(), RTLD_NOW | RTLD_LOCAL);
+  if (!handle)
+    throw std::runtime_error("WhisperRunner: dlopen failed: " + soPath + ": " +
+                             dlerror());
+  dlerror();
+  auto forward =
+      reinterpret_cast<ForwardFn>(dlsym(handle, "_mlir_ciface_forward"));
+  if (const char *err = dlerror()) {
+    dlclose(handle);
+    throw std::runtime_error("WhisperRunner: missing _mlir_ciface_forward in " +
+                             soPath + ": " + std::string(err));
+  }
+
+  // ── Containers ──────────────────────────────────────────────────────────
+  Text<size_t, 2> outputContainer;
+  outputContainer.loadVocab(vocabPath);
+
+  MemRef<float, 1> paramsContainer({kParamsSize});
+  {
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    std::ifstream paramFile(weightsPath, std::ios::in | std::ios::binary);
+    if (!paramFile.is_open()) {
+      dlclose(handle);
+      throw std::runtime_error("WhisperRunner: failed to open weights: " +
+                               weightsPath);
+    }
+    paramFile.read(reinterpret_cast<char *>(paramsContainer.getData()),
+                   sizeof(float) * paramsContainer.getSize());
+    if (paramFile.fail()) {
+      dlclose(handle);
+      throw std::runtime_error("WhisperRunner: error reading weights: " +
+                               weightsPath);
+    }
+    const auto t1 = std::chrono::high_resolution_clock::now();
+    printLog(
+        "Weights loaded in " +
+            std::to_string(std::chrono::duration<double>(t1 - t0).count()) +
+            "s",
+        suppress);
+  }
+
+  // ── Decoder state ───────────────────────────────────────────────────────
+  MemRef<size_t, 2> textContainer({1, kMaxTokenLength}, kSotToken);
+
+  // Upper bound on decode steps (respect --max-tokens, capped to window).
+  size_t maxSteps = kMaxTokenLength - 1;
+  if (cfg.maxNewTokens > 0)
+    maxSteps =
+        std::min<size_t>(maxSteps, static_cast<size_t>(cfg.maxNewTokens));
+
+  // ── Greedy autoregressive decode ────────────────────────────────────────
+  // Two correctness requirements per step:
+  //   1. The compiled encoder mutates its mel-feature input in place, so the
+  //      audio features must be regenerated fresh before every forward call.
+  //   2. Each forward writes freshly-allocated result MemRefs, so the result
+  //      containers must also start from a clean struct each iteration.
+  for (size_t i = 0; i < maxSteps; i++) {
+    Audio<double, 1> rawAudioContainer(audioPath);
+    MemRef<float, 3> audioInput({1, kMelBins, kAudioFrames});
+    dap::whisperPreprocess(&rawAudioContainer, &audioInput);
+
+    MemRef<float, 3> resultContainer[2] = {
+        MemRef<float, 3>({1, kEncSeq, kEncDim}, false, 0),
+        MemRef<float, 3>({1, kMaxTokenLength, kMaxVocabSize}, false, 0),
+    };
+
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    forward(resultContainer, &paramsContainer, &audioInput, &textContainer);
+    const auto t1 = std::chrono::high_resolution_clock::now();
+
+    const float *startPtr = resultContainer[1].getData() + i * kMaxVocabSize;
+    const float *endPtr = startPtr + kMaxVocabSize;
+    const int maxIndex = findMaxIndex(startPtr, endPtr);
+
+    if (!suppress) {
+      std::cout << "\033[32;1m[Iteration " << i << "] \033[0m"
+                << "Token: " << outputContainer.getStr(maxIndex)
+                << " | Time: " << std::chrono::duration<double>(t1 - t0).count()
+                << "s\n";
+    }
+
+    if (maxIndex != kEotToken) {
+      textContainer.getData()[i + 1] = maxIndex;
+      outputContainer.appendTokenIdx(maxIndex);
+    }
+
+    free(resultContainer[0].release());
+    free(resultContainer[1].release());
+
+    if (maxIndex == kEotToken)
+      break;
+  }
+
+  std::cout << "\033[33;1m[Output]\033[0m " << outputContainer.revertWhisper()
+            << std::endl;
+
+  dlclose(handle);
+}
+
+} // namespace runtime
+} // namespace buddy

--- a/models/whisper/WhisperRunnerPlugin.cpp
+++ b/models/whisper/WhisperRunnerPlugin.cpp
@@ -1,0 +1,26 @@
+//===- WhisperRunnerPlugin.cpp - Whisper runner plugin -------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/models/WhisperRunner.h"
+
+extern "C" buddy::runtime::InferenceRunner *buddy_create_inference_runner_v1() {
+  return new buddy::runtime::WhisperRunner();
+}
+
+extern "C" void
+buddy_destroy_inference_runner_v1(buddy::runtime::InferenceRunner *runner) {
+  delete runner;
+}

--- a/models/whisper/codegen/gen_whisper_manifest.py
+++ b/models/whisper/codegen/gen_whisper_manifest.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# ===- gen_whisper_manifest.py - RHAL .mlir manifest for Whisper -----------===//
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ===----------------------------------------------------------------------===//
+#
+# Generates the RHAL dialect .mlir manifest that rax-pack consumes for the
+# Whisper encoder-decoder model.
+#
+# Unlike the LLM manifest (tools/buddy-codegen/gen_manifest.py), Whisper has a
+# single `forward` entrypoint, no KV cache, and an audio-feature input.  buddy-cli
+# does not interpret the rhal.func/buffer bodies at runtime; it only reads the
+# external constant (weights), the host_shared_lib code object (model .so), and
+# the module attrs (model_name, vocab_uri, runner_library).  The func/buffer
+# entries exist only so rax-pack can parse a well-formed module.
+#
+# Usage:
+#   python gen_whisper_manifest.py --spec specs/base.json -o whisper.mlir
+#
+# ===----------------------------------------------------------------------===//
+
+import argparse
+import json
+import os
+import sys
+
+
+def gen_manifest(spec: dict, runner_library: str) -> str:
+    model_id = spec.get("model_id", f"{spec['model_family']}_{spec['variant']}")
+    params_size = spec["params_size"]
+    vocab_size = spec["vocab_size"]
+    max_token_len = spec["max_token_len"]
+    mel_bins = spec["mel_bins"]
+    audio_frames = spec["audio_frames"]
+    so_name = spec.get("so_name", "whisper_model.so")
+    weight_file = spec.get("weight_file", "arg0.data")
+    vocab_file = spec.get("vocab_file", "vocab.txt")
+
+    lines = []
+    p = lines.append
+
+    # -- Module header ---------------------------------------------------------
+    p("rhal.module @whisper attributes {")
+    p('    version = "0.1.0",')
+    p(f'    model_name = "{model_id}",')
+    p(f'    vocab_uri = "file:{vocab_file}",')
+    p(f'    runner_library = "{runner_library}"}} {{')
+    p("")
+
+    # -- External constant (weight blob) ---------------------------------------
+    p('  rhal.constant @params {id = 1 : i32, storage = "external",')
+    p(f"                         type = tensor<{params_size}xf32>,")
+    p(f'                         uri = "file:{weight_file}"}}')
+    p("")
+
+    # -- Code object (the compiled MLIR kernels) -------------------------------
+    p('  rhal.codeobj @model_kernels {id = 1 : i32, kind = "host_shared_lib",')
+    p('                                backend = "cpu",')
+    p(f'                                uri = "file:{so_name}"}}')
+    p("")
+
+    # -- Buffer descriptors (informational; not read by buddy-cli) -------------
+    p(
+        f'  rhal.buffer @audio_features {{space = "host", '
+        f"type = tensor<1x{mel_bins}x{audio_frames}xf32>}}"
+    )
+    p(
+        f'  rhal.buffer @decoder_tokens {{space = "host", '
+        f"type = tensor<1x{max_token_len}xi64>}}"
+    )
+    p(
+        f'  rhal.buffer @logits {{space = "host", '
+        f"type = tensor<1x{max_token_len}x{vocab_size}xf32>}}"
+    )
+    p("")
+
+    # -- forward entrypoint ----------------------------------------------------
+    p("  rhal.func @forward {")
+    p('    inputs   = ["audio_features", "decoder_tokens"],')
+    p('    outputs  = ["logits"],')
+    p('    dispatch = "model_kernels",')
+    p('    args     = ["audio_features", "decoder_tokens", "logits"]}')
+    p("}")
+
+    return "\n".join(lines) + "\n"
+
+
+def _normalize_uri(raw: str) -> str:
+    s = raw.strip()
+    if ":" in s:
+        return s
+    return f"file:{s}"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate RHAL .mlir manifest for the Whisper model."
+    )
+    parser.add_argument(
+        "--spec", required=True, help="Path to the variant spec JSON"
+    )
+    parser.add_argument(
+        "--runner-library",
+        default="whisper_runner.so",
+        help="Runner plugin library URI/name for module attrs.",
+    )
+    parser.add_argument(
+        "-o", "--output", default="-", help="Output path (- for stdout)"
+    )
+    args = parser.parse_args()
+
+    with open(args.spec) as f:
+        spec = json.load(f)
+
+    text = gen_manifest(spec, _normalize_uri(args.runner_library))
+
+    if args.output == "-":
+        sys.stdout.write(text)
+    else:
+        os.makedirs(
+            os.path.dirname(os.path.abspath(args.output)), exist_ok=True
+        )
+        with open(args.output, "w") as f:
+            f.write(text)
+        print(f"[gen_whisper_manifest] Written: {args.output}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/models/whisper/codegen/import-whisper.py
+++ b/models/whisper/codegen/import-whisper.py
@@ -1,0 +1,133 @@
+# ===- import-whisper.py -------------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ===---------------------------------------------------------------------------
+#
+# AOT importer for the Whisper model used by models/whisper (buddy-cli / .rax).
+#
+# Produces three artifacts in --output-dir:
+#   forward.mlir    main graph (calls into subgraph0)
+#   subgraph0.mlir  lowered top-level IR for the compute subgraph
+#   arg0.data       concatenated model parameters (f32)
+#
+# The model is resolved in this order:
+#   1. $WHISPER_MODEL_PATH        (local HF snapshot, set by CMake)
+#   2. --spec base.json hf_model_path
+#   3. "openai/whisper-base"      (downloaded on demand)
+#
+# ===---------------------------------------------------------------------------
+
+import argparse
+import json
+import os
+
+import numpy
+import torch
+from buddy.compiler.frontend import DynamoCompiler
+from buddy.compiler.graph import GraphDriver
+from buddy.compiler.graph.transform import simply_fuse
+from buddy.compiler.ops import tosa
+from torch._inductor.decomposition import decompositions as inductor_decomp
+from transformers import WhisperForConditionalGeneration
+
+# Parse command-line arguments.
+parser = argparse.ArgumentParser(description="Whisper model AOT importer")
+parser.add_argument(
+    "--output-dir",
+    type=str,
+    default="./",
+    help="Directory to save output files.",
+)
+parser.add_argument(
+    "--spec",
+    type=str,
+    default=None,
+    help="Path to the variant spec JSON (for hf_model_path fallback).",
+)
+args = parser.parse_args()
+
+output_dir = args.output_dir
+os.makedirs(output_dir, exist_ok=True)
+
+# Resolve the Whisper model path.
+model_path = os.environ.get("WHISPER_MODEL_PATH")
+if not model_path and args.spec:
+    with open(args.spec) as f:
+        model_path = json.load(f).get("hf_model_path")
+if not model_path:
+    model_path = "openai/whisper-base"
+
+print(f"[import-whisper] Loading model from: {model_path}")
+
+# Initialize the model from the specified model path.
+model = WhisperForConditionalGeneration.from_pretrained(model_path)
+model.config.use_cache = False
+
+# Generate placeholder for inputs.
+input_features = torch.zeros(size=(1, 80, 3000), dtype=torch.float32)
+decoder_input_ids = torch.zeros(size=(1, 448), dtype=torch.long)
+inputs = {
+    "input_features": input_features,
+    "decoder_input_ids": decoder_input_ids,
+}
+
+# ── Work around a transformers tracing bug ───────────────────────────────────
+# transformers' masking_utils.find_packed_sequence_indices() keeps a
+# "packed-sequence" attention mask whenever it runs under tracing (its
+# `if not is_tracing(...): return None` single-sequence early-out is skipped).
+# Whisper decoding is always a single sequence, so this spurious mask gets baked
+# into the exported graph and collapses decoder self-attention to the diagonal
+# (every position attends only to itself) at run time, producing empty output.
+# Force the single-sequence behaviour (return None) before tracing.
+try:
+    import transformers.masking_utils as _mu
+
+    _mu.find_packed_sequence_indices = lambda *a, **k: None
+except (
+    Exception
+) as _e:  # pragma: no cover - older transformers without this util
+    print(f"[import-whisper] packed-sequence patch skipped: {_e}")
+
+# Initialize Dynamo Compiler with specific configurations as an importer.
+dynamo_compiler = DynamoCompiler(
+    primary_registry=tosa.ops_registry,
+    aot_autograd_decomposition=inductor_decomp,
+)
+
+# Import the model into MLIR module and parameters.
+with torch.no_grad():
+    graphs = dynamo_compiler.importer(model, **inputs)
+
+assert len(graphs) == 1
+graph = graphs[0]
+params = dynamo_compiler.imported_params[graph]
+pattern_list = [simply_fuse]
+graphs[0].fuse_ops(pattern_list)
+driver = GraphDriver(graphs[0])
+driver.subgraphs[0].lower_to_top_level_ir()
+
+# Save the MLIR files and parameter data to the specified output directory.
+with open(os.path.join(output_dir, "subgraph0.mlir"), "w") as module_file:
+    print(driver.subgraphs[0]._imported_module, file=module_file)
+
+with open(os.path.join(output_dir, "forward.mlir"), "w") as module_file:
+    print(driver.construct_main_graph(True), file=module_file)
+
+all_param = numpy.concatenate(
+    [param.detach().numpy().reshape([-1]) for param in params]
+)
+all_param.tofile(os.path.join(output_dir, "arg0.data"))
+print(
+    f"[import-whisper] Wrote forward.mlir, subgraph0.mlir, arg0.data → {output_dir}"
+)

--- a/models/whisper/include/buddy/runtime/models/WhisperRunner.h
+++ b/models/whisper/include/buddy/runtime/models/WhisperRunner.h
@@ -1,0 +1,40 @@
+//===- WhisperRunner.h - Whisper inference runner -------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_MODELS_WHISPERRUNNER_H
+#define BUDDY_RUNTIME_MODELS_WHISPERRUNNER_H
+
+#include "buddy/runtime/core/InferenceRunner.h"
+
+namespace buddy {
+namespace runtime {
+
+/// Full inference runner for the Whisper encoder-decoder ASR model.
+///
+/// Implements the complete loop: load weights → preprocess audio → greedy
+/// autoregressive decode over a single `_mlir_ciface_forward` entrypoint →
+/// detokenize.  Handles both Mode A (.rax manifest) and Mode B (explicit
+/// --model-so / --weights paths).  The audio file comes from cfg.audioPath
+/// (--audio); when empty it falls back to `audio.wav` next to the model.
+class WhisperRunner : public InferenceRunner {
+public:
+  void run(const RunConfig &cfg) override;
+};
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_MODELS_WHISPERRUNNER_H

--- a/models/whisper/specs/base.json
+++ b/models/whisper/specs/base.json
@@ -1,0 +1,18 @@
+{
+  "hf_model_path": "openai/whisper-base",
+  "model_family": "whisper",
+  "variant": "base",
+  "model_id": "whisper_base",
+  "params_size": 72593920,
+  "vocab_size": 51865,
+  "max_token_len": 448,
+  "mel_bins": 80,
+  "audio_frames": 3000,
+  "enc_seq": 1500,
+  "enc_dim": 512,
+  "sot_token": 50258,
+  "eot_token": 50257,
+  "weight_file": "arg0.data",
+  "so_name": "whisper_model.so",
+  "vocab_file": "vocab.txt"
+}

--- a/runtime/include/buddy/runtime/core/InferenceRunner.h
+++ b/runtime/include/buddy/runtime/core/InferenceRunner.h
@@ -50,6 +50,10 @@ struct RunConfig {
   /// element instead of broadcasting `prompt`.
   std::vector<std::string> prompts;
 
+  /// Path to an audio file (e.g. .wav) for speech models such as Whisper.
+  /// Ignored by text-only LLM runners. Empty = let the runner pick a default.
+  std::string audioPath;
+
   /// Optional fixed prompt/prefill length. 0 means use the encoded prompt
   /// length for single-prompt runs, or the longest encoded prompt for batched
   /// prompt-file runs.

--- a/tools/buddy-cli/buddy-cli.cpp
+++ b/tools/buddy-cli/buddy-cli.cpp
@@ -280,6 +280,8 @@ static void usage(const char *prog) {
       << "  --prompt     <text>      Input prompt (interactive if omitted)\n"
       << "  --prompt-file <path>     One prompt per line for fixed-batch runs\n"
       << "  --prompt-length <N>      Fixed prompt/prefill length in tokens\n"
+      << "  --audio      <path>      Audio file for speech models (e.g. "
+         "Whisper)\n"
       << "  --max-tokens <N>         Max generated tokens (default "
          "1024)\n"
       << "  --batch-size <N>         Batch size override for fixed-batch "
@@ -349,6 +351,7 @@ int main(int argc, char **argv) {
   std::string prompt;
   std::string promptFile;
   int promptLength = 0;
+  std::string audioPath;
   int maxTokens = 4096;
   int batchSize = 0;
 
@@ -393,6 +396,8 @@ int main(int argc, char **argv) {
       promptFile = argv[++i];
     else if (a == "--prompt-length" && i + 1 < argc)
       promptLength = std::stoi(argv[++i]);
+    else if (a == "--audio" && i + 1 < argc)
+      audioPath = argv[++i];
     else if (a == "--max-tokens" && i + 1 < argc)
       maxTokens = std::stoi(argv[++i]);
     else if (a == "--batch-size" && i + 1 < argc)
@@ -490,7 +495,8 @@ int main(int argc, char **argv) {
     }
   }
 
-  if (prompt.empty() && prompts.empty() && !interactive) {
+  // Speech models (e.g. Whisper) take --audio instead of a text prompt.
+  if (prompt.empty() && prompts.empty() && audioPath.empty() && !interactive) {
     std::cout << "Prompt: ";
     std::getline(std::cin, prompt);
     std::cout << "\n";
@@ -530,6 +536,7 @@ int main(int argc, char **argv) {
   cfg.vocabPath = vocabPath;
   cfg.prompt = prompt;
   cfg.prompts = std::move(prompts);
+  cfg.audioPath = audioPath;
   cfg.promptLength = promptLength;
   cfg.maxNewTokens = maxTokens;
   cfg.batchSize = batchSize;

--- a/tools/buddy-codegen/build_model.py
+++ b/tools/buddy-codegen/build_model.py
@@ -17,8 +17,7 @@
 # ===----------------------------------------------------------------------===//
 #
 # You maintain **one** JSON file under models/<family>/specs/ (e.g. w8a16.json).
-# This script configures the Buddy build (sets BUDDY_BUILD_DEEPSEEK_R1_MODEL=ON;
-# DeepSeek R1 uses buddy-codegen only) and builds the model artifacts.
+# This script configures the Buddy build and builds the model artifacts.
 #
 # Usage: relative paths
 # (--spec, --build-dir, --hf-config, --local-model, --source-dir) are
@@ -56,6 +55,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -108,8 +108,8 @@ def main() -> int:
     )
     ap.add_argument(
         "--target",
-        default="deepseek_r1_rax",
-        help="Semicolon-separated CMake targets (default: deepseek_r1_rax)",
+        default=None,
+        help="Semicolon-separated CMake targets (default: <model_family>_rax)",
     )
     ap.add_argument(
         "--jobs",
@@ -175,6 +175,19 @@ def main() -> int:
     spec = resolve_from_cwd(args.spec)
     if not spec.is_file():
         print(f"error: spec not found: {spec}", file=sys.stderr)
+        return 1
+    try:
+        spec_data = json.loads(spec.read_text())
+    except Exception as e:
+        print(f"error: failed to read spec JSON {spec}: {e}", file=sys.stderr)
+        return 1
+    model_family = spec_data.get("model_family")
+    if model_family not in {"deepseek_r1", "whisper"}:
+        print(
+            "error: unsupported model_family in spec: "
+            f"{model_family!r} (supported: deepseek_r1, whisper)",
+            file=sys.stderr,
+        )
         return 1
 
     build_dir = resolve_from_cwd(args.build_dir)
@@ -243,23 +256,41 @@ def main() -> int:
             )
             return 1
 
-    cmake_args = [
-        f"-DBUDDY_DSR1_SPEC={spec}",
-        "-DBUDDY_BUILD_DEEPSEEK_R1_MODEL=ON",
-        # Syncs frontend/Python → build/python_packages/buddy/compiler (import_model.py).
-        # Without this, buddy_add_model sets PYTHONPATH but the tree is empty → No module named 'buddy'.
-        "-DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON",
-    ]
-    if local_model is not None:
-        cmake_args.append(f"-DBUDDY_DSR1_LOCAL_MODEL={local_model}")
+    # Syncs frontend/Python → build/python_packages/buddy/compiler for import.
+    # Without this, import scripts see an empty PYTHONPATH tree.
+    cmake_args = ["-DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON"]
+    if model_family == "deepseek_r1":
+        cmake_args.extend(
+            [
+                f"-DBUDDY_DSR1_SPEC={spec}",
+                "-DBUDDY_BUILD_DEEPSEEK_R1_MODEL=ON",
+            ]
+        )
+        if local_model is not None:
+            cmake_args.append(f"-DBUDDY_DSR1_LOCAL_MODEL={local_model}")
 
-    if args.hf_config is not None:
-        hf = resolve_from_cwd(args.hf_config)
-        cmake_args.append(f"-DBUDDY_DSR1_HF_CONFIG={hf}")
-    elif local_model is not None:
-        auto_cfg = local_model / "config.json"
-        if auto_cfg.is_file():
-            cmake_args.append(f"-DBUDDY_DSR1_HF_CONFIG={auto_cfg}")
+        if args.hf_config is not None:
+            hf = resolve_from_cwd(args.hf_config)
+            cmake_args.append(f"-DBUDDY_DSR1_HF_CONFIG={hf}")
+        elif local_model is not None:
+            auto_cfg = local_model / "config.json"
+            if auto_cfg.is_file():
+                cmake_args.append(f"-DBUDDY_DSR1_HF_CONFIG={auto_cfg}")
+    elif model_family == "whisper":
+        cmake_args.extend(
+            [
+                f"-DBUDDY_WHISPER_SPEC={spec}",
+                "-DBUDDY_BUILD_WHISPER_MODEL=ON",
+            ]
+        )
+        if local_model is not None:
+            cmake_args.append(f"-DBUDDY_WHISPER_MODEL_PATH={local_model}")
+        if args.hf_config is not None:
+            print(
+                "warning: --hf-config is ignored for whisper; the Whisper "
+                "importer uses --spec and optional --local-model.",
+                file=sys.stderr,
+            )
 
     if args.is_rvv_crosscompile:
         cmake_args.extend(
@@ -291,8 +322,9 @@ def main() -> int:
         if rc != 0:
             return rc
 
+    target = args.target or f"{model_family}_rax"
     build_cmd = ["cmake", "--build", str(build_dir), "--target"]
-    build_cmd.extend(args.target.split(";"))
+    build_cmd.extend(target.split(";"))
     if args.jobs > 0:
         build_cmd.extend(["-j", str(args.jobs)])
     rc = run(build_cmd)

--- a/tools/buddy-codegen/cmake/buddy_model.cmake
+++ b/tools/buddy-codegen/cmake/buddy_model.cmake
@@ -82,16 +82,23 @@ endif()
 #   [NUM_THREADS  <N>]                      OpenMP threads (default from spec)
 #   [LLC_ATTRS    <string>]                 LLC target attributes
 #   [COMPILE_JOBS <N>]                      parallel MLIR compilation jobs
+#   [MODEL_KIND   <kind>]                   llm_prefill_decode (default) or single_forward
+#   [IMPORT_SCRIPT <path>]                  custom importer for single_forward
+#   [MANIFEST_SCRIPT <path>]                custom RHAL manifest generator
+#   [LOCAL_MODEL_ENV <name>]                env var used for LOCAL_MODEL in importer
+#   [MODEL_SO_NAME <name>]                  output model shared library basename
 #   [TIERED_KV_CACHE ON|OFF]                build multiple cache-sized entrypoints
 #   [TIERED_CACHE_SIZES <list>]             e.g. "32;64;128;256;512;1024"
+#   [ASSET_FILES <list>]                    files copied next to the .rax
+#   [RUNTIME_LINK_LIBS <list>]              extra libraries for runner static lib
 # )
 # ──────────────────────────────────────────────────────────────────────────────
 function(buddy_add_model)
   cmake_parse_arguments(
     MDL                                      # prefix
     ""                                       # flags
-    "NAME;SPEC;RUNNER_SRC;RUNNER_PLUGIN_SRC;HF_CONFIG;LOCAL_MODEL;BUILD_DIR;MLIR_DIR;NUM_THREADS;LLC_ATTRS;COMPILE_JOBS;TIERED_KV_CACHE"
-    "TIERED_CACHE_SIZES"                     # multi-value
+    "NAME;SPEC;RUNNER_SRC;RUNNER_PLUGIN_SRC;HF_CONFIG;LOCAL_MODEL;BUILD_DIR;MLIR_DIR;NUM_THREADS;LLC_ATTRS;COMPILE_JOBS;TIERED_KV_CACHE;MODEL_KIND;IMPORT_SCRIPT;MANIFEST_SCRIPT;LOCAL_MODEL_ENV;MODEL_SO_NAME"
+    "TIERED_CACHE_SIZES;ASSET_FILES;RUNTIME_LINK_LIBS" # multi-value
     ${ARGN}
   )
 
@@ -123,8 +130,25 @@ function(buddy_add_model)
   if(NOT MDL_COMPILE_JOBS)
     set(MDL_COMPILE_JOBS 1)
   endif()
+  if(NOT MDL_MODEL_KIND)
+    set(MDL_MODEL_KIND "llm_prefill_decode")
+  endif()
+  if(NOT MDL_MODEL_KIND STREQUAL "llm_prefill_decode" AND
+     NOT MDL_MODEL_KIND STREQUAL "single_forward")
+    message(FATAL_ERROR
+      "buddy_add_model (${MDL_NAME}): unsupported MODEL_KIND=${MDL_MODEL_KIND}")
+  endif()
   if(NOT MDL_RUNNER_PLUGIN_SRC)
     set(MDL_RUNNER_PLUGIN_SRC "${MDL_RUNNER_SRC}")
+  endif()
+  if(NOT MDL_IMPORT_SCRIPT)
+    set(MDL_IMPORT_SCRIPT "${BUDDY_CODEGEN_DIR}/import_model.py")
+  endif()
+  if(NOT MDL_MANIFEST_SCRIPT)
+    set(MDL_MANIFEST_SCRIPT "${BUDDY_CODEGEN_DIR}/gen_manifest.py")
+  endif()
+  if(NOT MDL_LOCAL_MODEL_ENV)
+    set(MDL_LOCAL_MODEL_ENV "DEEPSEEKR1_MODEL_PATH")
   endif()
 
   if(MDL_TIERED_KV_CACHE)
@@ -137,7 +161,9 @@ function(buddy_add_model)
   endif()
 
   set(MDL_LAYER_PARTITION OFF)
-  if(BUDDY_MODEL_LAYER_PARTITION AND NOT MDL_BUILD_DIR)
+  if(MDL_MODEL_KIND STREQUAL "single_forward")
+    set(MDL_LAYER_PARTITION OFF)
+  elseif(BUDDY_MODEL_LAYER_PARTITION AND NOT MDL_BUILD_DIR)
     if(IS_RVV_CROSSCOMPILE)
       message(STATUS
         "[${MDL_NAME}] Layer partitioning is disabled for RVV cross-compilation.")
@@ -208,46 +234,66 @@ function(buddy_add_model)
   set(GEN_SESS_CC "${GEN_DIR}/ModelSession.cpp")
   set(GEN_RHAL    "${GEN_DIR}/${MDL_NAME}.mlir")
   set(RUNNER_PLUGIN_NAME "${MDL_NAME}_runner.so")
+  set(IMPORT_STAMP "${BIN}/.buddy_import_done")
 
   # ── gen_config.py ─────────────────────────────────────────────────────────
-  set(GEN_CONFIG_CMD
-    "${Python3_EXECUTABLE}" "${BUDDY_CODEGEN_DIR}/gen_config.py"
-    --spec "${MDL_SPEC}" -o "${GEN_CONFIG}"
-  )
-  if(MDL_HF_CONFIG)
-    list(APPEND GEN_CONFIG_CMD --hf-config "${MDL_HF_CONFIG}")
+  if(MDL_MODEL_KIND STREQUAL "single_forward")
+    set(GEN_CONFIG "${MDL_SPEC}")
+  else()
+    set(GEN_CONFIG_CMD
+      "${Python3_EXECUTABLE}" "${BUDDY_CODEGEN_DIR}/gen_config.py"
+      --spec "${MDL_SPEC}" -o "${GEN_CONFIG}"
+    )
+    if(MDL_HF_CONFIG)
+      list(APPEND GEN_CONFIG_CMD --hf-config "${MDL_HF_CONFIG}")
+    endif()
+
+    add_custom_command(
+      OUTPUT  "${GEN_CONFIG}"
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${GEN_DIR}"
+      COMMAND ${GEN_CONFIG_CMD}
+      DEPENDS "${MDL_SPEC}" "${BUDDY_CODEGEN_DIR}/gen_config.py"
+      COMMENT "[${MDL_NAME}] Generating config.json from ${MDL_SPEC}"
+      VERBATIM
+    )
   endif()
 
-  add_custom_command(
-    OUTPUT  "${GEN_CONFIG}"
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${GEN_DIR}"
-    COMMAND ${GEN_CONFIG_CMD}
-    DEPENDS "${MDL_SPEC}" "${BUDDY_CODEGEN_DIR}/gen_config.py"
-    COMMENT "[${MDL_NAME}] Generating config.json from ${MDL_SPEC}"
-    VERBATIM
-  )
-
   # ── gen_session.py ────────────────────────────────────────────────────────
-  add_custom_command(
-    OUTPUT  "${GEN_SESS_H}" "${GEN_SESS_CC}"
-    COMMAND "${Python3_EXECUTABLE}" "${BUDDY_CODEGEN_DIR}/gen_session.py"
-            --config "${GEN_CONFIG}" --output-dir "${GEN_DIR}"
-    DEPENDS "${GEN_CONFIG}" "${BUDDY_CODEGEN_DIR}/gen_session.py"
-    COMMENT "[${MDL_NAME}] Generating ModelSession.{h,cpp}"
-    VERBATIM
-  )
+  if(NOT MDL_MODEL_KIND STREQUAL "single_forward")
+    add_custom_command(
+      OUTPUT  "${GEN_SESS_H}" "${GEN_SESS_CC}"
+      COMMAND "${Python3_EXECUTABLE}" "${BUDDY_CODEGEN_DIR}/gen_session.py"
+              --config "${GEN_CONFIG}" --output-dir "${GEN_DIR}"
+      DEPENDS "${GEN_CONFIG}" "${BUDDY_CODEGEN_DIR}/gen_session.py"
+      COMMENT "[${MDL_NAME}] Generating ModelSession.{h,cpp}"
+      VERBATIM
+    )
+  endif()
 
   # ── gen_manifest.py ───────────────────────────────────────────────────────
-  add_custom_command(
-    OUTPUT  "${GEN_RHAL}"
-    COMMAND "${Python3_EXECUTABLE}" "${BUDDY_CODEGEN_DIR}/gen_manifest.py"
-            --config "${GEN_CONFIG}" -o "${GEN_RHAL}"
-            --runner-library "${RUNNER_PLUGIN_NAME}"
-            ${MDL_GEN_MANIFEST_ARGS}
-    DEPENDS "${GEN_CONFIG}" "${BUDDY_CODEGEN_DIR}/gen_manifest.py"
-    COMMENT "[${MDL_NAME}] Generating ${MDL_NAME}.mlir (RHAL manifest)"
-    VERBATIM
-  )
+  if(MDL_MODEL_KIND STREQUAL "single_forward")
+    add_custom_command(
+      OUTPUT  "${GEN_RHAL}"
+      COMMAND "${Python3_EXECUTABLE}" "${MDL_MANIFEST_SCRIPT}"
+              --spec "${GEN_CONFIG}" -o "${GEN_RHAL}"
+              --runner-library "${RUNNER_PLUGIN_NAME}"
+              ${MDL_GEN_MANIFEST_ARGS}
+      DEPENDS "${GEN_CONFIG}" "${MDL_MANIFEST_SCRIPT}"
+      COMMENT "[${MDL_NAME}] Generating ${MDL_NAME}.mlir (RHAL manifest)"
+      VERBATIM
+    )
+  else()
+    add_custom_command(
+      OUTPUT  "${GEN_RHAL}"
+      COMMAND "${Python3_EXECUTABLE}" "${MDL_MANIFEST_SCRIPT}"
+              --config "${GEN_CONFIG}" -o "${GEN_RHAL}"
+              --runner-library "${RUNNER_PLUGIN_NAME}"
+              ${MDL_GEN_MANIFEST_ARGS}
+      DEPENDS "${GEN_CONFIG}" "${MDL_MANIFEST_SCRIPT}"
+      COMMENT "[${MDL_NAME}] Generating ${MDL_NAME}.mlir (RHAL manifest)"
+      VERBATIM
+    )
+  endif()
 
   # ════════════════════════════════════════════════════════════════════════════
   # Part 1: Runtime static library
@@ -255,10 +301,11 @@ function(buddy_add_model)
 
   set(LIB_TARGET "buddy_models_${MDL_NAME}")
 
-  add_library(${LIB_TARGET} STATIC
-    "${GEN_SESS_CC}"
-    "${CMAKE_CURRENT_SOURCE_DIR}/${MDL_RUNNER_SRC}"
-  )
+  set(MDL_RUNTIME_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/${MDL_RUNNER_SRC}")
+  if(NOT MDL_MODEL_KIND STREQUAL "single_forward")
+    list(PREPEND MDL_RUNTIME_SOURCES "${GEN_SESS_CC}")
+  endif()
+  add_library(${LIB_TARGET} STATIC ${MDL_RUNTIME_SOURCES})
 
   target_include_directories(${LIB_TARGET} PUBLIC
     "${GEN_DIR}"
@@ -270,10 +317,13 @@ function(buddy_add_model)
   target_compile_features(${LIB_TARGET} PUBLIC cxx_std_17)
   target_link_libraries(${LIB_TARGET} PUBLIC
     buddy_runtime_core
-    buddy_runtime_llm
     ${CMAKE_DL_LIBS}
     LLVMSupport
+    ${MDL_RUNTIME_LINK_LIBS}
   )
+  if(NOT MDL_MODEL_KIND STREQUAL "single_forward")
+    target_link_libraries(${LIB_TARGET} PUBLIC buddy_runtime_llm)
+  endif()
   install(FILES ${MDL_RUNNER_SRC}
     DESTINATION include/buddy-mlir/buddy/runtime/models/
     COMPONENT buddy_runtime
@@ -304,11 +354,20 @@ function(buddy_add_model)
   # Subgraph / decode file naming and extra flags are handled in compile_pipeline.py.
   # ════════════════════════════════════════════════════════════════════════════
 
-  set(MODEL_SO "${BIN}/${MDL_NAME}_model.so")
+  if(MDL_MODEL_SO_NAME)
+    set(MODEL_SO_BASENAME "${MDL_MODEL_SO_NAME}")
+  else()
+    set(MODEL_SO_BASENAME "${MDL_NAME}_model.so")
+  endif()
+  set(MODEL_SO "${BIN}/${MODEL_SO_BASENAME}")
 
   set(OBJ_FILES)
   set(MLIR_COMPILE_DEPS)
-  if(MDL_TIERED_KV_CACHE)
+  if(MDL_MODEL_KIND STREQUAL "single_forward")
+    list(APPEND OBJ_FILES
+      "${BIN}/forward.o"
+      "${BIN}/subgraph0.o")
+  elseif(MDL_TIERED_KV_CACHE)
     foreach(CACHE_SIZE ${MDL_TIERED_CACHE_SIZES})
       list(APPEND OBJ_FILES
         "${BIN}/forward_prefill_${CACHE_SIZE}.o"
@@ -324,7 +383,103 @@ function(buddy_add_model)
       "${BIN}/subgraph_decode.o")
   endif()
 
-  if(MDL_BUILD_DIR)
+  if(MDL_MODEL_KIND STREQUAL "single_forward")
+    if(NOT BUDDY_MLIR_ENABLE_PYTHON_PACKAGES)
+      message(FATAL_ERROR
+        "buddy_add_model (${MDL_NAME}): PyTorch→MLIR import needs the Buddy Python package under "
+        "build/python_packages. Re-configure with:\n"
+        "  -DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON\n"
+        "tools/buddy-codegen/build_model.py passes this by default.")
+    endif()
+
+    set(BUDDY_PY_PKG_ROOT "${CMAKE_BINARY_DIR}/python_packages")
+    set(IMPORT_DEPS "${GEN_CONFIG}" "${MDL_IMPORT_SCRIPT}")
+    if(TARGET python-package-buddy)
+      list(APPEND IMPORT_DEPS python-package-buddy)
+    endif()
+    if(MDL_LOCAL_MODEL)
+      set(_IMPORT_ENV ${CMAKE_COMMAND} -E env
+        "PYTHONPATH=${BUDDY_PY_PKG_ROOT}"
+        "${MDL_LOCAL_MODEL_ENV}=${MDL_LOCAL_MODEL}")
+    else()
+      set(_IMPORT_ENV ${CMAKE_COMMAND} -E env "PYTHONPATH=${BUDDY_PY_PKG_ROOT}")
+    endif()
+
+    add_custom_command(
+      OUTPUT "${IMPORT_STAMP}"
+      BYPRODUCTS
+        "${BIN}/forward.mlir"
+        "${BIN}/subgraph0.mlir"
+        "${BIN}/arg0.data"
+      COMMAND ${_IMPORT_ENV}
+              "${Python3_EXECUTABLE}" "${MDL_IMPORT_SCRIPT}"
+              --spec "${GEN_CONFIG}" --output-dir "${BIN}"
+      COMMAND "${CMAKE_COMMAND}" -E touch "${IMPORT_STAMP}"
+      DEPENDS ${IMPORT_DEPS}
+      COMMENT "[${MDL_NAME}] Stage 1: importing single-forward model -> MLIR + weights"
+      VERBATIM
+    )
+
+    add_custom_command(
+      OUTPUT "${BIN}/forward.o"
+      COMMAND ${LLVM_TOOLS_BINARY_DIR}/mlir-opt "${BIN}/forward.mlir"
+                -pass-pipeline "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith), empty-tensor-to-alloc-tensor, convert-elementwise-to-linalg)" |
+              ${BUDDY_BINARY_DIR}/buddy-opt
+                -pass-pipeline "builtin.module(func.func(buffer-deallocation-simplification, convert-linalg-to-loops),matmul-parallel-vectorization-optimize, batchmatmul-optimize, eliminate-empty-tensors, func.func(llvm-request-c-wrappers),convert-scf-to-openmp, convert-openmp-to-llvm, convert-math-to-llvm, convert-math-to-libm, convert-scf-to-cf,  convert-arith-to-llvm, expand-strided-metadata, finalize-memref-to-llvm, convert-func-to-llvm, reconcile-unrealized-casts)" |
+              ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+              ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+              ${LLVM_TOOLS_BINARY_DIR}/llc -filetype=obj -relocation-model=pic -O0 -o "${BIN}/forward.o"
+      DEPENDS "${IMPORT_STAMP}" buddy-opt
+      COMMENT "[${MDL_NAME}] Stage 2: forward.mlir -> forward.o"
+      VERBATIM)
+
+    add_custom_command(
+      OUTPUT "${BIN}/subgraph0.o"
+      COMMAND ${LLVM_TOOLS_BINARY_DIR}/mlir-opt "${BIN}/subgraph0.mlir"
+                -pass-pipeline "builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor, tosa-to-arith))" |
+              ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+                -test-linalg-transform-patterns=test-decompose-pad-tensor |
+              ${BUDDY_BINARY_DIR}/buddy-opt
+                -arith-expand
+                -eliminate-empty-tensors
+                -convert-elementwise-to-linalg
+                -empty-tensor-to-alloc-tensor
+                -one-shot-bufferize=bufferize-function-boundaries
+                -ownership-based-buffer-deallocation
+                -buffer-deallocation-simplification
+                -bufferization-lower-deallocations
+                -matmul-parallel-vectorization-optimize
+                -convert-linalg-to-affine-loops
+                -affine-loop-fusion
+                -affine-parallelize
+                -lower-affine
+                -convert-scf-to-openmp
+                -convert-linalg-to-loops
+                -convert-vector-to-scf
+                -expand-strided-metadata
+                -lower-affine
+                -cse
+                -convert-vector-to-llvm
+                -memref-expand
+                -convert-arith-to-llvm
+                -finalize-memref-to-llvm
+                -convert-scf-to-cf
+                -convert-cf-to-llvm
+                -llvm-request-c-wrappers
+                -convert-openmp-to-llvm
+                -convert-arith-to-llvm
+                -convert-math-to-llvm
+                -convert-math-to-libm
+                -convert-func-to-llvm
+                -reconcile-unrealized-casts |
+              ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+              ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+              ${LLVM_TOOLS_BINARY_DIR}/llc -filetype=obj -relocation-model=pic -O3 -o "${BIN}/subgraph0.o"
+      DEPENDS "${IMPORT_STAMP}" buddy-opt
+      COMMENT "[${MDL_NAME}] Stage 2: subgraph0.mlir -> subgraph0.o"
+      VERBATIM)
+
+  elseif(MDL_BUILD_DIR)
     # ── Mode A: pre-built .o ───────────────────────────────────────────────
     set(OBJ_FILES)
     if(MDL_TIERED_KV_CACHE)
@@ -492,19 +647,27 @@ function(buddy_add_model)
   # ── Stage 3: link .o → .so ─────────────────────────────────────────────
   set(MDL_STAGE3_LINKER "${CMAKE_CXX_COMPILER}")
   set(MDL_STAGE3_LINK_OPTS)
-  set(MDL_STAGE3_LIB_DIRS
-    "-L${LLVM_LIBRARY_DIR}"
-    "-Wl,-rpath,${LLVM_LIBRARY_DIR}")
-  if(BUDDY_OPENMP_RUNTIME_DIR)
-    list(APPEND MDL_STAGE3_LIB_DIRS
-      "-L${BUDDY_OPENMP_RUNTIME_DIR}"
-      "-Wl,-rpath,${BUDDY_OPENMP_RUNTIME_DIR}")
-  endif()
-  set(MDL_STAGE3_LIBS -lmlir_c_runner_utils -lm)
-  if(BUDDY_OPENMP_RUNTIME_LIBRARY)
-    list(INSERT MDL_STAGE3_LIBS 0 "${BUDDY_OPENMP_RUNTIME_LIBRARY}")
+  set(MDL_STAGE3_LIBS -lomp -lmlir_c_runner_utils -lm)
+  set(MDL_STAGE3_LINK_DIRS "${LLVM_LIBRARY_DIR}")
+  set(MDL_STAGE3_RPATH_DIRS "${LLVM_LIBRARY_DIR}")
+
+  if(BUDDY_OPENMP_RUNTIME_LIBRARY AND EXISTS "${BUDDY_OPENMP_RUNTIME_LIBRARY}")
+    get_filename_component(_BUDDY_OPENMP_RUNTIME_DIR
+      "${BUDDY_OPENMP_RUNTIME_LIBRARY}" DIRECTORY)
+    set(MDL_STAGE3_LIBS
+      "${BUDDY_OPENMP_RUNTIME_LIBRARY}"
+      -lmlir_c_runner_utils
+      -lm)
+    list(APPEND MDL_STAGE3_LINK_DIRS "${_BUDDY_OPENMP_RUNTIME_DIR}")
+    list(APPEND MDL_STAGE3_RPATH_DIRS "${_BUDDY_OPENMP_RUNTIME_DIR}")
   else()
-    list(INSERT MDL_STAGE3_LIBS 0 -lomp)
+    get_filename_component(_BUDDY_LLVM_BUILD_DIR "${LLVM_LIBRARY_DIR}" DIRECTORY)
+    set(_BUDDY_OPENMP_RUNTIME_DIR
+      "${_BUDDY_LLVM_BUILD_DIR}/runtimes/runtimes-bins/openmp/runtime/src")
+    if(EXISTS "${_BUDDY_OPENMP_RUNTIME_DIR}/libomp${CMAKE_SHARED_LIBRARY_SUFFIX}")
+      list(APPEND MDL_STAGE3_LINK_DIRS "${_BUDDY_OPENMP_RUNTIME_DIR}")
+      list(APPEND MDL_STAGE3_RPATH_DIRS "${_BUDDY_OPENMP_RUNTIME_DIR}")
+    endif()
   endif()
 
   if(IS_RVV_CROSSCOMPILE)
@@ -528,14 +691,23 @@ function(buddy_add_model)
 
   if(APPLE)
     set(_BUDDY_MODEL_LINK_FLAGS
-      "-Wl,-install_name,@rpath/${MDL_NAME}_model.so"
+      "-Wl,-install_name,@rpath/${MODEL_SO_BASENAME}"
     )
   else()
     set(_BUDDY_MODEL_LINK_FLAGS
-      "-Wl,-soname,${MDL_NAME}_model.so"
+      "-Wl,-soname,${MODEL_SO_BASENAME}"
       "-Wl,--allow-multiple-definition"
     )
   endif()
+
+  set(MDL_STAGE3_LINK_DIR_ARGS)
+  foreach(_link_dir ${MDL_STAGE3_LINK_DIRS})
+    list(APPEND MDL_STAGE3_LINK_DIR_ARGS "-L${_link_dir}")
+  endforeach()
+  set(MDL_STAGE3_RPATH_ARGS)
+  foreach(_rpath_dir ${MDL_STAGE3_RPATH_DIRS})
+    list(APPEND MDL_STAGE3_RPATH_ARGS "-Wl,-rpath,${_rpath_dir}")
+  endforeach()
 
   if(NOT MDL_LAYER_PARTITION)
     add_custom_command(
@@ -546,7 +718,8 @@ function(buddy_add_model)
                 ${_BUDDY_MODEL_LINK_FLAGS}
                 -o "${MODEL_SO}"
                 ${OBJ_FILES}
-                ${MDL_STAGE3_LIB_DIRS}
+                ${MDL_STAGE3_LINK_DIR_ARGS}
+                ${MDL_STAGE3_RPATH_ARGS}
                 ${MDL_STAGE3_LIBS}
       DEPENDS ${OBJ_FILES}
       COMMENT "[${MDL_NAME}] Stage 3: linking ${MDL_NAME}_model.so"
@@ -556,25 +729,40 @@ function(buddy_add_model)
 
   add_custom_target(${MDL_NAME}_model_so
     DEPENDS "${MODEL_SO}"
-    COMMENT "${MDL_NAME}_model.so → ${MODEL_SO}"
+    COMMENT "${MODEL_SO_BASENAME} -> ${MODEL_SO}"
   )
 
   # ════════════════════════════════════════════════════════════════════════════
   # Part 3: rax-pack → .rax
   # ════════════════════════════════════════════════════════════════════════════
 
-  # Copy vocab.txt alongside the .rax (and make it visible to rax-pack payload
-  # embedding via file:vocab.txt URI).
-  set(VOCAB_SRC "${CMAKE_SOURCE_DIR}/examples/BuddyDeepSeekR1/vocab.txt")
-  set(VOCAB_DST "${BIN}/vocab.txt")
-
-  add_custom_command(
-    OUTPUT  "${VOCAB_DST}"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${VOCAB_SRC}" "${VOCAB_DST}"
-    DEPENDS "${VOCAB_SRC}"
-    COMMENT "[${MDL_NAME}] Copying vocab.txt"
-    VERBATIM
-  )
+  if(MDL_ASSET_FILES)
+    set(MDL_ASSET_DSTS)
+    foreach(_asset_src ${MDL_ASSET_FILES})
+      get_filename_component(_asset_name "${_asset_src}" NAME)
+      set(_asset_dst "${BIN}/${_asset_name}")
+      add_custom_command(
+        OUTPUT "${_asset_dst}"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${_asset_src}" "${_asset_dst}"
+        DEPENDS "${_asset_src}"
+        COMMENT "[${MDL_NAME}] Copying ${_asset_name}"
+        VERBATIM
+      )
+      list(APPEND MDL_ASSET_DSTS "${_asset_dst}")
+    endforeach()
+  else()
+    set(VOCAB_SRC "${CMAKE_SOURCE_DIR}/examples/BuddyDeepSeekR1/vocab.txt")
+    set(VOCAB_DST "${BIN}/vocab.txt")
+    add_custom_command(
+      OUTPUT  "${VOCAB_DST}"
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${VOCAB_SRC}" "${VOCAB_DST}"
+      DEPENDS "${VOCAB_SRC}"
+      COMMENT "[${MDL_NAME}] Copying vocab.txt"
+      VERBATIM
+    )
+    set(MDL_ASSET_DSTS "${VOCAB_DST}")
+  endif()
 
   set(MODEL_RAX "${BIN}/${MDL_NAME}.rax")
   set(RAX_PACK_ARGS)
@@ -587,7 +775,10 @@ function(buddy_add_model)
     "${GEN_RHAL}"
     "${MODEL_SO}"
     ${RUNNER_PLUGIN_TARGET}
-    "${VOCAB_DST}")
+    ${MDL_ASSET_DSTS})
+  if(MDL_MODEL_KIND STREQUAL "single_forward")
+    list(APPEND MDL_STAGE4_DEPS "${BIN}/arg0.data")
+  endif()
   list(APPEND MDL_STAGE4_DEPS ${MDL_EXTRA_STAGE4_DEPS})
 
   add_custom_command(
@@ -600,8 +791,8 @@ function(buddy_add_model)
   )
 
   add_custom_target(${MDL_NAME}_rax
-    DEPENDS "${MODEL_RAX}" "${VOCAB_DST}"
-    COMMENT "${MDL_NAME}.rax + vocab.txt → ${BIN}"
+    DEPENDS "${MODEL_RAX}" ${MDL_ASSET_DSTS}
+    COMMENT "${MDL_NAME}.rax -> ${BIN}"
   )
 
 endfunction()


### PR DESCRIPTION
  Adds openai/whisper-base under models/whisper, served through the existing buddy-cli / .rax
  runtime (same contract as models/deepseek_r1). Since Whisper is encoder-decoder ASR (single
  forward, audio input, no KV cache), it ships as a self-contained build + InferenceRunner plugin
  and doesn't touch the LLM buddy_add_model pipeline.

  - New models/whisper/: spec, import/manifest codegen, WhisperRunner + plugin, CMake, README.
  - buddy-cli: new --audio option (+ RunConfig::audioPath).
  - BUDDY_BUILD_WHISPER_MODEL CMake option (default off).

  Build & run: see models/whisper/README.md
<img width="686" height="423" alt="image" src="https://github.com/user-attachments/assets/6c6702a2-d293-4e90-bf67-225175244f03" />

 
