### PR TITLE
[model] Add ProteinGLM buddy-cli integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,9 @@ option(BUDDY_BUILD_LLAMA32_TT_MODEL
 option(BUDDY_BUILD_BGE_M3_MODEL
   "Build models/bge_m3 dense embedding runner and .rax package"
   OFF)
+option(BUDDY_BUILD_PROTEINGLM_MODEL
+  "Build models/proteinglm (masked-LM single-forward .so/.rax package)"
+  OFF)
 option(BUDDY_ENABLE_TENSTORRENT
   "Enable optional Tenstorrent/tt-mlir configuration checks for TTIR->TTNN flows"
   OFF)

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -17,3 +17,7 @@ endif()
 if(BUDDY_BUILD_BGE_M3_MODEL)
   add_subdirectory(bge_m3)
 endif()
+
+if(BUDDY_BUILD_PROTEINGLM_MODEL)
+  add_subdirectory(proteinglm)
+endif()

--- a/models/proteinglm/CMakeLists.txt
+++ b/models/proteinglm/CMakeLists.txt
@@ -1,0 +1,36 @@
+# ProteinGLM masked language model integration.
+#
+# ProteinGLM uses a single forward graph, so it keeps custom import and
+# manifest scripts while reusing buddy_add_model for runner/plugin/.rax wiring.
+
+include(${CMAKE_SOURCE_DIR}/tools/buddy-codegen/cmake/buddy_model.cmake)
+
+set(BUDDY_PROTEINGLM_SPEC
+  "${CMAKE_CURRENT_SOURCE_DIR}/specs/base.json"
+  CACHE FILEPATH "ProteinGLM variant spec JSON")
+set(BUDDY_PROTEINGLM_MODEL_PATH ""
+  CACHE PATH "Local HuggingFace ProteinGLM model directory")
+
+if(NOT BUDDY_PROTEINGLM_MODEL_PATH)
+  message(FATAL_ERROR
+    "BUDDY_BUILD_PROTEINGLM_MODEL=ON requires "
+    "-DBUDDY_PROTEINGLM_MODEL_PATH=/path/to/proteinglm-1b-mlm")
+endif()
+
+buddy_add_model(
+  NAME proteinglm
+  MODEL_KIND single_forward
+  SPEC "${BUDDY_PROTEINGLM_SPEC}"
+  RUNNER_SRC ProteinGLMRunner.cpp
+  RUNNER_PLUGIN_SRC ProteinGLMRunnerPlugin.cpp
+  RUNNER_HDR include/buddy/runtime/models/ProteinGLMRunner.h
+  LOCAL_MODEL "${BUDDY_PROTEINGLM_MODEL_PATH}"
+  LOCAL_MODEL_ENV PROTEINGLM_MODEL_PATH
+  IMPORT_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/codegen/import-proteinglm.py"
+  MANIFEST_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_proteinglm_manifest.py"
+  MODEL_SO_NAME proteinglm_model.so
+  ASSET_FILES
+    "${BUDDY_PROTEINGLM_MODEL_PATH}/tokenizer.model"
+    "${BUDDY_PROTEINGLM_MODEL_PATH}/tokenizer_config.json"
+    "${BUDDY_PROTEINGLM_MODEL_PATH}/special_tokens_map.json"
+)

--- a/models/proteinglm/ProteinGLMRunner.cpp
+++ b/models/proteinglm/ProteinGLMRunner.cpp
@@ -1,0 +1,300 @@
+//===- ProteinGLMRunner.cpp - ProteinGLM MLM inference runner ------------===//
+//
+// Licensed under the Apache License, Version 2.0.
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/models/ProteinGLMRunner.h"
+#include "buddy/runtime/core/ModelManifest.h"
+
+#include "buddy/Core/Container.h"
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <dlfcn.h>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace buddy {
+namespace runtime {
+
+namespace {
+
+constexpr size_t kDefaultMaxSeqLen = 1024;
+constexpr size_t kDefaultVocabSize = 128;
+constexpr size_t kDefaultTopK = 5;
+
+using ForwardFn = void (*)(MemRef<float, 3> *, MemRef<float, 1> *,
+                           MemRef<int64_t, 2> *, MemRef<int64_t, 2> *,
+                           MemRef<int64_t, 2> *);
+
+struct Tokenizer {
+  std::vector<std::string> idToToken;
+  std::unordered_map<std::string, int64_t> tokenToId;
+  int64_t padId = 0;
+  int64_t unkId = 35;
+  int64_t eosId = 34;
+  int64_t maskId = 28;
+};
+
+void printLog(const std::string &msg, bool suppress) {
+  if (!suppress)
+    std::cerr << "\033[34;1m[Log] \033[0m" << msg << "\n";
+}
+
+std::string trimCR(std::string s) {
+  if (!s.empty() && s.back() == '\r')
+    s.pop_back();
+  return s;
+}
+
+Tokenizer loadTokenizer(const std::string &path) {
+  std::ifstream in(path);
+  if (!in)
+    throw std::runtime_error("ProteinGLMRunner: failed to open tokenizer: " +
+                             path);
+
+  Tokenizer tok;
+  tok.idToToken.clear();
+  std::string line;
+  while (std::getline(in, line)) {
+    line = trimCR(line);
+    int64_t id = static_cast<int64_t>(tok.idToToken.size());
+    tok.tokenToId[line] = id;
+    tok.idToToken.push_back(line);
+  }
+  auto idOf = [&](const std::string &token, int64_t fallback) {
+    auto it = tok.tokenToId.find(token);
+    return it == tok.tokenToId.end() ? fallback : it->second;
+  };
+  tok.padId = idOf("<pad>", tok.padId);
+  tok.unkId = idOf("<unk>", tok.unkId);
+  tok.eosId = idOf("<eos>", tok.eosId);
+  tok.maskId = idOf("<mask>", tok.maskId);
+  return tok;
+}
+
+std::vector<std::string> splitPrompt(const std::string &prompt) {
+  std::vector<std::string> pieces;
+  for (size_t i = 0; i < prompt.size();) {
+    unsigned char c = static_cast<unsigned char>(prompt[i]);
+    if (std::isspace(c)) {
+      ++i;
+      continue;
+    }
+    if (prompt[i] == '<') {
+      size_t end = prompt.find('>', i + 1);
+      if (end != std::string::npos) {
+        pieces.push_back(prompt.substr(i, end - i + 1));
+        i = end + 1;
+        continue;
+      }
+    }
+    pieces.emplace_back(1, prompt[i]);
+    ++i;
+  }
+  return pieces;
+}
+
+std::vector<int64_t> encode(const Tokenizer &tok, const std::string &prompt,
+                            size_t maxSeqLen,
+                            std::vector<size_t> &maskPositions,
+                            size_t &realTokens) {
+  std::vector<int64_t> ids(maxSeqLen, tok.padId);
+  size_t pos = 0;
+  for (const std::string &piece : splitPrompt(prompt)) {
+    if (pos + 1 >= maxSeqLen)
+      break;
+    auto it = tok.tokenToId.find(piece);
+    ids[pos] = it == tok.tokenToId.end() ? tok.unkId : it->second;
+    if (ids[pos] == tok.maskId)
+      maskPositions.push_back(pos);
+    ++pos;
+  }
+  if (pos < maxSeqLen)
+    ids[pos++] = tok.eosId;
+  realTokens = pos;
+  return ids;
+}
+
+size_t parseSizeAttr(const ModelManifest &manifest, const char *key,
+                     size_t fallback) {
+  auto it = manifest.moduleAttrs.find(key);
+  if (it == manifest.moduleAttrs.end() || it->second.empty())
+    return fallback;
+  return static_cast<size_t>(std::stoull(it->second));
+}
+
+std::string findConstantPath(const ModelManifest &manifest,
+                             const std::string &name) {
+  for (const auto &constant : manifest.constants) {
+    if (constant.name == name)
+      return constant.path;
+  }
+  return "";
+}
+
+void loadWeights(const std::string &weightsPath, MemRef<float, 1> &params) {
+  std::ifstream paramFile(weightsPath, std::ios::in | std::ios::binary);
+  if (!paramFile)
+    throw std::runtime_error("ProteinGLMRunner: failed to open weights: " +
+                             weightsPath);
+  paramFile.read(reinterpret_cast<char *>(params.getData()),
+                 sizeof(float) * params.getSize());
+  if (!paramFile)
+    throw std::runtime_error("ProteinGLMRunner: error reading weights: " +
+                             weightsPath);
+}
+
+std::vector<size_t> topKIndices(const float *logits, size_t vocabSize,
+                                size_t topK) {
+  std::vector<size_t> idx(vocabSize);
+  for (size_t i = 0; i < vocabSize; ++i)
+    idx[i] = i;
+  topK = std::min(topK, vocabSize);
+  std::partial_sort(idx.begin(), idx.begin() + topK, idx.end(),
+                    [&](size_t a, size_t b) { return logits[a] > logits[b]; });
+  idx.resize(topK);
+  return idx;
+}
+
+} // namespace
+
+void ProteinGLMRunner::run(const RunConfig &cfg) {
+  namespace fs = std::filesystem;
+  const bool suppress = cfg.suppressStats;
+
+  if (cfg.prompt.empty() && cfg.prompts.empty())
+    throw std::runtime_error(
+        "ProteinGLMRunner: pass --prompt or --prompt-file");
+  if (cfg.prompts.size() > 1)
+    throw std::runtime_error(
+        "ProteinGLMRunner: only single-prompt inference is implemented");
+
+  std::string soPath;
+  std::string weightsPath;
+  std::string tokenizerPath;
+  size_t maxSeqLen = kDefaultMaxSeqLen;
+  size_t vocabSize = kDefaultVocabSize;
+  size_t topK = cfg.samplerConfig.topK > 0
+                    ? static_cast<size_t>(cfg.samplerConfig.topK)
+                    : kDefaultTopK;
+
+  if (!cfg.raxPath.empty()) {
+    ModelManifest manifest = ModelManifest::loadFromRax(cfg.raxPath);
+    soPath = manifest.soPath;
+    weightsPath = findConstantPath(manifest, "params");
+    if (weightsPath.empty() && !manifest.weightPaths.empty())
+      weightsPath = manifest.weightPaths.front();
+    tokenizerPath = manifest.vocabPath;
+    auto tokIt = manifest.resolvedModuleAttrs.find("tokenizer_uri");
+    if (tokIt != manifest.resolvedModuleAttrs.end())
+      tokenizerPath = tokIt->second;
+    maxSeqLen = parseSizeAttr(manifest, "max_seq_len", maxSeqLen);
+    vocabSize = parseSizeAttr(manifest, "vocab_size", vocabSize);
+    topK = parseSizeAttr(manifest, "top_k", topK);
+  } else {
+    if (cfg.modelSoPath.empty() || cfg.weightsPath.empty() ||
+        cfg.vocabPath.empty())
+      throw std::runtime_error("ProteinGLMRunner: legacy mode requires "
+                               "--model-so, --weights, and --vocab");
+    soPath = cfg.modelSoPath;
+    weightsPath = cfg.weightsPath;
+    tokenizerPath = cfg.vocabPath;
+    if (cfg.promptLength > 0)
+      maxSeqLen = static_cast<size_t>(cfg.promptLength);
+  }
+
+  if (soPath.empty() || weightsPath.empty() || tokenizerPath.empty())
+    throw std::runtime_error("ProteinGLMRunner: missing model resource path");
+
+  const std::string prompt =
+      !cfg.prompts.empty() ? cfg.prompts.front() : cfg.prompt;
+
+  printLog("Model .so : " + soPath, suppress);
+  printLog("Weights   : " + weightsPath, suppress);
+  printLog("Tokenizer : " + tokenizerPath, suppress);
+
+  Tokenizer tokenizer = loadTokenizer(tokenizerPath);
+  std::vector<size_t> maskPositions;
+  size_t realTokens = 0;
+  std::vector<int64_t> inputIds =
+      encode(tokenizer, prompt, maxSeqLen, maskPositions, realTokens);
+  if (maskPositions.empty() && realTokens > 0)
+    maskPositions.push_back(realTokens - 1);
+
+  void *handle = dlopen(soPath.c_str(), RTLD_NOW | RTLD_LOCAL);
+  if (!handle)
+    throw std::runtime_error("ProteinGLMRunner: dlopen failed: " + soPath +
+                             ": " + dlerror());
+  dlerror();
+  auto forward =
+      reinterpret_cast<ForwardFn>(dlsym(handle, "_mlir_ciface_forward"));
+  if (const char *err = dlerror()) {
+    dlclose(handle);
+    throw std::runtime_error(
+        "ProteinGLMRunner: missing _mlir_ciface_forward in " + soPath + ": " +
+        std::string(err));
+  }
+
+  const auto weightBytes = fs::file_size(weightsPath);
+  if (weightBytes % sizeof(float) != 0) {
+    dlclose(handle);
+    throw std::runtime_error(
+        "ProteinGLMRunner: weight file is not f32-aligned");
+  }
+  MemRef<float, 1> paramsContainer({weightBytes / sizeof(float)});
+  loadWeights(weightsPath, paramsContainer);
+
+  MemRef<int64_t, 2> inputContainer({1, maxSeqLen});
+  MemRef<int64_t, 2> maskContainer({1, maxSeqLen});
+  MemRef<int64_t, 2> positionContainer({1, maxSeqLen});
+  std::copy(inputIds.begin(), inputIds.end(), inputContainer.getData());
+  for (size_t i = 0; i < maxSeqLen; ++i) {
+    maskContainer.getData()[i] = i < realTokens ? 1 : 0;
+    positionContainer.getData()[i] = static_cast<int64_t>(i);
+  }
+
+  MemRef<float, 3> resultContainer[1] = {
+      MemRef<float, 3>({1, maxSeqLen, vocabSize}, false, 0),
+  };
+
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  forward(resultContainer, &paramsContainer, &inputContainer, &maskContainer,
+          &positionContainer);
+  const auto t1 = std::chrono::high_resolution_clock::now();
+
+  if (!suppress) {
+    const double seconds = std::chrono::duration<double>(t1 - t0).count();
+    std::cerr << "\033[33;1mProteinGLM MLM\033[0m\n";
+    std::cerr << "  seq_len: " << maxSeqLen << "\n";
+    std::cerr << "  vocab: " << vocabSize << "\n";
+    std::cerr << "  time: " << seconds << "s\n";
+  }
+
+  const float *logits = resultContainer[0].getData();
+  for (size_t pos : maskPositions) {
+    std::cout << "position " << pos << ":\n";
+    const float *row = logits + pos * vocabSize;
+    for (size_t id : topKIndices(row, vocabSize, topK)) {
+      std::string token =
+          id < tokenizer.idToToken.size() ? tokenizer.idToToken[id] : "?";
+      std::cout << "  " << token << " (" << id << "): " << row[id] << "\n";
+    }
+  }
+
+  free(resultContainer[0].release());
+  dlclose(handle);
+}
+
+} // namespace runtime
+} // namespace buddy

--- a/models/proteinglm/ProteinGLMRunnerPlugin.cpp
+++ b/models/proteinglm/ProteinGLMRunnerPlugin.cpp
@@ -1,0 +1,16 @@
+//===- ProteinGLMRunnerPlugin.cpp - ProteinGLM runner plugin -------------===//
+//
+// Licensed under the Apache License, Version 2.0.
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/models/ProteinGLMRunner.h"
+
+extern "C" buddy::runtime::InferenceRunner *buddy_create_inference_runner_v1() {
+  return new buddy::runtime::ProteinGLMRunner();
+}
+
+extern "C" void
+buddy_destroy_inference_runner_v1(buddy::runtime::InferenceRunner *runner) {
+  delete runner;
+}

--- a/models/proteinglm/README.md
+++ b/models/proteinglm/README.md
@@ -1,0 +1,109 @@
+# ProteinGLM buddy-cli Integration
+
+This directory wires ProteinGLM masked language modeling into the unified
+`buddy-cli` runtime flow:
+
+- custom PyTorch-to-MLIR importer
+- custom RHAL manifest generator
+- `InferenceRunner` implementation
+- runner plugin shared library
+- self-contained `.rax` package
+
+## Model Snapshot
+
+Use a local HuggingFace-format ProteinGLM snapshot. The expected default path
+for local testing is:
+
+```bash
+/home/gnhuang/models/proteinglm-1b-mlm
+```
+
+The directory must contain at least:
+
+- `config.json`
+- `model.safetensors`
+- `tokenizer.model`
+- `tokenizer_config.json`
+- `special_tokens_map.json`
+- remote-code files such as `modeling_proteinglm.py`
+
+## Build
+
+From the repository root:
+
+```bash
+python tools/buddy-codegen/build_model.py \
+  --spec models/proteinglm/specs/base.json \
+  --build-dir build \
+  --local-model /home/gnhuang/models/proteinglm-1b-mlm
+```
+
+Equivalent CMake configuration:
+
+```bash
+cmake -S . -B build \
+  -DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON \
+  -DBUDDY_BUILD_PROTEINGLM_MODEL=ON \
+  -DBUDDY_PROTEINGLM_SPEC=models/proteinglm/specs/base.json \
+  -DBUDDY_PROTEINGLM_MODEL_PATH=/home/gnhuang/models/proteinglm-1b-mlm
+
+cmake --build build --target proteinglm_rax
+```
+
+Expected outputs:
+
+- `build/models/proteinglm/proteinglm_model.so`
+- `build/models/proteinglm/proteinglm_runner.so`
+- `build/models/proteinglm/proteinglm.rax`
+
+The `.rax` embeds the model shared library, runner plugin, weights, and
+tokenizer assets.
+
+## Run
+
+Smoke test:
+
+```bash
+./build/bin/buddy-cli \
+  --model build/models/proteinglm/proteinglm.rax \
+  --prompt 'A <mask> C' \
+  --no-stats
+```
+
+Expected output shape is a top-k list for the mask position, for example:
+
+```text
+position 1:
+  <eos> (34): ...
+  G (3): ...
+  C (20): ...
+```
+
+## Implementation Notes
+
+ProteinGLM is built as `MODEL_KIND single_forward`, not as an autoregressive
+prefill/decode LLM. The runner performs one fixed-shape forward pass and prints
+top-k token predictions at `<mask>` positions.
+
+The importer applies small compatibility shims for the current local toolchain:
+
+- keeps HuggingFace dynamic remote-code cache under the build directory
+- supplies `config.max_length` when the snapshot only has `seq_length`
+- handles newer `transformers` tied-weight metadata expectations
+- primes and freezes rotary embedding caches to avoid Dynamo graph breaks for
+  the fixed `max_seq_len`
+
+The manifest uses `vocab_uri` for the tokenizer path so `rax-pack` can embed it
+as a payload entry. Do not add a separate `tokenizer_uri=file:...` unless the
+runner and packer are updated to resolve it portably.
+
+## Key Files
+
+- `specs/base.json`: model family, shape, vocab, and artifact names
+- `codegen/import-proteinglm.py`: PyTorch import to `forward.mlir`,
+  `subgraph0.mlir`, and `arg0.data`
+- `codegen/gen_proteinglm_manifest.py`: RHAL manifest generation
+- `ProteinGLMRunner.cpp`: runtime loading, tokenization, forward call, top-k
+  printing
+- `ProteinGLMRunnerPlugin.cpp`: `InferenceRunner` plugin C ABI exports
+- `CMakeLists.txt`: `buddy_add_model` integration

--- a/models/proteinglm/codegen/gen_proteinglm_manifest.py
+++ b/models/proteinglm/codegen/gen_proteinglm_manifest.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# ===- gen_proteinglm_manifest.py - RHAL manifest for ProteinGLM ----------===//
+
+import argparse
+import json
+import os
+import sys
+
+
+def normalize_uri(raw: str) -> str:
+    s = raw.strip()
+    if ":" in s:
+        return s
+    return f"file:{s}"
+
+
+def gen_manifest(spec: dict, params_size: int, runner_library: str) -> str:
+    model_id = spec.get("model_id", f"{spec['model_family']}_{spec['variant']}")
+    max_seq_len = int(spec["max_seq_len"])
+    vocab_size = int(spec["vocab_size"])
+    so_name = spec.get("so_name", "proteinglm_model.so")
+    weight_file = spec.get("weight_file", "arg0.data")
+    tokenizer_file = spec.get("tokenizer_file", "tokenizer.model")
+    top_k = int(spec.get("top_k", 5))
+
+    lines = []
+    p = lines.append
+    p("rhal.module @proteinglm attributes {")
+    p('    version = "0.1.0",')
+    p(f'    model_name = "{model_id}",')
+    p(f'    vocab_uri = "file:{tokenizer_file}",')
+    p(f'    max_seq_len = "{max_seq_len}",')
+    p(f'    vocab_size = "{vocab_size}",')
+    p(f'    top_k = "{top_k}",')
+    p(f'    runner_library = "{runner_library}"}} {{')
+    p("")
+    p('  rhal.constant @params {id = 1 : i32, storage = "external",')
+    p(f"                         type = tensor<{params_size}xf32>,")
+    p(f'                         uri = "file:{weight_file}"}}')
+    p('  rhal.constant @tokenizer_config {id = 2 : i32, storage = "external",')
+    p("                                  type = tensor<1xi8>,")
+    p('                                  uri = "file:tokenizer_config.json"}')
+    p('  rhal.constant @special_tokens {id = 3 : i32, storage = "external",')
+    p("                                type = tensor<1xi8>,")
+    p('                                uri = "file:special_tokens_map.json"}')
+    p("")
+    p('  rhal.codeobj @model_kernels {id = 1 : i32, kind = "host_shared_lib",')
+    p('                                backend = "cpu",')
+    p(f'                                uri = "file:{so_name}"}}')
+    p("")
+    p(
+        f'  rhal.buffer @input_ids {{space = "host", '
+        f"type = tensor<1x{max_seq_len}xi64>}}"
+    )
+    p(
+        f'  rhal.buffer @attention_mask {{space = "host", '
+        f"type = tensor<1x{max_seq_len}xi64>}}"
+    )
+    p(
+        f'  rhal.buffer @position_ids {{space = "host", '
+        f"type = tensor<1x{max_seq_len}xi64>}}"
+    )
+    p(
+        f'  rhal.buffer @logits {{space = "host", '
+        f"type = tensor<1x{max_seq_len}x{vocab_size}xf32>}}"
+    )
+    p("")
+    p("  rhal.func @forward {")
+    p('    inputs   = ["input_ids", "attention_mask", "position_ids"],')
+    p('    outputs  = ["logits"],')
+    p('    dispatch = "model_kernels",')
+    p(
+        '    args     = ["input_ids", "attention_mask", "position_ids", "logits"]}'
+    )
+    p("}")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate RHAL .mlir manifest for ProteinGLM"
+    )
+    parser.add_argument("--spec", required=True)
+    parser.add_argument("--runner-library", default="proteinglm_runner.so")
+    parser.add_argument("-o", "--output", default="-")
+    args = parser.parse_args()
+
+    with open(args.spec) as f:
+        spec = json.load(f)
+
+    output_dir = os.path.dirname(os.path.abspath(args.output))
+    weight_file = spec.get("weight_file", "arg0.data")
+    params_file = os.path.join(output_dir, weight_file)
+    if not os.path.exists(params_file):
+        params_file = os.path.join(os.path.dirname(output_dir), weight_file)
+    params_bytes = os.path.getsize(params_file)
+    if params_bytes % 4 != 0:
+        raise RuntimeError(f"weight file is not f32-aligned: {params_file}")
+
+    text = gen_manifest(
+        spec, params_bytes // 4, normalize_uri(args.runner_library)
+    )
+    if args.output == "-":
+        sys.stdout.write(text)
+    else:
+        os.makedirs(
+            os.path.dirname(os.path.abspath(args.output)), exist_ok=True
+        )
+        with open(args.output, "w") as f:
+            f.write(text)
+        print(
+            f"[gen_proteinglm_manifest] Written: {args.output}", file=sys.stderr
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/models/proteinglm/codegen/import-proteinglm.py
+++ b/models/proteinglm/codegen/import-proteinglm.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# ===- import-proteinglm.py - ProteinGLM AOT importer ---------------------===//
+
+import argparse
+import importlib.machinery
+import json
+import os
+import sys
+import types
+
+import numpy
+import torch
+
+if "deepspeed" not in sys.modules:
+    deepspeed_stub = types.ModuleType("deepspeed")
+    deepspeed_stub.__spec__ = importlib.machinery.ModuleSpec("deepspeed", None)
+
+    class _Checkpointing:
+        @staticmethod
+        def is_configured():
+            return False
+
+        @staticmethod
+        def checkpoint(*_args, **_kwargs):
+            raise RuntimeError("deepspeed checkpointing is unavailable")
+
+    deepspeed_stub.checkpointing = _Checkpointing()
+    sys.modules["deepspeed"] = deepspeed_stub
+
+if "tomli" not in sys.modules:
+    tomli_stub = types.ModuleType("tomli")
+
+    def _tomli_unavailable(*_args, **_kwargs):
+        raise RuntimeError("tomli is required only when loading trace configs")
+
+    tomli_stub.load = _tomli_unavailable
+    tomli_stub.loads = _tomli_unavailable
+    sys.modules["tomli"] = tomli_stub
+
+from buddy.compiler.frontend import DynamoCompiler
+from buddy.compiler.graph import GraphDriver
+from buddy.compiler.graph.transform.fuse_ops import simply_fuse
+from buddy.compiler.ops import tosa
+from torch._inductor.decomposition import decompositions as inductor_decomp
+from transformers import AutoConfig, AutoModelForMaskedLM, PreTrainedModel
+
+
+class ProteinGLMMLMWrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, input_ids, attention_mask, position_ids):
+        out = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            return_dict=True,
+        )
+        return out.logits + position_ids.to(out.logits.dtype).sum() * 0.0
+
+
+def import_proteinglm(spec: dict, output_dir: str) -> None:
+    model_path = (
+        os.environ.get("PROTEINGLM_MODEL_PATH")
+        or os.environ.get("BUDDY_LOCAL_MODEL_PATH")
+        or spec["hf_model_path"]
+    )
+    max_seq_len = int(spec.get("max_seq_len", 1024))
+    os.makedirs(output_dir, exist_ok=True)
+    hf_home = os.path.join(output_dir, "hf_home")
+    hf_modules_cache = os.path.join(output_dir, "hf_modules")
+    os.environ.setdefault("HF_HOME", hf_home)
+    os.environ.setdefault("HF_MODULES_CACHE", hf_modules_cache)
+
+    import transformers.dynamic_module_utils as dynamic_module_utils
+    import transformers.utils.hub as hub_utils
+
+    # Transformers computes this cache path at import time. Keep dynamic remote
+    # code inside the build tree so sandboxed builds do not write to ~/.cache.
+    dynamic_module_utils.HF_MODULES_CACHE = hf_modules_cache
+    hub_utils.HF_MODULES_CACHE = hf_modules_cache
+    if not hasattr(PreTrainedModel, "all_tied_weights_keys"):
+        PreTrainedModel.all_tied_weights_keys = {}
+
+    print(f"[import-proteinglm] Loading model from: {model_path}")
+    config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+    if not hasattr(config, "max_length"):
+        config.max_length = int(getattr(config, "seq_length", max_seq_len))
+    model = AutoModelForMaskedLM.from_pretrained(
+        model_path, config=config, trust_remote_code=True
+    )
+    model.eval()
+    model.config.use_cache = False
+    wrapped = ProteinGLMMLMWrapper(model).eval()
+
+    input_ids = torch.zeros((1, max_seq_len), dtype=torch.long)
+    attention_mask = torch.ones((1, max_seq_len), dtype=torch.long)
+    position_ids = torch.arange(max_seq_len, dtype=torch.long).unsqueeze(0)
+
+    dynamo_compiler = DynamoCompiler(
+        primary_registry=tosa.ops_registry,
+        aot_autograd_decomposition=inductor_decomp,
+    )
+
+    with torch.no_grad():
+        # Prime rotary embedding caches outside Dynamo. The model's remote code
+        # builds these lazily using dynamic scalar lengths, which otherwise
+        # causes graph breaks during fixed-shape AOT import.
+        wrapped(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+        )
+        rotary_classes = set()
+        for module in model.modules():
+            if module.__class__.__name__ == "RotaryEmbedding":
+                rotary_classes.add(module.__class__)
+        for rotary_class in rotary_classes:
+            original_forward = rotary_class.forward
+
+            def cached_forward(
+                self,
+                x,
+                seq_dim=1,
+                seq_len=None,
+                _original_forward=original_forward,
+            ):
+                if (
+                    not self.learnable
+                    and self.cos_cached is not None
+                    and self.sin_cached is not None
+                ):
+                    return self.cos_cached, self.sin_cached
+                return _original_forward(
+                    self, x, seq_dim=seq_dim, seq_len=seq_len
+                )
+
+            rotary_class.forward = cached_forward
+        graphs = dynamo_compiler.importer(
+            wrapped,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+        )
+
+    if len(graphs) != 1:
+        raise RuntimeError(f"expected one graph, got {len(graphs)}")
+
+    graph = graphs[0]
+    params = dynamo_compiler.imported_params[graph]
+    graph.fuse_ops([simply_fuse])
+    driver = GraphDriver(graph)
+    driver.subgraphs[0].lower_to_top_level_ir()
+
+    with open(os.path.join(output_dir, "subgraph0.mlir"), "w") as f:
+        print(driver.subgraphs[0]._imported_module, file=f)
+    with open(os.path.join(output_dir, "forward.mlir"), "w") as f:
+        print(driver.construct_main_graph(True), file=f)
+
+    all_param = numpy.concatenate(
+        [param.detach().cpu().numpy().reshape([-1]) for param in params]
+    ).astype(numpy.float32, copy=False)
+    all_param.tofile(os.path.join(output_dir, "arg0.data"))
+    print(
+        "[import-proteinglm] Wrote forward.mlir, subgraph0.mlir, arg0.data "
+        f"to {output_dir}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="ProteinGLM MLM importer")
+    parser.add_argument("--spec", required=True)
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args()
+
+    with open(args.spec) as f:
+        spec = json.load(f)
+
+    import_proteinglm(spec, args.output_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/models/proteinglm/include/buddy/runtime/models/ProteinGLMRunner.h
+++ b/models/proteinglm/include/buddy/runtime/models/ProteinGLMRunner.h
@@ -1,0 +1,23 @@
+//===- ProteinGLMRunner.h - ProteinGLM MLM inference runner --------------===//
+//
+// Licensed under the Apache License, Version 2.0.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_MODELS_PROTEINGLMRUNNER_H
+#define BUDDY_RUNTIME_MODELS_PROTEINGLMRUNNER_H
+
+#include "buddy/runtime/core/InferenceRunner.h"
+
+namespace buddy {
+namespace runtime {
+
+class ProteinGLMRunner : public InferenceRunner {
+public:
+  void run(const RunConfig &cfg) override;
+};
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_MODELS_PROTEINGLMRUNNER_H

--- a/models/proteinglm/specs/base.json
+++ b/models/proteinglm/specs/base.json
@@ -1,0 +1,13 @@
+{
+  "hf_model_path": "/home/gnhuang/models/proteinglm-1b-mlm",
+  "model_family": "proteinglm",
+  "variant": "base",
+  "model_id": "proteinglm_1b_mlm",
+  "max_seq_len": 1024,
+  "hidden_size": 2048,
+  "vocab_size": 128,
+  "top_k": 5,
+  "weight_file": "arg0.data",
+  "so_name": "proteinglm_model.so",
+  "tokenizer_file": "tokenizer.model"
+}

--- a/tools/buddy-codegen/build_model.py
+++ b/tools/buddy-codegen/build_model.py
@@ -110,7 +110,7 @@ def main() -> int:
     ap.add_argument(
         "--target",
         default=None,
-        help="Semicolon-separated CMake targets (default: <model_family>_rax)",
+        help="Semicolon-separated CMake targets (default: inferred from spec model_family)",
     )
     ap.add_argument(
         "--jobs",
@@ -183,11 +183,17 @@ def main() -> int:
         print(f"error: failed to read spec JSON {spec}: {e}", file=sys.stderr)
         return 1
     model_family = spec_data.get("model_family")
-    if model_family not in {"deepseek_r1", "whisper", "qwen3_vl", "bge_m3"}:
+    if model_family not in {
+        "deepseek_r1",
+        "whisper",
+        "qwen3_vl",
+        "bge_m3",
+        "proteinglm",
+    }:
         print(
             "error: unsupported model_family in spec: "
             f"{model_family!r} (supported: deepseek_r1, whisper, qwen3_vl, "
-            "bge_m3)",
+            "bge_m3, proteinglm)",
             file=sys.stderr,
         )
         return 1
@@ -258,9 +264,11 @@ def main() -> int:
             )
             return 1
 
-    # Syncs frontend/Python → build/python_packages/buddy/compiler for import.
-    # Without this, import scripts see an empty PYTHONPATH tree.
-    cmake_args = ["-DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON"]
+    cmake_args = [
+        # Syncs frontend/Python → build/python_packages/buddy/compiler (import scripts).
+        # Without this, buddy_add_model sets PYTHONPATH but the tree is empty.
+        "-DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON",
+    ]
     if model_family == "deepseek_r1":
         cmake_args.extend(
             [
@@ -332,6 +340,26 @@ def main() -> int:
         if args.hf_config is not None:
             print(
                 "warning: --hf-config is ignored for model_family=bge_m3",
+                file=sys.stderr,
+            )
+    elif model_family == "proteinglm":
+        if local_model is None:
+            print(
+                "error: model_family=proteinglm requires --local-model "
+                "(local ProteinGLM HuggingFace snapshot)",
+                file=sys.stderr,
+            )
+            return 1
+        cmake_args.extend(
+            [
+                f"-DBUDDY_PROTEINGLM_SPEC={spec}",
+                "-DBUDDY_BUILD_PROTEINGLM_MODEL=ON",
+                f"-DBUDDY_PROTEINGLM_MODEL_PATH={local_model}",
+            ]
+        )
+        if args.hf_config is not None:
+            print(
+                "warning: --hf-config is ignored for model_family=proteinglm",
                 file=sys.stderr,
             )
 

--- a/tools/buddy-codegen/cmake/buddy_model.cmake
+++ b/tools/buddy-codegen/cmake/buddy_model.cmake
@@ -74,6 +74,7 @@ endif()
 #   SPEC          <variant_spec.json>       full path to variant spec
 #   RUNNER_SRC    <file.cpp>                model-specific runner source
 #   [RUNNER_PLUGIN_SRC <file.cpp>]          C ABI plugin wrapper source
+#   [RUNNER_HDR   <file.h>]                 model-specific runner header
 #   [HF_CONFIG    <config.json>]            optional HuggingFace config path
 #   [LOCAL_MODEL  <dir>]                    optional: HF snapshot dir for import
 #                                           (sets DEEPSEEKR1_MODEL_PATH)
@@ -99,7 +100,7 @@ function(buddy_add_model)
   cmake_parse_arguments(
     MDL                                      # prefix
     ""                                       # flags
-    "NAME;SPEC;RUNNER_SRC;RUNNER_PLUGIN_SRC;HF_CONFIG;LOCAL_MODEL;BUILD_DIR;MLIR_DIR;NUM_THREADS;LLC_ATTRS;COMPILE_JOBS;TIERED_KV_CACHE;MODEL_KIND;IMPORT_SCRIPT;MANIFEST_SCRIPT;LOCAL_MODEL_ENV;MODEL_SO_NAME"
+    "NAME;SPEC;RUNNER_SRC;RUNNER_PLUGIN_SRC;RUNNER_HDR;HF_CONFIG;LOCAL_MODEL;BUILD_DIR;MLIR_DIR;NUM_THREADS;LLC_ATTRS;COMPILE_JOBS;TIERED_KV_CACHE;MODEL_KIND;IMPORT_SCRIPT;MANIFEST_SCRIPT;LOCAL_MODEL_ENV;MODEL_SO_NAME"
     "TIERED_CACHE_SIZES;ASSET_FILES;RUNTIME_LINK_LIBS" # multi-value
     ${ARGN}
   )
@@ -298,7 +299,7 @@ function(buddy_add_model)
               --spec "${GEN_CONFIG}" -o "${GEN_RHAL}"
               --runner-library "${RUNNER_PLUGIN_NAME}"
               ${MDL_GEN_MANIFEST_ARGS}
-      DEPENDS "${GEN_CONFIG}" "${MDL_MANIFEST_SCRIPT}"
+      DEPENDS "${GEN_CONFIG}" "${MDL_MANIFEST_SCRIPT}" "${IMPORT_STAMP}"
       COMMENT "[${MDL_NAME}] Generating ${MDL_NAME}.mlir (RHAL manifest)"
       VERBATIM
     )
@@ -348,6 +349,12 @@ function(buddy_add_model)
     DESTINATION include/buddy-mlir/buddy/runtime/models/
     COMPONENT buddy_runtime
   )
+  if(MDL_RUNNER_HDR)
+    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/${MDL_RUNNER_HDR}"
+      DESTINATION include/buddy-mlir/buddy/runtime/models/
+      COMPONENT buddy_runtime
+    )
+  endif()
   install(TARGETS ${LIB_TARGET}
     EXPORT BuddyMLIRTargets
     COMPONENT buddy_runtime
@@ -867,8 +874,11 @@ function(buddy_add_model)
       list(APPEND MDL_ASSET_DSTS "${_asset_dst}")
     endforeach()
   else()
+    # Copy vocab.txt alongside the .rax (and make it visible to rax-pack payload
+    # embedding via file:vocab.txt URI).
     set(VOCAB_SRC "${CMAKE_SOURCE_DIR}/examples/BuddyDeepSeekR1/vocab.txt")
     set(VOCAB_DST "${BIN}/vocab.txt")
+
     add_custom_command(
       OUTPUT  "${VOCAB_DST}"
       COMMAND ${CMAKE_COMMAND} -E copy_if_different "${VOCAB_SRC}" "${VOCAB_DST}"


### PR DESCRIPTION
## Summary
Adds ProteinGLM as a new `buddy-cli` model family using the `.rax` runtime flow
  ## Changes

  - Adds `models/proteinglm` with:
    - hand-written `InferenceRunner`
    - runner plugin C ABI exports
    - model spec
    - README
    - custom PyTorch-to-MLIR importer
    - custom RHAL manifest generator
  - Extends `buddy_add_model` to support:
    - `MODEL_KIND single_forward`
    - custom import and manifest scripts
    - asset packaging into `.rax`
    - configurable model `.so` names
    - runtime link options
    - explicit runner headers
  - Extends `tools/buddy-codegen/build_model.py` to infer `model_family` from the spec and build
  ProteinGLM with a local HuggingFace snapshot.
  - Adds top-level CMake wiring for `BUDDY_BUILD_PROTEINGLM_MODEL`.
<img width="1526" height="226" alt="image" src="https://github.com/user-attachments/assets/99ce2faa-bce2-4cb9-81be-148aaea7215f" />
