### PR TITLE
[frontend][midend] Panel-pack decode matmul weights (DeepSeek-R1 decode ~2x)

### DIFF
--- a/docs/DecodeWeightPacking.md
+++ b/docs/DecodeWeightPacking.md
@@ -1,0 +1,179 @@
+# Decode Weight Packing
+
+This document describes decode weight panel-packing. It repacks the matmul
+weights read by the decode phase into the layout its GEMV kernel walks, so the
+inner loop reads memory contiguously instead of striding across pages.
+
+The current implementation and validation use DeepSeek R1 as the worked example.
+Other models can use the same flow, but each needs its weight shapes checked
+against the packing constraints below before being enabled.
+
+## Environment
+
+Run from the repository root and activate the Python environment used for model
+import:
+
+```bash
+cd buddy-mlir
+conda activate buddy
+```
+
+## Background
+
+Decode generates one token at a time, so every matmul is a GEMV (`m == 1`). Each
+weight byte is read once and never reused, which means the phase is limited by
+how the weights are laid out, not by how many of them there are.
+
+`matmul-vectorization-decode` tiles `N` into `vecSize`-wide panels and reduces
+over `K` inside each panel. For a row-major `B[K, N]`, consecutive `k` in that
+inner loop are `N` elements apart:
+
+| weight | shape (K x N) | inner-loop stride |
+|--------|---------------|-------------------|
+| q_proj, o_proj | 1536 x 1536 | 6 KB |
+| gate_proj, up_proj | 1536 x 8960 | 35 KB |
+| down_proj | 8960 x 1536 | 6 KB |
+| lm_head | 1536 x 151936 | 594 KB |
+
+Every iteration lands on a different page and the hardware prefetcher stops
+working ahead. Panel-packing reorders each weight to
+
+```
+Bpacked[N/V][K][V]                        V = vecSize
+offset(nt, k, v) = nt*K*V + k*V + v
+```
+
+so consecutive `k` are `V` elements apart: one contiguous stream. The same bytes
+are moved, in a different order. This is the standard BLIS/oneDNN/ggml GEMV
+prepack, and it can be done once at import time because decode weights are
+static.
+
+Packing permutes the bytes inside each weight. It does not change the weight's
+shape, its offset, or the size of the parameter buffer, so the decode MLIR is
+unchanged: the same function signature and the same subviews. The packing
+produces a second parameter file, `arg0-decode.data`, alongside the plain
+`arg0.data`. Prefill is handed the plain file and decode the packed one; that is
+the whole of the difference.
+
+Prefill keeps the plain weights because the two phases want opposite layouts.
+Prefill is compute-bound at `m = 1024` -- its `matmul-vectorization-blis` kernel
+reuses each resident tile of `B` across many rows of `A` -- and it reads
+row-major `B`. Handing it packed bytes does not fail loudly: it reads them as
+row-major and produces fluent but wrong output.
+
+## Default Build Integration
+
+Packing is off by default. It is enabled per spec, by setting
+`decode_pack_vector_size` to the panel width, which must match the decode
+`vector-size` in use:
+
+```json
+{
+  "variant": "f32",
+  "decode_pack_vector_size": 32
+}
+```
+
+`models/deepseek_r1/specs/f32_packed_decode.json` is the f32 DeepSeek R1 spec
+with packing enabled. Build it the usual way:
+
+```bash
+python3 tools/buddy-codegen/build_model.py \
+  --spec models/deepseek_r1/specs/f32_packed_decode.json \
+  --build-dir build
+```
+
+When the spec enables packing, the importer runs the
+`pack_decode_matmul_weights` graph transform over the decode graph and writes
+decode's parameters to `arg0-decode.data`; `compile_pipeline.py` compiles decode
+with `-matmul-vectorization-decode-packed` in place of the plain kernel; and
+`gen_session.py` loads both parameter files and gives each phase the one it
+expects.
+
+Two restrictions are enforced at config time:
+
+- f32, f16 and bf16 only. Quantized variants lay their weights out through the
+  dequant kernels and are not in scope.
+- Not supported together with `tiered_kv_cache`. Only `gen_impl` was taught to
+  hand decode a different weight buffer, so `gen_impl_tiered` would give decode
+  the plain weights while compiling it with the packed kernel.
+
+`examples/BuddyDeepSeekR1` has its own packed target, built the usual way:
+
+```bash
+ninja buddy-deepseek-r1-packed-run
+```
+
+It imports with `--pack-decode-weights --pack-vector-size 32` and writes its
+artifacts to `packed_decode/` so they do not clobber the plain f32 outputs.
+
+## Adapting To Other Models
+
+The packed kernel selects per matmul, by shape. It cannot look at a memref and
+tell packed bytes from plain ones, so a weight that was left unpacked but
+compiled with the packed kernel is read through panel-layout addressing: a wrong
+model, with no crash and no failing test.
+
+`pack_decode_matmul_weights` therefore packs *every* matmul weight in the decode
+graph and raises if it cannot pack one, rather than packing what it can. Because
+there are then no exceptions, the pass can be given an empty `packed-shapes`,
+which means "all", and there is no opt-in list to keep in step with the packer.
+
+When enabling this for another model, check:
+
+- **every** matmul weight can be packed. `N` must be divisible by the panel
+  width for all of them, and each must be a parameter rather than a computed
+  value. The transform refuses the graph otherwise, which is the intended
+  behaviour; do not work around it by packing a subset.
+- both matmul op types are covered. `MatmulOp`'s weight is `args[1]`,
+  `AddMMOp`'s is `args[2]`. Projections with a bias import as `AddMMOp` -- in
+  Qwen2 that is q/k/v -- and a version of the transform that handled only
+  `MatmulOp` silently packed 113 of DeepSeek R1's 197 weights.
+- weights that are not matmul operands are left alone. The embedding table in
+  particular must not be packed: it is `[vocab, hidden]`, the transpose of
+  `lm_head` and with an identical element count, and it is read by a gather. The
+  transform selects by matmul operand rather than by size, so the embedding is
+  excluded by construction, but any size-based heuristic added later would
+  confuse the two.
+- decode's parameter list is packed, not prefill's. The two graphs are traced
+  separately and own separate parameter lists, though the tensors inside them
+  are the same objects. The transform rebinds list entries
+  (`_params_ref[i] = packed`) rather than mutating tensors in place. An in-place
+  repack is visible through prefill's list as well and corrupts it.
+
+Weight reuse (`BUDDY_MODEL_REUSE_WEIGHTS`) accounts for packing: the packed file
+is a weight entry of its own, so a build in which it was never written is not
+reused, and the panel width is recorded in `.buddy_weights_manifest.json`, so
+changing it invalidates the reuse. This matters because the packed file is the
+same size as the plain one, and a size check alone cannot tell one panel width
+from another.
+
+## Observed DeepSeek R1 Results
+
+On the f32 DeepSeek R1 Distill Qwen 1.5B experiment, with 48 threads bound to
+both NUMA nodes (`numactl --cpunodebind=0,1 --interleave=0,1 taskset -c 0-47`):
+
+- Per-operator decode time, layer 0:
+
+  | operator | plain | packed |
+  |----------|-------|--------|
+  | q_proj | 0.087 ms | 0.048 ms |
+  | k_proj | 0.056 ms | 0.028 ms |
+  | v_proj | 0.055 ms | 0.028 ms |
+  | o_proj | 0.078 ms | 0.046 ms |
+  | gate_proj | 0.519 ms | 0.315 ms |
+  | up_proj | 0.446 ms | 0.241 ms |
+  | down_proj | 0.411 ms | 0.234 ms |
+  | lm_head (once per token) | 6.03 ms | about 1.5 ms |
+
+- Decode throughput roughly doubles.
+- Measured against a 267.9 GB/s STREAM read ceiling on the test machine, the
+  plain kernel reached 40-58% of peak on these weights.
+- Generated tokens are identical to the unpacked build.
+- The packed parameter file is the same size as the plain one, and a packed build
+  holds both: about 13.5 GB of weights in memory for this model instead of 6.8.
+
+These numbers are machine-dependent. Note also that end-to-end decode tokens/s
+is a poor measure here: on the test machine it varied by about 65% run to run
+for the same binary, so the per-operator figures above were taken from
+instrumented per-region timings averaged over a full generation.

--- a/examples/BuddyDeepSeekR1/CMakeLists.txt
+++ b/examples/BuddyDeepSeekR1/CMakeLists.txt
@@ -231,7 +231,6 @@ add_custom_command(
             -matmul-vectorization-blis
             -batchmatmul-optimize
             -convert-linalg-to-affine-loops
-            -affine-parallelize
             -convert-vector-to-scf
             -lower-affine
             -convert-scf-to-openmp=${OPENMP_NUM_THREADS}
@@ -308,6 +307,239 @@ add_custom_command(
             -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph_decode.o
     DEPENDS buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode.mlir
     COMMENT "Building subgraph_decode.o "
+    VERBATIM)
+
+# ── Decode-only weight panel-packing (see the pack_decode_matmul_weights
+# graph transform and MatMulVectorizationDecodePacked.cpp). Written to its own
+# subdirectory so it doesn't clobber the plain f32 outputs above.
+set(PACKED_DECODE_DIR ${CMAKE_CURRENT_BINARY_DIR}/packed_decode)
+
+# pack_decode_matmul_weights repacks every matmul weight in the decode graph,
+# producing a second parameter file (arg0-decode.data) that is the same size and
+# layout as arg0.data with only the bytes inside each weight permuted. Prefill
+# is handed the plain one, decode the packed one; that is the whole difference.
+set(PACKED_DECODE_VECTOR_SIZE 32)
+
+add_custom_command(
+  OUTPUT ${PACKED_DECODE_DIR}/forward_prefill.mlir
+          ${PACKED_DECODE_DIR}/subgraph0_prefill.mlir
+          ${PACKED_DECODE_DIR}/forward_decode.mlir
+          ${PACKED_DECODE_DIR}/subgraph0_decode.mlir
+          ${PACKED_DECODE_DIR}/arg0.data
+          ${PACKED_DECODE_DIR}/arg0-decode.data
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${PACKED_DECODE_DIR}
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/import-deepseek-r1.py
+          --output-dir ${PACKED_DECODE_DIR}
+          --pack-decode-weights --pack-vector-size ${PACKED_DECODE_VECTOR_SIZE}
+  COMMENT "Generating packed-decode forward.mlir, subgraph0.mlir and weight data..."
+)
+
+add_custom_command(
+  OUTPUT forward_prefill-packed.o
+  COMMAND ${BUDDY_BINARY_DIR}/buddy-opt ${PACKED_DECODE_DIR}/forward_prefill.mlir
+            -simplify-tosa-reshape |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+            -pass-pipeline ${TOSA_PIPELINE} |
+          ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -canonicalize
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -cse
+            -canonicalize
+            -optimize-allocation-liveness
+            -eliminate-memref-copy
+            -assume-tight-memref-layout
+            -staticize-memref-layout
+            -matmul-vectorization-blis
+            -batchmatmul-optimize
+            -convert-linalg-to-affine-loops
+            -affine-parallelize
+            -convert-vector-to-scf
+            -lower-affine
+            -convert-scf-to-openmp=${OPENMP_NUM_THREADS}
+            -memref-expand
+            -arith-expand
+            -convert-vector-to-llvm
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -llvm-request-c-wrappers
+            -convert-openmp-to-llvm
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+        ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+        ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+        ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} -filetype=obj -relocation-model=pic -O3
+          -o ${CMAKE_CURRENT_BINARY_DIR}/forward_prefill-packed.o
+  DEPENDS buddy-opt ${PACKED_DECODE_DIR}/forward_prefill.mlir
+  COMMENT "Building forward_prefill-packed.o "
+  VERBATIM)
+
+add_custom_command(
+    OUTPUT subgraph_prefill-packed.o
+    COMMAND ${BUDDY_BINARY_DIR}/buddy-opt ${PACKED_DECODE_DIR}/subgraph0_prefill.mlir
+              -simplify-tosa-reshape |
+            ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+              -pass-pipeline ${TOSA_PIPELINE} |
+            ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -convert-elementwise-to-linalg
+            -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -canonicalize
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -cse
+            -canonicalize
+            -optimize-allocation-liveness
+            -eliminate-memref-copy
+            -assume-tight-memref-layout
+            -staticize-memref-layout
+            -matmul-vectorization-blis
+            -batchmatmul-optimize
+            -batchmatmul-transpose-b-vectorization
+            -convert-linalg-to-affine-loops
+            -affine-parallelize
+            -convert-vector-to-scf
+            -lower-affine
+            -convert-scf-to-openmp=${OPENMP_NUM_THREADS}
+            -cse
+            -memref-expand
+            -arith-expand
+            -convert-vector-to-llvm
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -llvm-request-c-wrappers
+            -convert-openmp-to-llvm
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+          ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+          ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} -filetype=obj -relocation-model=pic -O3
+            -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph_prefill-packed.o
+    DEPENDS buddy-opt ${PACKED_DECODE_DIR}/subgraph0_prefill.mlir
+    COMMENT "Building subgraph_prefill-packed.o "
+    VERBATIM)
+
+add_custom_command(
+  OUTPUT forward_decode-packed.o
+  COMMAND ${BUDDY_BINARY_DIR}/buddy-opt ${PACKED_DECODE_DIR}/forward_decode.mlir
+            -simplify-tosa-reshape |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+            -pass-pipeline ${TOSA_PIPELINE} |
+          ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -canonicalize
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -cse
+            -canonicalize
+            -optimize-allocation-liveness
+            -eliminate-memref-copy
+            -assume-tight-memref-layout
+            -staticize-memref-layout
+            -matmul-vectorization-blis
+            -batchmatmul-optimize
+            -convert-linalg-to-affine-loops
+            -affine-parallelize
+            -convert-vector-to-scf
+            -lower-affine
+            -convert-scf-to-openmp=${OPENMP_NUM_THREADS}
+            -memref-expand
+            -arith-expand
+            -convert-vector-to-llvm
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -llvm-request-c-wrappers
+            -convert-openmp-to-llvm
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+        ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+        ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+        ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} -filetype=obj -relocation-model=pic -O3
+          -o ${CMAKE_CURRENT_BINARY_DIR}/forward_decode-packed.o
+  DEPENDS buddy-opt ${PACKED_DECODE_DIR}/forward_decode.mlir
+  COMMENT "Building forward_decode-packed.o "
+  VERBATIM)
+
+add_custom_command(
+    OUTPUT subgraph_decode-packed.o
+    COMMAND ${BUDDY_BINARY_DIR}/buddy-opt ${PACKED_DECODE_DIR}/subgraph0_decode.mlir
+              -simplify-tosa-reshape
+              -simplify-tosa-matmul-scalar |
+            ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+              -pass-pipeline ${TOSA_PIPELINE} |
+            ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -convert-elementwise-to-linalg
+            -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -canonicalize
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -cse
+            -canonicalize
+            -optimize-allocation-liveness
+            -eliminate-memref-copy
+            -assume-tight-memref-layout
+            -staticize-memref-layout
+            # No packed-shapes: every matmul weight here is packed.
+            "-matmul-vectorization-decode-packed=vector-size=${PACKED_DECODE_VECTOR_SIZE}"
+            -matmul-vectorization-decode=vector-size=32
+            -batch-matmul-vectorization-decode=vector-size=128
+            -batchmatmul-transpose-b-vectorization=vector-size=16
+            -convert-linalg-to-affine-loops
+            -convert-vector-to-scf
+            -lower-affine
+            -convert-scf-to-openmp=${OPENMP_NUM_THREADS}
+            -cse
+            -memref-expand
+            -arith-expand
+            -convert-vector-to-llvm
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -llvm-request-c-wrappers
+            -convert-openmp-to-llvm
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+          ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+          ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} -filetype=obj -relocation-model=pic -O3
+            -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph_decode-packed.o
+    DEPENDS buddy-opt ${PACKED_DECODE_DIR}/subgraph0_decode.mlir
+    COMMENT "Building subgraph_decode-packed.o "
     VERBATIM)
 
 add_custom_command(
@@ -1513,6 +1745,7 @@ add_library(DEEPSEEKR1_W8A32 STATIC forward_prefill-w8a32.o subgraph_prefill-w8a
 add_library(DEEPSEEKR1_W4A16 STATIC forward_prefill-w4a16.o subgraph_prefill-w4a16.o forward_decode-w4a16.o subgraph_decode-w4a16.o)
 add_library(DEEPSEEKR1_W8A16 STATIC forward_prefill-w8a16.o subgraph_prefill-w8a16.o forward_decode-w8a16.o subgraph_decode-w8a16.o)
 add_library(DEEPSEEKR1_W8A8 STATIC forward_prefill-w8a8.o subgraph_prefill-w8a8.o forward_decode-w8a8.o subgraph_decode-w8a8.o)
+add_library(DEEPSEEKR1_PACKED STATIC forward_prefill-packed.o subgraph_prefill-packed.o forward_decode-packed.o subgraph_decode-packed.o)
 
 SET_SOURCE_FILES_PROPERTIES(
   template.o
@@ -1555,6 +1788,11 @@ SET_TARGET_PROPERTIES(
   PROPERTIES
   LINKER_LANGUAGE C)
 
+SET_TARGET_PROPERTIES(
+  DEEPSEEKR1_PACKED
+  PROPERTIES
+  LINKER_LANGUAGE C)
+
 add_executable(buddy-deepseek-r1-run buddy-deepseek-r1-main.cpp)
 add_executable(buddy-deepseek-r1-f16-run buddy-deepseek-r1-f16-main.cpp)
 add_executable(buddy-deepseek-r1-bf16-run buddy-deepseek-r1-bf16-main.cpp)
@@ -1562,10 +1800,16 @@ add_executable(buddy-deepseek-r1-w8a32-run buddy-deepseek-r1-w8a32-main.cpp)
 add_executable(buddy-deepseek-r1-w8a8-run buddy-deepseek-r1-w8a8-main.cpp)
 add_executable(buddy-deepseek-r1-w4a16-run buddy-deepseek-r1-w4a16-main.cpp)
 add_executable(buddy-deepseek-r1-w8a16-run buddy-deepseek-r1-w8a16-main.cpp)
+add_executable(buddy-deepseek-r1-packed-run buddy-deepseek-r1-packed-main.cpp)
 add_executable(buddy-deepseek-r1-cli buddy-deepseek-r1-cli.cpp)
 
 set(DEEPSEEKR1_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 set(DEEPSEEKR1_EXAMPLE_BUILD_PATH ${CMAKE_CURRENT_BINARY_DIR})
+
+target_compile_definitions(buddy-deepseek-r1-packed-run PRIVATE
+  DEEPSEEKR1_EXAMPLE_PATH="${DEEPSEEKR1_EXAMPLE_PATH}/"
+  DEEPSEEKR1_EXAMPLE_BUILD_PATH="${PACKED_DECODE_DIR}/"
+)
 
 target_compile_definitions(buddy-deepseek-r1-run PRIVATE
   DEEPSEEKR1_EXAMPLE_PATH="${DEEPSEEKR1_EXAMPLE_PATH}/"
@@ -1614,6 +1858,7 @@ target_link_directories(buddy-deepseek-r1-w8a32-run PRIVATE ${LLVM_LIBRARY_DIR})
 target_link_directories(buddy-deepseek-r1-w8a8-run PRIVATE ${LLVM_LIBRARY_DIR})
 target_link_directories(buddy-deepseek-r1-w4a16-run PRIVATE ${LLVM_LIBRARY_DIR})
 target_link_directories(buddy-deepseek-r1-w8a16-run PRIVATE ${LLVM_LIBRARY_DIR})
+target_link_directories(buddy-deepseek-r1-packed-run PRIVATE ${LLVM_LIBRARY_DIR})
 target_link_directories(buddy-deepseek-r1-cli PRIVATE ${LLVM_LIBRARY_DIR})
 
 set(BUDDY_DEEPSEEKR1_LIBS
@@ -1651,6 +1896,11 @@ set(BUDDY_DEEPSEEKR1_W8A16_LIBS
   mlir_c_runner_utils
   omp
 )
+set(BUDDY_DEEPSEEKR1_PACKED_LIBS
+  DEEPSEEKR1_PACKED
+  mlir_c_runner_utils
+  omp
+)
 if(BUDDY_MLIR_USE_MIMALLOC)
   list(APPEND BUDDY_DEEPSEEKR1_LIBS mimalloc)
   list(APPEND BUDDY_DEEPSEEKR1_F16_LIBS mimalloc)
@@ -1659,6 +1909,7 @@ if(BUDDY_MLIR_USE_MIMALLOC)
   list(APPEND BUDDY_DEEPSEEKR1_W8A8_LIBS mimalloc)
   list(APPEND BUDDY_DEEPSEEKR1_W4A16_LIBS mimalloc)
   list(APPEND BUDDY_DEEPSEEKR1_W8A16_LIBS mimalloc)
+  list(APPEND BUDDY_DEEPSEEKR1_PACKED_LIBS mimalloc)
 endif()
 
 target_link_libraries(buddy-deepseek-r1-run ${BUDDY_DEEPSEEKR1_LIBS})
@@ -1668,6 +1919,7 @@ target_link_libraries(buddy-deepseek-r1-w8a32-run ${BUDDY_DEEPSEEKR1_W8A32_LIBS}
 target_link_libraries(buddy-deepseek-r1-w8a8-run ${BUDDY_DEEPSEEKR1_W8A8_LIBS})
 target_link_libraries(buddy-deepseek-r1-w4a16-run ${BUDDY_DEEPSEEKR1_W4A16_LIBS})
 target_link_libraries(buddy-deepseek-r1-w8a16-run ${BUDDY_DEEPSEEKR1_W8A16_LIBS})
+target_link_libraries(buddy-deepseek-r1-packed-run ${BUDDY_DEEPSEEKR1_PACKED_LIBS})
 target_link_libraries(buddy-deepseek-r1-cli ${BUDDY_DEEPSEEKR1_LIBS} LLVMOption buddy_runtime_core)
 
 # Create a distributable package

--- a/examples/BuddyDeepSeekR1/buddy-deepseek-r1-packed-main.cpp
+++ b/examples/BuddyDeepSeekR1/buddy-deepseek-r1-packed-main.cpp
@@ -1,0 +1,735 @@
+//===- buddy-deepseek-r1-main.cpp -----------------------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include <array>
+#include <buddy/Core/Container.h>
+#include <buddy/LLM/TextContainer.h>
+#include <chrono>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sys/time.h>
+
+using namespace buddy;
+double total_time = 0;
+constexpr size_t ParamsSize = 1777088064;
+// arg0-decode.data holds the same parameters as arg0.data with every matmul
+// weight in panel layout (see pack_decode_matmul_weights). Both files are
+// exactly ParamsSize floats. Prefill must get the plain one: its kernel expects
+// row-major B and would read packed bytes without complaint.
+constexpr size_t MaxVocabSize = 151936;
+constexpr size_t MaxTokenLength = 1024;
+
+constexpr size_t NUM_LAYERS = 56;
+constexpr size_t HiddenSize = 128;
+constexpr size_t HeadNum = 2;
+
+extern "C" double _mlir_ciface_rtclock() {
+#ifndef _WIN32
+  struct timeval tp;
+  int stat = gettimeofday(&tp, nullptr);
+  if (stat != 0)
+    fprintf(stderr, "Error returning time from gettimeofday: %d\n", stat);
+  return (tp.tv_sec + tp.tv_usec * 1.0e-6);
+#else
+  fprintf(stderr, "Timing utility not implemented on Windows\n");
+  return 0.0;
+#endif // _WIN32
+}
+
+struct PrefillReturns {
+  MemRef<float, 4> kv0;
+  MemRef<float, 4> kv1;
+  MemRef<float, 4> kv2;
+  MemRef<float, 4> kv3;
+  MemRef<float, 4> kv4;
+  MemRef<float, 4> kv5;
+  MemRef<float, 4> kv6;
+  MemRef<float, 4> kv7;
+  MemRef<float, 4> kv8;
+  MemRef<float, 4> kv9;
+  MemRef<float, 4> kv10;
+  MemRef<float, 4> kv11;
+  MemRef<float, 4> kv12;
+  MemRef<float, 4> kv13;
+  MemRef<float, 4> kv14;
+  MemRef<float, 4> kv15;
+  MemRef<float, 4> kv16;
+  MemRef<float, 4> kv17;
+  MemRef<float, 4> kv18;
+  MemRef<float, 4> kv19;
+  MemRef<float, 4> kv20;
+  MemRef<float, 4> kv21;
+  MemRef<float, 4> kv22;
+  MemRef<float, 4> kv23;
+  MemRef<float, 4> kv24;
+  MemRef<float, 4> kv25;
+  MemRef<float, 4> kv26;
+  MemRef<float, 4> kv27;
+  MemRef<float, 4> kv28;
+  MemRef<float, 4> kv29;
+  MemRef<float, 4> kv30;
+  MemRef<float, 4> kv31;
+  MemRef<float, 4> kv32;
+  MemRef<float, 4> kv33;
+  MemRef<float, 4> kv34;
+  MemRef<float, 4> kv35;
+  MemRef<float, 4> kv36;
+  MemRef<float, 4> kv37;
+  MemRef<float, 4> kv38;
+  MemRef<float, 4> kv39;
+  MemRef<float, 4> kv40;
+  MemRef<float, 4> kv41;
+  MemRef<float, 4> kv42;
+  MemRef<float, 4> kv43;
+  MemRef<float, 4> kv44;
+  MemRef<float, 4> kv45;
+  MemRef<float, 4> kv46;
+  MemRef<float, 4> kv47;
+  MemRef<float, 4> kv48;
+  MemRef<float, 4> kv49;
+  MemRef<float, 4> kv50;
+  MemRef<float, 4> kv51;
+  MemRef<float, 4> kv52;
+  MemRef<float, 4> kv53;
+  MemRef<float, 4> kv54;
+  MemRef<float, 4> kv55;
+  MemRef<float, 3> logits;
+};
+
+/// Decode returns: updated cache_position, then 27 groups of (kv, kv, dummy),
+/// followed by the final two kvs and logits. Total 85 fields.
+struct DecodeReturns {
+  // First return value: updated cache_position (memref<1xi64>)
+  MemRef<long long, 1> cache_position_out;
+
+  MemRef<float, 4> kv0;
+  MemRef<float, 4> kv1;
+  MemRef<long long, 1> ret_dummy0;
+  MemRef<float, 4> kv2;
+  MemRef<float, 4> kv3;
+  MemRef<long long, 1> ret_dummy1;
+  MemRef<float, 4> kv4;
+  MemRef<float, 4> kv5;
+  MemRef<long long, 1> ret_dummy2;
+  MemRef<float, 4> kv6;
+  MemRef<float, 4> kv7;
+  MemRef<long long, 1> ret_dummy3;
+  MemRef<float, 4> kv8;
+  MemRef<float, 4> kv9;
+  MemRef<long long, 1> ret_dummy4;
+  MemRef<float, 4> kv10;
+  MemRef<float, 4> kv11;
+  MemRef<long long, 1> ret_dummy5;
+  MemRef<float, 4> kv12;
+  MemRef<float, 4> kv13;
+  MemRef<long long, 1> ret_dummy6;
+  MemRef<float, 4> kv14;
+  MemRef<float, 4> kv15;
+  MemRef<long long, 1> ret_dummy7;
+  MemRef<float, 4> kv16;
+  MemRef<float, 4> kv17;
+  MemRef<long long, 1> ret_dummy8;
+  MemRef<float, 4> kv18;
+  MemRef<float, 4> kv19;
+  MemRef<long long, 1> ret_dummy9;
+  MemRef<float, 4> kv20;
+  MemRef<float, 4> kv21;
+  MemRef<long long, 1> ret_dummy10;
+  MemRef<float, 4> kv22;
+  MemRef<float, 4> kv23;
+  MemRef<long long, 1> ret_dummy11;
+  MemRef<float, 4> kv24;
+  MemRef<float, 4> kv25;
+  MemRef<long long, 1> ret_dummy12;
+  MemRef<float, 4> kv26;
+  MemRef<float, 4> kv27;
+  MemRef<long long, 1> ret_dummy13;
+  MemRef<float, 4> kv28;
+  MemRef<float, 4> kv29;
+  MemRef<long long, 1> ret_dummy14;
+  MemRef<float, 4> kv30;
+  MemRef<float, 4> kv31;
+  MemRef<long long, 1> ret_dummy15;
+  MemRef<float, 4> kv32;
+  MemRef<float, 4> kv33;
+  MemRef<long long, 1> ret_dummy16;
+  MemRef<float, 4> kv34;
+  MemRef<float, 4> kv35;
+  MemRef<long long, 1> ret_dummy17;
+  MemRef<float, 4> kv36;
+  MemRef<float, 4> kv37;
+  MemRef<long long, 1> ret_dummy18;
+  MemRef<float, 4> kv38;
+  MemRef<float, 4> kv39;
+  MemRef<long long, 1> ret_dummy19;
+  MemRef<float, 4> kv40;
+  MemRef<float, 4> kv41;
+  MemRef<long long, 1> ret_dummy20;
+  MemRef<float, 4> kv42;
+  MemRef<float, 4> kv43;
+  MemRef<long long, 1> ret_dummy21;
+  MemRef<float, 4> kv44;
+  MemRef<float, 4> kv45;
+  MemRef<long long, 1> ret_dummy22;
+  MemRef<float, 4> kv46;
+  MemRef<float, 4> kv47;
+  MemRef<long long, 1> ret_dummy23;
+  MemRef<float, 4> kv48;
+  MemRef<float, 4> kv49;
+  MemRef<long long, 1> ret_dummy24;
+  MemRef<float, 4> kv50;
+  MemRef<float, 4> kv51;
+  MemRef<long long, 1> ret_dummy25;
+  MemRef<float, 4> kv52;
+  MemRef<float, 4> kv53;
+  MemRef<long long, 1> ret_dummy26;
+  MemRef<float, 4> kv54;
+  MemRef<float, 4> kv55;
+  MemRef<float, 3> logits;
+};
+
+using KVPtrArray = std::array<MemRef<float, 4> *, 56>;
+
+KVPtrArray buildPrefillKVPtrs(PrefillReturns &ret) {
+  return {&ret.kv0,  &ret.kv1,  &ret.kv2,  &ret.kv3,  &ret.kv4,  &ret.kv5,
+          &ret.kv6,  &ret.kv7,  &ret.kv8,  &ret.kv9,  &ret.kv10, &ret.kv11,
+          &ret.kv12, &ret.kv13, &ret.kv14, &ret.kv15, &ret.kv16, &ret.kv17,
+          &ret.kv18, &ret.kv19, &ret.kv20, &ret.kv21, &ret.kv22, &ret.kv23,
+          &ret.kv24, &ret.kv25, &ret.kv26, &ret.kv27, &ret.kv28, &ret.kv29,
+          &ret.kv30, &ret.kv31, &ret.kv32, &ret.kv33, &ret.kv34, &ret.kv35,
+          &ret.kv36, &ret.kv37, &ret.kv38, &ret.kv39, &ret.kv40, &ret.kv41,
+          &ret.kv42, &ret.kv43, &ret.kv44, &ret.kv45, &ret.kv46, &ret.kv47,
+          &ret.kv48, &ret.kv49, &ret.kv50, &ret.kv51, &ret.kv52, &ret.kv53,
+          &ret.kv54, &ret.kv55};
+}
+
+KVPtrArray buildDecodeKVPtrs(DecodeReturns &ret) {
+  return {&ret.kv0,  &ret.kv1,  &ret.kv2,  &ret.kv3,  &ret.kv4,  &ret.kv5,
+          &ret.kv6,  &ret.kv7,  &ret.kv8,  &ret.kv9,  &ret.kv10, &ret.kv11,
+          &ret.kv12, &ret.kv13, &ret.kv14, &ret.kv15, &ret.kv16, &ret.kv17,
+          &ret.kv18, &ret.kv19, &ret.kv20, &ret.kv21, &ret.kv22, &ret.kv23,
+          &ret.kv24, &ret.kv25, &ret.kv26, &ret.kv27, &ret.kv28, &ret.kv29,
+          &ret.kv30, &ret.kv31, &ret.kv32, &ret.kv33, &ret.kv34, &ret.kv35,
+          &ret.kv36, &ret.kv37, &ret.kv38, &ret.kv39, &ret.kv40, &ret.kv41,
+          &ret.kv42, &ret.kv43, &ret.kv44, &ret.kv45, &ret.kv46, &ret.kv47,
+          &ret.kv48, &ret.kv49, &ret.kv50, &ret.kv51, &ret.kv52, &ret.kv53,
+          &ret.kv54, &ret.kv55};
+}
+
+// One parameter buffer per phase, exactly as in the unpacked build: packing
+// does not add a buffer, it changes the bytes inside one.
+extern "C" void _mlir_ciface_forward_prefill(PrefillReturns *result,
+                                             MemRef<float, 1> *arg0,
+                                             Text<size_t, 2> *arg1);
+
+extern "C" void _mlir_ciface_forward_decode(
+    DecodeReturns *result, MemRef<float, 1> *arg0, MemRef<long long, 2> *arg1,
+    MemRef<long long, 1> *arg2,
+
+    MemRef<float, 4> *kv0, MemRef<float, 4> *kv1, MemRef<long long, 1> *dummy0,
+    MemRef<float, 4> *kv2, MemRef<float, 4> *kv3, MemRef<long long, 1> *dummy1,
+    MemRef<float, 4> *kv4, MemRef<float, 4> *kv5, MemRef<long long, 1> *dummy2,
+    MemRef<float, 4> *kv6, MemRef<float, 4> *kv7, MemRef<long long, 1> *dummy3,
+    MemRef<float, 4> *kv8, MemRef<float, 4> *kv9, MemRef<long long, 1> *dummy4,
+    MemRef<float, 4> *kv10, MemRef<float, 4> *kv11,
+    MemRef<long long, 1> *dummy5, MemRef<float, 4> *kv12,
+    MemRef<float, 4> *kv13, MemRef<long long, 1> *dummy6,
+    MemRef<float, 4> *kv14, MemRef<float, 4> *kv15,
+    MemRef<long long, 1> *dummy7, MemRef<float, 4> *kv16,
+    MemRef<float, 4> *kv17, MemRef<long long, 1> *dummy8,
+    MemRef<float, 4> *kv18, MemRef<float, 4> *kv19,
+    MemRef<long long, 1> *dummy9, MemRef<float, 4> *kv20,
+    MemRef<float, 4> *kv21, MemRef<long long, 1> *dummy10,
+    MemRef<float, 4> *kv22, MemRef<float, 4> *kv23,
+    MemRef<long long, 1> *dummy11, MemRef<float, 4> *kv24,
+    MemRef<float, 4> *kv25, MemRef<long long, 1> *dummy12,
+    MemRef<float, 4> *kv26, MemRef<float, 4> *kv27,
+    MemRef<long long, 1> *dummy13, MemRef<float, 4> *kv28,
+    MemRef<float, 4> *kv29, MemRef<long long, 1> *dummy14,
+    MemRef<float, 4> *kv30, MemRef<float, 4> *kv31,
+    MemRef<long long, 1> *dummy15, MemRef<float, 4> *kv32,
+    MemRef<float, 4> *kv33, MemRef<long long, 1> *dummy16,
+    MemRef<float, 4> *kv34, MemRef<float, 4> *kv35,
+    MemRef<long long, 1> *dummy17, MemRef<float, 4> *kv36,
+    MemRef<float, 4> *kv37, MemRef<long long, 1> *dummy18,
+    MemRef<float, 4> *kv38, MemRef<float, 4> *kv39,
+    MemRef<long long, 1> *dummy19, MemRef<float, 4> *kv40,
+    MemRef<float, 4> *kv41, MemRef<long long, 1> *dummy20,
+    MemRef<float, 4> *kv42, MemRef<float, 4> *kv43,
+    MemRef<long long, 1> *dummy21, MemRef<float, 4> *kv44,
+    MemRef<float, 4> *kv45, MemRef<long long, 1> *dummy22,
+    MemRef<float, 4> *kv46, MemRef<float, 4> *kv47,
+    MemRef<long long, 1> *dummy23, MemRef<float, 4> *kv48,
+    MemRef<float, 4> *kv49, MemRef<long long, 1> *dummy24,
+    MemRef<float, 4> *kv50, MemRef<float, 4> *kv51,
+    MemRef<long long, 1> *dummy25, MemRef<float, 4> *kv52,
+    MemRef<float, 4> *kv53, MemRef<long long, 1> *dummy26,
+    MemRef<float, 4> *kv54, MemRef<float, 4> *kv55);
+
+// -----------------------------------------------------------------------------
+// Helper Functions
+// -----------------------------------------------------------------------------
+
+/// Capture input message.
+void getUserInput(std::string &inputStr) {
+  std::cout << "\nPlease send a message:" << std::endl;
+  std::cout << ">>> ";
+  getline(std::cin, inputStr);
+  std::cout << std::endl;
+}
+
+/// Print [Log] label in bold blue format.
+void printLogLabel() { std::cout << "\033[34;1m[Log] \033[0m"; }
+
+/// Print information for each iteration.
+void printIterInfo(size_t iterIdx, std::string str, double time) {
+  total_time += time;
+  std::cout << "\033[32;1m[Iteration " << iterIdx << "] \033[0m";
+  std::cout << "Token: " << str << " | "
+            << "Time: " << time << "s" << std::endl;
+}
+
+/// Tokenize input data in the container.
+void tokenizeInput(const std::string &vocabFile,
+                   Text<size_t, 2> &inputContainer) {
+  printLogLabel();
+  std::cout << "Vocab file: " << std::filesystem::canonical(vocabFile)
+            << std::endl;
+  const auto buddyTokenizeStart = std::chrono::high_resolution_clock::now();
+  inputContainer.tokenizeDeepSeekR1(vocabFile, MaxTokenLength);
+  const auto buddyTokenizeEnd = std::chrono::high_resolution_clock::now();
+  const std::chrono::duration<double, std::milli> buddyTokenizeTime =
+      buddyTokenizeEnd - buddyTokenizeStart;
+  printLogLabel();
+  std::cout << "Tokenize time: " << buddyTokenizeTime.count() << "ms"
+            << std::endl;
+}
+
+/// Load parameters into data container.
+void loadParameters(const std::string &paramFilePath,
+                    MemRef<float, 1> &params) {
+  const auto loadStart = std::chrono::high_resolution_clock::now();
+  std::ifstream paramFile(paramFilePath, std::ios::in | std::ios::binary);
+  if (!paramFile.is_open()) {
+    throw std::runtime_error("[Error] Failed to open params file!");
+  }
+  printLogLabel();
+  std::cout << "Loading params..." << std::endl;
+  printLogLabel();
+  std::cout << "Params file: " << std::filesystem::canonical(paramFilePath)
+            << std::endl;
+
+  // Fail loudly on a size mismatch. Reading fewer floats than the file holds
+  // is otherwise completely silent: the model still runs, just on weights
+  // sliced at the wrong offsets. This is the failure mode when the packed
+  // buffer's size constant drifts from what import-deepseek-r1.py actually
+  // wrote (it prints the element count).
+  const auto expectedBytes =
+      static_cast<std::streamsize>(sizeof(float) * params.getSize());
+  paramFile.seekg(0, std::ios::end);
+  const auto actualBytes = paramFile.tellg();
+  paramFile.seekg(0, std::ios::beg);
+  if (actualBytes != expectedBytes) {
+    throw std::runtime_error(
+        "[Error] Params file size mismatch for " + paramFilePath +
+        ": expected " + std::to_string(expectedBytes) + " bytes (" +
+        std::to_string(params.getSize()) + " floats), file has " +
+        std::to_string(static_cast<long long>(actualBytes)) + " bytes.");
+  }
+
+  paramFile.read(reinterpret_cast<char *>(params.getData()), expectedBytes);
+  if (paramFile.fail()) {
+    throw std::runtime_error("Error occurred while reading params file!");
+  }
+  paramFile.close();
+  const auto loadEnd = std::chrono::high_resolution_clock::now();
+  const std::chrono::duration<double, std::milli> loadTime =
+      loadEnd - loadStart;
+  printLogLabel();
+  std::cout << "Params load time: " << (double)(loadTime.count()) / 1000
+            << "s\n"
+            << std::endl;
+}
+
+/// Find the index of the max value.
+int findMaxIndex(const float *start, const float *end) {
+  return std::distance(start, std::max_element(start, end));
+}
+
+void copy_kv_by_cache_position_block(const KVPtrArray &prefillPtrs,
+                                     const KVPtrArray &decodePtrs,
+                                     int cache_position) {
+  constexpr int num_kv = 56;
+  const size_t copy_len = std::min<size_t>(static_cast<size_t>(cache_position),
+                                           static_cast<size_t>(MaxTokenLength));
+
+  for (int k = 0; k < num_kv; ++k) {
+    auto &src = *prefillPtrs[k];
+    auto &dst = *decodePtrs[k];
+
+    for (int h = 0; h < (int)HeadNum; ++h) {
+      size_t bytes_to_copy = copy_len * HiddenSize * sizeof(float);
+
+      float *src_ptr = src.getData() + h * MaxTokenLength * HiddenSize;
+      float *dst_ptr = dst.getData() + h * MaxTokenLength * HiddenSize;
+
+      std::memcpy(dst_ptr, src_ptr, bytes_to_copy);
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// DeepSeekR1 Inference Main Entry
+// -----------------------------------------------------------------------------
+
+int main() {
+  /// Print the title of this example.
+  const std::string title = "DeepSeekR1 Inference Powered by Buddy Compiler";
+  std::cout << "\033[33;1m" << title << "\033[0m" << std::endl;
+
+  /// Define directories of vocabulary and parameter file.
+  std::string deepSeekR1Dir = DEEPSEEKR1_EXAMPLE_PATH;
+  std::string deepSeekR1BuildDir = DEEPSEEKR1_EXAMPLE_BUILD_PATH;
+  const std::string vocabDir = deepSeekR1Dir + "vocab.txt";
+  const std::string paramsDir = deepSeekR1BuildDir + "arg0.data";
+  const std::string paramsDecodeDir = deepSeekR1BuildDir + "arg0-decode.data";
+
+  /// Get user message.
+  std::string inputStr;
+  getUserInput(inputStr);
+
+  /// Initialize data containers
+  Text<size_t, 2> outputContainer;
+  Text<size_t, 2> inputContainerPrefill(inputStr);
+  MemRef<long long, 2> inputContainerDecode({1, 1}, 0LL);
+  MemRef<float, 1> ParamsContainer({ParamsSize});
+  MemRef<float, 1> ParamsDecodeContainer({ParamsSize});
+  MemRef<long long, 1> cachePosition({1}, 0LL);
+
+  MemRef<float, 3> logits_prefill({1, MaxTokenLength, MaxVocabSize});
+
+  // Helper lambda to create a zero-initialized KV MemRef.
+  auto makeKV = []() {
+    return MemRef<float, 4>({1, HeadNum, MaxTokenLength, HiddenSize}, 0);
+  };
+
+  MemRef<float, 4> kv0 = makeKV();
+  MemRef<float, 4> kv1 = makeKV();
+  MemRef<float, 4> kv2 = makeKV();
+  MemRef<float, 4> kv3 = makeKV();
+  MemRef<float, 4> kv4 = makeKV();
+  MemRef<float, 4> kv5 = makeKV();
+  MemRef<float, 4> kv6 = makeKV();
+  MemRef<float, 4> kv7 = makeKV();
+  MemRef<float, 4> kv8 = makeKV();
+  MemRef<float, 4> kv9 = makeKV();
+  MemRef<float, 4> kv10 = makeKV();
+  MemRef<float, 4> kv11 = makeKV();
+  MemRef<float, 4> kv12 = makeKV();
+  MemRef<float, 4> kv13 = makeKV();
+  MemRef<float, 4> kv14 = makeKV();
+  MemRef<float, 4> kv15 = makeKV();
+  MemRef<float, 4> kv16 = makeKV();
+  MemRef<float, 4> kv17 = makeKV();
+  MemRef<float, 4> kv18 = makeKV();
+  MemRef<float, 4> kv19 = makeKV();
+  MemRef<float, 4> kv20 = makeKV();
+  MemRef<float, 4> kv21 = makeKV();
+  MemRef<float, 4> kv22 = makeKV();
+  MemRef<float, 4> kv23 = makeKV();
+  MemRef<float, 4> kv24 = makeKV();
+  MemRef<float, 4> kv25 = makeKV();
+  MemRef<float, 4> kv26 = makeKV();
+  MemRef<float, 4> kv27 = makeKV();
+  MemRef<float, 4> kv28 = makeKV();
+  MemRef<float, 4> kv29 = makeKV();
+  MemRef<float, 4> kv30 = makeKV();
+  MemRef<float, 4> kv31 = makeKV();
+  MemRef<float, 4> kv32 = makeKV();
+  MemRef<float, 4> kv33 = makeKV();
+  MemRef<float, 4> kv34 = makeKV();
+  MemRef<float, 4> kv35 = makeKV();
+  MemRef<float, 4> kv36 = makeKV();
+  MemRef<float, 4> kv37 = makeKV();
+  MemRef<float, 4> kv38 = makeKV();
+  MemRef<float, 4> kv39 = makeKV();
+  MemRef<float, 4> kv40 = makeKV();
+  MemRef<float, 4> kv41 = makeKV();
+  MemRef<float, 4> kv42 = makeKV();
+  MemRef<float, 4> kv43 = makeKV();
+  MemRef<float, 4> kv44 = makeKV();
+  MemRef<float, 4> kv45 = makeKV();
+  MemRef<float, 4> kv46 = makeKV();
+  MemRef<float, 4> kv47 = makeKV();
+  MemRef<float, 4> kv48 = makeKV();
+  MemRef<float, 4> kv49 = makeKV();
+  MemRef<float, 4> kv50 = makeKV();
+  MemRef<float, 4> kv51 = makeKV();
+  MemRef<float, 4> kv52 = makeKV();
+  MemRef<float, 4> kv53 = makeKV();
+  MemRef<float, 4> kv54 = makeKV();
+  MemRef<float, 4> kv55 = makeKV();
+
+  // Initialize Prefill returns (aggregate initialization).
+  PrefillReturns prefillRet = {
+      kv0,  kv1,  kv2,  kv3,  kv4,  kv5,  kv6,           kv7,  kv8,  kv9,
+      kv10, kv11, kv12, kv13, kv14, kv15, kv16,          kv17, kv18, kv19,
+      kv20, kv21, kv22, kv23, kv24, kv25, kv26,          kv27, kv28, kv29,
+      kv30, kv31, kv32, kv33, kv34, kv35, kv36,          kv37, kv38, kv39,
+      kv40, kv41, kv42, kv43, kv44, kv45, kv46,          kv47, kv48, kv49,
+      kv50, kv51, kv52, kv53, kv54, kv55, logits_prefill};
+
+  /// Fill data into containers
+  tokenizeInput(vocabDir, inputContainerPrefill);
+  outputContainer.loadVocab(vocabDir);
+  loadParameters(paramsDir, ParamsContainer);
+  loadParameters(paramsDecodeDir, ParamsDecodeContainer);
+
+  /// Run DeepSeekR1 Inference - Prefill phase
+  double prefillTokensPerSec = 0.0;
+  const auto inferenceStart = std::chrono::high_resolution_clock::now();
+  _mlir_ciface_forward_prefill(&prefillRet, &ParamsContainer,
+                               &inputContainerPrefill);
+  const auto inferenceEnd = std::chrono::high_resolution_clock::now();
+  const std::chrono::duration<double, std::milli> inferenceTime =
+      inferenceEnd - inferenceStart;
+
+  int tokenIndex = inputContainerPrefill.getTokenCnt() - 1;
+  const float *startPtr =
+      prefillRet.logits.getData() + tokenIndex * MaxVocabSize;
+  const float *endPtr = startPtr + MaxVocabSize;
+  int maxIndex = findMaxIndex(startPtr, endPtr);
+  std::string tok = inputContainerPrefill.getStr(maxIndex);
+  printIterInfo(0, tok, inferenceTime.count() / 1000);
+  const double prefillSeconds = inferenceTime.count() / 1000.0;
+  if (prefillSeconds > 0.0) {
+    prefillTokensPerSec = static_cast<double>(MaxTokenLength) / prefillSeconds;
+  }
+  inputContainerDecode.getData()[0] = (long long)maxIndex;
+  outputContainer.appendTokenIdx(maxIndex);
+
+  // Build Prefill KV pointer array for copying.
+  KVPtrArray prefillPtrs = buildPrefillKVPtrs(prefillRet);
+
+  // Initialize Decode returns.
+  MemRef<float, 3> logits_decode({1, 1, MaxVocabSize});
+  DecodeReturns decodeRet = {
+      MemRef<long long, 1>({1}, 0LL), // cache_position_out
+      kv0,
+      kv1,
+      MemRef<long long, 1>({1}, 0LL),
+      kv2,
+      kv3,
+      MemRef<long long, 1>({1}, 0LL),
+      kv4,
+      kv5,
+      MemRef<long long, 1>({1}, 0LL),
+      kv6,
+      kv7,
+      MemRef<long long, 1>({1}, 0LL),
+      kv8,
+      kv9,
+      MemRef<long long, 1>({1}, 0LL),
+      kv10,
+      kv11,
+      MemRef<long long, 1>({1}, 0LL),
+      kv12,
+      kv13,
+      MemRef<long long, 1>({1}, 0LL),
+      kv14,
+      kv15,
+      MemRef<long long, 1>({1}, 0LL),
+      kv16,
+      kv17,
+      MemRef<long long, 1>({1}, 0LL),
+      kv18,
+      kv19,
+      MemRef<long long, 1>({1}, 0LL),
+      kv20,
+      kv21,
+      MemRef<long long, 1>({1}, 0LL),
+      kv22,
+      kv23,
+      MemRef<long long, 1>({1}, 0LL),
+      kv24,
+      kv25,
+      MemRef<long long, 1>({1}, 0LL),
+      kv26,
+      kv27,
+      MemRef<long long, 1>({1}, 0LL),
+      kv28,
+      kv29,
+      MemRef<long long, 1>({1}, 0LL),
+      kv30,
+      kv31,
+      MemRef<long long, 1>({1}, 0LL),
+      kv32,
+      kv33,
+      MemRef<long long, 1>({1}, 0LL),
+      kv34,
+      kv35,
+      MemRef<long long, 1>({1}, 0LL),
+      kv36,
+      kv37,
+      MemRef<long long, 1>({1}, 0LL),
+      kv38,
+      kv39,
+      MemRef<long long, 1>({1}, 0LL),
+      kv40,
+      kv41,
+      MemRef<long long, 1>({1}, 0LL),
+      kv42,
+      kv43,
+      MemRef<long long, 1>({1}, 0LL),
+      kv44,
+      kv45,
+      MemRef<long long, 1>({1}, 0LL),
+      kv46,
+      kv47,
+      MemRef<long long, 1>({1}, 0LL),
+      kv48,
+      kv49,
+      MemRef<long long, 1>({1}, 0LL),
+      kv50,
+      kv51,
+      MemRef<long long, 1>({1}, 0LL),
+      kv52,
+      kv53,
+      MemRef<long long, 1>({1}, 0LL),
+      kv54,
+      kv55,
+      logits_decode};
+
+  KVPtrArray decodePtrs = buildDecodeKVPtrs(decodeRet);
+
+  // Copy KV cache from prefill to decode.
+  copy_kv_by_cache_position_block(
+      prefillPtrs, decodePtrs,
+      static_cast<int>(inputContainerPrefill.getTokenCnt()));
+
+  cachePosition.getData()[0] = inputContainerPrefill.getTokenCnt();
+  int generateLen = MaxTokenLength - inputContainerPrefill.getTokenCnt();
+  double decodeTimeAccumMs = 0.0;
+  size_t decodeTokens = 0;
+
+  /// Decode loop.
+  for (int i = 1; i <= generateLen; i++) {
+    const auto inferenceStart = std::chrono::high_resolution_clock::now();
+
+    // Update dummy fields with current cache position.
+    decodeRet.ret_dummy0.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy1.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy2.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy3.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy4.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy5.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy6.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy7.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy8.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy9.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy10.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy11.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy12.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy13.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy14.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy15.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy16.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy17.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy18.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy19.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy20.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy21.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy22.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy23.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy24.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy25.getData()[0] = cachePosition.getData()[0];
+    decodeRet.ret_dummy26.getData()[0] = cachePosition.getData()[0];
+
+    _mlir_ciface_forward_decode(
+        &decodeRet, &ParamsDecodeContainer, &inputContainerDecode,
+        &cachePosition, &decodeRet.kv0, &decodeRet.kv1, &decodeRet.ret_dummy0,
+        &decodeRet.kv2, &decodeRet.kv3, &decodeRet.ret_dummy1, &decodeRet.kv4,
+        &decodeRet.kv5, &decodeRet.ret_dummy2, &decodeRet.kv6, &decodeRet.kv7,
+        &decodeRet.ret_dummy3, &decodeRet.kv8, &decodeRet.kv9,
+        &decodeRet.ret_dummy4, &decodeRet.kv10, &decodeRet.kv11,
+        &decodeRet.ret_dummy5, &decodeRet.kv12, &decodeRet.kv13,
+        &decodeRet.ret_dummy6, &decodeRet.kv14, &decodeRet.kv15,
+        &decodeRet.ret_dummy7, &decodeRet.kv16, &decodeRet.kv17,
+        &decodeRet.ret_dummy8, &decodeRet.kv18, &decodeRet.kv19,
+        &decodeRet.ret_dummy9, &decodeRet.kv20, &decodeRet.kv21,
+        &decodeRet.ret_dummy10, &decodeRet.kv22, &decodeRet.kv23,
+        &decodeRet.ret_dummy11, &decodeRet.kv24, &decodeRet.kv25,
+        &decodeRet.ret_dummy12, &decodeRet.kv26, &decodeRet.kv27,
+        &decodeRet.ret_dummy13, &decodeRet.kv28, &decodeRet.kv29,
+        &decodeRet.ret_dummy14, &decodeRet.kv30, &decodeRet.kv31,
+        &decodeRet.ret_dummy15, &decodeRet.kv32, &decodeRet.kv33,
+        &decodeRet.ret_dummy16, &decodeRet.kv34, &decodeRet.kv35,
+        &decodeRet.ret_dummy17, &decodeRet.kv36, &decodeRet.kv37,
+        &decodeRet.ret_dummy18, &decodeRet.kv38, &decodeRet.kv39,
+        &decodeRet.ret_dummy19, &decodeRet.kv40, &decodeRet.kv41,
+        &decodeRet.ret_dummy20, &decodeRet.kv42, &decodeRet.kv43,
+        &decodeRet.ret_dummy21, &decodeRet.kv44, &decodeRet.kv45,
+        &decodeRet.ret_dummy22, &decodeRet.kv46, &decodeRet.kv47,
+        &decodeRet.ret_dummy23, &decodeRet.kv48, &decodeRet.kv49,
+        &decodeRet.ret_dummy24, &decodeRet.kv50, &decodeRet.kv51,
+        &decodeRet.ret_dummy25, &decodeRet.kv52, &decodeRet.kv53,
+        &decodeRet.ret_dummy26, &decodeRet.kv54, &decodeRet.kv55);
+
+    const auto inferenceEnd = std::chrono::high_resolution_clock::now();
+    const std::chrono::duration<double, std::milli> inferenceTime =
+        inferenceEnd - inferenceStart;
+    decodeTimeAccumMs += inferenceTime.count();
+    decodeTokens += 1;
+
+    // Determine the generated token.
+    const float *startPtr = decodeRet.logits.getData();
+    const float *endPtr = startPtr + MaxVocabSize;
+    maxIndex = findMaxIndex(startPtr, endPtr);
+    std::string tok = inputContainerPrefill.getStr(maxIndex);
+    // Print the generated token and inference time.
+    printIterInfo(i, tok, inferenceTime.count() / 1000);
+
+    // Stop if a <|end▁of▁sentence|> token is generated.
+    if (maxIndex == 151643) {
+      break;
+    }
+    // Append the generated token into the input and output container.
+    inputContainerDecode.getData()[0] = maxIndex;
+    outputContainer.appendTokenIdx(maxIndex);
+    cachePosition.getData()[0] += 1;
+  }
+
+  const double decodeSeconds = decodeTimeAccumMs / 1000.0;
+  const double decodeTokensPerSec =
+      decodeSeconds > 0.0 ? static_cast<double>(decodeTokens) / decodeSeconds
+                          : 0.0;
+
+  /// Print the final result
+  std::cout << "\n\033[33;1m[Total time]\033[0m " << total_time << std::endl;
+  std::cout << "\033[33;1m[Prefilling]\033[0m " << prefillTokensPerSec
+            << " tokens/s" << std::endl;
+  std::cout << "\033[33;1m[Decoding]\033[0m " << decodeTokensPerSec
+            << " tokens/s" << std::endl;
+  std::cout << "\033[33;1m[Input]\033[0m " << inputStr << std::endl;
+  std::cout << "\033[33;1m[Output]\033[0m "
+            << outputContainer.revertDeepSeekR1() << std::endl;
+
+  return 0;
+}

--- a/examples/BuddyDeepSeekR1/import-deepseek-r1.py
+++ b/examples/BuddyDeepSeekR1/import-deepseek-r1.py
@@ -33,6 +33,7 @@ from buddy.compiler.graph.transform import (
     eliminate_transpose,
     flash_attention_prefill,
     gqa_attention_fusion,
+    pack_decode_matmul_weights,
     simply_fuse,
 )
 from buddy.compiler.graph.type import DeviceType
@@ -58,7 +59,29 @@ parser.add_argument(
     choices=["f32", "f16", "bf16"],
     help="Precision mode for MLIR/input data. Choose from %(choices)s.",
 )
+parser.add_argument(
+    "--pack-decode-weights",
+    action="store_true",
+    help="Panel-pack every decode matmul weight (q/k/v/o_proj, "
+    "gate/up/down_proj, lm_head) and write decode's parameters to their own "
+    "file, arg0-decode.data, instead of sharing prefill's arg0.data. Decode "
+    "is a GEMV (m == 1) and reads each weight byte once, so it is bound by "
+    "how the weights are laid out; prefill is compute-bound and wants them "
+    "plain, so the two phases genuinely need different layouts and therefore "
+    "different buffers. Compiling decode then requires "
+    "-matmul-vectorization-decode-packed with a matching --pack-vector-size; "
+    "the plain decode kernel would read the packed bytes as row-major and "
+    "silently produce a wrong model. f32 only for now.",
+)
+parser.add_argument(
+    "--pack-vector-size",
+    type=int,
+    default=32,
+    help="Panel width used by --pack-decode-weights. Must match the "
+    "vector-size passed to -matmul-vectorization-decode-packed.",
+)
 args = parser.parse_args()
+
 
 # Ensure the output directory exists.
 output_dir = args.output_dir
@@ -235,6 +258,7 @@ else:
     graph_decode = graphs_decode[0]
 
     params = dynamo_compiler_prefill.imported_params[graph_prefill]
+    params_decode = dynamo_compiler_decode.imported_params[graph_decode]
     # Enable verbose mode for debugging eliminate_matmul_transpose_reshape
     graphs_prefill[0].perform(
         [eliminate_transpose, eliminate_matmul_transpose_reshape]
@@ -242,6 +266,20 @@ else:
     graphs_decode[0].perform(
         [eliminate_transpose, eliminate_matmul_transpose_reshape]
     )
+
+    if args.pack_decode_weights:
+        # Decode only, and after eliminate_transpose so the weights are
+        # already [K, N]. Prefill's copies stay plain -- see
+        # pack_decode_matmul_weights for what makes that hold.
+        packed = pack_decode_matmul_weights(
+            graph_decode, vecsize=args.pack_vector_size
+        )
+        print(
+            f"[import-deepseek-r1] packed {len(packed)} decode matmul weights "
+            f"into panel layout (vector-size={args.pack_vector_size}); "
+            "prefill's weights stay plain."
+        )
+
     pattern_list_prefill = [
         simply_fuse,
         apply_classic_fusion,
@@ -327,20 +365,41 @@ else:
         os.path.join(output_dir, "subgraph0_prefill.mlir"), "w"
     ) as module_file:
         print(driver_prefill.subgraphs[0]._imported_module, file=module_file)
-    with open(
-        os.path.join(output_dir, "forward_prefill.mlir"), "w"
-    ) as module_file:
-        print(driver_prefill.construct_main_graph(True), file=module_file)
-    all_param = numpy.concatenate(
-        [param.detach().numpy().reshape([-1]) for param in params]
-    )
-    all_param.tofile(os.path.join(output_dir, "arg0.data"))
+    forward_prefill_text = str(driver_prefill.construct_main_graph(True))
 
     with open(
         os.path.join(output_dir, "subgraph0_decode.mlir"), "w"
     ) as module_file:
         print(driver_decode.subgraphs[0]._imported_module, file=module_file)
+    forward_decode_text = str(driver_decode.construct_main_graph(True))
+
+    with open(
+        os.path.join(output_dir, "forward_prefill.mlir"), "w"
+    ) as module_file:
+        print(forward_prefill_text, file=module_file)
     with open(
         os.path.join(output_dir, "forward_decode.mlir"), "w"
     ) as module_file:
-        print(driver_decode.construct_main_graph(True), file=module_file)
+        print(forward_decode_text, file=module_file)
+
+    # arg0.data: prefill's parameters, always plain row-major.
+    all_param = numpy.concatenate(
+        [param.detach().numpy().reshape([-1]) for param in params]
+    )
+    all_param.tofile(os.path.join(output_dir, "arg0.data"))
+
+    if args.pack_decode_weights:
+        # The same parameters, with every matmul weight in panel layout.
+        # Identical size and offsets to arg0.data, so the two files are drop-in
+        # interchangeable -- which one a phase is handed is the whole of the
+        # difference, and decode's MLIR needs no rewriting at all.
+        all_param_decode = numpy.concatenate(
+            [param.detach().numpy().reshape([-1]) for param in params_decode]
+        )
+        if all_param_decode.size != all_param.size:
+            raise RuntimeError(
+                "[import-deepseek-r1] decode params have "
+                f"{all_param_decode.size} elements but prefill params have "
+                f"{all_param.size}; packing must not change the layout."
+            )
+        all_param_decode.tofile(os.path.join(output_dir, "arg0-decode.data"))

--- a/frontend/Python/graph/transform/__init__.py
+++ b/frontend/Python/graph/transform/__init__.py
@@ -32,6 +32,7 @@ from .onednn_replace import (
     replace_matmul_with_onednn,
     replace_matmul_with_onednn_selective,
 )
+from .pack_decode_weights import pack_decode_matmul_weights
 from .quantization import (
     weight_only_channel_wise,
 )
@@ -49,6 +50,7 @@ __all__ = [
     "flash_attention_prefill",
     "gqa_attention_fusion",
     "maxpool2d_simplify",
+    "pack_decode_matmul_weights",
     "replace_matmul_with_buddy_runtime",
     "replace_matmul_with_onednn",
     "replace_matmul_with_onednn_selective",

--- a/frontend/Python/graph/transform/pack_decode_weights.py
+++ b/frontend/Python/graph/transform/pack_decode_weights.py
@@ -1,0 +1,124 @@
+# ===- pack_decode_weights.py --------------------------------------------------
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ===---------------------------------------------------------------------------
+#
+# Repack matmul weights into N-panel layout for the decode (m == 1, GEMV) phase.
+# See docs/DecodeWeightPacking.md.
+#
+# ===---------------------------------------------------------------------------
+
+from .. import Graph
+from ..operation import AddMMOp, MatmulOp, PlaceholderOp
+
+# Which operand is the weight (B in A @ B): mm(lhs, rhs), addmm(bias, lhs, rhs).
+# Both op types matter -- Qwen2's q/k/v projections carry a bias and so import as
+# AddMMOp, everything else as MatmulOp -- and missing one is not a missed
+# optimisation but a wrong model; see the all-or-nothing check at the end.
+_WEIGHT_OPERAND = {MatmulOp: 1, AddMMOp: 2}
+
+
+def pack_decode_matmul_weights(graph: Graph, vecsize: int = 32):
+    """Rewrite every matmul weight in `graph` into panel-blocked layout:
+
+        Bpacked[n / V][k][n % V] == B[k, n]        V = vecsize
+
+    The declared shape stays [K, N]; only the byte order changes, so nothing
+    downstream sees a difference. -matmul-vectorization-decode-packed is the
+    kernel that reads it. See docs/DecodeWeightPacking.md for why.
+
+    ONLY call this on the decode graph. Prefill's matmul kernel expects
+    row-major B and would read packed bytes as if they were row-major, without
+    complaint. What keeps it safe is that this *rebinds* entries in
+    `graph._params_ref` -- a per-graph list -- rather than mutating the tensors,
+    which prefill's graph still shares by reference. Do not "optimise" the clone
+    away into an in-place permute.
+
+    Args:
+        graph (Graph): the decode Graph. Mutated in place.
+        vecsize (int): panel width. Must equal the vector-size given to
+            -matmul-vectorization-decode-packed, and must divide every
+            weight's N.
+
+    Returns:
+        list[int]: indices into graph._params_ref that were repacked.
+    """
+    if graph._params_ref is None:
+        raise RuntimeError(
+            "pack_decode_matmul_weights: graph has no _params_ref; it can "
+            "only run on a graph imported with its parameters."
+        )
+
+    # graph.params[i] is the placeholder for graph._params_ref[i], so a name
+    # gives the index outright. (Matching on shape and dtype, the way
+    # eliminate_transpose does, is ambiguous the moment two weights share a
+    # shape -- and here many do.)
+    name_to_index = {p.name: i for i, p in enumerate(graph.params)}
+
+    packed_indices = []
+    unpacked = 0
+    for node in graph.body:
+        operand = _WEIGHT_OPERAND.get(type(node))
+        if operand is None or len(node.args) <= operand:
+            continue
+
+        weight_name = str(node.args[operand])
+        index = name_to_index.get(weight_name)
+        if index is None or not isinstance(
+            graph.node_table.get(weight_name), PlaceholderOp
+        ):
+            unpacked += 1  # B is a computed value: nothing static to prepack.
+            continue
+        if index in packed_indices:
+            # Packing it twice would apply the permutation twice.
+            raise RuntimeError(
+                f"pack_decode_matmul_weights: weight '{weight_name}' feeds "
+                "more than one matmul; refusing to pack it twice."
+            )
+
+        weight = graph._params_ref[index]
+        if weight.dim() != 2:
+            unpacked += 1
+            continue
+        k, n = weight.shape
+        if n % vecsize != 0:
+            raise RuntimeError(
+                f"pack_decode_matmul_weights: weight '{weight_name}' has "
+                f"N={n}, not divisible by vecsize={vecsize}."
+            )
+
+        # Rebind, never mutate: prefill's graph holds the same tensor object.
+        graph._params_ref[index] = (
+            weight.detach()
+            .reshape(k, n // vecsize, vecsize)
+            .permute(1, 0, 2)
+            .contiguous()
+            .reshape(k, n)
+        )
+        packed_indices.append(index)
+
+    # The packed kernel selects per matmul, by shape; it cannot tell a packed
+    # weight from a plain one. So packing *every* matmul weight is not a nicety
+    # but the precondition for compiling this graph with it -- one weight left
+    # behind is a wrong model, with no crash and no failing test.
+    if unpacked:
+        raise RuntimeError(
+            f"pack_decode_matmul_weights: {unpacked} matmul(s) in this graph "
+            f"take a weight that could not be packed ({len(packed_indices)} "
+            "were packed). The packed decode kernel cannot distinguish them "
+            "and would read those weights as if they were panel-packed. "
+            "Either make them packable or do not pack this graph."
+        )
+
+    return packed_indices

--- a/midend/lib/Conversion/MatMulOptimization/CMakeLists.txt
+++ b/midend/lib/Conversion/MatMulOptimization/CMakeLists.txt
@@ -3,6 +3,7 @@ add_mlir_library(MatMulOptimization
   MatMulOptimize.cpp
   MatMulVectorization.cpp
   MatMulVectorizationDecode.cpp
+  MatMulVectorizationDecodePacked.cpp
   DequantMatMulVectorizationDecode.cpp
   Int4DequantMatMulVectorizationDecode.cpp
   MatMulParallelVectorization.cpp

--- a/midend/lib/Conversion/MatMulOptimization/MatMulVectorizationDecodePacked.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/MatMulVectorizationDecodePacked.cpp
@@ -1,0 +1,344 @@
+//===- MatMulVectorizationDecodePacked.cpp -------------------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+//
+// Variant of matmul-vectorization-decode (m==1 GEMV) for weight operands
+// that have been physically repacked offline into N-tile panels:
+//
+//   Bpacked[nt][k][v] == B[k, nt*vecSize + v]   for nt in [0, N/vecSize)
+//
+// stored as a flat row-major buffer of K*N elements. Repacking removes the
+// N-stride the plain MatMulVectorizationDecode kernel pays for on the
+// inner-K loop (see MatMulVectorizationDecode.cpp): consecutive k now read
+// vecSize contiguous elements apart instead of N apart.
+//
+// This pass only rewrites matmuls whose static (K, N) operand-B shape is
+// listed in the `packed-shapes` option, so it is a no-op unless a caller
+// explicitly opts a given (K, N) pair in. Physically repacking the weight
+// bytes at that shape is the caller's responsibility (done offline, since
+// decode weights are static across calls); this pass only changes how the
+// kernel addresses them.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/StringExtras.h"
+
+using namespace mlir;
+
+namespace {
+
+static bool hasDefaultMatmulIndexingMaps(linalg::MatmulOp op) {
+  SmallVector<AffineMap, 3> maps = op.getIndexingMapsArray();
+  if (maps.size() != 3)
+    return false;
+
+  MLIRContext *context = op.getContext();
+  AffineExpr m = getAffineDimExpr(0, context);
+  AffineExpr n = getAffineDimExpr(1, context);
+  AffineExpr k = getAffineDimExpr(2, context);
+  SmallVector<AffineMap, 3> expected = {
+      AffineMap::get(3, 0, {m, k}, context),
+      AffineMap::get(3, 0, {k, n}, context),
+      AffineMap::get(3, 0, {m, n}, context),
+  };
+
+  return maps[0] == expected[0] && maps[1] == expected[1] &&
+         maps[2] == expected[2];
+}
+
+static bool isZeroAttribute(Attribute attr) {
+  if (auto floatAttr = dyn_cast<FloatAttr>(attr))
+    return floatAttr.getValue().isZero();
+  if (auto intAttr = dyn_cast<IntegerAttr>(attr))
+    return intAttr.getValue().isZero();
+  return false;
+}
+
+static bool isZeroGlobal(Value value, ModuleOp module) {
+  auto getGlobal = value.getDefiningOp<memref::GetGlobalOp>();
+  if (!getGlobal)
+    return false;
+
+  auto global = module.lookupSymbol<memref::GlobalOp>(getGlobal.getNameAttr());
+  if (!global || !global.getInitialValue().has_value())
+    return false;
+
+  auto dense = dyn_cast<DenseElementsAttr>(*global.getInitialValue());
+  if (!dense || !dense.isSplat())
+    return false;
+
+  return isZeroAttribute(dense.getSplatValue<Attribute>());
+}
+
+static memref::CopyOp findZeroInitCopy(Value output, linalg::MatmulOp matmulOp,
+                                       ModuleOp module) {
+  for (Operation *user : output.getUsers()) {
+    auto copyOp = dyn_cast<memref::CopyOp>(user);
+    if (!copyOp || copyOp.getTarget() != output)
+      continue;
+    if (copyOp->getBlock() != matmulOp->getBlock() ||
+        !copyOp->isBeforeInBlock(matmulOp))
+      continue;
+    if (isZeroGlobal(copyOp.getSource(), module))
+      return copyOp;
+  }
+  return nullptr;
+}
+
+/// Parses a `packed-shapes` option value like "1536x8960,8960x1536" into a
+/// set of (K, N) pairs.
+static llvm::SmallDenseSet<std::pair<int64_t, int64_t>, 4>
+parsePackedShapes(StringRef spec) {
+  llvm::SmallDenseSet<std::pair<int64_t, int64_t>, 4> result;
+  SmallVector<StringRef, 4> pairs;
+  spec.split(pairs, ',', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
+  for (StringRef pair : pairs) {
+    StringRef kStr, nStr;
+    std::tie(kStr, nStr) = pair.split('x');
+    int64_t k, n;
+    if (kStr.trim().getAsInteger(10, k) || nStr.trim().getAsInteger(10, n))
+      continue;
+    result.insert({k, n});
+  }
+  return result;
+}
+
+class MatMulVectorizationDecodePackedPattern : public ConversionPattern {
+public:
+  MatMulVectorizationDecodePackedPattern(
+      MLIRContext *ctx, ModuleOp module, int64_t vecSize,
+      llvm::SmallDenseSet<std::pair<int64_t, int64_t>, 4> packedShapes)
+      : ConversionPattern(linalg::MatmulOp::getOperationName(), 1, ctx),
+        module(module), vecSize(vecSize),
+        packedShapes(std::move(packedShapes)) {}
+
+  bool matchesPackedShape(linalg::MatmulOp op) const {
+    auto aType = dyn_cast<MemRefType>(op.getInputs()[0].getType());
+    auto bType = dyn_cast<MemRefType>(op.getInputs()[1].getType());
+    auto cType = dyn_cast<MemRefType>(op.getOutputs()[0].getType());
+    if (!aType || !bType || !cType)
+      return false;
+    if (!hasDefaultMatmulIndexingMaps(op))
+      return false;
+    if (!aType.hasStaticShape() || aType.getRank() != 2)
+      return false;
+    if (aType.getDimSize(0) != 1)
+      return false;
+    if (cType.getRank() != 2 || cType.getDimSize(0) != 1)
+      return false;
+    if (!bType.hasStaticShape() || bType.getRank() != 2)
+      return false;
+    int64_t k = bType.getDimSize(0);
+    int64_t n = bType.getDimSize(1);
+    if (n % vecSize != 0)
+      return false;
+    // Empty `packed-shapes` means every m==1 matmul weight in this module is
+    // packed -- what pack_decode_matmul_weights guarantees -- so take them all.
+    // With no exceptions there is no opt-in list to fall out of step with.
+    if (packedShapes.empty())
+      return true;
+    return packedShapes.contains({k, n});
+  }
+
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> /*operands*/,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto matmulOp = cast<linalg::MatmulOp>(op);
+    if (!matchesPackedShape(matmulOp))
+      return failure();
+
+    auto loc = matmulOp.getLoc();
+
+    Value A = matmulOp.getInputs()[0];
+    Value B = matmulOp.getInputs()[1];
+    Value C = matmulOp.getOutputs()[0];
+
+    auto bType = cast<MemRefType>(B.getType());
+    int64_t K = bType.getDimSize(0);
+    int64_t N = bType.getDimSize(1);
+    Type elementType = cast<MemRefType>(C.getType()).getElementType();
+    auto vectorType = VectorType::get({vecSize}, elementType);
+
+    // Reinterpret B's underlying buffer as a flat [K*N] row-major view,
+    // regardless of whatever layout/offset it currently carries. The
+    // physical bytes are expected (by construction, offline) to already be
+    // in panel-packed order: flat[n*K + k*vecSize + v] == B[k, n + v].
+    auto metadata = memref::ExtractStridedMetadataOp::create(rewriter, loc, B);
+    auto flatLayout = StridedLayoutAttr::get(
+        rewriter.getContext(), ShapedType::kDynamic, ArrayRef<int64_t>{1});
+    auto flatType = MemRefType::get({K * N}, elementType, flatLayout);
+    Value flatB = memref::ReinterpretCastOp::create(
+        rewriter, loc, flatType, metadata.getBaseBuffer(), metadata.getOffset(),
+        /*sizes=*/ArrayRef<OpFoldResult>{rewriter.getIndexAttr(K * N)},
+        /*strides=*/ArrayRef<OpFoldResult>{rewriter.getIndexAttr(1)});
+
+    Value c0 = arith::ConstantIndexOp::create(rewriter, loc, 0);
+    Value c1 = arith::ConstantIndexOp::create(rewriter, loc, 1);
+    Value cK = arith::ConstantIndexOp::create(rewriter, loc, K);
+    Value step = arith::ConstantIndexOp::create(rewriter, loc, vecSize);
+
+    Value n = memref::DimOp::create(rewriter, loc, C, c1);
+    Value k = memref::DimOp::create(rewriter, loc, A, c1);
+    memref::CopyOp zeroInitCopy = findZeroInitCopy(C, matmulOp, module);
+    bool zeroInitialized = zeroInitCopy != nullptr;
+
+    scf::ParallelOp::create(
+        rewriter, loc,
+        /*lowerBounds=*/ValueRange{c0},
+        /*upperBounds=*/ValueRange{n},
+        /*steps=*/ValueRange{step},
+        [&](OpBuilder &builder, Location loc, ValueRange ivs) {
+          Value nIdx = ivs.front();
+          Value cVec;
+          if (zeroInitialized) {
+            Value zero = arith::ConstantOp::create(
+                builder, loc, elementType, builder.getZeroAttr(elementType));
+            cVec = vector::BroadcastOp::create(builder, loc, vectorType, zero);
+          } else {
+            cVec = vector::LoadOp::create(builder, loc, vectorType, C,
+                                          ValueRange{c0, nIdx});
+          }
+
+          // Panel base offset: nt*K*vecSize == nIdx*K, since nIdx is always
+          // an exact multiple of vecSize (the scf.parallel step).
+          Value panelBase = arith::MulIOp::create(builder, loc, nIdx, cK);
+
+          auto sumIter = scf::ForOp::create(
+              builder, loc, c0, k, c1, ValueRange{cVec},
+              [&](OpBuilder &builder, Location loc, Value kIdx,
+                  ValueRange iterArgs) {
+                Value aElem = memref::LoadOp::create(builder, loc, A,
+                                                     ValueRange{c0, kIdx});
+                Value aVec = vector::BroadcastOp::create(builder, loc,
+                                                         vectorType, aElem);
+                Value kOffset = arith::MulIOp::create(builder, loc, kIdx, step);
+                Value linOffset =
+                    arith::AddIOp::create(builder, loc, panelBase, kOffset);
+                Value bVec = vector::LoadOp::create(
+                    builder, loc, vectorType, flatB, ValueRange{linOffset});
+                Value res = vector::FMAOp::create(builder, loc, aVec, bVec,
+                                                  iterArgs.front());
+                scf::YieldOp::create(builder, loc, res);
+              });
+
+          vector::StoreOp::create(builder, loc, sumIter.getResult(0), C,
+                                  ValueRange{c0, nIdx});
+        });
+
+    rewriter.eraseOp(op);
+    if (zeroInitCopy) {
+      auto getGlobal =
+          zeroInitCopy.getSource().getDefiningOp<memref::GetGlobalOp>();
+      rewriter.eraseOp(zeroInitCopy);
+      if (getGlobal && getGlobal->use_empty())
+        rewriter.eraseOp(getGlobal);
+    }
+
+    return success();
+  }
+
+private:
+  ModuleOp module;
+  int64_t vecSize;
+  llvm::SmallDenseSet<std::pair<int64_t, int64_t>, 4> packedShapes;
+};
+
+class MatMulVectorizationDecodePackedPass
+    : public PassWrapper<MatMulVectorizationDecodePackedPass,
+                         OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(
+      MatMulVectorizationDecodePackedPass)
+
+  StringRef getArgument() const final {
+    return "matmul-vectorization-decode-packed";
+  }
+  StringRef getDescription() const final {
+    return "Vectorize linalg.matmul with m==1 for decode workloads whose B "
+           "operand has been offline-repacked into N-tile panels. Only "
+           "matmuls whose static (K, N) shape is listed in `packed-shapes` "
+           "are rewritten; all others are left for a later pass (e.g. plain "
+           "matmul-vectorization-decode) to handle.";
+  }
+
+  MatMulVectorizationDecodePackedPass() = default;
+  MatMulVectorizationDecodePackedPass(
+      const MatMulVectorizationDecodePackedPass &) {}
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect, scf::SCFDialect,
+                    vector::VectorDialect, memref::MemRefDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp module = getOperation();
+
+    auto packedShapes = parsePackedShapes(packedShapesOpt);
+
+    ConversionTarget target(*context);
+    target.addLegalDialect<arith::ArithDialect, memref::MemRefDialect,
+                           scf::SCFDialect, vector::VectorDialect,
+                           func::FuncDialect>();
+    target.addLegalOp<ModuleOp, func::FuncOp, func::ReturnOp>();
+    target.addDynamicallyLegalOp<linalg::MatmulOp>(
+        [&](linalg::MatmulOp op) -> bool {
+          MatMulVectorizationDecodePackedPattern matcher(
+              context, module, vectorSize, packedShapes);
+          return !matcher.matchesPackedShape(op);
+        });
+
+    RewritePatternSet patterns(context);
+    patterns.add<MatMulVectorizationDecodePackedPattern>(
+        context, module, vectorSize, packedShapes);
+
+    if (failed(applyPartialConversion(module, target, std::move(patterns))))
+      signalPassFailure();
+  }
+
+  Option<int64_t> vectorSize{
+      *this, "vector-size",
+      llvm::cl::desc("Panel width used both by the offline repacking and by "
+                     "this pass's addressing math. Must match the width "
+                     "the weight file was packed with."),
+      llvm::cl::init(32)};
+  Option<std::string> packedShapesOpt{
+      *this, "packed-shapes",
+      llvm::cl::desc("Comma-separated KxN pairs (e.g. '1536x8960,8960x1536') "
+                     "identifying which matmul B operands are pre-packed. "
+                     "Matmuls whose (K,N) shape isn't listed are left "
+                     "untouched."),
+      llvm::cl::init("")};
+};
+
+} // namespace
+
+namespace mlir {
+namespace buddy {
+void registerMatMulVectorizationDecodePackedPass() {
+  PassRegistration<MatMulVectorizationDecodePackedPass>();
+}
+} // namespace buddy
+} // namespace mlir

--- a/midend/lib/InitAll.cpp
+++ b/midend/lib/InitAll.cpp
@@ -68,6 +68,7 @@ void registerMatMulOptimizePass();
 void registerMatMulParallelVectorizationPass();
 void registerMatMulVectorizationPass();
 void registerMatMulVectorizationDecodePass();
+void registerMatMulVectorizationDecodePackedPass();
 void registerDequantMatMulVectorizationDecodePass();
 void registerInt4DequantMatMulVectorizationDecodePass();
 void registerBatchMatMulVectorizationDecodePass();
@@ -131,6 +132,7 @@ void mlir::buddy::registerAllPasses() {
   mlir::buddy::registerMatMulParallelVectorizationPass();
   mlir::buddy::registerMatMulVectorizationPass();
   mlir::buddy::registerMatMulVectorizationDecodePass();
+  mlir::buddy::registerMatMulVectorizationDecodePackedPass();
   mlir::buddy::registerDequantMatMulVectorizationDecodePass();
   mlir::buddy::registerInt4DequantMatMulVectorizationDecodePass();
   mlir::buddy::registerBatchMatMulVectorizationDecodePass();

--- a/models/deepseek_r1/specs/f32_packed_decode.json
+++ b/models/deepseek_r1/specs/f32_packed_decode.json
@@ -1,0 +1,14 @@
+{
+  "hf_model_path": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+  "model_family": "deepseek_r1",
+  "variant": "f32",
+  "max_token_len": 1024,
+  "num_threads": 48,
+  "decode_pack_vector_size": 32,
+  "weights_override": {
+    "total": 1777088064,
+    "linear_elements": 0,
+    "linear_output_channels": 0,
+    "other_elements": 0
+  }
+}

--- a/tests/Conversion/matmul-vectorization-decode-packed-all.mlir
+++ b/tests/Conversion/matmul-vectorization-decode-packed-all.mlir
@@ -1,0 +1,56 @@
+// RUN: buddy-opt %s -matmul-vectorization-decode-packed="vector-size=32" | FileCheck %s
+
+// An empty `packed-shapes` means "every m == 1 matmul weight in this module is
+// panel-packed", so all of them are rewritten regardless of shape. This is what
+// the pack_decode_matmul_weights graph transform guarantees: it packs every
+// matmul weight in the decode graph, and refuses to run if it cannot, so there
+// is no opt-in list to keep in step with it.
+//
+// Both functions below have a different (K, N); both must be rewritten.
+
+func.func @matmul_decode_packed_128x64(%A: memref<1x128xf32>,
+                                       %B: memref<128x64xf32>,
+                                       %C: memref<1x64xf32>) {
+  linalg.matmul
+    ins(%A, %B: memref<1x128xf32>, memref<128x64xf32>)
+    outs(%C: memref<1x64xf32>)
+  return
+}
+
+// CHECK-LABEL: func.func @matmul_decode_packed_128x64
+// CHECK: memref.reinterpret_cast %base_buffer to offset: [%offset], sizes: [8192], strides: [1]
+// CHECK: scf.parallel
+// CHECK: vector.load
+// CHECK: vector.fma
+// CHECK-NOT: linalg.matmul
+
+func.func @matmul_decode_packed_64x96(%A: memref<1x64xf32>,
+                                      %B: memref<64x96xf32>,
+                                      %C: memref<1x96xf32>) {
+  linalg.matmul
+    ins(%A, %B: memref<1x64xf32>, memref<64x96xf32>)
+    outs(%C: memref<1x96xf32>)
+  return
+}
+
+// CHECK-LABEL: func.func @matmul_decode_packed_64x96
+// CHECK: memref.reinterpret_cast %base_buffer to offset: [%offset], sizes: [6144], strides: [1]
+// CHECK: scf.parallel
+// CHECK: vector.load
+// CHECK: vector.fma
+// CHECK-NOT: linalg.matmul
+
+// N not divisible by vecSize cannot be panel-packed at this width, so it is
+// left alone even in "pack everything" mode -- the kernel's addressing assumes
+// whole panels.
+func.func @matmul_decode_ragged_n_untouched(%A: memref<1x64xf32>,
+                                            %B: memref<64x50xf32>,
+                                            %C: memref<1x50xf32>) {
+  linalg.matmul
+    ins(%A, %B: memref<1x64xf32>, memref<64x50xf32>)
+    outs(%C: memref<1x50xf32>)
+  return
+}
+
+// CHECK-LABEL: func.func @matmul_decode_ragged_n_untouched
+// CHECK: linalg.matmul

--- a/tests/Conversion/matmul-vectorization-decode-packed.mlir
+++ b/tests/Conversion/matmul-vectorization-decode-packed.mlir
@@ -1,0 +1,41 @@
+// RUN: buddy-opt %s -matmul-vectorization-decode-packed="vector-size=32 packed-shapes=128x64" | FileCheck %s
+
+// %B is expected to already be physically repacked offline into N-tile
+// panels: Bpacked[nt][k][v] == B[k, nt*32 + v]. This pass only changes how
+// the kernel addresses the buffer (linear offset = n*K + k*vecSize), not
+// the declared memref type, so unpacked shapes are left untouched (see the
+// second function below).
+func.func @matmul_decode_packed(%A: memref<1x128xf32>,
+                                 %B: memref<128x64xf32>,
+                                 %C: memref<1x64xf32>) {
+  linalg.matmul
+    ins(%A, %B: memref<1x128xf32>, memref<128x64xf32>)
+    outs(%C: memref<1x64xf32>)
+  return
+}
+
+// CHECK-LABEL: func.func @matmul_decode_packed
+// CHECK: memref.extract_strided_metadata %arg1
+// CHECK: memref.reinterpret_cast %base_buffer to offset: [%offset], sizes: [8192], strides: [1]
+// CHECK: scf.parallel
+// CHECK: %[[PANEL_BASE:.*]] = arith.muli %arg3, %c128
+// CHECK: scf.for
+// CHECK: %[[K_OFF:.*]] = arith.muli %arg4, %c32
+// CHECK: %[[LIN:.*]] = arith.addi %[[PANEL_BASE]], %[[K_OFF]]
+// CHECK: vector.load %reinterpret_cast[%[[LIN]]]
+// CHECK: vector.fma
+// CHECK-NOT: linalg.matmul
+
+// A (K, N) shape not listed in packed-shapes must be left as a plain
+// linalg.matmul (no matching pattern fires).
+func.func @matmul_decode_unpacked_shape_untouched(%A: memref<1x128xf32>,
+                                                   %B: memref<128x96xf32>,
+                                                   %C: memref<1x96xf32>) {
+  linalg.matmul
+    ins(%A, %B: memref<1x128xf32>, memref<128x96xf32>)
+    outs(%C: memref<1x96xf32>)
+  return
+}
+
+// CHECK-LABEL: func.func @matmul_decode_unpacked_shape_untouched
+// CHECK: linalg.matmul

--- a/tools/buddy-codegen/compile_pipeline.py
+++ b/tools/buddy-codegen/compile_pipeline.py
@@ -79,6 +79,7 @@ def build_stages(
     llc_attrs: str,
     variant: str = "f32",
     tiered: bool = False,
+    decode_pack: dict | None = None,
 ):
     """
     Build the list of (tool_name, [args]) stages for a given pipeline type.
@@ -173,6 +174,22 @@ def build_stages(
             opts.append("-matmul-vectorization-decode=vector-size=32")
         elif variant != "w8a8":
             vector_size = 128 if tiered else 32
+            if decode_pack and decode_pack.get("enabled"):
+                if decode_pack["vector_size"] != vector_size:
+                    raise ValueError(
+                        f"decode_pack vector_size={decode_pack['vector_size']} must "
+                        f"match the decode vector-size={vector_size} in use"
+                    )
+                # No packed-shapes: pack_decode_matmul_weights packed *every*
+                # matmul weight in the decode graph -- and refuses to run at all
+                # if it cannot -- so there is no list of exceptions to keep in
+                # step, and hence no way for one to drift. A drifted list is
+                # silent corruption: the plain kernel would read panel-packed
+                # bytes as row-major and answer fluently and wrongly.
+                opts.append(
+                    "-matmul-vectorization-decode-packed="
+                    f"vector-size={vector_size}"
+                )
             opts.append(
                 f"-matmul-vectorization-decode=vector-size={vector_size}"
             )
@@ -384,6 +401,7 @@ def _compile_one(task: dict) -> str:
         task["llc_attrs"],
         task.get("variant", "f32"),
         task.get("tiered", False),
+        task.get("decode_pack"),
     )
     run_pipeline(
         stages,
@@ -409,6 +427,7 @@ def compile_all(
     pipelines = config["compilation"]["pipelines"]
     num_threads = config["compilation"]["num_threads"]
     variant = config.get("variant", "")
+    decode_pack = config.get("decode_pack", {"enabled": False})
 
     os.makedirs(output_dir, exist_ok=True)
 
@@ -431,6 +450,7 @@ def compile_all(
                 "llc_attrs": llc_attrs,
                 "variant": variant,
                 "tiered": is_tiered_kv_cache(config),
+                "decode_pack": decode_pack,
                 "input": input_path,
                 "output": output_path,
                 "buddy_opt": buddy_opt,
@@ -612,6 +632,7 @@ def compile_partitioned(
 
     num_threads = config["compilation"]["num_threads"]
     variant = config.get("variant", "")
+    decode_pack = config.get("decode_pack", {"enabled": False})
     os.makedirs(output_dir, exist_ok=True)
 
     tasks = []
@@ -623,6 +644,7 @@ def compile_partitioned(
                 "num_threads": num_threads,
                 "llc_attrs": llc_attrs,
                 "variant": variant,
+                "decode_pack": decode_pack,
                 "tiered": is_tiered_kv_cache(config),
                 "input": mlir_name
                 if os.path.isabs(mlir_name)
@@ -935,6 +957,7 @@ def main():
             args.llc_attrs,
             variant,
             is_tiered_kv_cache(config),
+            config.get("decode_pack"),
         )
 
         print(

--- a/tools/buddy-codegen/gen_config.py
+++ b/tools/buddy-codegen/gen_config.py
@@ -299,6 +299,42 @@ def derive_shapes(hf: dict, spec: dict) -> dict:
     }
 
 
+def derive_decode_pack(hf: dict, spec: dict) -> dict:
+    """Opt-in panel-packing of the decode matmul weights (see the
+    pack_decode_matmul_weights graph transform). Off unless the spec sets
+    `decode_pack_vector_size`, so existing specs are unaffected.
+
+    When on, import_model.py runs the pack_decode_matmul_weights graph
+    transform over the decode graph -- rewriting every matmul weight into
+    N-tile panel layout -- and writes decode's parameters to their own file.
+    compile_pipeline.py then compiles decode with
+    -matmul-vectorization-decode-packed instead of the plain row-major kernel.
+
+    Decode needs its own file because the two phases want opposite layouts:
+    decode is a GEMV that reads each weight byte once (so the layout is what
+    limits it), prefill is compute-bound and its matmul kernel expects plain
+    row-major B. Handing prefill the packed bytes does not fail loudly; it just
+    reads them as row-major and produces fluent, wrong output.
+
+    Packing is a permutation of each weight's bytes: same shape, same offsets,
+    same element count. So this is not an extra weight blob -- it is the same
+    blob with a second file, and the only thing that differs between the phases
+    is which of the two they are handed.
+    """
+    vecsize = spec.get("decode_pack_vector_size")
+    if not vecsize:
+        return {"enabled": False}
+
+    return {
+        "enabled": True,
+        "vector_size": vecsize,
+        # Divisibility of every weight's N by vecsize is checked by the graph
+        # transform, which is the only thing that knows the full weight set --
+        # it covers lm_head and the attention projections, not just the FFN.
+        "decode_file": "arg0-decode.data",
+    }
+
+
 def derive_tokens(hf: dict, spec: dict) -> dict:
     return {
         "eos_id": hf.get("eos_token_id", 0),
@@ -326,6 +362,25 @@ def gen_config(spec: dict, hf_config_path: str | None = None) -> dict:
     param_counts = count_params(spec)
     weights = compute_weights(variant, param_counts)
     tiered_kv_cache = derive_tiered_kv_cache(spec)
+    decode_pack = derive_decode_pack(hf, spec)
+    if decode_pack["enabled"] and variant not in ("f32", "f16", "bf16"):
+        raise RuntimeError(
+            f"decode_pack_vector_size is only supported for f32/f16/bf16 "
+            f"variants (got variant={variant!r})"
+        )
+    if decode_pack["enabled"] and tiered_kv_cache["enabled"]:
+        # Refuse here rather than at import time: only gen_impl was taught to
+        # hand decode a different weight buffer, so gen_impl_tiered would
+        # silently give decode the plain weights and compile it with the packed
+        # kernel -- fluent, wrong output, nothing to catch it.
+        raise RuntimeError(
+            "decode_pack_vector_size is not supported together with "
+            "tiered_kv_cache"
+        )
+    if decode_pack["enabled"]:
+        # Not a second blob: the same blob with a second file. weights[0]
+        # ("file") stays plain for prefill; decode is handed "decode_file".
+        weights[0]["decode_file"] = decode_pack["decode_file"]
 
     if tiered_kv_cache["enabled"]:
         if variant != "f32":
@@ -347,6 +402,8 @@ def gen_config(spec: dict, hf_config_path: str | None = None) -> dict:
     model_id = f"{model_family}_{variant}"
     if tiered_kv_cache["enabled"]:
         model_id = f"{model_id}_tiered_kv_cache"
+    if decode_pack["enabled"]:
+        model_id = f"{model_id}_packed_ffn"
 
     return {
         "model_family": model_family,
@@ -363,6 +420,7 @@ def gen_config(spec: dict, hf_config_path: str | None = None) -> dict:
         "weights": weights,
         "tokens": tokens,
         "tiered_kv_cache": tiered_kv_cache,
+        "decode_pack": decode_pack,
         "cpp_types": {
             "kv": ELEMENT_TYPE_CPP[kv_type],
             "logits": ELEMENT_TYPE_CPP[precision["logits_type"]],

--- a/tools/buddy-codegen/gen_manifest.py
+++ b/tools/buddy-codegen/gen_manifest.py
@@ -96,6 +96,20 @@ def gen_manifest(
         p(f'  rhal.constant @{tag} {{id = 1 : i32, storage = "external",')
         p(f"                         type = tensor<{num}x{mlir_t}>,")
         p(f'                         uri = "file:{fname}"}}')
+    # One logical constant, two layouts; it needs its own entry only because
+    # the two have to resolve to two files.
+    for w in weights:
+        if not w.get("decode_file"):
+            continue
+        p(
+            f"  rhal.constant @{w['tag']}_decode {{id = 1 : i32, "
+            'storage = "external",'
+        )
+        p(
+            f"                         type = tensor<{w['num_elements']}x"
+            f"{w['mlir_type']}>,"
+        )
+        p(f'                         uri = "file:{w["decode_file"]}"}}')
     p()
 
     # -- Code object -----------------------------------------------------------

--- a/tools/buddy-codegen/gen_session.py
+++ b/tools/buddy-codegen/gen_session.py
@@ -276,6 +276,9 @@ def gen_header(config: dict) -> str:
     for w in weights:
         memref_t = f"MemRef<{w['cpp_type']}, 1>"
         p(f"  std::unique_ptr<{memref_t}> {w['tag']}_;")
+        if w.get("decode_file"):
+            # Same weights, panel-packed. Only decode reads this one.
+            p(f"  std::unique_ptr<{memref_t}> {w['tag']}_decode_;")
 
     if need_logits_conv:
         p("  // Scratch buffer when logits are not stored as float (e.g. f16).")
@@ -1286,14 +1289,23 @@ def gen_impl(config: dict) -> str:
     p()
 
     # ── loadWeights ──────────────────────────────────────────────────────────
+    # Packed copies come after all the plain ones, matching gen_manifest.
+    load_targets = [(idx, w, f"{w['tag']}_") for idx, w in enumerate(weights)]
+    next_idx = len(weights)
+    for w in weights:
+        if w.get("decode_file"):
+            load_targets.append((next_idx, w, f"{w['tag']}_decode_"))
+            next_idx += 1
+    n_paths = next_idx
+
     p("void ModelSession::loadWeights(const std::vector<std::string> &paths) {")
-    p(f"  if (paths.size() < {len(weights)}u)")
+    p(f"  if (paths.size() < {n_paths}u)")
     p(
-        f'    throw std::runtime_error("[BuddyRuntime] Expected {len(weights)} weight '
+        f'    throw std::runtime_error("[BuddyRuntime] Expected {n_paths} weight '
         f'file(s), got " + std::to_string(paths.size()));'
     )
     p()
-    for idx, w in enumerate(weights):
+    for idx, w, member in load_targets:
         tag = w["tag"]
         cpp_type = w["cpp_type"]
         macro_suffix = (
@@ -1301,15 +1313,15 @@ def gen_impl(config: dict) -> str:
         )
         p("  {")
         p(f"    intptr_t shape[1] = {{{mp}_{macro_suffix}}};")
-        p(f"    {tag}_ = std::make_unique<MemRef<{cpp_type}, 1>>(shape);")
+        p(f"    {member} = std::make_unique<MemRef<{cpp_type}, 1>>(shape);")
         p(f"    std::ifstream f(paths[{idx}], std::ios::binary);")
         p("    if (!f)")
         p(
             f'      throw std::runtime_error("[BuddyRuntime] Cannot open weights: " + '
             f"paths[{idx}]);"
         )
-        p(f"    f.read(reinterpret_cast<char *>({tag}_->getData()),")
-        p(f"           sizeof({cpp_type}) * {tag}_->getSize());")
+        p(f"    f.read(reinterpret_cast<char *>({member}->getData()),")
+        p(f"           sizeof({cpp_type}) * {member}->getSize());")
         p("    if (f.fail())")
         p(
             f'      throw std::runtime_error("[BuddyRuntime] Read failed: " + '
@@ -1377,7 +1389,9 @@ def gen_impl(config: dict) -> str:
 
     call_parts = ["&result"]
     for w in weights:
-        call_parts.append(f"{w['tag']}_.get()")
+        # Decode gets the panel-packed copy where there is one.
+        suffix = "_decode_" if w.get("decode_file") else "_"
+        call_parts.append(f"{w['tag']}{suffix}.get()")
     call_parts.append("decodeTokenInput_.get()")
     call_parts.append("cachePosition_.get()")
     call_parts.extend(["&state.kv(0)", "&state.kv(1)"])

--- a/tools/buddy-codegen/import_model.py
+++ b/tools/buddy-codegen/import_model.py
@@ -79,6 +79,7 @@ try:
         eliminate_transpose,
         flash_attention_prefill,
         gqa_attention_fusion,
+        pack_decode_matmul_weights,
         simply_fuse,
     )
     from buddy.compiler.graph.type import DeviceType
@@ -459,6 +460,27 @@ def compile_and_export_tiered_graphs(
 # ──────────────────────────────────────────────────────────────────────────────
 
 
+def pack_decode_weights(graph_decode, decode_pack: dict) -> None:
+    """Panel-pack every matmul weight in the decode graph (see the
+    pack_decode_matmul_weights transform).
+
+    Must run before write_weights(), which is what turns the (now packed)
+    decode parameter list into arg0-decode.data. Prefill's parameters are
+    untouched: the two graphs were traced separately and own separate parameter
+    lists, and the transform rebinds entries in decode's rather than mutating
+    the tensors -- which are still shared objects -- in place.
+    """
+    packed = pack_decode_matmul_weights(
+        graph_decode, vecsize=decode_pack["vector_size"]
+    )
+    print(
+        f"[import] packed {len(packed)} decode matmul weights into panel "
+        f"layout (vector_size={decode_pack['vector_size']}); prefill's weights "
+        "stay plain.",
+        file=sys.stderr,
+    )
+
+
 def apply_pre_transforms(graph_prefill, graph_decode):
     """Eliminate transposes and fused matmul reshapes."""
     graph_prefill.perform(
@@ -705,27 +727,37 @@ def plain_weight_dtype(config: dict):
 
 
 def export_plain_weights_direct(
-    params: list, config: dict, output_dir: str
+    params: list, config: dict, output_dir: str, file_key: str = "file"
 ) -> dict:
-    """Write non-quantized weights directly without a giant concatenate."""
-    if len(config["weights"]) != 1:
-        raise ValueError("plain direct weight export expects one weight bucket")
+    """Write non-quantized weights directly without a giant concatenate.
 
-    weight = config["weights"][0]
-    if weight["tag"] != "params":
-        raise ValueError("plain direct weight export expects the params bucket")
+    Only handles the primary "params" bucket. `file_key` selects which of its
+    file names to write: "file" for the plain weights, "decode_file" for the
+    panel-packed copy that decode is handed when decode_pack is on. Both hold the
+    same parameters at the same offsets -- packing only permutes the bytes
+    inside each matmul weight -- so the same writer serves for both.
+    """
+    weight = next((w for w in config["weights"] if w["tag"] == "params"), None)
+    if weight is None:
+        raise ValueError("plain direct weight export expects a params bucket")
 
     dtype = plain_weight_dtype(config)
     total_elements = sum(p.numel() for p in params)
-    if int(weight["num_elements"]) != total_elements:
+    if file_key == "file" and int(weight["num_elements"]) != total_elements:
         print(
             f"[import] Updated {weight['tag']}: "
             f"{weight['num_elements']} → {total_elements}",
             file=sys.stderr,
         )
         weight["num_elements"] = total_elements
+    if int(weight["num_elements"]) != total_elements:
+        raise ValueError(
+            f"{weight[file_key]} has {total_elements} elements but "
+            f"{weight['file']} has {weight['num_elements']}; packing must not "
+            "change the parameter layout."
+        )
 
-    path = os.path.join(output_dir, weight["file"])
+    path = os.path.join(output_dir, weight[file_key])
     mm = numpy.memmap(path, dtype=dtype, mode="w+", shape=(total_elements,))
     offset = 0
     activation = config["precision"]["activation_type"]
@@ -748,7 +780,7 @@ def export_plain_weights_direct(
 
     size_mb = os.path.getsize(path) / (1024 * 1024)
     print(
-        f"[import] Written: {weight['file']} ({size_mb:.1f} MB, "
+        f"[import] Written: {weight[file_key]} ({size_mb:.1f} MB, "
         f"{total_elements:,} elements)",
         file=sys.stderr,
     )
@@ -928,6 +960,19 @@ def expected_weight_entries(config: dict, output_dir: str) -> list[dict]:
                 "path": os.path.join(output_dir, weight["file"]),
             }
         )
+        # Listed so the reuse check sees it. Its size matches the plain file
+        # exactly, so size alone cannot tell them apart -- that is what the
+        # vector_size in the manifest payload is for.
+        if weight.get("decode_file"):
+            entries.append(
+                {
+                    "tag": f"{weight['tag']}_decode",
+                    "file": weight["decode_file"],
+                    "bytes_per_element": int(weight["bytes_per_element"]),
+                    "num_elements": int(weight["num_elements"]),
+                    "path": os.path.join(output_dir, weight["decode_file"]),
+                }
+            )
     return entries
 
 
@@ -941,6 +986,11 @@ def weights_manifest_payload(config: dict, output_dir: str) -> dict:
         "model_family": config.get("model_family"),
         "variant": config.get("variant"),
         "precision": config.get("precision", {}),
+        # Packing changes the bytes of a weight file but not its size, so a
+        # size check cannot see a change of panel width. Record it, so that
+        # changing it invalidates the reuse check instead of silently leaving
+        # decode reading weights packed for a different kernel.
+        "decode_pack": config.get("decode_pack", {"enabled": False}),
         "weights": [
             {
                 "tag": entry["tag"],
@@ -1043,6 +1093,10 @@ def import_model(
             raise ValueError(
                 "tiered KV cache import does not support quantized variants"
             )
+        if config.get("decode_pack", {}).get("enabled"):
+            raise ValueError(
+                "decode_pack is not yet supported with tiered_kv_cache"
+            )
         with timed_import_step("compile_tiered_graphs"):
             original_params = compile_and_export_tiered_graphs(
                 model,
@@ -1082,6 +1136,18 @@ def import_model(
     # 3. Pre-fusion transforms
     with timed_import_step("pre_transforms"):
         apply_pre_transforms(graphs_prefill[0], graphs_decode[0])
+
+    # 3b. Opt-in decode weight panel-packing (see gen_config.derive_decode_pack).
+    # Must come after apply_pre_transforms, so the weights are already [K, N],
+    # and before the decode parameters are written out in step 8.
+    decode_pack = config.get("decode_pack", {"enabled": False})
+    if decode_pack.get("enabled"):
+        if is_quantized:
+            raise ValueError(
+                "decode_pack is only supported for f32/f16/bf16 variants"
+            )
+        with timed_import_step("pack_decode_weights"):
+            pack_decode_weights(graphs_decode[0], decode_pack)
 
     # 4. Quantization (if applicable)
     if is_quantized:
@@ -1145,6 +1211,18 @@ def import_model(
             actual_sizes = export_plain_weights_direct(
                 original_params, config, output_dir
             )
+            if decode_pack.get("enabled"):
+                # The same parameters again, now with every matmul weight in
+                # panel layout -- decode reads this file, prefill the plain one.
+                # graphs_decode[0]._params_ref is decode's own list, which
+                # pack_decode_matmul_weights rebound in step 3b; prefill's is a
+                # separate list and still holds the plain tensors.
+                export_plain_weights_direct(
+                    graphs_decode[0]._params_ref,
+                    config,
+                    output_dir,
+                    file_key="decode_file",
+                )
             update_config(config, actual_sizes, output_dir)
             write_weights_manifest(config, output_dir)
     elif weight_buckets:

--- a/tools/buddy-opt/buddy-opt.cpp
+++ b/tools/buddy-opt/buddy-opt.cpp
@@ -92,6 +92,7 @@ void registerLowerRVVPass();
 void registerMatMulOptimizePass();
 void registerMatMulVectorizationPass();
 void registerMatMulVectorizationDecodePass();
+void registerMatMulVectorizationDecodePackedPass();
 void registerDequantMatMulVectorizationDecodePass();
 void registerInt4DequantMatMulVectorizationDecodePass();
 void registerMatMulParallelVectorizationTilingPass();
@@ -187,6 +188,7 @@ int main(int argc, char **argv) {
   mlir::buddy::registerMatMulParallelVectorizationTilingPass();
   mlir::buddy::registerMatMulVectorizationPass();
   mlir::buddy::registerMatMulVectorizationDecodePass();
+  mlir::buddy::registerMatMulVectorizationDecodePackedPass();
   mlir::buddy::registerDequantMatMulVectorizationDecodePass();
   mlir::buddy::registerInt4DequantMatMulVectorizationDecodePass();
   mlir::buddy::registerMatMulParallelVectorizationPass();


### PR DESCRIPTION
## Summary

Decode generates one token at a time, so every matmul is a GEMV (`m == 1`): each weight byte is read once and never reused. The phase is therefore limited by how the weights are laid out, not by how many of them there are — and today's layout is the wrong one.

`matmul-vectorization-decode` tiles `N` into `vecSize`-wide panels and reduces over `K` inside each panel. For a row-major `B[K, N]`, consecutive `k` in that inner loop are `N` elements apart:

| weight | shape (K × N) | inner-loop stride |
|---|---|---|
| q_proj, o_proj | 1536 × 1536 | 6 KB |
| gate_proj, up_proj | 1536 × 8960 | 35 KB |
| down_proj | 8960 × 1536 | 6 KB |
| lm_head | 1536 × 151936 | **594 KB** |

Every iteration lands on a different page and the prefetcher stops working ahead. Against a measured 267.9 GB/s STREAM ceiling, the plain kernel reaches only **40–58% of peak** on these weights.

This PR repacks each decode weight into panel-blocked order (`Bpacked[N/V][K][V]`), so consecutive `k` are `V` elements apart: one contiguous stream. Same bytes, different order — the standard BLIS/oneDNN/ggml GEMV prepack. It is a one-off at import time because decode weights are static.

## Results

f32 DeepSeek-R1-Distill-Qwen-1.5B, 48 threads on both NUMA nodes (`numactl --cpunodebind=0,1 --interleave=0,1 taskset -c 0-47`), layer 0:

| operator | plain | packed |
|---|---|---|
| q_proj | 0.087 ms | 0.048 ms |
| k_proj | 0.056 ms | 0.028 ms |
| v_proj | 0.055 ms | 0.028 ms |
| o_proj | 0.078 ms | 0.046 ms |
| gate_proj | 0.519 ms | 0.315 ms |
| up_proj | 0.446 ms | 0.241 ms |
| down_proj | 0.411 ms | 0.234 ms |
| **lm_head** (1×/token) | **6.03 ms** | **~1.5 ms** |

**Decode throughput roughly doubles.** Generated tokens are identical to the unpacked build.

Combined with #837, the end-to-end performance is:

<img width="946" height="464" alt="image" src="https://github.com/user-attachments/assets/725ec9c7-a8cf-4f7f-b484-098d27a33d27" />


## How it works

Packing permutes the bytes **inside** each weight. Shape, offsets and buffer size are unchanged, so **decode's MLIR is not touched at all** — same function signature, same subviews. The whole mechanism is a second parameter file:

- `pack_decode_matmul_weights` (new graph transform) rewrites every matmul weight in the *decode* graph.
- The importer writes decode's parameters to `arg0-decode.data`, next to the plain `arg0.data`.
- Decode compiles with `-matmul-vectorization-decode-packed` (new pass) instead of the plain kernel.
- At runtime prefill gets `arg0.data`, decode gets `arg0-decode.data`.

Both files are the same size with the same per-weight offsets, so nothing else in the pipeline needs to know which is which.

## Notes for reviewers

**Why prefill is unaffected.** The two phases genuinely want opposite layouts — prefill is compute-bound at `m = 1024` and its blis kernel reads row-major `B`. An earlier attempt repacked in place and quietly corrupted prefill: it read the packed bytes as row-major and still emitted grammatical text. What makes this safe is that prefill and decode are traced separately and own **separate parameter lists**, though the tensors inside them are the same objects. The transform *rebinds* list entries (`_params_ref[i] = packed`) rather than mutating tensors in place — the same thing `eliminate_transpose` already does.

**Why it is all-or-nothing.** The packed kernel selects per matmul, by shape; it cannot look at a memref and tell packed bytes from plain ones. One weight left unpacked, but compiled with the packed kernel, is a wrong model — no crash, no failing test. So the transform packs *every* matmul weight and **raises if it cannot**, rather than packing what it can. That check earned its keep immediately: Qwen2's q/k/v projections carry a bias and import as `AddMMOp` (weight is `args[2]`, not `args[1]`), so a first version silently packed 113 of the 197 weights.

With no exceptions, `packed-shapes=` can be left empty (meaning "all"), so there is no opt-in list to keep in step with the packer, and no way for one to drift.

**The embedding is deliberately not packed.** It is lm_head's transpose with an *identical element count* (233,373,696), so any size-based heuristic would confuse the two — and it is read by a gather, not a matmul. Selection is by matmul operand.

**Weight reuse.** Packing changes a weight file's bytes but not its size, so `can_reuse_existing_weights` cannot tell one panel width from another by size alone. The packed file is listed as a weight entry of its own, and the panel width is recorded in the manifest, so changing it invalidates the reuse.

## Enabling

Off by default. Enabled per spec via `decode_pack_vector_size` (see `models/deepseek_r1/specs/f32_packed_decode.json`); `examples/BuddyDeepSeekR1` has its own `buddy-deepseek-r1-packed-run` target.

Restrictions enforced at config time: f32/f16/bf16 only, and not together with `tiered_kv_cache` (only `gen_impl` was taught to hand decode a different weight buffer).

## Testing

- Two lit tests for the pass: the explicit `packed-shapes` opt-in, and the empty-`packed-shapes` ("all") path, including the `N % vecSize != 0` case that must be left alone.
- Both build paths verified end-to-end (`examples/BuddyDeepSeekR1`, and `models/deepseek_r1` via buddy-codegen): the two weight files differ in bytes but match in size, decode's MLIR signature is unchanged, and generated tokens match the unpacked build token for token.

Docs: `docs/DecodeWeightPacking.md`.

## Checklist

- [x] The code builds successfully
- [x] Existing tests pass
- [x] New tests are added where appropriate
- [x] Code follows the project coding style
- [x] Documentation is updated if needed
