### PR TITLE
[ci] Use abi3 for release

### DIFF
--- a/.github/workflows/build-manylinux.yml
+++ b/.github/workflows/build-manylinux.yml
@@ -97,7 +97,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x64, riscv64]
-        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python: ["3.12"]
         include:
           - arch: x64
             target_arch: x86_64
@@ -120,9 +120,11 @@ jobs:
           set -euo pipefail
           PY_VER="${{ matrix.python }}"
           PY_NODOT="${PY_VER//./}"
-          PY_TAG="cp${PY_NODOT}-cp${PY_NODOT}"
+          PY_TAG="cp${PY_NODOT}"
+          PY_WHEEL_TAG="${PY_TAG}-abi3"
           BUDDY_HASH="$(git rev-parse HEAD)"
           echo "py_tag=${PY_TAG}" >> "$GITHUB_OUTPUT"
+          echo "py_wheel_tag=${PY_WHEEL_TAG}" >> "$GITHUB_OUTPUT"
           echo "buddy_hash=${BUDDY_HASH}" >> "$GITHUB_OUTPUT"
           if [[ "${{ matrix.target_arch }}" == "riscv64" ]]; then
             echo "host_build_dir=/data/runner/workspace/buddy-mlir-release" >> "$GITHUB_OUTPUT"
@@ -153,18 +155,17 @@ jobs:
         run: |
           set -euo pipefail
           gh release upload "${{ needs.prepare_release.outputs.tag_name }}" \
-            ${{ steps.vars.outputs.host_build_dir }}/${{ matrix.target_arch }}/buddy/${{ steps.vars.outputs.py_tag }}/${{ steps.vars.outputs.buddy_hash }}/target/buddy-${{ needs.prepare_release.outputs.version }}-${{ steps.vars.outputs.py_tag }}-manylinux* \
-            ${{ steps.vars.outputs.host_build_dir }}/${{ matrix.target_arch }}/buddy/${{ steps.vars.outputs.py_tag }}/${{ steps.vars.outputs.buddy_hash }}/target/llvm-*-${{ steps.vars.outputs.py_tag }}-manylinux* \
+            ${{ steps.vars.outputs.host_build_dir }}/${{ matrix.target_arch }}/buddy/${{ steps.vars.outputs.py_wheel_tag }}/${{ steps.vars.outputs.buddy_hash }}/target/buddy-${{ needs.prepare_release.outputs.version }}-${{ steps.vars.outputs.py_wheel_tag }}-manylinux* \
+            ${{ steps.vars.outputs.host_build_dir }}/${{ matrix.target_arch }}/buddy/${{ steps.vars.outputs.py_wheel_tag }}/${{ steps.vars.outputs.buddy_hash }}/target/llvm-*-${{ steps.vars.outputs.py_wheel_tag }}-manylinux* \
             --clobber
 
       - name: Upload buddy-cli
-        if: ${{ (matrix.target_arch == 'x86_64' && matrix.python == '3.10') || (matrix.target_arch == 'riscv64' && matrix.python == '3.12') }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          BUDDY_BUILD_DIR=${{ steps.vars.outputs.host_build_dir }}/${{ matrix.target_arch }}/buddy/${{ steps.vars.outputs.py_tag }}/${{ steps.vars.outputs.buddy_hash }}
+          BUDDY_BUILD_DIR=${{ steps.vars.outputs.host_build_dir }}/${{ matrix.target_arch }}/buddy/${{ steps.vars.outputs.py_wheel_tag }}/${{ steps.vars.outputs.buddy_hash }}
           cp -a "${BUDDY_BUILD_DIR}/dist/bin/buddy-cli" "${BUDDY_BUILD_DIR}/target/buddy-cli-${{ needs.prepare_release.outputs.version }}.${{ matrix.target_arch }}"
           gh release upload "${{ needs.prepare_release.outputs.tag_name }}" \
             "${BUDDY_BUILD_DIR}/target/buddy-cli-${{ needs.prepare_release.outputs.version }}.${{ matrix.target_arch }}" \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,9 +11,18 @@ set -euo pipefail
 # Cli Inputs
 # -----------------------------------------------------------------------------
 
-PY_TAG="${1:?Error: Python ABI (parameter 1, format \"cp310-cp310\") is required but not set.}"
+PY_TAG="${1:?Error: Python tag (parameter 1, format \"cp312\") is required but not set.}"
 VERSION="${2:?Error: VERSION (parameter 2, format \"0.0.0\") is required but not set.}"
 TARGET_ARCH="${3:?Error: TARGET_ARCH (parameter 3, format \"x86_64|riscv64\") is required but not set.}"
+
+if [[ ! "${PY_TAG}" =~ ^cp[0-9]+$ ]]; then
+  echo "Error: Python tag must match cp312." >&2
+  exit 1
+fi
+
+PYTHON_BUILD_TAG="${PY_TAG}-${PY_TAG}"
+PYTHON_WHEEL_TAG="${PY_TAG}-abi3"
+PYTHON_CACHE_TAG="${PYTHON_WHEEL_TAG}"
 
 # -----------------------------------------------------------------------------
 # Env Inputs
@@ -172,7 +181,7 @@ else
   # Container side: build layout and exit cleanup
   # ---------------------------------------------------------------------------
 
-  ARTIFACT_SUFFIX="${PY_TAG}-${MANYLINUX_TAG}"
+  ARTIFACT_SUFFIX="${PYTHON_WHEEL_TAG}-${MANYLINUX_TAG}"
 
   cleanup_workspace_staging() {
     shopt -s globstar nullglob
@@ -186,11 +195,11 @@ else
   # Don't create __pyccache__ in tree
   export PYTHONDONTWRITEBYTECODE=1
 
-  # Note: build trees are split by arch + python tag + source hash to avoid stale CMake cache reuse.
+  # Note: build trees are split by arch + Python ABI tag + source hash to avoid stale CMake cache reuse.
   export BUDDY_BUILD_ROOT="${WORKSPACE_BUILD_DIR}/${TARGET_ARCH}"
   export LLVM_BUILD_ROOT="${WORKSPACE_BUILD_DIR}/${TARGET_ARCH}"
-  export BUDDY_BUILD_DIR="${BUDDY_BUILD_ROOT}/buddy/${PY_TAG}/${BUDDY_HASH}"
-  export LLVM_BUILD_DIR="${LLVM_BUILD_ROOT}/llvm/${PY_TAG}/${LLVM_HASH}"
+  export BUDDY_BUILD_DIR="${BUDDY_BUILD_ROOT}/buddy/${PYTHON_CACHE_TAG}/${BUDDY_HASH}"
+  export LLVM_BUILD_DIR="${LLVM_BUILD_ROOT}/llvm/${PYTHON_CACHE_TAG}/${LLVM_HASH}"
   export PYTHONPYCACHEPREFIX="${LLVM_BUILD_DIR}/.pycache"
   mkdir -p "${PYTHONPYCACHEPREFIX}"
 
@@ -204,9 +213,9 @@ else
   # manylinux stores multiple Python versions under /opt/python; PATH does not
   # select a version by default, so we choose explicitly.
   # Docs: https://github.com/pypa/manylinux#docker-images
-  PYBIN=/opt/python/${PY_TAG}/bin/python
+  PYBIN=/opt/python/${PYTHON_BUILD_TAG}/bin/python
   if [ ! -x "$PYBIN" ]; then
-    echo "Python tag ${PY_TAG} not found under /opt/python" >&2
+    echo "Python tag ${PYTHON_BUILD_TAG} not found under /opt/python" >&2
     ls /opt/python >&2
     exit 1
   fi
@@ -215,7 +224,7 @@ else
     ls -ld "${WORKSPACE_LLVM_SRC}" "${WORKSPACE_LLVM_SRC}/llvm" 2>/dev/null || true
     exit 1
   fi
-  export PATH="/opt/python/${PY_TAG}/bin:$PATH"
+  export PATH="/opt/python/${PYTHON_BUILD_TAG}/bin:$PATH"
 
   # x86_64 image uses gcc-toolset, riscv64 image uses system GCC under /usr.
   GCC_TOOLCHAIN_ROOT=""
@@ -389,6 +398,7 @@ EOF
       -DLLVM_ENABLE_ASSERTIONS=OFF \
       -DCMAKE_BUILD_TYPE=RELEASE \
       -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+      -DMLIR_ENABLE_PYTHON_STABLE_ABI=ON \
       -DLLVM_INSTALL_UTILS=ON \
       -DPython3_EXECUTABLE="$PYBIN" \
       -DPython_EXECUTABLE="$PYBIN" \
@@ -427,7 +437,7 @@ EOF
   stage_llvm_runtime_libs_for_tests
 
   KEEP=2
-  LLVM_CACHE_DIR="${LLVM_BUILD_ROOT}/llvm/${PY_TAG}"
+  LLVM_CACHE_DIR="${LLVM_BUILD_ROOT}/llvm/${PYTHON_CACHE_TAG}"
   if [ -d "${LLVM_CACHE_DIR}" ]; then
     (
       cd "${LLVM_CACHE_DIR}"
@@ -457,6 +467,7 @@ EOF
     -DCMAKE_BUILD_TYPE=Release \
     -DBUDDY_ENABLE_TESTS=ON \
     -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+    -DMLIR_ENABLE_PYTHON_STABLE_ABI=ON \
     -DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON \
     -DBUDDY_MLIR_ENABLE_DIP_LIB=ON \
     -DBUDDY_BUILD_DEEPSEEK_R1_MODEL=OFF \
@@ -477,8 +488,9 @@ EOF
   ${BUDDY_BUILD_DIR}/bin/buddy-opt --version
 
   export PYTHONPATH="${BUDDY_BUILD_DIR}/python_packages${PYTHONPATH:+:${PYTHONPATH}}"
+  export BUDDY_PY_LIMITED_API="${PY_TAG}"
   "$PYBIN" -m build --wheel --outdir "${ARTIFACT_DIR}" $PWD
-  auditwheel repair "${ARTIFACT_DIR}"/buddy-${BUDDY_PACKAGE_VERSION}-${PY_TAG}-linux_*.whl -w "${ARTIFACT_DIR}"
+  auditwheel repair "${ARTIFACT_DIR}"/buddy-${BUDDY_PACKAGE_VERSION}-${PYTHON_WHEEL_TAG}-linux_*.whl -w "${ARTIFACT_DIR}"
 
   BUDDY_TAR_NAME="buddy-${BUDDY_PACKAGE_VERSION}-${ARTIFACT_SUFFIX}.tar.gz"
   BUDDY_TAR_TMP="${BUDDY_BUILD_DIR}/${BUDDY_TAR_NAME}"
@@ -489,7 +501,7 @@ EOF
   # Cache pruning and final summary
   # ---------------------------------------------------------------------------
 
-  BUDDY_CACHE_DIR="${BUDDY_BUILD_ROOT}/buddy/${PY_TAG}"
+  BUDDY_CACHE_DIR="${BUDDY_BUILD_ROOT}/buddy/${PYTHON_CACHE_TAG}"
   if [ -d "${BUDDY_CACHE_DIR}" ]; then
     (
       cd "${BUDDY_CACHE_DIR}"

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ from setuptools.dist import Distribution
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
 ROOT = Path(__file__).parent.resolve()
+PY_LIMITED_API = os.environ.get("BUDDY_PY_LIMITED_API")
 
 
 def _resolve_build_dir() -> Path:
@@ -93,6 +94,7 @@ class build_py(_build_py):
         self._copy_tree(
             STAGING_SRC / "buddy_mlir" / "_mlir_libs", mlir_libs_dir
         )
+        self._check_limited_api_outputs(mlir_libs_dir)
 
         self._copy_tree(BIN_DIR, tools_root / "bin", allow_missing=True)
         self._copy_tree(LIB_DIR, tools_root / "lib", allow_missing=True)
@@ -133,6 +135,29 @@ class build_py(_build_py):
             shutil.copy2(path, target)
             self._extra_outputs.append(str(target))
 
+    def _check_limited_api_outputs(self, mlir_libs_dir: Path):
+        if not PY_LIMITED_API:
+            return
+
+        cpython_extensions = sorted(mlir_libs_dir.glob("*.cpython-*.so"))
+        if cpython_extensions:
+            rel_paths = "\n".join(
+                f"  {path.relative_to(Path(self.build_lib))}"
+                for path in cpython_extensions
+            )
+            raise SystemExit(
+                "BUDDY_PY_LIMITED_API is set, but the build contains "
+                f"CPython-specific extension modules:\n{rel_paths}\n"
+                "Rebuild LLVM/buddy with MLIR_ENABLE_PYTHON_STABLE_ABI=ON."
+            )
+
+        abi3_extensions = sorted(mlir_libs_dir.glob("*.abi3.so"))
+        if not abi3_extensions:
+            raise SystemExit(
+                "BUDDY_PY_LIMITED_API is set, but no abi3 extension modules "
+                f"were found under {mlir_libs_dir}."
+            )
+
 
 ENTRY_POINTS = {
     "console_scripts": [
@@ -162,6 +187,8 @@ class bdist_wheel(_bdist_wheel):
         super().finalize_options()
         # Force platform-specific wheel since we bundle native libs.
         self.root_is_pure = False
+        if PY_LIMITED_API:
+            self.py_limited_api = PY_LIMITED_API
 
 
 class BinaryDistribution(Distribution):


### PR DESCRIPTION
## Summary

LLVM/MLIR already supports [PEP 384 Defining a Stable ABI](https://peps.python.org/pep-0384/) stable ABI python bindings through `MLIR_ENABLE_PYTHON_STABLE_ABI` (only for >= python 3.12). 

In this PR, I enable this option for both the LLVM and Buddy builds, using CPython 3.12 as the minimum ABI level.

A cp312-abi3 wheel can be used by CPython 3.12 and newer without rebuilding it for every Python minor version. This reduces release jobs, build time, artifact duplication, and maintenance for new Python
versions.
