### PR TITLE
[frontend][midend] Add FP16 panel-packed decode matmul support

### DIFF
--- a/docs/DecodeWeightPacking.md
+++ b/docs/DecodeWeightPacking.md
@@ -74,6 +74,11 @@ Packing is off by default. It is enabled per spec, by setting
 }
 ```
 
+Ready-to-use DeepSeek-R1 specs are provided for both precisions:
+`models/deepseek_r1/specs/f32_packed_decode.json` and
+`models/deepseek_r1/specs/f16_packed_decode.json`. The FP16 path keeps the
+weights packed as FP16 values and emits native `vector<32xf16>` loads and FMA.
+
 `models/deepseek_r1/specs/f32_packed_decode.json` is the f32 DeepSeek R1 spec
 with packing enabled. Build it the usual way:
 

--- a/docs/DecodeWeightPacking.md
+++ b/docs/DecodeWeightPacking.md
@@ -109,8 +109,16 @@ Two restrictions are enforced at config time:
 ninja buddy-deepseek-r1-packed-run
 ```
 
+The FP16 example uses a separate target and output directory:
+
+```bash
+ninja buddy-deepseek-r1-packed-f16-run
+./bin/buddy-deepseek-r1-packed-f16-run
+```
+
 It imports with `--pack-decode-weights --pack-vector-size 32` and writes its
-artifacts to `packed_decode/` so they do not clobber the plain f32 outputs.
+artifacts to `packed_decode/` (FP32) or `packed_decode_f16/` (FP16), so they do
+not clobber the plain outputs.
 
 ## Adapting To Other Models
 

--- a/examples/BuddyDeepSeekR1/CMakeLists.txt
+++ b/examples/BuddyDeepSeekR1/CMakeLists.txt
@@ -2,6 +2,8 @@
 set(BUFFERIZE_FULL_OPTS "unknown-type-conversion=identity-layout-map function-boundary-type-conversion=identity-layout-map bufferize-function-boundaries")
 set(BUFFERIZE_SIMPLE_OPTS "bufferize-function-boundaries")
 set(TOSA_PIPELINE "builtin.module(func.func(tosa-to-linalg-named),func.func(tosa-to-linalg),func.func(tosa-to-tensor),func.func(tosa-to-arith))")
+set(DEEPSEEKR1_IMPORT_PYTHONPATH
+    "${CMAKE_BINARY_DIR}/python_packages:${LLVM_BINARY_DIR}/tools/mlir/python_packages/mlir_core:$ENV{PYTHONPATH}")
 
 # Detect RISC-V Vector (RVV) platform
 # Use HAVE_LOCAL_RVV from check_simd.cmake which is already called in the main CMakeLists.txt
@@ -27,7 +29,9 @@ add_custom_command(
           ${CMAKE_CURRENT_BINARY_DIR}/forward_decode.mlir
           ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode.mlir
           ${CMAKE_CURRENT_BINARY_DIR}/arg0.data
-  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/import-deepseek-r1.py
+  COMMAND ${CMAKE_COMMAND} -E env
+          "PYTHONPATH=${DEEPSEEKR1_IMPORT_PYTHONPATH}"
+          ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/import-deepseek-r1.py
           --output-dir ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Generating forward.mlir, subgraph0.mlir and arg0.data..."
 )
@@ -38,7 +42,9 @@ add_custom_command(
           ${CMAKE_CURRENT_BINARY_DIR}/forward_decode-f16.mlir
           ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode-f16.mlir
           ${CMAKE_CURRENT_BINARY_DIR}/arg0-f16.data
-  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/import-deepseek-r1.py
+  COMMAND ${CMAKE_COMMAND} -E env
+          "PYTHONPATH=${DEEPSEEKR1_IMPORT_PYTHONPATH}"
+          ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/import-deepseek-r1.py
           --output-dir ${CMAKE_CURRENT_BINARY_DIR}
           --precision f16
   COMMENT "Generating forward.mlir, subgraph0.mlir and arg0.data..."
@@ -50,7 +56,9 @@ add_custom_command(
           ${CMAKE_CURRENT_BINARY_DIR}/forward_decode-bf16.mlir
           ${CMAKE_CURRENT_BINARY_DIR}/subgraph0_decode-bf16.mlir
           ${CMAKE_CURRENT_BINARY_DIR}/arg0-bf16.data
-  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/import-deepseek-r1.py
+  COMMAND ${CMAKE_COMMAND} -E env
+          "PYTHONPATH=${DEEPSEEKR1_IMPORT_PYTHONPATH}"
+          ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/import-deepseek-r1.py
           --output-dir ${CMAKE_CURRENT_BINARY_DIR}
           --precision bf16
   COMMENT "Generating forward.mlir, subgraph0.mlir and arg0.data..."
@@ -319,6 +327,7 @@ set(PACKED_DECODE_DIR ${CMAKE_CURRENT_BINARY_DIR}/packed_decode)
 # layout as arg0.data with only the bytes inside each weight permuted. Prefill
 # is handed the plain one, decode the packed one; that is the whole difference.
 set(PACKED_DECODE_VECTOR_SIZE 32)
+set(PACKED_DECODE_F16_DIR ${CMAKE_CURRENT_BINARY_DIR}/packed_decode_f16)
 
 add_custom_command(
   OUTPUT ${PACKED_DECODE_DIR}/forward_prefill.mlir
@@ -328,7 +337,9 @@ add_custom_command(
           ${PACKED_DECODE_DIR}/arg0.data
           ${PACKED_DECODE_DIR}/arg0-decode.data
   COMMAND ${CMAKE_COMMAND} -E make_directory ${PACKED_DECODE_DIR}
-  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/import-deepseek-r1.py
+  COMMAND ${CMAKE_COMMAND} -E env
+          "PYTHONPATH=${DEEPSEEKR1_IMPORT_PYTHONPATH}"
+          ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/import-deepseek-r1.py
           --output-dir ${PACKED_DECODE_DIR}
           --pack-decode-weights --pack-vector-size ${PACKED_DECODE_VECTOR_SIZE}
   COMMENT "Generating packed-decode forward.mlir, subgraph0.mlir and weight data..."
@@ -436,6 +447,82 @@ add_custom_command(
     DEPENDS buddy-opt ${PACKED_DECODE_DIR}/subgraph0_prefill.mlir
     COMMENT "Building subgraph_prefill-packed.o "
     VERBATIM)
+
+# FP16 variant of the packed decode example. The top-level prefill/decode
+# wrappers and the prefill subgraph have the same ABI as the ordinary FP16
+# build, so only the decode subgraph needs a distinct packed-kernel object.
+add_custom_command(
+  OUTPUT ${PACKED_DECODE_F16_DIR}/forward_prefill-f16.mlir
+         ${PACKED_DECODE_F16_DIR}/subgraph0_prefill-f16.mlir
+         ${PACKED_DECODE_F16_DIR}/forward_decode-f16.mlir
+         ${PACKED_DECODE_F16_DIR}/subgraph0_decode-f16.mlir
+         ${PACKED_DECODE_F16_DIR}/arg0-f16.data
+         ${PACKED_DECODE_F16_DIR}/arg0-decode.data
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${PACKED_DECODE_F16_DIR}
+  COMMAND ${CMAKE_COMMAND} -E env
+          "PYTHONPATH=${DEEPSEEKR1_IMPORT_PYTHONPATH}"
+          ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/import-deepseek-r1.py
+          --output-dir ${PACKED_DECODE_F16_DIR}
+          --precision f16
+          --pack-decode-weights --pack-vector-size ${PACKED_DECODE_VECTOR_SIZE}
+  COMMENT "Generating FP16 packed-decode MLIR and weight data..."
+)
+
+add_custom_command(
+  OUTPUT subgraph_decode-packed-f16.o
+  COMMAND ${BUDDY_BINARY_DIR}/buddy-opt
+            ${PACKED_DECODE_F16_DIR}/subgraph0_decode-f16.mlir
+            -simplify-tosa-reshape
+            -simplify-tosa-matmul-scalar |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-opt
+            -pass-pipeline ${TOSA_PIPELINE} |
+          ${BUDDY_BINARY_DIR}/buddy-opt
+            -eliminate-empty-tensors
+            -empty-tensor-to-alloc-tensor
+            -convert-elementwise-to-linalg
+            -one-shot-bufferize=${BUFFERIZE_SIMPLE_OPTS}
+            -expand-strided-metadata
+            -ownership-based-buffer-deallocation
+            -canonicalize
+            -buffer-deallocation-simplification
+            -bufferization-lower-deallocations
+            -cse
+            -canonicalize
+            -optimize-allocation-liveness
+            -eliminate-memref-copy
+            -assume-tight-memref-layout
+            -staticize-memref-layout
+            "-matmul-vectorization-decode-packed=vector-size=${PACKED_DECODE_VECTOR_SIZE}"
+            -matmul-vectorization-decode=vector-size=32
+            -batch-matmul-vectorization-decode=vector-size=128
+            -batchmatmul-transpose-b-vectorization=vector-size=16
+            -convert-linalg-to-affine-loops
+            -convert-vector-to-scf
+            -lower-affine
+            -convert-scf-to-openmp=${OPENMP_NUM_THREADS}
+            -cse
+            -memref-expand
+            -arith-expand
+            -convert-vector-to-llvm
+            -convert-arith-to-llvm
+            -finalize-memref-to-llvm
+            -convert-scf-to-cf
+            -convert-cf-to-llvm
+            -llvm-request-c-wrappers
+            -convert-openmp-to-llvm
+            -convert-arith-to-llvm
+            -convert-math-to-llvm
+            -convert-math-to-libm
+            -convert-func-to-llvm
+            -reconcile-unrealized-casts |
+          ${LLVM_TOOLS_BINARY_DIR}/mlir-translate -mlir-to-llvmir |
+          ${LLVM_TOOLS_BINARY_DIR}/llvm-as |
+          ${LLVM_TOOLS_BINARY_DIR}/llc ${LLC_RISCV_ATTRS} -filetype=obj
+            -relocation-model=pic -O3
+            -o ${CMAKE_CURRENT_BINARY_DIR}/subgraph_decode-packed-f16.o
+  DEPENDS buddy-opt ${PACKED_DECODE_F16_DIR}/subgraph0_decode-f16.mlir
+  COMMENT "Building FP16 packed decode subgraph object"
+  VERBATIM)
 
 add_custom_command(
   OUTPUT forward_decode-packed.o
@@ -1746,6 +1833,7 @@ add_library(DEEPSEEKR1_W4A16 STATIC forward_prefill-w4a16.o subgraph_prefill-w4a
 add_library(DEEPSEEKR1_W8A16 STATIC forward_prefill-w8a16.o subgraph_prefill-w8a16.o forward_decode-w8a16.o subgraph_decode-w8a16.o)
 add_library(DEEPSEEKR1_W8A8 STATIC forward_prefill-w8a8.o subgraph_prefill-w8a8.o forward_decode-w8a8.o subgraph_decode-w8a8.o)
 add_library(DEEPSEEKR1_PACKED STATIC forward_prefill-packed.o subgraph_prefill-packed.o forward_decode-packed.o subgraph_decode-packed.o)
+add_library(DEEPSEEKR1_PACKED_F16 STATIC forward_prefill-f16.o subgraph_prefill-f16.o forward_decode-f16.o subgraph_decode-packed-f16.o)
 
 SET_SOURCE_FILES_PROPERTIES(
   template.o
@@ -1793,6 +1881,11 @@ SET_TARGET_PROPERTIES(
   PROPERTIES
   LINKER_LANGUAGE C)
 
+SET_TARGET_PROPERTIES(
+  DEEPSEEKR1_PACKED_F16
+  PROPERTIES
+  LINKER_LANGUAGE C)
+
 add_executable(buddy-deepseek-r1-run buddy-deepseek-r1-main.cpp)
 add_executable(buddy-deepseek-r1-f16-run buddy-deepseek-r1-f16-main.cpp)
 add_executable(buddy-deepseek-r1-bf16-run buddy-deepseek-r1-bf16-main.cpp)
@@ -1801,6 +1894,7 @@ add_executable(buddy-deepseek-r1-w8a8-run buddy-deepseek-r1-w8a8-main.cpp)
 add_executable(buddy-deepseek-r1-w4a16-run buddy-deepseek-r1-w4a16-main.cpp)
 add_executable(buddy-deepseek-r1-w8a16-run buddy-deepseek-r1-w8a16-main.cpp)
 add_executable(buddy-deepseek-r1-packed-run buddy-deepseek-r1-packed-main.cpp)
+add_executable(buddy-deepseek-r1-packed-f16-run buddy-deepseek-r1-f16-main.cpp)
 add_executable(buddy-deepseek-r1-cli buddy-deepseek-r1-cli.cpp)
 
 set(DEEPSEEKR1_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
@@ -1809,6 +1903,11 @@ set(DEEPSEEKR1_EXAMPLE_BUILD_PATH ${CMAKE_CURRENT_BINARY_DIR})
 target_compile_definitions(buddy-deepseek-r1-packed-run PRIVATE
   DEEPSEEKR1_EXAMPLE_PATH="${DEEPSEEKR1_EXAMPLE_PATH}/"
   DEEPSEEKR1_EXAMPLE_BUILD_PATH="${PACKED_DECODE_DIR}/"
+)
+target_compile_definitions(buddy-deepseek-r1-packed-f16-run PRIVATE
+  DEEPSEEKR1_PACKED_DECODE=1
+  DEEPSEEKR1_EXAMPLE_PATH="${DEEPSEEKR1_EXAMPLE_PATH}/"
+  DEEPSEEKR1_EXAMPLE_BUILD_PATH="${PACKED_DECODE_F16_DIR}/"
 )
 
 target_compile_definitions(buddy-deepseek-r1-run PRIVATE
@@ -1859,6 +1958,7 @@ target_link_directories(buddy-deepseek-r1-w8a8-run PRIVATE ${LLVM_LIBRARY_DIR})
 target_link_directories(buddy-deepseek-r1-w4a16-run PRIVATE ${LLVM_LIBRARY_DIR})
 target_link_directories(buddy-deepseek-r1-w8a16-run PRIVATE ${LLVM_LIBRARY_DIR})
 target_link_directories(buddy-deepseek-r1-packed-run PRIVATE ${LLVM_LIBRARY_DIR})
+target_link_directories(buddy-deepseek-r1-packed-f16-run PRIVATE ${LLVM_LIBRARY_DIR})
 target_link_directories(buddy-deepseek-r1-cli PRIVATE ${LLVM_LIBRARY_DIR})
 
 set(BUDDY_DEEPSEEKR1_LIBS
@@ -1901,6 +2001,11 @@ set(BUDDY_DEEPSEEKR1_PACKED_LIBS
   mlir_c_runner_utils
   omp
 )
+set(BUDDY_DEEPSEEKR1_PACKED_F16_LIBS
+  DEEPSEEKR1_PACKED_F16
+  mlir_c_runner_utils
+  omp
+)
 if(BUDDY_MLIR_USE_MIMALLOC)
   list(APPEND BUDDY_DEEPSEEKR1_LIBS mimalloc)
   list(APPEND BUDDY_DEEPSEEKR1_F16_LIBS mimalloc)
@@ -1910,6 +2015,7 @@ if(BUDDY_MLIR_USE_MIMALLOC)
   list(APPEND BUDDY_DEEPSEEKR1_W4A16_LIBS mimalloc)
   list(APPEND BUDDY_DEEPSEEKR1_W8A16_LIBS mimalloc)
   list(APPEND BUDDY_DEEPSEEKR1_PACKED_LIBS mimalloc)
+  list(APPEND BUDDY_DEEPSEEKR1_PACKED_F16_LIBS mimalloc)
 endif()
 
 target_link_libraries(buddy-deepseek-r1-run ${BUDDY_DEEPSEEKR1_LIBS})
@@ -1920,6 +2026,7 @@ target_link_libraries(buddy-deepseek-r1-w8a8-run ${BUDDY_DEEPSEEKR1_W8A8_LIBS})
 target_link_libraries(buddy-deepseek-r1-w4a16-run ${BUDDY_DEEPSEEKR1_W4A16_LIBS})
 target_link_libraries(buddy-deepseek-r1-w8a16-run ${BUDDY_DEEPSEEKR1_W8A16_LIBS})
 target_link_libraries(buddy-deepseek-r1-packed-run ${BUDDY_DEEPSEEKR1_PACKED_LIBS})
+target_link_libraries(buddy-deepseek-r1-packed-f16-run ${BUDDY_DEEPSEEKR1_PACKED_F16_LIBS})
 target_link_libraries(buddy-deepseek-r1-cli ${BUDDY_DEEPSEEKR1_LIBS} LLVMOption buddy_runtime_core)
 
 # Create a distributable package

--- a/examples/BuddyDeepSeekR1/buddy-deepseek-r1-f16-main.cpp
+++ b/examples/BuddyDeepSeekR1/buddy-deepseek-r1-f16-main.cpp
@@ -390,13 +390,17 @@ void copy_kv_by_cache_position_block(const KVPtrArray &prefillPtrs,
 }
 
 // -----------------------------------------------------------------------------
-// DeepSeekR1 BF16 Inference Main Entry
+// DeepSeekR1 FP16 Inference Main Entry
 // -----------------------------------------------------------------------------
 
 int main() {
   /// Print the title of this example.
   const std::string title =
-      "DeepSeekR1 BF16 Inference Powered by Buddy Compiler";
+#ifdef DEEPSEEKR1_PACKED_DECODE
+      "DeepSeekR1 FP16 Packed Decode Inference Powered by Buddy Compiler";
+#else
+      "DeepSeekR1 FP16 Inference Powered by Buddy Compiler";
+#endif
   std::cout << "\033[33;1m" << title << "\033[0m" << std::endl;
 
   /// Define directories of vocabulary and parameter file.
@@ -404,6 +408,9 @@ int main() {
   std::string deepSeekR1BuildDir = DEEPSEEKR1_EXAMPLE_BUILD_PATH;
   const std::string vocabDir = deepSeekR1Dir + "vocab.txt";
   const std::string paramsDir = deepSeekR1BuildDir + "arg0-f16.data";
+#ifdef DEEPSEEKR1_PACKED_DECODE
+  const std::string paramsDecodeDir = deepSeekR1BuildDir + "arg0-decode.data";
+#endif
 
   /// Get user message.
   std::string inputStr;
@@ -414,6 +421,9 @@ int main() {
   Text<size_t, 2> inputContainerPrefill(inputStr);
   MemRef<long long, 2> inputContainerDecode({1, 1}, 0LL);
   MemRef<uint16_t, 1> ParamsContainer({ParamsSize});
+#ifdef DEEPSEEKR1_PACKED_DECODE
+  MemRef<uint16_t, 1> ParamsDecodeContainer({ParamsSize});
+#endif
   MemRef<long long, 1> cachePosition({1}, 0LL);
 
   MemRef<uint16_t, 3> logits_prefill({1, MaxTokenLength, MaxVocabSize});
@@ -493,6 +503,9 @@ int main() {
   tokenizeInput(vocabDir, inputContainerPrefill);
   outputContainer.loadVocab(vocabDir);
   loadParameters(paramsDir, ParamsContainer);
+#ifdef DEEPSEEKR1_PACKED_DECODE
+  loadParameters(paramsDecodeDir, ParamsDecodeContainer);
+#endif
 
   /// Run DeepSeekR1 Inference - Prefill phase
   double prefillTokensPerSec = 0.0;
@@ -654,9 +667,15 @@ int main() {
     decodeRet.ret_dummy26.getData()[0] = cachePosition.getData()[0];
 
     _mlir_ciface_forward_decode(
-        &decodeRet, &ParamsContainer, &inputContainerDecode, &cachePosition,
-        &decodeRet.kv0, &decodeRet.kv1, &decodeRet.ret_dummy0, &decodeRet.kv2,
-        &decodeRet.kv3, &decodeRet.ret_dummy1, &decodeRet.kv4, &decodeRet.kv5,
+        &decodeRet,
+#ifdef DEEPSEEKR1_PACKED_DECODE
+        &ParamsDecodeContainer,
+#else
+        &ParamsContainer,
+#endif
+        &inputContainerDecode, &cachePosition, &decodeRet.kv0, &decodeRet.kv1,
+        &decodeRet.ret_dummy0, &decodeRet.kv2, &decodeRet.kv3,
+        &decodeRet.ret_dummy1, &decodeRet.kv4, &decodeRet.kv5,
         &decodeRet.ret_dummy2, &decodeRet.kv6, &decodeRet.kv7,
         &decodeRet.ret_dummy3, &decodeRet.kv8, &decodeRet.kv9,
         &decodeRet.ret_dummy4, &decodeRet.kv10, &decodeRet.kv11,

--- a/examples/BuddyDeepSeekR1/import-deepseek-r1.py
+++ b/examples/BuddyDeepSeekR1/import-deepseek-r1.py
@@ -71,7 +71,7 @@ parser.add_argument(
     "different buffers. Compiling decode then requires "
     "-matmul-vectorization-decode-packed with a matching --pack-vector-size; "
     "the plain decode kernel would read the packed bytes as row-major and "
-    "silently produce a wrong model. f32 only for now.",
+    "silently produce a wrong model. Supported for f32, f16, and bf16.",
 )
 parser.add_argument(
     "--pack-vector-size",
@@ -215,6 +215,7 @@ if args.precision == "f16":
     graph_decode = graphs_decode[0]
 
     params = dynamo_compiler_prefill.imported_params[graph_prefill]
+    params_decode = dynamo_compiler_decode.imported_params[graph_decode]
     # Enable verbose mode for debugging eliminate_matmul_transpose_reshape
     graphs_prefill[0].perform(
         [eliminate_transpose, eliminate_matmul_transpose_reshape]
@@ -222,6 +223,15 @@ if args.precision == "f16":
     graphs_decode[0].perform(
         [eliminate_transpose, eliminate_matmul_transpose_reshape]
     )
+    if args.pack_decode_weights:
+        packed = pack_decode_matmul_weights(
+            graph_decode, vecsize=args.pack_vector_size
+        )
+        print(
+            f"[import-deepseek-r1] packed {len(packed)} decode matmul weights "
+            f"into panel layout (vector-size={args.pack_vector_size}); "
+            "prefill's weights stay plain."
+        )
     pattern_list_prefill = [
         simply_fuse,
         apply_classic_fusion,
@@ -324,6 +334,11 @@ if args.precision == "f16":
         [param.detach().numpy().reshape([-1]) for param in params]
     )
     all_param.tofile(os.path.join(output_dir, "arg0-f16.data"))
+    if args.pack_decode_weights:
+        all_param_decode = numpy.concatenate(
+            [param.detach().numpy().reshape([-1]) for param in params_decode]
+        )
+        all_param_decode.tofile(os.path.join(output_dir, "arg0-decode.data"))
 
     with open(
         os.path.join(output_dir, "subgraph0_decode-f16.mlir"), "w"

--- a/midend/lib/Conversion/MatMulOptimization/MatMulVectorizationDecodePacked.cpp
+++ b/midend/lib/Conversion/MatMulOptimization/MatMulVectorizationDecodePacked.cpp
@@ -152,6 +152,16 @@ public:
       return false;
     int64_t k = bType.getDimSize(0);
     int64_t n = bType.getDimSize(1);
+    Type aElementType = aType.getElementType();
+    Type bElementType = bType.getElementType();
+    Type cElementType = cType.getElementType();
+    // The packed decode kernel currently performs the FMA in the tensor's
+    // native element type.  Check this explicitly instead of reinterpreting
+    // B using C's element type below: that happened to work for f32, but made
+    // the advertised f16/bf16 support depend on an unchecked assumption.
+    if (aElementType != bElementType || bElementType != cElementType ||
+        !isa<FloatType>(cElementType))
+      return false;
     if (n % vecSize != 0)
       return false;
     // Empty `packed-shapes` means every m==1 matmul weight in this module is
@@ -178,7 +188,7 @@ public:
     auto bType = cast<MemRefType>(B.getType());
     int64_t K = bType.getDimSize(0);
     int64_t N = bType.getDimSize(1);
-    Type elementType = cast<MemRefType>(C.getType()).getElementType();
+    Type elementType = bType.getElementType();
     auto vectorType = VectorType::get({vecSize}, elementType);
 
     // Reinterpret B's underlying buffer as a flat [K*N] row-major view,

--- a/models/deepseek_r1/specs/f16_packed_decode.json
+++ b/models/deepseek_r1/specs/f16_packed_decode.json
@@ -1,0 +1,14 @@
+{
+  "hf_model_path": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+  "model_family": "deepseek_r1",
+  "variant": "f16",
+  "max_token_len": 1024,
+  "num_threads": 48,
+  "decode_pack_vector_size": 32,
+  "weights_override": {
+    "total": 1777088064,
+    "linear_elements": 0,
+    "linear_output_channels": 0,
+    "other_elements": 0
+  }
+}

--- a/tests/Conversion/matmul-vectorization-decode-packed.mlir
+++ b/tests/Conversion/matmul-vectorization-decode-packed.mlir
@@ -39,3 +39,22 @@ func.func @matmul_decode_unpacked_shape_untouched(%A: memref<1x128xf32>,
 
 // CHECK-LABEL: func.func @matmul_decode_unpacked_shape_untouched
 // CHECK: linalg.matmul
+
+// FP16 uses the same packed addressing as FP32, but loads, accumulates, and
+// stores native f16 vectors.  Keep this coverage here so the packed pass does
+// not silently regress to being f32-only.
+func.func @matmul_decode_packed_f16(%A: memref<1x128xf16>,
+                                     %B: memref<128x64xf16>,
+                                     %C: memref<1x64xf16>) {
+  linalg.matmul
+    ins(%A, %B: memref<1x128xf16>, memref<128x64xf16>)
+    outs(%C: memref<1x64xf16>)
+  return
+}
+
+// CHECK-LABEL: func.func @matmul_decode_packed_f16
+// CHECK: memref.reinterpret_cast {{.*}} sizes: [8192], strides: [1] : memref<f16> to memref<8192xf16, strided<[1], offset: ?>>
+// CHECK: vector.load {{.*}} : memref<8192xf16, strided<[1], offset: ?>>, vector<32xf16>
+// CHECK: vector.fma {{.*}} : vector<32xf16>
+// CHECK: vector.store {{.*}} : memref<1x64xf16>, vector<32xf16>
+// CHECK-NOT: linalg.matmul


### PR DESCRIPTION
## Summary

Extend the panel-packed decode matmul optimization introduced in #839 to FP16 and integrate it into both DeepSeek-R1 build paths.

- make `matmul-vectorization-decode-packed` explicitly support same-type floating-point A/B/C operands, including native `vector<32xf16>` loads, FMA, and stores
- add an FP16 packed-decode lit test and a ready-to-use `f16_packed_decode.json` buddy-codegen spec
- teach `examples/BuddyDeepSeekR1/import-deepseek-r1.py` to pack FP16 decode weights and emit a separate `arg0-decode.data`
- add the `buddy-deepseek-r1-packed-f16-run` example target while keeping prefill on the ordinary row-major FP16 weights
- make the example importer Python path explicit so the target builds in a clean configured tree

## Usage

```bash
cmake --build build --target buddy-deepseek-r1-packed-f16-run -j2
build/bin/buddy-deepseek-r1-packed-f16-run
```

For the buddy-codegen path, select:

```text
models/deepseek_r1/specs/f16_packed_decode.json
```

## Performance

DeepSeek-R1-Distill-Qwen-1.5B FP16, Intel Xeon Platinum 8488C, 48 CPUs (`0-47`), NUMA nodes `0,1`, greedy decode, with identical output across the two runs (111 generated tokens):

| Configuration | Decode | Prefill | Total |
| --- | ---: | ---: | ---: |
| Plain FP16 | 25.2014 tokens/s | 8.93988 s | 13.3444 s |
| Packed FP16 | 59.9245 tokens/s | 8.79446 s | 10.6468 s |

This is a **2.38x decode speedup**. End-to-end time decreases by **20.2%**, while prefill remains effectively unchanged.

The standalone example path also completed end-to-end generation successfully at 55.31 tokens/s decode.

### Benchmark screenshots

Plain FP16:
<img width="735" height="382" alt="image" src="https://github.com/user-attachments/assets/0a1615ba-a58b-4e38-845e-2458ee242bd6" />

Packed FP16:
<img width="754" height="393" alt="image" src="https://github.com/user-attachments/assets/bda5d43d-cd38-4e71-944a-0b0aac1a3dad" />


## Testing

- rebuilt `buddy-opt`
- passed the explicit-shape and pack-all packed decode FileCheck tests
- verified FP16 lowering from linalg/vector MLIR through LLVM IR to an x86-64 ELF object
- generated the FP16 buddy-codegen configuration and verified its FP16 weights and decode weight entry
- built `buddy-deepseek-r1-packed-f16-run` from the example path
- ran plain and packed FP16 `.rax` models end to end and confirmed identical generated tokens
- ran the new FP16 packed example executable end to end