### PR TITLE
[Conversion][GPU] Lower strided memref.copy for GPU

### DIFF
--- a/examples/BuddyGPU/makefile
+++ b/examples/BuddyGPU/makefile
@@ -16,7 +16,7 @@ buddy-gpu-matmul:
 	${BUDDY_OPT} --pass-pipeline='builtin.module(func.func(nvgpu-optimize-shared-memory))' | \
 	${BUDDY_OPT} -arith-expand -eliminate-empty-tensors -empty-tensor-to-alloc-tensor -linalg-bufferize -convert-linalg-to-affine-loops -affine-loop-fusion -affine-parallelize -lower-affine -canonicalize -func-bufferize -arith-bufferize -tensor-bufferize -buffer-deallocation -finalizing-bufferize -canonicalize | \
 	${BUDDY_OPT} -gpu-launch-sink-index-computations -canonicalize -legalize-shmem-outlining -canonicalize | \
-	${BUDDY_OPT} -convert-memcpy-to-gpu -gpu-async-region -canonicalize | \
+	${BUDDY_OPT} -pass-pipeline='builtin.module(func.func(convert-memcpy-to-gpu))' -gpu-async-region -canonicalize | \
 	${BUDDY_OPT} -convert-scf-to-cf -memref-expand -finalize-memref-to-llvm -convert-arith-to-llvm --convert-vector-to-llvm -convert-gpu-to-nvvm='has-redux=1' | \
 	${BUDDY_OPT} -llvm-request-c-wrappers -canonicalize -cse -sccp | \
 	${MLIR_OPT} --test-lower-to-nvvm="cubin-chip=sm_80 cubin-features=+ptx71 cubin-format=fatbin" -o matmul-cubin.mlir

--- a/examples/BuddyLeNet/CMakeLists.txt
+++ b/examples/BuddyLeNet/CMakeLists.txt
@@ -97,7 +97,7 @@ add_custom_command(
   OUTPUT forward_gpu.o
   COMMAND ${BUDDY_BINARY_DIR}/buddy-opt ${CMAKE_CURRENT_BINARY_DIR}/forward.mlir
           -buffer-hoisting
-          -canonicalize -cse -expand-strided-metadata -convert-memcpy-to-gpu -gpu-async-region |
+          -canonicalize -cse -expand-strided-metadata -pass-pipeline="builtin.module(func.func(convert-memcpy-to-gpu))" -gpu-async-region |
           ${LLVM_TOOLS_BINARY_DIR}/mlir-opt -llvm-request-c-wrappers --gpu-to-llvm |
           ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
           ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
@@ -123,7 +123,7 @@ add_custom_command(
           -buffer-hoisting
           -canonicalize
           -cse |
-          ${BUDDY_BINARY_DIR}/buddy-opt -convert-memcpy-to-gpu=${CONVERT_MEMCPY_TO_GPU_OPTION_DISABLE_PROCESS_ARG} -gpu-async-region -canonicalize |
+          ${BUDDY_BINARY_DIR}/buddy-opt -pass-pipeline="builtin.module(func.func(convert-memcpy-to-gpu{${CONVERT_MEMCPY_TO_GPU_OPTION_DISABLE_PROCESS_ARG}}))" -gpu-async-region -canonicalize |
           ${LLVM_TOOLS_BINARY_DIR}/mlir-opt -llvm-request-c-wrappers -gpu-lower-to-nvvm-pipeline=${LOWER_TO_NVVM_OPTION} |
           ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
           ${LLVM_TOOLS_BINARY_DIR}/llvm-as |

--- a/midend/lib/Conversion/MLIRGPU/CMakeLists.txt
+++ b/midend/lib/Conversion/MLIRGPU/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_library(MLIRGPUPasses
   ConvertMemcpyToGPU.cpp
+  ConvertStridedMemrefCopyToLinalg.cpp
   LegalizeShmemOutlining.cpp
 
   ADDITIONAL_HEADER_DIRS
@@ -13,6 +14,8 @@ add_mlir_library(MLIRGPUPasses
   MLIRFunctionInterfaces
   MLIRInferTypeOpInterface
   MLIRIR
+  MLIRLinalgDialect
+  MLIRLinalgUtils
   MLIRMemRefDialect
   MLIRPass
   MLIRTensorDialect

--- a/midend/lib/Conversion/MLIRGPU/ConvertMemcpyToGPU.cpp
+++ b/midend/lib/Conversion/MLIRGPU/ConvertMemcpyToGPU.cpp
@@ -166,12 +166,25 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
     else if (auto copyOp = dyn_cast<memref::CopyOp>(nestedOp)) {
       auto src = copyOp.getOperand(0);
       auto dst = copyOp.getOperand(1);
+      auto srcType = dyn_cast<MemRefType>(src.getType());
+      auto dstType = dyn_cast<MemRefType>(dst.getType());
+      if (!srcType || !dstType) {
+        copyOp.emitOpError("expected memref operands");
+        signalPassFailure();
+        return WalkResult::interrupt();
+      }
+      if (!srcType.getLayout().isIdentity() ||
+          !dstType.getLayout().isIdentity()) {
+        copyOp.emitOpError("strided memref.copy must be converted by "
+                           "convert-strided-memref-copy-to-linalg before "
+                           "convert-memcpy-to-gpu");
+        signalPassFailure();
+        return WalkResult::interrupt();
+      }
       // Notice: GPU.memcpy has a different src dst order
       builder.setInsertionPointAfter(copyOp);
-      auto gpuMemcpyOp = gpu::MemcpyOp::create(
-          builder, copyOp->getLoc(), TypeRange(), ValueRange(), dst, src);
-      src.replaceAllUsesWith(gpuMemcpyOp->getResult(1));
-      dst.replaceAllUsesWith(gpuMemcpyOp->getResult(0));
+      gpu::MemcpyOp::create(builder, copyOp->getLoc(), TypeRange(),
+                            ValueRange(), dst, src);
       copyOp->erase();
     }
     // Allocate space on GPU and copy global memrefs to GPU, needs deallocation

--- a/midend/lib/Conversion/MLIRGPU/ConvertMemcpyToGPU.cpp
+++ b/midend/lib/Conversion/MLIRGPU/ConvertMemcpyToGPU.cpp
@@ -18,33 +18,23 @@
 //
 //===---------------------------------------------------------------------===//
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/AffineMap.h"
-#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/OperationSupport.h"
-#include "mlir/IR/TypeRange.h"
-#include "mlir/IR/Types.h"
-#include "mlir/IR/ValueRange.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Visitors.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/Casting.h"
-#include "llvm/Support/ErrorHandling.h"
-#include <mlir/Dialect/Affine/IR/AffineOps.h>
-#include <mlir/Dialect/Func/IR/FuncOps.h>
-#include <mlir/Dialect/Linalg/Transforms/Transforms.h>
-#include <mlir/IR/Dialect.h>
-#include <mlir/IR/Operation.h>
-#include <mlir/IR/TypeUtilities.h>
-#include <mlir/IR/Value.h>
-#include <mlir/Pass/Pass.h>
 
 #include <vector>
 
 using namespace mlir;
-using namespace vector;
 
 //===----------------------------------------------------------------------===//
 // ConvertMemcpyToGPUPass
@@ -53,7 +43,8 @@ using namespace vector;
 namespace {
 
 class ConvertMemcpyToGPUPass
-    : public PassWrapper<ConvertMemcpyToGPUPass, OperationPass<func::FuncOp>> {
+    : public PassWrapper<ConvertMemcpyToGPUPass,
+                         InterfacePass<FunctionOpInterface>> {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ConvertMemcpyToGPUPass)
   StringRef getArgument() const final { return "convert-memcpy-to-gpu"; }
@@ -81,25 +72,25 @@ MemRefType stripMemRefLayout(const MemRefType &base) {
 }
 
 void ConvertMemcpyToGPUPass::runOnOperation() {
-  auto funcOp = getOperation();
+  FunctionOpInterface funcOp = getOperation();
 
-  if (funcOp.isDeclaration() || funcOp.isExternal())
+  if (funcOp.isExternal())
     return;
 
   // Make sure the gpu function is already outlined.
   funcOp->walk<WalkOrder::PreOrder>([&](Operation *nestedOp) {
-    if (auto gpuLaunchOp = dyn_cast<gpu::LaunchOp>(nestedOp)) {
+    if (isa<gpu::LaunchOp>(nestedOp)) {
       nestedOp->emitOpError("The gpu function should be outlined.");
     }
     return WalkResult::advance();
   });
 
   std::vector<Value> unDeallocatedValue;
-  OpBuilder builder(funcOp->getContext());
+  IRRewriter rewriter(funcOp->getContext());
 
   // Copy all function arguments to gpu, needs deallocation
   if (processArgs) {
-    builder.setInsertionPointToStart(&(funcOp.getBody().front()));
+    rewriter.setInsertionPointToStart(&funcOp.front());
     unsigned numArgs = funcOp.getNumArguments();
     for (unsigned i = 0; i < numArgs; ++i) {
       BlockArgument arg = funcOp.getArgument(i);
@@ -108,11 +99,11 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
       auto memrefType = dyn_cast<MemRefType>(arg.getType());
 
       auto gpuAllocOp = gpu::AllocOp::create(
-          builder, builder.getUnknownLoc(),
+          rewriter, rewriter.getUnknownLoc(),
           TypeRange({stripMemRefLayout(memrefType)}), ValueRange({}));
       unDeallocatedValue.push_back(gpuAllocOp->getResult(0));
       auto gpuMemcpyOp =
-          gpu::MemcpyOp::create(builder, gpuAllocOp.getLoc(), TypeRange(),
+          gpu::MemcpyOp::create(rewriter, gpuAllocOp.getLoc(), TypeRange(),
                                 ValueRange(), gpuAllocOp.getResult(0), arg);
       arg.replaceAllUsesExcept(gpuAllocOp->getResult(0), gpuMemcpyOp);
     }
@@ -122,7 +113,7 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
     // Replace all allocations with GPU.alloc
     if (auto allocOp = dyn_cast<memref::AllocOp>(nestedOp)) {
       // Rewrite this allocOp to gpu.alloc, change for all users
-      builder.setInsertionPointAfter(allocOp);
+      rewriter.setInsertionPointAfter(allocOp);
       auto result = allocOp->getResult(0);
       auto memrefType = dyn_cast<MemRefType>(result.getType());
       auto memorySpace = memrefType.getMemorySpace();
@@ -143,15 +134,15 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
       }
 
       auto gpuAllocOp = gpu::AllocOp::create(
-          builder, allocOp->getLoc(),
+          rewriter, allocOp->getLoc(),
           TypeRange({stripMemRefLayout(memrefType)}), ValueRange({}));
 
       for (auto user : llvm::make_early_inc_range(result.getUsers())) {
         if (auto deallocOp = dyn_cast<memref::DeallocOp>(user)) {
-          builder.setInsertionPointAfter(deallocOp);
-          gpu::DeallocOp::create(builder, deallocOp->getLoc(), TypeRange(),
+          rewriter.setInsertionPointAfter(deallocOp);
+          gpu::DeallocOp::create(rewriter, deallocOp->getLoc(), TypeRange(),
                                  ValueRange(), gpuAllocOp.getResult(0));
-          deallocOp->erase();
+          rewriter.eraseOp(deallocOp);
         } else {
           for (auto &opOperand : user->getOpOperands()) {
             if (opOperand.is(result)) {
@@ -160,7 +151,7 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
           }
         }
       }
-      allocOp->erase();
+      rewriter.eraseOp(allocOp);
     }
     // Replace all memory.copy operations with gpu.memcpy
     else if (auto copyOp = dyn_cast<memref::CopyOp>(nestedOp)) {
@@ -180,53 +171,53 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
         return WalkResult::interrupt();
       }
       // Notice: GPU.memcpy has a different src dst order
-      builder.setInsertionPointAfter(copyOp);
-      gpu::MemcpyOp::create(builder, copyOp->getLoc(), TypeRange(),
+      rewriter.setInsertionPointAfter(copyOp);
+      gpu::MemcpyOp::create(rewriter, copyOp->getLoc(), TypeRange(),
                             ValueRange(), dst, src);
-      copyOp->erase();
+      rewriter.eraseOp(copyOp);
     }
     // Allocate space on GPU and copy global memrefs to GPU, needs deallocation
     else if (auto getGlobalOp = dyn_cast<memref::GetGlobalOp>(nestedOp)) {
-      builder.setInsertionPointAfter(getGlobalOp);
+      rewriter.setInsertionPointAfter(getGlobalOp);
       auto result = getGlobalOp->getResult(0);
       auto memrefType = dyn_cast<MemRefType>(result.getType());
       auto gpuAllocOp = gpu::AllocOp::create(
-          builder, getGlobalOp->getLoc(),
+          rewriter, getGlobalOp->getLoc(),
           TypeRange({stripMemRefLayout(memrefType)}), ValueRange({}));
       unDeallocatedValue.push_back(gpuAllocOp->getResult(0));
 
       auto src = result;
       auto dst = gpuAllocOp->getResult(0);
       auto gpuMemcpyOp = gpu::MemcpyOp::create(
-          builder, gpuAllocOp->getLoc(), TypeRange(), ValueRange(), dst, src);
+          rewriter, gpuAllocOp->getLoc(), TypeRange(), ValueRange(), dst, src);
       src.replaceAllUsesExcept(dst, gpuMemcpyOp);
     }
     // Copy data back to CPU, deallocate GPU, then return
     else if (auto returnOp = dyn_cast<func::ReturnOp>(nestedOp)) {
-      builder.setInsertionPoint(returnOp);
-      llvm::SmallVector<Type> outputTypes(
-          funcOp.getFunctionType().getResults());
+      rewriter.setInsertionPoint(returnOp);
+      auto fnType = cast<FunctionType>(funcOp.getFunctionType());
+      llvm::SmallVector<Type> outputTypes(fnType.getResults());
       for (unsigned i = 0; i < returnOp.getNumOperands(); ++i) {
         auto val = returnOp->getOperand(i);
         if (auto memrefType = dyn_cast<MemRefType>(val.getType())) {
           auto identityMemrefType = stripMemRefLayout(memrefType);
-          auto allocOp = memref::AllocOp::create(builder, returnOp->getLoc(),
+          auto allocOp = memref::AllocOp::create(rewriter, returnOp->getLoc(),
                                                  identityMemrefType);
-          gpu::MemcpyOp::create(builder, allocOp.getLoc(), TypeRange(),
+          gpu::MemcpyOp::create(rewriter, allocOp.getLoc(), TypeRange(),
                                 ValueRange(), allocOp->getResult(0), val);
           // FIXME: may be leak memory
-          // auto gpuDeallocOp = builder.create<gpu::DeallocOp>(
+          // auto gpuDeallocOp = rewriter.create<gpu::DeallocOp>(
           //     gpuMemcpyOp->getLoc(), TypeRange(), ValueRange(), val);
           outputTypes[i] = identityMemrefType;
           returnOp->setOperand(i, allocOp->getResult(0));
         }
       }
       for (auto value : unDeallocatedValue) {
-        gpu::DeallocOp::create(builder, returnOp->getLoc(), TypeRange(),
+        gpu::DeallocOp::create(rewriter, returnOp->getLoc(), TypeRange(),
                                ValueRange(), value);
       }
       funcOp.setType(
-          builder.getFunctionType(funcOp.getArgumentTypes(), outputTypes));
+          rewriter.getFunctionType(funcOp.getArgumentTypes(), outputTypes));
     }
     return WalkResult::advance();
   });

--- a/midend/lib/Conversion/MLIRGPU/ConvertMemcpyToGPU.cpp
+++ b/midend/lib/Conversion/MLIRGPU/ConvertMemcpyToGPU.cpp
@@ -118,7 +118,7 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
     }
   }
 
-  funcOp->walk<WalkOrder::PreOrder>([&](Operation *nestedOp) {
+  auto walkResult = funcOp->walk<WalkOrder::PreOrder>([&](Operation *nestedOp) {
     // Replace all allocations with GPU.alloc
     if (auto allocOp = dyn_cast<memref::AllocOp>(nestedOp)) {
       // Rewrite this allocOp to gpu.alloc, change for all users
@@ -170,7 +170,6 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
       auto dstType = dyn_cast<MemRefType>(dst.getType());
       if (!srcType || !dstType) {
         copyOp.emitOpError("expected memref operands");
-        signalPassFailure();
         return WalkResult::interrupt();
       }
       if (!srcType.getLayout().isIdentity() ||
@@ -178,7 +177,6 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
         copyOp.emitOpError("strided memref.copy must be converted by "
                            "convert-strided-memref-copy-to-linalg before "
                            "convert-memcpy-to-gpu");
-        signalPassFailure();
         return WalkResult::interrupt();
       }
       // Notice: GPU.memcpy has a different src dst order
@@ -232,6 +230,8 @@ void ConvertMemcpyToGPUPass::runOnOperation() {
     }
     return WalkResult::advance();
   });
+  if (walkResult.wasInterrupted())
+    return signalPassFailure();
 }
 } // end anonymous namespace.
 

--- a/midend/lib/Conversion/MLIRGPU/ConvertStridedMemrefCopyToLinalg.cpp
+++ b/midend/lib/Conversion/MLIRGPU/ConvertStridedMemrefCopyToLinalg.cpp
@@ -19,12 +19,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
 
 using namespace mlir;
@@ -33,7 +33,7 @@ namespace {
 
 class ConvertStridedMemrefCopyToLinalgPass
     : public PassWrapper<ConvertStridedMemrefCopyToLinalgPass,
-                         OperationPass<func::FuncOp>> {
+                         InterfacePass<FunctionOpInterface>> {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(
       ConvertStridedMemrefCopyToLinalgPass)
@@ -49,11 +49,11 @@ public:
   }
 
   void runOnOperation() override {
-    func::FuncOp funcOp = getOperation();
+    FunctionOpInterface funcOp = getOperation();
     SmallVector<memref::CopyOp> copies;
     funcOp.walk([&](memref::CopyOp op) { copies.push_back(op); });
 
-    OpBuilder builder(funcOp.getContext());
+    IRRewriter rewriter(funcOp.getContext());
     for (memref::CopyOp copyOp : copies) {
       Value src = copyOp.getSource();
       Value dst = copyOp.getTarget();
@@ -73,9 +73,9 @@ public:
         return signalPassFailure();
       }
 
-      builder.setInsertionPoint(copyOp);
-      linalg::makeMemRefCopyOp(builder, copyOp.getLoc(), src, dst);
-      copyOp.erase();
+      rewriter.setInsertionPoint(copyOp);
+      linalg::makeMemRefCopyOp(rewriter, copyOp.getLoc(), src, dst);
+      rewriter.eraseOp(copyOp);
     }
   }
 };

--- a/midend/lib/Conversion/MLIRGPU/ConvertStridedMemrefCopyToLinalg.cpp
+++ b/midend/lib/Conversion/MLIRGPU/ConvertStridedMemrefCopyToLinalg.cpp
@@ -1,0 +1,83 @@
+//===- ConvertStridedMemrefCopyToLinalg.cpp -------------------------------===//
+//
+// Rewrite non-identity-layout memref.copy to linalg.generic so they lower
+// through parallel-loops → GPU kernels. Contiguous copies stay as memref.copy
+// for convert-memcpy-to-gpu. Identity self-copies are erased.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Pass/Pass.h"
+
+using namespace mlir;
+
+namespace {
+
+class ConvertStridedMemrefCopyToLinalgPass
+    : public PassWrapper<ConvertStridedMemrefCopyToLinalgPass,
+                         OperationPass<func::FuncOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(
+      ConvertStridedMemrefCopyToLinalgPass)
+  StringRef getArgument() const final {
+    return "convert-strided-memref-copy-to-linalg";
+  }
+  StringRef getDescription() const final {
+    return "Convert strided memref.copy to linalg.generic copy.";
+  }
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect, memref::MemRefDialect>();
+  }
+
+  void runOnOperation() override {
+    func::FuncOp funcOp = getOperation();
+    SmallVector<memref::CopyOp> copies;
+    funcOp.walk([&](memref::CopyOp op) { copies.push_back(op); });
+
+    for (memref::CopyOp copyOp : copies) {
+      Value src = copyOp.getSource();
+      Value dst = copyOp.getTarget();
+      if (src == dst) {
+        copyOp.erase();
+        continue;
+      }
+
+      auto srcType = dyn_cast<MemRefType>(src.getType());
+      auto dstType = dyn_cast<MemRefType>(dst.getType());
+      if (!srcType || !dstType) {
+        copyOp.emitOpError("expected memref operands");
+        signalPassFailure();
+        return;
+      }
+
+      if (srcType.getLayout().isIdentity() && dstType.getLayout().isIdentity())
+        continue;
+
+      if (srcType.getRank() != dstType.getRank()) {
+        copyOp.emitOpError("rank mismatch between source and target");
+        signalPassFailure();
+        return;
+      }
+
+      OpBuilder builder(copyOp);
+      linalg::makeMemRefCopyOp(builder, copyOp.getLoc(), src, dst);
+      copyOp.erase();
+    }
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace buddy {
+void registerConvertStridedMemrefCopyToLinalgPass() {
+  PassRegistration<ConvertStridedMemrefCopyToLinalgPass>();
+}
+} // namespace buddy
+} // namespace mlir

--- a/midend/lib/Conversion/MLIRGPU/ConvertStridedMemrefCopyToLinalg.cpp
+++ b/midend/lib/Conversion/MLIRGPU/ConvertStridedMemrefCopyToLinalg.cpp
@@ -1,8 +1,21 @@
 //===- ConvertStridedMemrefCopyToLinalg.cpp -------------------------------===//
 //
-// Rewrite non-identity-layout memref.copy to linalg.generic so they lower
-// through parallel-loops → GPU kernels. Contiguous copies stay as memref.copy
-// for convert-memcpy-to-gpu. Identity self-copies are erased.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the pass that converts strided memref.copy operations
+// to linalg.generic before GPU lowering.
 //
 //===----------------------------------------------------------------------===//
 
@@ -40,20 +53,16 @@ public:
     SmallVector<memref::CopyOp> copies;
     funcOp.walk([&](memref::CopyOp op) { copies.push_back(op); });
 
+    OpBuilder builder(funcOp.getContext());
     for (memref::CopyOp copyOp : copies) {
       Value src = copyOp.getSource();
       Value dst = copyOp.getTarget();
-      if (src == dst) {
-        copyOp.erase();
-        continue;
-      }
 
       auto srcType = dyn_cast<MemRefType>(src.getType());
       auto dstType = dyn_cast<MemRefType>(dst.getType());
       if (!srcType || !dstType) {
         copyOp.emitOpError("expected memref operands");
-        signalPassFailure();
-        return;
+        return signalPassFailure();
       }
 
       if (srcType.getLayout().isIdentity() && dstType.getLayout().isIdentity())
@@ -61,11 +70,10 @@ public:
 
       if (srcType.getRank() != dstType.getRank()) {
         copyOp.emitOpError("rank mismatch between source and target");
-        signalPassFailure();
-        return;
+        return signalPassFailure();
       }
 
-      OpBuilder builder(copyOp);
+      builder.setInsertionPoint(copyOp);
       linalg::makeMemRefCopyOp(builder, copyOp.getLoc(), src, dst);
       copyOp.erase();
     }

--- a/tests/Conversion/convert-memcpy-to-gpu.mlir
+++ b/tests/Conversion/convert-memcpy-to-gpu.mlir
@@ -1,4 +1,4 @@
-// RUN: buddy-opt -convert-memcpy-to-gpu="process-args=1" %s | FileCheck %s
+// RUN: buddy-opt -pass-pipeline="builtin.module(func.func(convert-memcpy-to-gpu{process-args=1}))" %s | FileCheck %s
 
 #map = affine_map<(d0)[s0, s1] -> (d0 * s0 + s1)>
 module attributes {gpu.container_module} {

--- a/tests/Conversion/convert-strided-memref-copy-to-linalg.mlir
+++ b/tests/Conversion/convert-strided-memref-copy-to-linalg.mlir
@@ -1,4 +1,4 @@
-// RUN: buddy-opt -convert-strided-memref-copy-to-linalg %s | FileCheck %s
+// RUN: buddy-opt -pass-pipeline="builtin.module(func.func(convert-strided-memref-copy-to-linalg))" %s | FileCheck %s
 
 module {
   // CHECK-LABEL: func.func @strided_copy

--- a/tests/Conversion/convert-strided-memref-copy-to-linalg.mlir
+++ b/tests/Conversion/convert-strided-memref-copy-to-linalg.mlir
@@ -1,44 +1,48 @@
-// RUN: buddy-opt -pass-pipeline="builtin.module(func.func(convert-strided-memref-copy-to-linalg))" %s | FileCheck %s
+// RUN: buddy-opt %s -split-input-file \
+// RUN:   -pass-pipeline="builtin.module(func.func(convert-strided-memref-copy-to-linalg))" \
+// RUN: | FileCheck %s
 
-module {
-  // CHECK-LABEL: func.func @strided_copy
-  // CHECK-NOT: memref.copy
-  // CHECK: linalg.generic
-  // CHECK-SAME: iterator_types = ["parallel", "parallel"]
-  // CHECK: ^bb0(%[[IN:.*]]: f32, %[[OUT:.*]]: f32):
-  // CHECK: linalg.yield %[[IN]] : f32
-  func.func @strided_copy(%arg0: memref<4x8xf32, strided<[?, ?], offset: ?>>,
-                          %arg1: memref<4x8xf32>) {
-    memref.copy %arg0, %arg1
-      : memref<4x8xf32, strided<[?, ?], offset: ?>> to memref<4x8xf32>
-    return
-  }
+// CHECK-LABEL: func @strided_copy
+//   CHECK-NOT: memref.copy
+//       CHECK: linalg.generic
+//  CHECK-SAME: iterator_types = ["parallel", "parallel"]
+//       CHECK: ^bb0(%[[IN:.*]]: f32, %[[OUT:.*]]: f32):
+//       CHECK: linalg.yield %[[IN]] : f32
+func.func @strided_copy(%arg0: memref<4x8xf32, strided<[?, ?], offset: ?>>,
+                        %arg1: memref<4x8xf32>) {
+  memref.copy %arg0, %arg1
+    : memref<4x8xf32, strided<[?, ?], offset: ?>> to memref<4x8xf32>
+  return
+}
 
-  // CHECK-LABEL: func.func @identity_copy
-  // CHECK: memref.copy
-  // CHECK-NOT: linalg.generic
-  func.func @identity_copy(%arg0: memref<4x8xf32>, %arg1: memref<4x8xf32>) {
-    memref.copy %arg0, %arg1 : memref<4x8xf32> to memref<4x8xf32>
-    return
-  }
+// -----
 
-  // CHECK-LABEL: func.func @subview_copy
-  // CHECK: %[[SRC:.*]] = memref.subview
-  // CHECK: %[[DST:.*]] = memref.subview
-  // CHECK-NOT: memref.copy
-  // CHECK: linalg.generic
-  // CHECK-SAME: ins(%[[SRC]]
-  // CHECK-SAME: outs(%[[DST]]
-  // CHECK: linalg.yield
-  func.func @subview_copy(%arg0: memref<8x8xf32>, %arg1: memref<8x8xf32>) {
-    %c0 = arith.constant 0 : index
-    %src = memref.subview %arg0[%c0, %c0] [4, 4] [1, 1]
-      : memref<8x8xf32> to memref<4x4xf32, strided<[8, 1], offset: ?>>
-    %dst = memref.subview %arg1[%c0, %c0] [4, 4] [1, 1]
-      : memref<8x8xf32> to memref<4x4xf32, strided<[8, 1], offset: ?>>
-    memref.copy %src, %dst
-      : memref<4x4xf32, strided<[8, 1], offset: ?>>
-        to memref<4x4xf32, strided<[8, 1], offset: ?>>
-    return
-  }
+// CHECK-LABEL: func @identity_copy
+//       CHECK: memref.copy
+//   CHECK-NOT: linalg.generic
+func.func @identity_copy(%arg0: memref<4x8xf32>, %arg1: memref<4x8xf32>) {
+  memref.copy %arg0, %arg1 : memref<4x8xf32> to memref<4x8xf32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @subview_copy
+//       CHECK: %[[SRC:.*]] = memref.subview
+//       CHECK: %[[DST:.*]] = memref.subview
+//   CHECK-NOT: memref.copy
+//       CHECK: linalg.generic
+//  CHECK-SAME: ins(%[[SRC]]
+//  CHECK-SAME: outs(%[[DST]]
+//       CHECK: linalg.yield
+func.func @subview_copy(%arg0: memref<8x8xf32>, %arg1: memref<8x8xf32>) {
+  %c0 = arith.constant 0 : index
+  %src = memref.subview %arg0[%c0, %c0] [4, 4] [1, 1]
+    : memref<8x8xf32> to memref<4x4xf32, strided<[8, 1], offset: ?>>
+  %dst = memref.subview %arg1[%c0, %c0] [4, 4] [1, 1]
+    : memref<8x8xf32> to memref<4x4xf32, strided<[8, 1], offset: ?>>
+  memref.copy %src, %dst
+    : memref<4x4xf32, strided<[8, 1], offset: ?>>
+      to memref<4x4xf32, strided<[8, 1], offset: ?>>
+  return
 }

--- a/tests/Conversion/convert-strided-memref-copy-to-linalg.mlir
+++ b/tests/Conversion/convert-strided-memref-copy-to-linalg.mlir
@@ -1,0 +1,44 @@
+// RUN: buddy-opt -convert-strided-memref-copy-to-linalg %s | FileCheck %s
+
+module {
+  // CHECK-LABEL: func.func @strided_copy
+  // CHECK-NOT: memref.copy
+  // CHECK: linalg.generic
+  // CHECK-SAME: iterator_types = ["parallel", "parallel"]
+  // CHECK: ^bb0(%[[IN:.*]]: f32, %[[OUT:.*]]: f32):
+  // CHECK: linalg.yield %[[IN]] : f32
+  func.func @strided_copy(%arg0: memref<4x8xf32, strided<[?, ?], offset: ?>>,
+                          %arg1: memref<4x8xf32>) {
+    memref.copy %arg0, %arg1
+      : memref<4x8xf32, strided<[?, ?], offset: ?>> to memref<4x8xf32>
+    return
+  }
+
+  // CHECK-LABEL: func.func @identity_copy
+  // CHECK: memref.copy
+  // CHECK-NOT: linalg.generic
+  func.func @identity_copy(%arg0: memref<4x8xf32>, %arg1: memref<4x8xf32>) {
+    memref.copy %arg0, %arg1 : memref<4x8xf32> to memref<4x8xf32>
+    return
+  }
+
+  // CHECK-LABEL: func.func @subview_copy
+  // CHECK: %[[SRC:.*]] = memref.subview
+  // CHECK: %[[DST:.*]] = memref.subview
+  // CHECK-NOT: memref.copy
+  // CHECK: linalg.generic
+  // CHECK-SAME: ins(%[[SRC]]
+  // CHECK-SAME: outs(%[[DST]]
+  // CHECK: linalg.yield
+  func.func @subview_copy(%arg0: memref<8x8xf32>, %arg1: memref<8x8xf32>) {
+    %c0 = arith.constant 0 : index
+    %src = memref.subview %arg0[%c0, %c0] [4, 4] [1, 1]
+      : memref<8x8xf32> to memref<4x4xf32, strided<[8, 1], offset: ?>>
+    %dst = memref.subview %arg1[%c0, %c0] [4, 4] [1, 1]
+      : memref<8x8xf32> to memref<4x4xf32, strided<[8, 1], offset: ?>>
+    memref.copy %src, %dst
+      : memref<4x4xf32, strided<[8, 1], offset: ?>>
+        to memref<4x4xf32, strided<[8, 1], offset: ?>>
+    return
+  }
+}

--- a/tools/buddy-opt/buddy-opt.cpp
+++ b/tools/buddy-opt/buddy-opt.cpp
@@ -125,6 +125,7 @@ void registerLowerBOSCAMEPass();
 void registerAssumeTightMemRefLayoutPass();
 void registerStaticizeMemRefLayoutPass();
 void registerConvertMemcpyToGPUPass();
+void registerConvertStridedMemrefCopyToLinalgPass();
 void registerLegalizeShmemOutliningPass();
 void registerMatMulTransposeBVecPass();
 void registerMatMulTransposeBVecDecodePass();
@@ -218,6 +219,7 @@ int main(int argc, char **argv) {
   mlir::buddy::registerSiLUFusionPass();
   // Register gpu passes
   mlir::buddy::registerConvertMemcpyToGPUPass();
+  mlir::buddy::registerConvertStridedMemrefCopyToLinalgPass();
   mlir::buddy::registerLegalizeShmemOutliningPass();
 
   mlir::DialectRegistry registry;


### PR DESCRIPTION
## Summary

NVVM cannot lower gpu.memcpy on non-identity layouts (e.g. RoPE half-dim subviews). Convert those copies to linalg.generic first and reject leftover strided memref.copy in convert-memcpy-to-gpu.


## Checklist

- [x] The code builds successfully
- [ ] Existing tests pass
- [ ] New tests are added where appropriate
- [x] Code follows the project coding style
- [ ] Documentation is updated if needed
