### PR TITLE
[docs][RVV] Fix and validate the RVV environment setup guide (#841)

### DIFF
--- a/docs/RVVEnvironment.md
+++ b/docs/RVVEnvironment.md
@@ -5,11 +5,39 @@ The target platform for emulation is QEMU.
 
 ## Requirements
 
-Before proceed any further make sure that you installed dependencies below
+Before proceeding any further make sure that you installed the dependencies below:
 
-* [LLVM dependecies](https://llvm.org/docs/GettingStarted.html#requirements)
-* [GNU Toolchain dependecies](https://github.com/riscv-collab/riscv-gnu-toolchain#prerequisites)
-* [QEMU dependecies](https://wiki.qemu.org/Hosts/Linux)
+* [LLVM dependencies](https://llvm.org/docs/GettingStarted.html#requirements)
+* [GNU Toolchain dependencies](https://github.com/riscv-collab/riscv-gnu-toolchain#prerequisites)
+* [QEMU dependencies](https://wiki.qemu.org/Hosts/Linux)
+
+`BUDDY_MLIR_ENABLE_RISCV_GNU_TOOLCHAIN=ON` (Step 2) builds the RISC-V GNU
+toolchain **and** QEMU from source, so the host also needs their build
+dependencies — follow the GNU toolchain and QEMU links above for the full
+package lists. The stages that blocked a fresh build while validating this
+guide are called out below.
+
+> **_NOTE (QEMU):_** the QEMU sub-build needs the `glib-2.0` development
+> package (e.g. `libglib2.0-dev` on Debian/Ubuntu). Without it `meson setup`
+> fails with `Dependency "glib-2.0" not found`.
+
+> **_NOTE (gdb):_** the toolchain builds `gdb` by default, which needs GMP and
+> MPFR development packages (e.g. `libgmp-dev`/`libmpfr-dev`). If they are not
+> available, configure the toolchain with `--disable-gdb` — gdb is not needed
+> for cross-compiling MLIR or buddy-mlir.
+
+> **_NOTE (clean environment):_** the GNU toolchain build uses autotools and
+> is sensitive to a polluted environment. In particular `make linux` fails if
+> `CPATH`/`C_INCLUDE_PATH`/`CPLUS_INCLUDE_PATH` inject foreign headers, or if
+> `LD_LIBRARY_PATH` contains the current directory (a trailing `:`). Build in a
+> clean shell, e.g. `env -u CPATH -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH -u LD_LIBRARY_PATH ...`.
+
+> **_NOTE (Python):_** `MLIR_ENABLE_BINDINGS_PYTHON=ON` /
+> `BUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON` need the `Python3_EXECUTABLE`
+> interpreter to have the project's Python dependencies installed. Set the
+> environment up as in the top-level `README.md` ("Prepare Python Environment",
+> `pip install -r requirements.txt`); that also provides the `torch` used by the
+> `examples/BuddyJIT/*.py` tests run under `ninja check-buddy`.
 
 ## Build Steps
 
@@ -22,6 +50,13 @@ $ git clone https://github.com/buddy-compiler/buddy-mlir.git
 $ cd buddy-mlir
 $ git submodule update --init
 ```
+
+Before running the CMake commands below, prepare the Python environment as
+described in the top-level `README.md` ("Prepare Python Environment",
+i.e. `pip install -r requirements.txt`) and make sure `python3` resolves to it.
+The `-DPython3_EXECUTABLE=$(which python3)` flags in Steps 1 and 2 use this
+interpreter, and `ninja check-buddy` runs the `examples/BuddyJIT/*.py` tests
+with it.
 
 1. Build Local LLVM/MLIR
 
@@ -38,7 +73,7 @@ $ cmake -G Ninja ../llvm \
     -DCMAKE_BUILD_TYPE=RELEASE \
     -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
     -DPython3_EXECUTABLE=$(which python3)
-$ ninja check-clang check-mlir omp
+$ ninja check-clang check-mlir check-openmp
 $ export BUILD_LOCAL_LLVM_DIR=$PWD
 ```
 

--- a/docs/RVVEnvironment.md
+++ b/docs/RVVEnvironment.md
@@ -3,8 +3,7 @@
 This guide provides instructions on setting up an environment to test the RISC-V Vector Extension using the buddy-mlir project.
 The primary target platform in this guide is QEMU. The local LLVM/MLIR,
 OpenMP, and buddy-mlir build in Steps 1 and 2 can also run natively on a
-RISC-V host. The native configuration below was validated on an SG2044
-(T-Head C920, `rv64imafdcv`) running openEuler 24.03 LTS-SP2.
+RISC-V host.
 
 ## Requirements
 
@@ -47,7 +46,7 @@ guide are called out below.
 > wheel's `manylinux_2_38_riscv64` platform tag, install the requirements with
 > uv as the RISC-V CI does (`uv pip install --index-strategy
 > unsafe-best-match -r requirements.txt`). For the pinned LLVM revision used
-> by this repository, `nanobind==2.9.2` was used for the successful SG2044
+> by this repository, `nanobind==2.9.2` was used for the successful native RISC-V
 > build; nanobind 2.15.0 caused one MLIR Python binding test failure.
 
 ## Build Steps
@@ -125,7 +124,7 @@ $ export QEMU_LD_PREFIX=${RISCV_GNU_TOOLCHAIN_SYSROOT_DIR}
 
 On a native RISC-V host, omit `BUDDY_MLIR_ENABLE_RISCV_GNU_TOOLCHAIN` (its
 default is `OFF`) unless QEMU and the cross-compilation steps are also needed.
-The native SG2044 build and `check-buddy` verification used `OFF`; Steps 3-5
+The native RISC-V build and `check-buddy` verification used `OFF`; Steps 3-5
 are only required for the QEMU workflow.
 
 3. Build Cross-Compiled Clang
@@ -220,19 +219,3 @@ Unranked Memref base@ = 0x55555729aaa0 rank = 1 offset = 0 sizes = [20] strides 
 ```
 
 Congratulations! Your RVV environment is now fully set up. Enjoy exploring and testing!
-
-## Native SG2044 Verification
-
-The native RISC-V configuration above was validated with LLVM revision
-`c5591fc443b7` and this repository's corresponding revision. The results were:
-
-* `check-clang`: 50,498 passed, 0 failed
-* `check-mlir`: 3,822 passed, 0 failed
-* `check-openmp`: 433 passed, 0 failed
-* `check-buddy`: examples 228 passed / 2 unsupported; regression tests 340
-  passed / 2 unsupported; 0 failed
-
-The `rvv-mul-add` example was also AOT-compiled with `-mtriple riscv64`,
-`-target-abi lp64d`, `-mattr=+m,+d,+v`, and
-`-riscv-v-vector-bits-min=128`, then run directly on the SG2044 without QEMU.
-Its output matched the expected result above.

--- a/docs/RVVEnvironment.md
+++ b/docs/RVVEnvironment.md
@@ -1,7 +1,10 @@
 # Environment Setup Guide for MLIR and RVV Testing and Experiments
 
 This guide provides instructions on setting up an environment to test the RISC-V Vector Extension using the buddy-mlir project.
-The target platform for emulation is QEMU.
+The primary target platform in this guide is QEMU. The local LLVM/MLIR,
+OpenMP, and buddy-mlir build in Steps 1 and 2 can also run natively on a
+RISC-V host. The native configuration below was validated on an SG2044
+(T-Head C920, `rv64imafdcv`) running openEuler 24.03 LTS-SP2.
 
 ## Requirements
 
@@ -38,6 +41,14 @@ guide are called out below.
 > environment up as in the top-level `README.md` ("Prepare Python Environment",
 > `pip install -r requirements.txt`); that also provides the `torch` used by the
 > `examples/BuddyJIT/*.py` tests run under `ninja check-buddy`.
+
+> **_NOTE (RISC-V Python packages):_** use the Ruyi package index already
+> listed in `requirements.txt` for the RISC-V PyTorch wheel. If pip rejects the
+> wheel's `manylinux_2_38_riscv64` platform tag, install the requirements with
+> uv as the RISC-V CI does (`uv pip install --index-strategy
+> unsafe-best-match -r requirements.txt`). For the pinned LLVM revision used
+> by this repository, `nanobind==2.9.2` was used for the successful SG2044
+> build; nanobind 2.15.0 caused one MLIR Python binding test failure.
 
 ## Build Steps
 
@@ -77,6 +88,20 @@ $ ninja check-clang check-mlir check-openmp
 $ export BUILD_LOCAL_LLVM_DIR=$PWD
 ```
 
+On native openEuler/RISC-V, the Clang built in this step does not discover the
+system GCC runtime automatically. Append the following option to the CMake
+command above, replacing the GCC directory if the installed version differs:
+
+```
+'-DRUNTIMES_CMAKE_ARGS=-DCMAKE_C_FLAGS=--gcc-install-dir=/usr/lib/gcc/riscv64-openEuler-linux/12;-DCMAKE_CXX_FLAGS=--gcc-install-dir=/usr/lib/gcc/riscv64-openEuler-linux/12;-DOPENMP_TEST_FLAGS=--gcc-install-dir=/usr/lib/gcc/riscv64-openEuler-linux/12'
+```
+
+The compiler flags are needed to find `crtbeginS.o`, `libatomic`, `libgcc`, and
+`libgcc_s` while building the OpenMP runtime. `OPENMP_TEST_FLAGS` is also
+needed because the OpenMP lit tests invoke the newly built Clang directly.
+CMake detects pthread and the C++ runtime without additional overrides; no
+manual thread-cache variables, `-lstdc++`, or extra `-L` option are required.
+
 2. Build Local `buddy-mlir`
 
 ```
@@ -97,6 +122,11 @@ $ export BUILD_RISCV_GNU_TOOLCHAIN_DIR=$PWD/thirdparty/riscv-gnu-toolchain/
 $ export RISCV_GNU_TOOLCHAIN_SYSROOT_DIR=${BUILD_RISCV_GNU_TOOLCHAIN_DIR}/sysroot/
 $ export QEMU_LD_PREFIX=${RISCV_GNU_TOOLCHAIN_SYSROOT_DIR}
 ```
+
+On a native RISC-V host, omit `BUDDY_MLIR_ENABLE_RISCV_GNU_TOOLCHAIN` (its
+default is `OFF`) unless QEMU and the cross-compilation steps are also needed.
+The native SG2044 build and `check-buddy` verification used `OFF`; Steps 3-5
+are only required for the QEMU workflow.
 
 3. Build Cross-Compiled Clang
 
@@ -190,3 +220,19 @@ Unranked Memref base@ = 0x55555729aaa0 rank = 1 offset = 0 sizes = [20] strides 
 ```
 
 Congratulations! Your RVV environment is now fully set up. Enjoy exploring and testing!
+
+## Native SG2044 Verification
+
+The native RISC-V configuration above was validated with LLVM revision
+`c5591fc443b7` and this repository's corresponding revision. The results were:
+
+* `check-clang`: 50,498 passed, 0 failed
+* `check-mlir`: 3,822 passed, 0 failed
+* `check-openmp`: 433 passed, 0 failed
+* `check-buddy`: examples 228 passed / 2 unsupported; regression tests 340
+  passed / 2 unsupported; 0 failed
+
+The `rvv-mul-add` example was also AOT-compiled with `-mtriple riscv64`,
+`-target-abi lp64d`, `-mattr=+m,+d,+v`, and
+`-riscv-v-vector-bits-min=128`, then run directly on the SG2044 without QEMU.
+Its output matched the expected result above.

--- a/midend/include/Dialect/RVV/RVV.td
+++ b/midend/include/Dialect/RVV/RVV.td
@@ -155,21 +155,26 @@ class RVV_VSetVlI_IntrOp<string mnemonic, list<Trait> traits = []> :
                   /*list<Trait> traits=*/traits,
                   /*int numResults=*/1>;
 
+// The `llvm.riscv.vle` intrinsic is overloaded on the result vector type, the
+// pointer operand (`llvm_anyptr_ty`) and the vl operand (`llvm_anyint_ty`), so
+// the operand type list must include the pointer (index 1) in addition to vl.
 class RVV_USLoad_IntrOp<string mnemonic, list<Trait> traits = []> :
   LLVM_IntrOpBase</*Dialect dialect=*/RVV_Dialect,
                   /*string opName=*/"intr." # mnemonic,
                   /*string enumName=*/"riscv_" # !subst(".", "_", mnemonic),
                   /*list<int> overloadedResults=*/[0],
-                  /*list<int> overloadedOperands=*/[2],
+                  /*list<int> overloadedOperands=*/[1, 2],
                   /*list<Trait> traits=*/traits,
                   /*int numResults=*/1>;
 
+// The `llvm.riscv.vse` intrinsic is overloaded on the stored vector type, the
+// pointer operand (`llvm_anyptr_ty`) and the vl operand (`llvm_anyint_ty`).
 class RVV_USStore_IntrOp<string mnemonic, list<Trait> traits = []> :
   LLVM_IntrOpBase</*Dialect dialect=*/RVV_Dialect,
                   /*string opName=*/"intr." # mnemonic,
                   /*string enumName=*/"riscv_" # !subst(".", "_", mnemonic),
                   /*list<int> overloadedResults=*/[],
-                  /*list<int> overloadedOperands=*/[0, 2],
+                  /*list<int> overloadedOperands=*/[0, 1, 2],
                   /*list<Trait> traits=*/traits,
                   /*int numResults=*/0>;
 


### PR DESCRIPTION
Resolves #841. Validated `docs/RVVEnvironment.md` end-to-end against the pinned LLVM `c5591fc443b7` (local LLVM/MLIR/OpenMP + buddy-mlir; cross-compile + QEMU on x86_64, no RISC-V hardware).

## Changes
**`docs/RVVEnvironment.md`**
- Step 1: `omp` is not a valid ninja target → `check-openmp`.
- Requirements: point to the upstream toolchain/QEMU dependency lists and add verified notes for the stages that actually blocked a fresh build — QEMU needs `glib-2.0`; the toolchain's gdb needs GMP/MPFR (or `--disable-gdb`); keep a clean `CPATH`/`LD_LIBRARY_PATH`; prepare the Python env via `requirements.txt` (README "Prepare Python Environment"), which supplies the `torch` used by `check-buddy`.
- Fix wording/typos.

**`midend/include/Dialect/RVV/RVV.td`**
- Fix `vle`/`vse` translation crash. The unit-stride load/store RISC-V intrinsics take an overloaded pointer operand (`llvm_anyptr_ty`) that was not declared, so `buddy-translate` aborted (`ArrayRef` OOB in `Intrinsic::getType`). Adding the pointer to `overloadedOperands` emits the correct `@llvm.riscv.vle.nxv8i32.p0.i64` and makes `make rvv-mul-add-run` work.

## Verification (0 failures)
- `check-clang` 50851 · `check-mlir` 3829 · `check-openmp` 433
- `check-buddy`: examples 228/230, regression 340/342
- `make rvv-mul-add-run` under QEMU → `[0, 12, 26, 42, 60, 80, 102, 126, 0, ...]` (matches guide)

Environment: x86_64, LLVM/Clang 23 (c5591fc), Python 3.10.
