### PR TITLE
[LLVM] Bump submodule to 3c95709b9b39

### DIFF
--- a/examples/lit.cfg.py
+++ b/examples/lit.cfg.py
@@ -131,6 +131,11 @@ if config.buddy_mlir_enable_python_packages:
     # copies in one process trigger OMP Error #15; LLVM OpenMP allows continuing
     # when this is set (common when mixing PyTorch with MLIR JIT on e.g. RISC-V)
     llvm_config.with_environment("KMP_DUPLICATE_LIB_OK", "TRUE")
+    # Prevent CUDA context initialization in CPU-only Python tests.
+    # When many workers run in parallel, each torch._dynamo import eagerly
+    # initialises a CUDA context; this exhausts GPU memory and causes
+    # spurious AcceleratorError / CUDA OOM failures.
+    llvm_config.with_environment("CUDA_VISIBLE_DEVICES", "")
 
 tool_dirs = [config.buddy_tools_dir, config.llvm_tools_dir]
 tools = [

--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -126,6 +126,11 @@ if config.buddy_mlir_enable_python_packages:
     # Same as examples/lit.cfg.py: PyTorch + Buddy ExecutionEngine can load two
     # libomp copies (OMP Error #15); LLVM OpenMP documents this workaround.
     llvm_config.with_environment("KMP_DUPLICATE_LIB_OK", "TRUE")
+    # Prevent CUDA context initialization in CPU-only Python tests.
+    # When many workers run in parallel, each torch._dynamo import eagerly
+    # initialises a CUDA context; this exhausts GPU memory and causes
+    # spurious AcceleratorError / CUDA OOM failures.
+    llvm_config.with_environment("CUDA_VISIBLE_DEVICES", "")
 
     buddy_init = os.path.join(
         config.buddy_python_packages_dir, "buddy_mlir", "__init__.py"


### PR DESCRIPTION
…tests

Bump the llvm submodule to 3c95709b9b39. Set CUDA_VISIBLE_DEVICES="" in tests/lit.cfg.py and examples/lit.cfg.py so CPU-only PyTorch/Dynamo tests do not initialize CUDA when many lit workers run in parallel.

