### PR TITLE
[midend] Fix copy elimination and mixed-type matmul vectorization

### DIFF
--- a/midend/lib/Conversion/EliminateMemRefCopy/EliminateMemRefCopy.cpp
+++ b/midend/lib/Conversion/EliminateMemRefCopy/EliminateMemRefCopy.cpp
@@ -50,23 +50,27 @@ static bool isFunctionArgument(Value value) {
   return isa<func::FuncOp>(arg.getOwner()->getParentOp());
 }
 
-static bool isAliasOfFunctionArgument(Value value) {
+static Value getFunctionArgumentRoot(Value value) {
   if (isFunctionArgument(value))
-    return true;
+    return value;
 
   if (auto castOp = value.getDefiningOp<memref::CastOp>())
-    return isAliasOfFunctionArgument(castOp.getSource());
+    return getFunctionArgumentRoot(castOp.getSource());
 
   if (auto reinterpretOp = value.getDefiningOp<memref::ReinterpretCastOp>())
-    return isAliasOfFunctionArgument(reinterpretOp.getSource());
+    return getFunctionArgumentRoot(reinterpretOp.getSource());
 
   if (auto result = dyn_cast<OpResult>(value)) {
     if (auto metadataOp =
             dyn_cast<memref::ExtractStridedMetadataOp>(result.getOwner()))
-      return isAliasOfFunctionArgument(metadataOp.getSource());
+      return getFunctionArgumentRoot(metadataOp.getSource());
   }
 
-  return false;
+  return {};
+}
+
+static bool isAliasOfFunctionArgument(Value value) {
+  return static_cast<bool>(getFunctionArgumentRoot(value));
 }
 
 static bool areAllUsesDominatedBy(Value value, Operation *dominator,
@@ -90,6 +94,34 @@ struct EliminateMemRefCopyPattern : public OpRewritePattern<memref::CopyOp> {
 
     // Check if the source is a function argument or an alias rooted at one.
     if (!isAliasOfFunctionArgument(source))
+      return failure();
+
+    // Replacing the snapshot allocation with the source argument is unsafe if
+    // the original source is also modified elsewhere. In particular, a swap
+    // lowers to two argument-to-allocation snapshots followed by copies back
+    // to both arguments. Eliminating the snapshots makes the second copy read
+    // the value written by the first one.
+    Value sourceRoot = getFunctionArgumentRoot(source);
+    func::FuncOp func = copyOp->getParentOfType<func::FuncOp>();
+    bool sourceIsExternallyModified = false;
+    func.walk([&](Operation *operation) {
+      if (operation == copyOp.getOperation())
+        return WalkResult::advance();
+
+      if (auto otherCopy = dyn_cast<memref::CopyOp>(operation)) {
+        if (getFunctionArgumentRoot(otherCopy.getTarget()) == sourceRoot) {
+          sourceIsExternallyModified = true;
+          return WalkResult::interrupt();
+        }
+      } else if (auto store = dyn_cast<memref::StoreOp>(operation)) {
+        if (getFunctionArgumentRoot(store.getMemRef()) == sourceRoot) {
+          sourceIsExternallyModified = true;
+          return WalkResult::interrupt();
+        }
+      }
+      return WalkResult::advance();
+    });
+    if (sourceIsExternallyModified)
       return failure();
 
     // Check if destination is an allocation

--- a/midend/lib/Conversion/MatMulOptimization/MatMulVectorization.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/MatMulVectorization.cpp
@@ -76,8 +76,45 @@ public:
 
     // Get element type and create vector type.
     ShapedType ATy = mlir::cast<mlir::ShapedType>(A.getType());
-    Type eleTy = ATy.getElementType();
-    VectorType vectorTy = VectorType::get({vecSize}, eleTy, {scalable});
+    ShapedType BTy = mlir::cast<mlir::ShapedType>(B.getType());
+    ShapedType CTy = mlir::cast<mlir::ShapedType>(C.getType());
+    Type aEleTy = ATy.getElementType();
+    Type bEleTy = BTy.getElementType();
+    Type accEleTy = CTy.getElementType();
+    VectorType bVectorTy = VectorType::get({vecSize}, bEleTy, {scalable});
+    VectorType accVectorTy = VectorType::get({vecSize}, accEleTy, {scalable});
+
+    auto isSupportedCast = [](Type sourceType, Type targetType) {
+      return sourceType == targetType ||
+             (isa<FloatType>(sourceType) && isa<FloatType>(targetType)) ||
+             (isa<IntegerType>(sourceType) && isa<IntegerType>(targetType));
+    };
+    if (!isSupportedCast(aEleTy, accEleTy) ||
+        !isSupportedCast(bEleTy, accEleTy) ||
+        (!isa<FloatType>(accEleTy) && !isa<IntegerType>(accEleTy)))
+      return failure();
+
+    auto castToAccumulatorType = [&](OpBuilder &builder, Location castLoc,
+                                     Value value, Type targetType) -> Value {
+      Type sourceType = value.getType();
+      if (sourceType == targetType)
+        return value;
+
+      Type sourceElementType = getElementTypeOrSelf(sourceType);
+      Type targetElementType = getElementTypeOrSelf(targetType);
+      if (auto sourceFloat = dyn_cast<FloatType>(sourceElementType)) {
+        auto targetFloat = cast<FloatType>(targetElementType);
+        if (sourceFloat.getWidth() < targetFloat.getWidth())
+          return arith::ExtFOp::create(builder, castLoc, targetType, value);
+        return arith::TruncFOp::create(builder, castLoc, targetType, value);
+      }
+
+      auto sourceInteger = cast<IntegerType>(sourceElementType);
+      auto targetInteger = cast<IntegerType>(targetElementType);
+      if (sourceInteger.getWidth() < targetInteger.getWidth())
+        return arith::ExtSIOp::create(builder, castLoc, targetType, value);
+      return arith::TruncIOp::create(builder, castLoc, targetType, value);
+    };
 
     // Define step.
     Value step = arith::ConstantIndexOp::create(rewriter, loc, vecSize);
@@ -85,11 +122,6 @@ public:
       Value vscale = vector::VectorScaleOp::create(rewriter, loc);
       step = arith::MulIOp::create(rewriter, loc, step, vscale);
     }
-    FloatType eleFloatTy =
-        eleTy.isF32()
-            ? static_cast<FloatType>(Float32Type::get(rewriter.getContext()))
-            : static_cast<FloatType>(Float64Type::get(rewriter.getContext()));
-
     auto tail_size = arith::RemUIOp::create(rewriter, loc, m, c8);
     auto parallel_size = arith::SubIOp::create(rewriter, loc, m, tail_size);
 
@@ -127,7 +159,7 @@ public:
                   SmallVector<Value> sumInitVecs;
                   for (auto mIndex : mIndices) {
                     auto sumInitVec = vector::LoadOp::create(
-                        rewriter, loc, vectorTy, C, ValueRange{mIndex, iv});
+                        rewriter, loc, accVectorTy, C, ValueRange{mIndex, iv});
                     sumInitVecs.push_back(sumInitVec);
                   }
 
@@ -140,17 +172,29 @@ public:
                       ValueRange(sumInitVecs),
                       [&](OpBuilder &builder, Location loc, Value kIdx,
                           ValueRange iterArgs) {
-                        auto bVec = vector::LoadOp::create(
-                            rewriter, loc, vectorTy, B, ValueRange{kIdx, iv});
+                        Value bVec = vector::LoadOp::create(
+                            rewriter, loc, bVectorTy, B, ValueRange{kIdx, iv});
+                        bVec = castToAccumulatorType(builder, loc, bVec,
+                                                     accVectorTy);
 
                         SmallVector<Value> resSumVecs;
                         for (int i = 0; i < unroll_size; i++) {
-                          auto aEle = memref::LoadOp::create(
+                          Value aEle = memref::LoadOp::create(
                               rewriter, loc, A, ValueRange{mIndices[i], kIdx});
+                          aEle = castToAccumulatorType(builder, loc, aEle,
+                                                       accEleTy);
                           auto aVec = vector::BroadcastOp::create(
-                              rewriter, loc, vectorTy, aEle);
-                          auto resSumVec = vector::FMAOp::create(
-                              rewriter, loc, aVec, bVec, iterArgs[i]);
+                              rewriter, loc, accVectorTy, aEle);
+                          Value resSumVec;
+                          if (isa<FloatType>(accEleTy)) {
+                            resSumVec = vector::FMAOp::create(
+                                rewriter, loc, aVec, bVec, iterArgs[i]);
+                          } else {
+                            Value product = arith::MulIOp::create(rewriter, loc,
+                                                                  aVec, bVec);
+                            resSumVec = arith::AddIOp::create(
+                                rewriter, loc, product, iterArgs[i]);
+                          }
                           resSumVecs.push_back(resSumVec);
                         }
                         scf::YieldOp::create(builder, loc,
@@ -175,7 +219,7 @@ public:
                   SmallVector<Value> sumInits;
                   for (auto mIndex : mIndices) {
                     auto sumInit = memref::LoadOp::create(
-                        rewriter, loc, eleFloatTy, C, ValueRange{mIndex, iv});
+                        rewriter, loc, C, ValueRange{mIndex, iv});
                     sumInits.push_back(sumInit);
                   }
                   auto sumIterVecs = scf::ForOp::create(
@@ -188,15 +232,28 @@ public:
                       [&](OpBuilder &builder, Location loc, Value kIdx,
                           ValueRange iterArgs) {
                         SmallVector<Value> resSums;
-                        auto bEle = memref::LoadOp::create(
+                        Value bEle = memref::LoadOp::create(
                             rewriter, loc, B, ValueRange{kIdx, iv});
+                        bEle =
+                            castToAccumulatorType(builder, loc, bEle, accEleTy);
                         for (int i = 0; i < unroll_size; i++) {
-                          auto aEle = memref::LoadOp::create(
+                          Value aEle = memref::LoadOp::create(
                               rewriter, loc, A, ValueRange{mIndices[i], kIdx});
-                          auto tmpEle =
-                              arith::MulFOp::create(rewriter, loc, aEle, bEle);
-                          auto resSum = arith::AddFOp::create(
-                              rewriter, loc, tmpEle, iterArgs[i]);
+                          aEle = castToAccumulatorType(builder, loc, aEle,
+                                                       accEleTy);
+                          Value tmpEle;
+                          Value resSum;
+                          if (isa<FloatType>(accEleTy)) {
+                            tmpEle = arith::MulFOp::create(rewriter, loc, aEle,
+                                                           bEle);
+                            resSum = arith::AddFOp::create(rewriter, loc,
+                                                           tmpEle, iterArgs[i]);
+                          } else {
+                            tmpEle = arith::MulIOp::create(rewriter, loc, aEle,
+                                                           bEle);
+                            resSum = arith::AddIOp::create(rewriter, loc,
+                                                           tmpEle, iterArgs[i]);
+                          }
                           resSums.push_back(resSum);
                         }
 

--- a/tests/Conversion/eliminate-memref-copy.mlir
+++ b/tests/Conversion/eliminate-memref-copy.mlir
@@ -83,6 +83,22 @@ module {
     memref.copy %arg0, %alloc : memref<10xf32, strided<[?], offset: ?>> to memref<10xf32>
     return %val : f32
   }
+
+  // Both allocations are snapshots. Replacing them with the function
+  // arguments would turn the second write into a read of the already modified
+  // first argument and break swap semantics.
+  func.func @test_swap_preserves_snapshots(
+      %arg0: memref<10xf32>, %arg1: memref<10xf32>) {
+    %lhs = memref.alloc() : memref<10xf32>
+    %rhs = memref.alloc() : memref<10xf32>
+    memref.copy %arg0, %lhs : memref<10xf32> to memref<10xf32>
+    memref.copy %arg1, %rhs : memref<10xf32> to memref<10xf32>
+    memref.copy %rhs, %arg0 : memref<10xf32> to memref<10xf32>
+    memref.copy %lhs, %arg1 : memref<10xf32> to memref<10xf32>
+    memref.dealloc %rhs : memref<10xf32>
+    memref.dealloc %lhs : memref<10xf32>
+    return
+  }
 }
 
 // CHECK-LABEL: func.func @test_basic
@@ -158,4 +174,10 @@ module {
 // CHECK: memref.alloc
 // CHECK: memref.load
 // CHECK: memref.copy
+// CHECK: return
+
+// CHECK-LABEL: func.func @test_swap_preserves_snapshots
+// CHECK-COUNT-2: memref.alloc
+// CHECK-COUNT-4: memref.copy
+// CHECK-COUNT-2: memref.dealloc
 // CHECK: return

--- a/tests/Conversion/matmul-vectorization-mixed-types.mlir
+++ b/tests/Conversion/matmul-vectorization-mixed-types.mlir
@@ -1,0 +1,36 @@
+// RUN: buddy-opt %s -matmul-vectorization="vector-size=8" | FileCheck %s
+
+module {
+  func.func @matmul_f16_f32(%a: memref<?x?xf16>, %b: memref<?x?xf16>,
+                            %c: memref<?x?xf32>) {
+    linalg.matmul
+      ins(%a, %b : memref<?x?xf16>, memref<?x?xf16>)
+      outs(%c : memref<?x?xf32>)
+    return
+  }
+
+  func.func @matmul_i8_i32(%a: memref<?x?xi8>, %b: memref<?x?xi8>,
+                           %c: memref<?x?xi32>) {
+    linalg.matmul
+      ins(%a, %b : memref<?x?xi8>, memref<?x?xi8>)
+      outs(%c : memref<?x?xi32>)
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @matmul_f16_f32
+// CHECK: vector.load {{.*}} : memref<?x?xf32>, vector<8xf32>
+// CHECK: vector.load {{.*}} : memref<?x?xf16>, vector<8xf16>
+// CHECK: arith.extf {{.*}} : vector<8xf16> to vector<8xf32>
+// CHECK: arith.extf {{.*}} : f16 to f32
+// CHECK: vector.fma {{.*}} : vector<8xf32>
+// CHECK: vector.store {{.*}} : memref<?x?xf32>, vector<8xf32>
+
+// CHECK-LABEL: func.func @matmul_i8_i32
+// CHECK: vector.load {{.*}} : memref<?x?xi32>, vector<8xi32>
+// CHECK: vector.load {{.*}} : memref<?x?xi8>, vector<8xi8>
+// CHECK: arith.extsi {{.*}} : vector<8xi8> to vector<8xi32>
+// CHECK: arith.extsi {{.*}} : i8 to i32
+// CHECK: arith.muli {{.*}} : vector<8xi32>
+// CHECK: arith.addi {{.*}} : vector<8xi32>
+// CHECK: vector.store {{.*}} : memref<?x?xi32>, vector<8xi32>


### PR DESCRIPTION
## Summary
- preserve snapshot copies when their source function argument is modified elsewhere, fixing swap semantics
- use the output element type for matmul accumulators and explicitly widen fp16/int8 inputs
- retain vector FMA for floating-point matmul and use integer mul/add for integer accumulation
- add regression coverage for swap, f16-to-f32, and i8-to-i32 matmul

## Validation
- `cmake --build build --target check-buddy -j2` (228 example tests and 343 regression tests passed; 4 unsupported)
- Triton integration: `pytest -q python/examples/test_swap.py python/examples/test_matmul_fp16.py python/examples/test_matmul_int8.py` (5 passed)
- Triton full examples: 197 passed, 14 skipped