### PR TITLE
[llvm] Bump llvm to 07f601762b73

### DIFF
--- a/midend/python/CMakeLists.txt
+++ b/midend/python/CMakeLists.txt
@@ -5,6 +5,8 @@ include(AddMLIRPython)
 # TODO: Add an upstream cmake param for this vs having a global here.
 add_compile_definitions("MLIR_PYTHON_PACKAGE_PREFIX=buddy_mlir.")
 
+set(MLIR_BINDINGS_PYTHON_NB_DOMAIN "buddy_mlir")
+
 ################################################################################
 # Structural groupings.
 ################################################################################


### PR DESCRIPTION
Set MLIR_BINDINGS_PYTHON_NB_DOMAIN to buddy_mlir so that MLIR's Python bindings get a unique nanobind domain (see
https://github.com/llvm/llvm-project/pull/171775), silencing the AddMLIRPython.cmake warning and avoiding type-registry collisions with other embedders that keep the default `mlir` domain.

