### PR TITLE
[runtime] Fix DeepSeekR1 decode ABI and OpenMP runtime linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,8 +72,29 @@ if(NOT LLVM_EXTERNAL_LIT)
 endif()
 
 list(GET LLVM_LIBRARY_DIRS 0 BUDDY_LLVM_LIBRARY_DIR)
-set(BUDDY_OPENMP_RUNTIME_LIBRARY
-  "${BUDDY_LLVM_LIBRARY_DIR}/${LLVM_HOST_TRIPLE}/libomp${CMAKE_SHARED_LIBRARY_SUFFIX}")
+get_filename_component(BUDDY_LLVM_BUILD_DIR "${BUDDY_LLVM_LIBRARY_DIR}" DIRECTORY)
+set(BUDDY_OPENMP_RUNTIME_CANDIDATE_DIRS
+  "${BUDDY_LLVM_LIBRARY_DIR}"
+  "${BUDDY_LLVM_LIBRARY_DIR}/${LLVM_HOST_TRIPLE}"
+  "${LLVM_BINARY_DIR}/runtimes/runtimes-bins/openmp/runtime/src"
+  "${BUDDY_LLVM_BUILD_DIR}/runtimes/runtimes-bins/openmp/runtime/src"
+)
+set(BUDDY_OPENMP_RUNTIME_DIR "")
+set(BUDDY_OPENMP_RUNTIME_LIBRARY "")
+foreach(_buddy_openmp_runtime_dir IN LISTS BUDDY_OPENMP_RUNTIME_CANDIDATE_DIRS)
+  set(_buddy_openmp_runtime_library
+    "${_buddy_openmp_runtime_dir}/libomp${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  if(EXISTS "${_buddy_openmp_runtime_library}")
+    set(BUDDY_OPENMP_RUNTIME_DIR "${_buddy_openmp_runtime_dir}")
+    set(BUDDY_OPENMP_RUNTIME_LIBRARY "${_buddy_openmp_runtime_library}")
+    break()
+  endif()
+endforeach()
+if(BUDDY_OPENMP_RUNTIME_LIBRARY)
+  message(STATUS "Using OpenMP runtime: ${BUDDY_OPENMP_RUNTIME_LIBRARY}")
+else()
+  message(WARNING "OpenMP runtime libomp${CMAKE_SHARED_LIBRARY_SUFFIX} was not found in the LLVM build tree.")
+endif()
 
 #-------------------------------------------------------------------------------
 # BUDDY configuration

--- a/frontend/Python/ops/tosa.py
+++ b/frontend/Python/ops/tosa.py
@@ -4406,11 +4406,13 @@ def flash_attention_for_cpu_prefill_op(
     mask_memref = None
     if attn_mask is not None:
         attn_mask = symbol_table.get((str(attn_mask), 0), attn_mask)
-        mask_memref = bufferization.ToBufferOp(
-            memref.MemRefType.get(attn_mask.type.shape, dtype_qkv),
-            attn_mask,
-            loc=loc,
-        )
+        mask_type = getattr(attn_mask, "type", None)
+        if mask_type is not None:
+            mask_memref = bufferization.ToBufferOp(
+                memref.MemRefType.get(mask_type.shape, dtype_qkv),
+                attn_mask,
+                loc=loc,
+            )
 
     batch_size = arith.ConstantOp(index, query_shape[0], loc=loc)
     num_heads = arith.ConstantOp(index, query_shape[1], loc=loc)
@@ -13951,10 +13953,13 @@ def gqa_attention_fused_op(node: GQAAttentionFusedOp, symbol_table):
     # ========= mask preprocess =========
     if attn_mask is not None:
         attn_mask = symbol_table.get((str(attn_mask), 0), attn_mask)
-        # Cast mask to compute_dtype (f32) if input is f16
-        if need_cast:
+        mask_type = getattr(attn_mask, "type", None)
+        if mask_type is None:
+            attn_mask = None
+        # Cast mask to compute_dtype (f32) if input is f16.
+        elif need_cast:
             mask_cast_type = ir.RankedTensorType.get(
-                list(attn_mask.type.shape), compute_dtype
+                list(mask_type.shape), compute_dtype
             )
             attn_mask = tosa.CastOp(mask_cast_type, attn_mask).result
 
@@ -14072,18 +14077,23 @@ def gqa_attention_fused_op(node: GQAAttentionFusedOp, symbol_table):
     scaled = tosa.MulOp(
         score_tensor_shape, score_tensor, scale_splat, shift
     ).result
-    add_op = _gen_arith_binary_op(scaled, attn_mask, tosa.AddOp)
+    if attn_mask is not None:
+        masked_score = _gen_arith_binary_op(
+            scaled, attn_mask, tosa.AddOp
+        ).result
+    else:
+        masked_score = scaled
 
     # ========= softmax (in f32 for stability) =========
-    softmax_output_shape = list(add_op.result.type.shape)
+    softmax_output_shape = list(masked_score.type.shape)
     softmax_dim = len(softmax_output_shape) - 1
-    max_vals = tosa.ReduceMaxOp(add_op.result, softmax_dim)
-    sub_op = tosa.SubOp(add_op.result.type, add_op, max_vals)
+    max_vals = tosa.ReduceMaxOp(masked_score, softmax_dim)
+    sub_op = tosa.SubOp(masked_score.type, masked_score, max_vals)
     exp_op = math.ExpOp(sub_op.result)
     reduce_sum_op = tosa.ReduceSumOp(exp_op, softmax_dim)
     log_op = tosa.LogOp(reduce_sum_op.result.type, reduce_sum_op)
     log_sumexp = tosa.AddOp(max_vals.result.type, max_vals, log_op)
-    log_weights = tosa.SubOp(add_op.result.type, add_op, log_sumexp)
+    log_weights = tosa.SubOp(masked_score.type, masked_score, log_sumexp)
     softmax_result = math.ExpOp(log_weights.result)
     # log_sumexp_operand = _create_shape_operand(list(output_shape[1]))
     log_sumexp_operand = _create_shape_operand(

--- a/midend/lib/Conversion/EliminateMemRefCopy/EliminateMemRefCopy.cpp
+++ b/midend/lib/Conversion/EliminateMemRefCopy/EliminateMemRefCopy.cpp
@@ -69,6 +69,15 @@ static bool isAliasOfFunctionArgument(Value value) {
   return false;
 }
 
+static bool areAllUsesDominatedBy(Value value, Operation *dominator,
+                                  DominanceInfo &dominance) {
+  for (OpOperand &use : value.getUses()) {
+    if (!dominance.dominates(dominator, use.getOwner()))
+      return false;
+  }
+  return true;
+}
+
 // Pattern to eliminate memref.copy from function arguments to allocations
 struct EliminateMemRefCopyPattern : public OpRewritePattern<memref::CopyOp> {
   using OpRewritePattern<memref::CopyOp>::OpRewritePattern;
@@ -102,9 +111,14 @@ struct EliminateMemRefCopyPattern : public OpRewritePattern<memref::CopyOp> {
     if (sourceType.getShape() != destType.getShape())
       return failure();
 
-    // Collect all uses of the allocation
-    SmallVector<OpOperand *> uses;
+    // Collect all uses of the allocation. A few bufferization patterns create
+    // a cast of the allocation before the copy and only use that cast after
+    // the copy. Rebuild those casts from the replacement value so the copy can
+    // still be eliminated without violating dominance.
+    SmallVector<OpOperand *> dominatedUses;
+    SmallVector<memref::CastOp> preCopyCasts;
     SmallVector<memref::DeallocOp> deallocs;
+    DominanceInfo dominance(allocOp->getParentOp());
     for (OpOperand &use : allocOp->getUses()) {
       // Skip the copy operation itself
       if (use.getOwner() == copyOp.getOperation())
@@ -115,13 +129,19 @@ struct EliminateMemRefCopyPattern : public OpRewritePattern<memref::CopyOp> {
         deallocs.push_back(deallocOp);
         continue;
       }
-      uses.push_back(&use);
-    }
 
-    DominanceInfo dominance(allocOp->getParentOp());
-    for (OpOperand *use : uses) {
-      if (!dominance.dominates(copyOp.getOperation(), use->getOwner()))
+      if (dominance.dominates(copyOp.getOperation(), use.getOwner())) {
+        dominatedUses.push_back(&use);
+        continue;
+      }
+
+      auto castOp = dyn_cast<memref::CastOp>(use.getOwner());
+      if (!castOp || use.getOperandNumber() != 0 ||
+          !areAllUsesDominatedBy(castOp.getResult(), copyOp.getOperation(),
+                                 dominance))
         return failure();
+
+      preCopyCasts.push_back(castOp);
     }
 
     // Check if source has strided layout and needs conversion
@@ -213,13 +233,31 @@ struct EliminateMemRefCopyPattern : public OpRewritePattern<memref::CopyOp> {
       }
     }
 
+    // Rebuild pre-copy casts at the copy position using the replacement value.
+    rewriter.setInsertionPoint(copyOp);
+    SmallVector<Operation *> aliasOpsToErase;
+    for (memref::CastOp castOp : preCopyCasts) {
+      Value aliasReplacement = replacementValue;
+      Type aliasType = castOp.getResult().getType();
+      if (aliasReplacement.getType() != aliasType)
+        aliasReplacement = memref::CastOp::create(rewriter, castOp.getLoc(),
+                                                  aliasType, aliasReplacement);
+      castOp.getResult().replaceAllUsesWith(aliasReplacement);
+      aliasOpsToErase.push_back(castOp.getOperation());
+    }
+
     // Replace all uses of the allocation with the replacement value
-    for (OpOperand *use : uses) {
+    for (OpOperand *use : dominatedUses) {
       use->set(replacementValue);
     }
 
     // Erase the copy operation
     rewriter.eraseOp(copyOp);
+
+    for (Operation *aliasOp : aliasOpsToErase) {
+      if (aliasOp->use_empty())
+        rewriter.eraseOp(aliasOp);
+    }
 
     for (memref::DeallocOp deallocOp : deallocs)
       rewriter.eraseOp(deallocOp);

--- a/midend/lib/Conversion/EliminateMemRefCopy/EliminateMemRefCopy.cpp
+++ b/midend/lib/Conversion/EliminateMemRefCopy/EliminateMemRefCopy.cpp
@@ -32,6 +32,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dominance.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
@@ -115,6 +116,12 @@ struct EliminateMemRefCopyPattern : public OpRewritePattern<memref::CopyOp> {
         continue;
       }
       uses.push_back(&use);
+    }
+
+    DominanceInfo dominance(allocOp->getParentOp());
+    for (OpOperand *use : uses) {
+      if (!dominance.dominates(copyOp.getOperation(), use->getOwner()))
+        return failure();
     }
 
     // Check if source has strided layout and needs conversion

--- a/tests/Conversion/eliminate-memref-copy.mlir
+++ b/tests/Conversion/eliminate-memref-copy.mlir
@@ -64,14 +64,24 @@ module {
     return
   }
 
-  // Test that copies are preserved when the destination allocation has a use
-  // before the copy. Replacing that earlier use with an alias created at the
-  // copy would violate dominance.
+  // Test that a pre-copy cast alias can be rebuilt at the copy point and the
+  // copy can still be eliminated.
   func.func @test_use_before_copy(%arg0: memref<10xf32, strided<[?], offset: ?>>) -> memref<10xf32, strided<[?], offset: ?>> {
     %alloc = memref.alloc() : memref<10xf32>
     %cast = memref.cast %alloc : memref<10xf32> to memref<10xf32, strided<[?], offset: ?>>
     memref.copy %arg0, %alloc : memref<10xf32, strided<[?], offset: ?>> to memref<10xf32>
     return %cast : memref<10xf32, strided<[?], offset: ?>>
+  }
+
+  // Test that the copy is preserved when the pre-copy alias is actually read
+  // before the copy.
+  func.func @test_real_use_before_copy(%arg0: memref<10xf32, strided<[?], offset: ?>>) -> f32 {
+    %alloc = memref.alloc() : memref<10xf32>
+    %cast = memref.cast %alloc : memref<10xf32> to memref<10xf32, strided<[?], offset: ?>>
+    %c0 = arith.constant 0 : index
+    %val = memref.load %cast[%c0] : memref<10xf32, strided<[?], offset: ?>>
+    memref.copy %arg0, %alloc : memref<10xf32, strided<[?], offset: ?>> to memref<10xf32>
+    return %val : f32
   }
 }
 
@@ -136,7 +146,16 @@ module {
 // CHECK: return
 
 // CHECK-LABEL: func.func @test_use_before_copy
-// CHECK: memref.alloc
+// CHECK-NOT: memref.alloc
+// CHECK-NOT: memref.copy
+// CHECK: memref.extract_strided_metadata
+// CHECK: memref.reinterpret_cast
 // CHECK: memref.cast
+// CHECK-NOT: memref.copy
+// CHECK: return
+
+// CHECK-LABEL: func.func @test_real_use_before_copy
+// CHECK: memref.alloc
+// CHECK: memref.load
 // CHECK: memref.copy
 // CHECK: return

--- a/tests/Conversion/eliminate-memref-copy.mlir
+++ b/tests/Conversion/eliminate-memref-copy.mlir
@@ -63,6 +63,16 @@ module {
     memref.dealloc %alloc : memref<10xf32>
     return
   }
+
+  // Test that copies are preserved when the destination allocation has a use
+  // before the copy. Replacing that earlier use with an alias created at the
+  // copy would violate dominance.
+  func.func @test_use_before_copy(%arg0: memref<10xf32, strided<[?], offset: ?>>) -> memref<10xf32, strided<[?], offset: ?>> {
+    %alloc = memref.alloc() : memref<10xf32>
+    %cast = memref.cast %alloc : memref<10xf32> to memref<10xf32, strided<[?], offset: ?>>
+    memref.copy %arg0, %alloc : memref<10xf32, strided<[?], offset: ?>> to memref<10xf32>
+    return %cast : memref<10xf32, strided<[?], offset: ?>>
+  }
 }
 
 // CHECK-LABEL: func.func @test_basic
@@ -123,4 +133,10 @@ module {
 // CHECK: memref.load
 // CHECK: memref.store
 // CHECK-NOT: memref.dealloc
+// CHECK: return
+
+// CHECK-LABEL: func.func @test_use_before_copy
+// CHECK: memref.alloc
+// CHECK: memref.cast
+// CHECK: memref.copy
 // CHECK: return

--- a/tools/buddy-codegen/cmake/buddy_model.cmake
+++ b/tools/buddy-codegen/cmake/buddy_model.cmake
@@ -430,6 +430,12 @@ function(buddy_add_model)
       endif()
     endif()
 
+    set(MDL_OPENMP_RUNTIME_ARGS)
+    if(BUDDY_OPENMP_RUNTIME_LIBRARY)
+      set(MDL_OPENMP_RUNTIME_ARGS
+        --openmp-runtime-lib "${BUDDY_OPENMP_RUNTIME_LIBRARY}")
+    endif()
+
     if(MDL_LAYER_PARTITION)
       # ── Stage 2/3: partitioned MLIR → .o → .so via compile_pipeline.py ───
       set(PARTITIONED_MLIR_SRC "${MLIR_SRC}/layer_partitioned")
@@ -449,6 +455,7 @@ function(buddy_add_model)
                 "--llc-attrs=${MDL_LLC_ATTRS}"
                 --cxx "${CMAKE_CXX_COMPILER}"
                 --llvm-lib-dir "${LLVM_LIBRARY_DIR}"
+                ${MDL_OPENMP_RUNTIME_ARGS}
                 -j "${MDL_COMPILE_JOBS}"
         DEPENDS
           buddy-opt
@@ -485,7 +492,20 @@ function(buddy_add_model)
   # ── Stage 3: link .o → .so ─────────────────────────────────────────────
   set(MDL_STAGE3_LINKER "${CMAKE_CXX_COMPILER}")
   set(MDL_STAGE3_LINK_OPTS)
-  set(MDL_STAGE3_LIBS -lomp -lmlir_c_runner_utils -lm)
+  set(MDL_STAGE3_LIB_DIRS
+    "-L${LLVM_LIBRARY_DIR}"
+    "-Wl,-rpath,${LLVM_LIBRARY_DIR}")
+  if(BUDDY_OPENMP_RUNTIME_DIR)
+    list(APPEND MDL_STAGE3_LIB_DIRS
+      "-L${BUDDY_OPENMP_RUNTIME_DIR}"
+      "-Wl,-rpath,${BUDDY_OPENMP_RUNTIME_DIR}")
+  endif()
+  set(MDL_STAGE3_LIBS -lmlir_c_runner_utils -lm)
+  if(BUDDY_OPENMP_RUNTIME_LIBRARY)
+    list(INSERT MDL_STAGE3_LIBS 0 "${BUDDY_OPENMP_RUNTIME_LIBRARY}")
+  else()
+    list(INSERT MDL_STAGE3_LIBS 0 -lomp)
+  endif()
 
   if(IS_RVV_CROSSCOMPILE)
     set(CMAKE_C_COMPILER "${BUDDY_MLIR_BUILD_DIR}/../llvm/build/bin/clang")
@@ -526,8 +546,7 @@ function(buddy_add_model)
                 ${_BUDDY_MODEL_LINK_FLAGS}
                 -o "${MODEL_SO}"
                 ${OBJ_FILES}
-                "-L${LLVM_LIBRARY_DIR}"
-                "-Wl,-rpath,${LLVM_LIBRARY_DIR}"
+                ${MDL_STAGE3_LIB_DIRS}
                 ${MDL_STAGE3_LIBS}
       DEPENDS ${OBJ_FILES}
       COMMENT "[${MDL_NAME}] Stage 3: linking ${MDL_NAME}_model.so"

--- a/tools/buddy-codegen/compile_pipeline.py
+++ b/tools/buddy-codegen/compile_pipeline.py
@@ -156,8 +156,7 @@ def build_stages(
     )
 
     if pipeline_type == "subgraph_decode":
-        if not variant.startswith("w"):
-            opts.append("-eliminate-memref-copy")
+        opts.append("-eliminate-memref-copy")
         opts.extend(
             [
                 "-assume-tight-memref-layout",

--- a/tools/buddy-codegen/compile_pipeline.py
+++ b/tools/buddy-codegen/compile_pipeline.py
@@ -90,6 +90,11 @@ def build_stages(
       - "subgraph_decode": subgraph_decode
     """
     stages = []
+    llc_base_args = llc_attrs.split()
+    if variant.startswith("w") and not any(
+        arg.startswith(("-code-model", "--code-model")) for arg in llc_base_args
+    ):
+        llc_base_args.append("-code-model=large")
 
     if pipeline_type == "forward":
         stages.append(
@@ -108,7 +113,7 @@ def build_stages(
         stages.append(
             (
                 "llc",
-                llc_attrs.split()
+                llc_base_args
                 + [
                     "-filetype=obj",
                     "-relocation-model=pic",
@@ -151,9 +156,10 @@ def build_stages(
     )
 
     if pipeline_type == "subgraph_decode":
+        if not variant.startswith("w"):
+            opts.append("-eliminate-memref-copy")
         opts.extend(
             [
-                "-eliminate-memref-copy",
                 "-assume-tight-memref-layout",
                 "-staticize-memref-layout",
             ]
@@ -218,7 +224,7 @@ def build_stages(
     stages.append(("mlir-translate", ["-mlir-to-llvmir"]))
     stages.append(("llvm-as", []))
 
-    llc_args = llc_attrs.split() + [
+    llc_args = llc_base_args + [
         "-filetype=obj",
         "-relocation-model=pic",
         "-O3",
@@ -456,73 +462,82 @@ def partitioned_compile_entries(
     mlir_dir: str,
     prefill_only: bool = False,
     full_mlir_dir: str | None = None,
+    tiered: bool = False,
 ) -> list[tuple[str, str, str, str]]:
     """Discover per-layer MLIR files emitted by import_model.py."""
-    patterns = [
-        (
-            re.compile(r"^forward_prefill_(\d+)\.mlir$"),
-            "forward_prefill",
-            "forward",
-        ),
-        (
-            re.compile(r"^forward_decode_(\d+)\.mlir$"),
-            "forward_decode",
-            "forward",
-        ),
-        (
-            re.compile(r"^subgraph0_prefill_(\d+)_(\d+)\.mlir$"),
-            "subgraph_prefill",
-            "subgraph",
-        ),
-        (
-            re.compile(r"^subgraph0_decode_(\d+)_(\d+)\.mlir$"),
-            "subgraph_decode",
-            "subgraph_decode",
-        ),
-        (
-            re.compile(r"^subgraph0_decode_(\d+)\.mlir$"),
-            "subgraph_decode",
-            "subgraph_decode",
-        ),
-        (
-            re.compile(r"^forward_prefill\.mlir$"),
-            "forward_prefill",
-            "forward",
-        ),
-        (
-            re.compile(r"^forward_decode\.mlir$"),
-            "forward_decode",
-            "forward",
-        ),
-        (
-            re.compile(r"^subgraph0_prefill(\d+)\.mlir$"),
-            "subgraph_prefill",
-            "subgraph",
-        ),
-        (
-            re.compile(r"^subgraph0_decode(\d+)\.mlir$"),
-            "subgraph_decode",
-            "subgraph_decode",
-        ),
-        (
-            re.compile(r"^forward_prefill(\d+)\.mlir$"),
-            "forward_prefill",
-            "standard",
-        ),
-        (
-            re.compile(r"^forward_decode(\d+)\.mlir$"),
-            "forward_decode",
-            "standard",
-        ),
-    ]
+    if tiered:
+        patterns = [
+            (
+                re.compile(r"^forward_prefill_(\d+)\.mlir$"),
+                "forward_prefill",
+                "forward",
+            ),
+            (
+                re.compile(r"^forward_decode_(\d+)\.mlir$"),
+                "forward_decode",
+                "forward",
+            ),
+            (
+                re.compile(r"^subgraph0_prefill_(\d+)_(\d+)\.mlir$"),
+                "subgraph_prefill",
+                "subgraph",
+            ),
+            (
+                re.compile(r"^subgraph0_decode_(\d+)_(\d+)\.mlir$"),
+                "subgraph_decode",
+                "subgraph_decode",
+            ),
+            (
+                re.compile(r"^subgraph0_decode_(\d+)\.mlir$"),
+                "subgraph_decode",
+                "subgraph_decode",
+            ),
+        ]
+    else:
+        patterns = [
+            (
+                re.compile(r"^forward_prefill\.mlir$"),
+                "forward_prefill",
+                "forward",
+            ),
+            (
+                re.compile(r"^forward_decode\.mlir$"),
+                "forward_decode",
+                "forward",
+            ),
+            (
+                re.compile(r"^subgraph0_prefill(\d+)\.mlir$"),
+                "subgraph_prefill",
+                "subgraph",
+            ),
+            (
+                re.compile(r"^subgraph0_decode(\d+)\.mlir$"),
+                "subgraph_decode",
+                "subgraph_decode",
+            ),
+            (
+                re.compile(r"^forward_prefill(\d+)\.mlir$"),
+                "forward_prefill",
+                "standard",
+            ),
+            (
+                re.compile(r"^forward_decode(\d+)\.mlir$"),
+                "forward_decode",
+                "standard",
+            ),
+        ]
 
     entries = []
     for filename in os.listdir(mlir_dir):
-        if prefill_only and (
+        is_decode_file = (
             filename == "forward_decode.mlir"
             or re.match(r"^forward_decode\d+\.mlir$", filename)
+            or re.match(r"^forward_decode_\d+\.mlir$", filename)
             or re.match(r"^subgraph0_decode\d+\.mlir$", filename)
-        ):
+            or re.match(r"^subgraph0_decode_\d+\.mlir$", filename)
+            or re.match(r"^subgraph0_decode_\d+_\d+\.mlir$", filename)
+        )
+        if prefill_only and is_decode_file:
             continue
         for regex, key_prefix, pipeline_type in patterns:
             match = regex.match(filename)
@@ -588,7 +603,10 @@ def compile_partitioned(
 ) -> None:
     """Compile all per-layer MLIR files from a layer_partitioned directory."""
     entries = partitioned_compile_entries(
-        mlir_dir, prefill_only=prefill_only, full_mlir_dir=full_mlir_dir
+        mlir_dir,
+        prefill_only=prefill_only,
+        full_mlir_dir=full_mlir_dir,
+        tiered=is_tiered_kv_cache(config),
     )
     if not entries:
         raise RuntimeError(f"No partitioned MLIR files found in {mlir_dir}")
@@ -725,17 +743,20 @@ def partitioned_runtime_objects(
         obj_files.sort()
         return obj_files
 
+    patterns = [
+        r"^subgraph0_prefill\d+\.o$",
+        r"^subgraph0_decode\d+\.o$",
+    ]
+    if prefill_only:
+        patterns = [
+            r"^subgraph0_prefill\d+\.o$",
+            r"^subgraph_decode\.o$",
+        ]
+
     obj_files = []
     for name in os.listdir(output_dir):
-        if not (name.startswith("subgraph") and name.endswith(".o")):
-            continue
-        if prefill_only:
-            keep = re.match(r"^subgraph0_prefill\d+\.o$", name) or name == (
-                "subgraph_decode.o"
-            )
-            if not keep:
-                continue
-        obj_files.append(os.path.join(output_dir, name))
+        if any(re.match(pattern, name) for pattern in patterns):
+            obj_files.append(os.path.join(output_dir, name))
     obj_files.sort()
 
     for name in ("forward_decode.o", "forward_prefill.o"):

--- a/tools/buddy-codegen/compile_pipeline.py
+++ b/tools/buddy-codegen/compile_pipeline.py
@@ -646,8 +646,28 @@ def link_shared_lib(
     output_so: str,
     cxx: str = "c++",
     llvm_lib_dir: str = "",
+    openmp_runtime_lib: str = "",
 ) -> None:
     """Link object files into a shared library."""
+    lib_dirs = []
+    if llvm_lib_dir:
+        llvm_lib_dir = os.path.normpath(llvm_lib_dir)
+        lib_dirs.append(llvm_lib_dir)
+
+    if openmp_runtime_lib:
+        openmp_runtime_lib = os.path.normpath(openmp_runtime_lib)
+        openmp_runtime_dir = os.path.dirname(openmp_runtime_lib)
+        if openmp_runtime_dir:
+            lib_dirs.append(openmp_runtime_dir)
+
+    deduped_lib_dirs = []
+    seen_lib_dirs = set()
+    for lib_dir in lib_dirs:
+        if lib_dir in seen_lib_dirs:
+            continue
+        seen_lib_dirs.add(lib_dir)
+        deduped_lib_dirs.append(lib_dir)
+
     cmd = [
         cxx,
         "-shared",
@@ -662,14 +682,15 @@ def link_shared_lib(
         cmd.insert(3, f"-Wl,-soname,{os.path.basename(output_so)}")
         cmd.insert(4, "-Wl,--allow-multiple-definition")
 
-    if llvm_lib_dir:
+    for lib_dir in deduped_lib_dirs:
         cmd.extend(
             [
-                f"-L{llvm_lib_dir}",
-                f"-Wl,-rpath,{llvm_lib_dir}",
+                f"-L{lib_dir}",
+                f"-Wl,-rpath,{lib_dir}",
             ]
         )
-    cmd.extend(["-lomp", "-lmlir_c_runner_utils", "-lm"])
+    omp_link_arg = openmp_runtime_lib if openmp_runtime_lib else "-lomp"
+    cmd.extend([omp_link_arg, "-lmlir_c_runner_utils", "-lm"])
 
     print(f"[link] {os.path.basename(output_so)}", file=sys.stderr)
     subprocess.check_call(cmd)
@@ -794,6 +815,11 @@ def main():
         "--llvm-lib-dir", default="", help="LLVM library directory"
     )
     parser.add_argument(
+        "--openmp-runtime-lib",
+        default="",
+        help="Full path to the OpenMP runtime library used for linking",
+    )
+    parser.add_argument(
         "--output-so",
         help="Output shared library path when --link is used",
     )
@@ -843,6 +869,7 @@ def main():
                 output_so=output_so,
                 cxx=args.cxx,
                 llvm_lib_dir=args.llvm_lib_dir,
+                openmp_runtime_lib=args.openmp_runtime_lib,
             )
     elif args.compile_partitioned:
         if not args.mlir_dir or not args.output_dir:
@@ -874,6 +901,7 @@ def main():
                 output_so=output_so,
                 cxx=args.cxx,
                 llvm_lib_dir=args.llvm_lib_dir,
+                openmp_runtime_lib=args.openmp_runtime_lib,
             )
     else:
         if not args.output or not args.pipeline:

--- a/tools/buddy-codegen/gen_session.py
+++ b/tools/buddy-codegen/gen_session.py
@@ -832,7 +832,10 @@ def gen_impl(config: dict) -> str:
     )
     p("//")
     p("// _mlir_ciface_forward_decode writes:")
-    p(f"//   [kv0..kv{kv_layers - 1} : {kv_memref} x {kv_layers}]")
+    p(
+        "//   [cache_position_out : Dummy1Ref]"
+        "[kv0, kv1, dummy0, kv2, kv3, dummy1, ...]"
+    )
     p(f"//   [logits : {logits_memref}]")
     p("//")
     p(
@@ -867,12 +870,39 @@ def gen_impl(config: dict) -> str:
     p("};")
     p()
     p("struct DecodeABI {")
-    p(f"  alignas(KV4Ref) char kv_[sizeof(KV4Ref) * {mp}_KV_LAYERS];")
+    p("  alignas(Dummy1Ref) char cachePositionOut_[sizeof(Dummy1Ref)];")
+    p("  alignas(KV4Ref) char kv0_[sizeof(KV4Ref)];")
+    p("  alignas(KV4Ref) char kv1_[sizeof(KV4Ref)];")
+    for i in range(dummy_groups):
+        p(f"  alignas(Dummy1Ref) char dummy{i}_[sizeof(Dummy1Ref)];")
+        p(f"  alignas(KV4Ref) char kv{2 + i * 2}_[sizeof(KV4Ref)];")
+        p(f"  alignas(KV4Ref) char kv{3 + i * 2}_[sizeof(KV4Ref)];")
     p("  alignas(Logits3Ref) char logits_[sizeof(Logits3Ref)];")
     p()
+    p("  Dummy1Ref &cachePositionOut() {")
+    p(
+        "    return *std::launder(reinterpret_cast<Dummy1Ref *>(cachePositionOut_));"
+    )
+    p("  }")
     p("  KV4Ref &kv(int i) {")
-    p("    return *std::launder(reinterpret_cast<KV4Ref *>(")
-    p("        kv_ + i * sizeof(KV4Ref)));")
+    p("    switch (i) {")
+    for i in range(kv_layers):
+        p(f"    case {i}:")
+        p(f"      return *std::launder(reinterpret_cast<KV4Ref *>(kv{i}_));")
+    p("    default:")
+    p('      throw std::out_of_range("DecodeABI::kv");')
+    p("    }")
+    p("  }")
+    p("  Dummy1Ref &dummy(int i) {")
+    p("    switch (i) {")
+    for i in range(dummy_groups):
+        p(f"    case {i}:")
+        p(
+            f"      return *std::launder(reinterpret_cast<Dummy1Ref *>(dummy{i}_));"
+        )
+    p("    default:")
+    p('      throw std::out_of_range("DecodeABI::dummy");')
+    p("    }")
     p("  }")
     p("  Logits3Ref &logits() {")
     p("    return *std::launder(reinterpret_cast<Logits3Ref *>(logits_));")
@@ -900,6 +930,7 @@ def gen_impl(config: dict) -> str:
 
     kv4 = "KV4Ref *"
     p(f"using KV4 = {kv4};")
+    p("using Dummy1 = Dummy1Ref *;")
     p()
     decode_sig_parts = [
         "DecodeABI *",
@@ -907,7 +938,9 @@ def gen_impl(config: dict) -> str:
         "MemRef<long long, 2> *",
         "MemRef<long long, 1> *",
     ]
-    decode_sig_parts.extend(["KV4" for _i in range(kv_layers)])
+    decode_sig_parts.extend(["KV4", "KV4"])
+    for _i in range(dummy_groups):
+        decode_sig_parts.extend(["Dummy1", "KV4", "KV4"])
     p("using DecodeFn = void (*)(")
     line = "    "
     for idx, part in enumerate(decode_sig_parts):
@@ -957,6 +990,12 @@ def gen_impl(config: dict) -> str:
     p(f"  for (int i = 0; i < {mp}_KV_LAYERS; ++i)")
     p("    new (&abi.kv(i)) KV4Ref(kvShape, false, 0);")
     p("  new (&abi.logits()) Logits3Ref(logitsShape, false, 0);")
+    p("}")
+    p()
+    p("template <typename T, size_t N>")
+    p("void releaseIfAliased(MemRef<T, N> &result, MemRef<T, N> &owner) {")
+    p("  if (result.getData() == owner.getData())")
+    p("    (void)result.release();")
     p("}")
     p("} // namespace")
     p()
@@ -1316,14 +1355,28 @@ def gen_impl(config: dict) -> str:
         p(line)
 
     p()
-    p("  std::memcpy(state.logits().getData(), result.logits().getData(),")
-    p(f"              (uint64_t)cfg_.vocabSize * {logits_sizeof});")
+    p("  if (result.logits().getData() != state.logits().getData())")
+    p("    std::memcpy(state.logits().getData(), result.logits().getData(),")
+    p(f"                (uint64_t)cfg_.vocabSize * {logits_sizeof});")
     p("  const uint64_t elemsPerLayer =")
     p("      (uint64_t)cfg_.headNum * cfg_.maxTokenLen * cfg_.hiddenSize;")
     p("  for (int i = 0; i < cfg_.kvLayers; ++i) {")
-    p("    std::memcpy(state.kv(i).getData(), result.kv(i).getData(),")
-    p(f"                elemsPerLayer * {kv_sizeof});")
+    p("    if (result.kv(i).getData() != state.kv(i).getData())")
+    p("      std::memcpy(state.kv(i).getData(), result.kv(i).getData(),")
+    p(f"                  elemsPerLayer * {kv_sizeof});")
     p("  }")
+    p()
+    p("  // Some lowered decode results alias the input/session memrefs. The")
+    p("  // temporary result ABI must not free those buffers when it is reset.")
+    p("  releaseIfAliased(result.cachePositionOut(), *cachePosition_);")
+    p(
+        "  releaseIfAliased(result.cachePositionOut(), state.cachePositionOut());"
+    )
+    p(f"  for (int i = 0; i < {dummy_groups}; ++i)")
+    p("    releaseIfAliased(result.dummy(i), state.dummy(i));")
+    p("  for (int i = 0; i < cfg_.kvLayers; ++i)")
+    p("    releaseIfAliased(result.kv(i), state.kv(i));")
+    p("  releaseIfAliased(result.logits(), state.logits());")
     p(
         "  intptr_t kvShape[4] = {1, cfg_.headNum, cfg_.maxTokenLen, cfg_.hiddenSize};"
     )

--- a/tools/buddy-codegen/gen_session.py
+++ b/tools/buddy-codegen/gen_session.py
@@ -377,6 +377,9 @@ def gen_impl_tiered(config: dict) -> str:
     p("} // namespace")
     p()
 
+    dummy_groups = kv_layers // 2 - 1
+
+    p("using Dummy1Ref = MemRef<long long, 1>;")
     p(f"using KV4Ref = {kv_memref};")
     p(f"using Logits3Ref = {logits_memref};")
     p()
@@ -396,12 +399,39 @@ def gen_impl_tiered(config: dict) -> str:
     p("};")
     p()
     p("struct DecodeABI {")
-    p(f"  alignas(KV4Ref) char kv_[sizeof(KV4Ref) * {mp}_KV_LAYERS];")
+    p("  alignas(Dummy1Ref) char cachePositionOut_[sizeof(Dummy1Ref)];")
+    p("  alignas(KV4Ref) char kv0_[sizeof(KV4Ref)];")
+    p("  alignas(KV4Ref) char kv1_[sizeof(KV4Ref)];")
+    for i in range(dummy_groups):
+        p(f"  alignas(Dummy1Ref) char dummy{i}_[sizeof(Dummy1Ref)];")
+        p(f"  alignas(KV4Ref) char kv{2 + i * 2}_[sizeof(KV4Ref)];")
+        p(f"  alignas(KV4Ref) char kv{3 + i * 2}_[sizeof(KV4Ref)];")
     p("  alignas(Logits3Ref) char logits_[sizeof(Logits3Ref)];")
     p()
+    p("  Dummy1Ref &cachePositionOut() {")
+    p(
+        "    return *std::launder(reinterpret_cast<Dummy1Ref *>(cachePositionOut_));"
+    )
+    p("  }")
     p("  KV4Ref &kv(int i) {")
-    p("    return *std::launder(reinterpret_cast<KV4Ref *>(")
-    p("        kv_ + i * sizeof(KV4Ref)));")
+    p("    switch (i) {")
+    for i in range(kv_layers):
+        p(f"    case {i}:")
+        p(f"      return *std::launder(reinterpret_cast<KV4Ref *>(kv{i}_));")
+    p("    default:")
+    p('      throw std::out_of_range("DecodeABI::kv");')
+    p("    }")
+    p("  }")
+    p("  Dummy1Ref &dummy(int i) {")
+    p("    switch (i) {")
+    for i in range(dummy_groups):
+        p(f"    case {i}:")
+        p(
+            f"      return *std::launder(reinterpret_cast<Dummy1Ref *>(dummy{i}_));"
+        )
+    p("    default:")
+    p('      throw std::out_of_range("DecodeABI::dummy");')
+    p("    }")
     p("  }")
     p("  Logits3Ref &logits() {")
     p("    return *std::launder(reinterpret_cast<Logits3Ref *>(logits_));")
@@ -412,13 +442,16 @@ def gen_impl_tiered(config: dict) -> str:
         f"using PrefillFn = void (*)(PrefillABI *, {weight_ptr_types}, Text<size_t, 2> *);"
     )
     p("using KV4 = KV4Ref *;")
+    p("using Dummy1 = Dummy1Ref *;")
     decode_sig_parts = [
         "DecodeABI *",
         *[f"MemRef<{w['cpp_type']}, 1> *" for w in weights],
         "MemRef<long long, 2> *",
         "MemRef<long long, 1> *",
     ]
-    decode_sig_parts.extend(["KV4" for _i in range(kv_layers)])
+    decode_sig_parts.extend(["KV4", "KV4"])
+    for _i in range(dummy_groups):
+        decode_sig_parts.extend(["Dummy1", "KV4", "KV4"])
     p("using DecodeFn = void (*)(")
     line = "    "
     for idx, part in enumerate(decode_sig_parts):
@@ -431,7 +464,6 @@ def gen_impl_tiered(config: dict) -> str:
             line = candidate
     if line.strip():
         p(line.rstrip())
-    p()
     p()
     p("namespace {")
     p("template <typename SrcABI, typename DstABI>")
@@ -464,7 +496,15 @@ def gen_impl_tiered(config: dict) -> str:
         call_parts.append(w["tag"])
     call_parts.append("decodeTokenInput")
     call_parts.append("cachePosition")
-    call_parts.extend(f"&a.kv({i})" for i in range(kv_layers))
+    call_parts.extend(["&a.kv(0)", "&a.kv(1)"])
+    for i in range(dummy_groups):
+        call_parts.extend(
+            [
+                f"&a.dummy({i})",
+                f"&a.kv({2 + i * 2})",
+                f"&a.kv({3 + i * 2})",
+            ]
+        )
     p("  fn(")
     line = "      "
     for idx, part in enumerate(call_parts):
@@ -494,6 +534,9 @@ def gen_impl_tiered(config: dict) -> str:
     p("  ~Impl() {")
     p("    if (abiInitialized) {")
     p("      for (int slot = 0; slot < kTieredCacheCount; ++slot) {")
+    p("        decodeAbi[slot].cachePositionOut().~Dummy1Ref();")
+    p(f"        for (int i = 0; i < {dummy_groups}; ++i)")
+    p("          decodeAbi[slot].dummy(i).~Dummy1Ref();")
     p(f"        for (int i = 0; i < {mp}_KV_LAYERS; ++i)")
     p("          prefillAbi[slot].kv(i).~KV4Ref();")
     p("        prefillAbi[slot].logits().~Logits3Ref();")
@@ -582,6 +625,10 @@ def gen_impl_tiered(config: dict) -> str:
     p("  for (int slot = 0; slot < kTieredCacheCount; ++slot) {")
     p("    int cacheLen = kTieredCacheSizes[slot];")
     p("    intptr_t kvShape[4] = {1, cfg_.headNum, cacheLen, cfg_.hiddenSize};")
+    p("    new (&impl_->decodeAbi[slot].cachePositionOut())")
+    p("        Dummy1Ref(pshape, 0LL);")
+    p(f"    for (int i = 0; i < {dummy_groups}; ++i)")
+    p("      new (&impl_->decodeAbi[slot].dummy(i)) Dummy1Ref(pshape, 0LL);")
     p(f"    for (int i = 0; i < {mp}_KV_LAYERS; ++i) {{")
     p("      new (&impl_->prefillAbi[slot].kv(i)) KV4Ref(kvShape, 0.0f);")
     p("      new (&impl_->decodeAbi[slot].kv(i)) KV4Ref(kvShape, 0.0f);")
@@ -672,6 +719,8 @@ def gen_impl_tiered(config: dict) -> str:
     p("  decodeTokenInput_->getData()[0] = (long long)tokenId;")
     p("  cachePosition_->getData()[0] = (long long)position_;")
     p("  auto &a = impl_->decodeAbi[impl_->activeSlot];")
+    p(f"  for (int i = 0; i < {dummy_groups}; ++i)")
+    p("    a.dummy(i).getData()[0] = (long long)position_;")
     p(
         f"  callDecodeFn(impl_->decodeFns[impl_->activeSlot], a, {weight_addrs_internal},"
     )


### PR DESCRIPTION

## Summary

This PR fixes DeepSeekR1 runtime issues after the LLVM/OpenMP layout update.

- Detects the OpenMP runtime from the current LLVM build layout and passes the exact `libomp.so` path into the model compile/link pipeline.
- Fixes the generated non-tiered DeepSeekR1 decode ABI to match the MLIR return/input layout, including `cache_position_out` and dummy cache-position memrefs.
- Prevents decode result memrefs that alias session/input buffers from being freed when the temporary result ABI is reset, which fixes the second-token decode segmentation fault.

Verification:

```bash
python3 -m py_compile tools/buddy-codegen/gen_session.py tools/buddy-codegen/compile_pipeline.py

python3 tools/buddy-codegen/build_model.py \
  --spec models/deepseek_r1/specs/f32.json \
  --build-dir build

./build/bin/buddy-cli --numa 0,1,2,3 --cpus 0-47 \
  --model ./build/models/deepseek_r1/deepseek_r1.rax \
  --prompt "Tell me a joke in 200 words." \
  --max-tokens 128 --no-stats
```

Also verified that `deepseek_r1_model.so` resolves `libomp.so` from the LLVM runtimes directory via RUNPATH.

## Checklist

- [x] The code builds successfully
- [x] Existing tests pass
- [ ] New tests are added where appropriate
- [x] Code follows the project coding style
- [x] Documentation is updated if needed
```