### PR TITLE
[frontend] Fix Conv1D accumulator initialization

### DIFF
--- a/frontend/Python/ops/tosa.py
+++ b/frontend/Python/ops/tosa.py
@@ -536,10 +536,9 @@ def _create_zero_tensor(
 
     # For small tensors, use dense constant
     if size_mb < size_threshold_mb:
-        if isinstance(element_type, ir.FloatType) or ir.BF16Type.isinstance(
-            element_type
+        if isinstance(element_type, ir.FloatType) or isinstance(
+            element_type, ir.BF16Type
         ):
-            zero_attr = ir.FloatAttr.get(element_type, 0.0)
         else:
             zero_attr = ir.IntegerAttr.get(element_type, 0)
         dense_attr = ir.DenseElementsAttr.get_splat(tensor_type, zero_attr)

--- a/frontend/Python/ops/tosa.py
+++ b/frontend/Python/ops/tosa.py
@@ -522,11 +522,11 @@ def _create_zero_tensor(
         num_elements *= dim
 
     # Determine element size based on type
-    if ir.FloatType.isinstance(element_type):
+    if isinstance(element_type, ir.FloatType):
         element_size = ir.FloatType(element_type).width // 8
-    elif ir.BF16Type.isinstance(element_type):
+    elif isinstance(element_type, ir.BF16Type):
         element_size = 2
-    elif ir.IntegerType.isinstance(element_type):
+    elif isinstance(element_type, ir.IntegerType):
         element_size = ir.IntegerType(element_type).width // 8
     else:
         element_size = 4  # Default to 4 bytes
@@ -536,7 +536,7 @@ def _create_zero_tensor(
 
     # For small tensors, use dense constant
     if size_mb < size_threshold_mb:
-        if ir.FloatType.isinstance(element_type) or ir.BF16Type.isinstance(
+        if isinstance(element_type, ir.FloatType) or ir.BF16Type.isinstance(
             element_type
         ):
             zero_attr = ir.FloatAttr.get(element_type, 0.0)
@@ -548,7 +548,7 @@ def _create_zero_tensor(
     # For large tensors, use tensor.empty + linalg.fill
     empty_tensor = tensor.EmptyOp(shape, element_type).result
 
-    if ir.FloatType.isinstance(element_type) or ir.BF16Type.isinstance(
+    if isinstance(element_type, ir.FloatType) or ir.BF16Type.isinstance(
         element_type
     ):
         zero_scalar = arith.ConstantOp(
@@ -3730,7 +3730,7 @@ def convolution2d_op(node: Conv2dOp, symbol_table):
             ).result
             input_val = tosa.PadOp(padded_type, input_val, pad_constant, pad_zp)
         output_type = ir.RankedTensorType.get(out_shape, result_element_type)
-        output_conv = tensor.EmptyOp(list(out_shape), result_element_type)
+        output_conv = _create_zero_tensor(output_type)
         assert groups == 1, "only support one group"
         # Con1D Operation Without Bias
         conv_op = linalg.conv_1d_ncw_fcw(

--- a/frontend/Python/ops/tosa.py
+++ b/frontend/Python/ops/tosa.py
@@ -536,9 +536,8 @@ def _create_zero_tensor(
 
     # For small tensors, use dense constant
     if size_mb < size_threshold_mb:
-        if isinstance(element_type, ir.FloatType) or isinstance(
-            element_type, ir.BF16Type
-        ):
+        if isinstance(element_type, (ir.FloatType, ir.BF16Type)):
+            zero_attr = ir.FloatAttr.get(element_type, 0.0)
         else:
             zero_attr = ir.IntegerAttr.get(element_type, 0)
         dense_attr = ir.DenseElementsAttr.get_splat(tensor_type, zero_attr)
@@ -547,9 +546,7 @@ def _create_zero_tensor(
     # For large tensors, use tensor.empty + linalg.fill
     empty_tensor = tensor.EmptyOp(shape, element_type).result
 
-    if isinstance(element_type, ir.FloatType) or ir.BF16Type.isinstance(
-        element_type
-    ):
+    if isinstance(element_type, (ir.FloatType, ir.BF16Type)):
         zero_scalar = arith.ConstantOp(
             element_type, ir.FloatAttr.get(element_type, 0.0)
         ).result


### PR DESCRIPTION
## Summary

- zero-initialize the accumulator passed to `linalg.conv_1d_ncw_fcw`
- avoid reading undefined values from `tensor.empty`

## Testing

- rebuilt the standard whisper-base model through the whisper_rax target
- verified that the generated Conv1D operation uses a zero-initialized accumulator
- ran end-to-end Whisper inference with the bundled audio.wav
- verified the transcription output:  Nor is Mr. Colter's manner less interesting than his matter.