### PR TITLE
[LLVM] Bump LLVM to 2d26d272a0ff

### DIFF
--- a/examples/BuddyNext/next-attention-fusion.mlir
+++ b/examples/BuddyNext/next-attention-fusion.mlir
@@ -24,11 +24,11 @@
 
 module {
   func.func private @rtclock() -> f64
-  memref.global "private" constant @__constant_1x32x40x128xf32 : memref<1x32x40x128xf32> = dense<8.000000e+00> {alignment = 64 : i64}
-  memref.global "private" constant @__constant_1x1x40x40xf32 : memref<1x1x40x40xf32> = dense<4.000000e+00> {alignment = 64 : i64}
-  memref.global "private" constant @__constant_32x128x40xf32 : memref<32x128x40xf32> = dense<2.000000e+00> {alignment = 64 : i64}
-  memref.global "private" constant @__constant_32x40x128xf32 : memref<32x40x128xf32> = dense<3.000000e+00> {alignment = 64 : i64}
-  memref.global "private" constant @__constant_1x32x40x40xf32 : memref<1x32x40x40xf32> = dense<11.3137083> {alignment = 64 : i64}
+  memref.global "private" constant @__constant_1x32x40x128xf32 : memref<1x32x40x128xf32> = dense<8.000000e+00> alignment = 64
+  memref.global "private" constant @__constant_1x1x40x40xf32 : memref<1x1x40x40xf32> = dense<4.000000e+00> alignment = 64
+  memref.global "private" constant @__constant_32x128x40xf32 : memref<32x128x40xf32> = dense<2.000000e+00> alignment = 64
+  memref.global "private" constant @__constant_32x40x128xf32 : memref<32x40x128xf32> = dense<3.000000e+00> alignment = 64
+  memref.global "private" constant @__constant_1x32x40x40xf32 : memref<1x32x40x40xf32> = dense<11.3137083> alignment = 64
   func.func @kenerl(%arg0: tensor<32x40x128xf32>, %arg1: tensor<32x128x40xf32>, %arg2: tensor<1x1x40x40xf32>, %arg3: tensor<1x32x40x128xf32>) {
     %t_start = call @rtclock() : () -> f64
     %cst = arith.constant 0.0883883461 : f32
@@ -44,7 +44,7 @@ module {
     // MatMul
     // %0 = tosa.matmul %t0, %t1 : (tensor<32x40x128xf32>, tensor<32x128x40xf32>) -> tensor<32x40x40xf32>
     // Initialize MatMul Output.
-    %alloc = memref.alloc() {alignment = 64 : i64} : memref<32x40x40xf32>
+    %alloc = memref.alloc() alignment = 64 : memref<32x40x40xf32>
     affine.for %arg4 = 0 to 32 {
       affine.for %arg5 = 0 to 40 {
         affine.for %arg6 = 0 to 40 {
@@ -76,8 +76,8 @@ module {
     // %5 = tosa.add %4, %t2 : (tensor<1x32x40x40xf32>, tensor<1x1x40x40xf32>) -> tensor<1x32x40x40xf32>
     // %6 = tosa.reduce_max %5 {axis = 3 : i32} : (tensor<1x32x40x40xf32>) -> tensor<1x32x40x1xf32>
     %expand_shape = memref.expand_shape %alloc [[0, 1], [2], [3]] output_shape [1, 32, 40, 40]: memref<32x40x40xf32> into memref<1x32x40x40xf32>
-    %alloc_5 = memref.alloc() {alignment = 64 : i64} : memref<1x32x40x40xf32>
-    %alloc_6 = memref.alloc() {alignment = 64 : i64} : memref<1x32x40xf32>
+    %alloc_5 = memref.alloc() alignment = 64 : memref<1x32x40x40xf32>
+    %alloc_6 = memref.alloc() alignment = 64 : memref<1x32x40xf32>
     affine.for %arg4 = 0 to 1 {
       affine.for %arg5 = 0 to 32 {
         affine.for %arg6 = 0 to 40 {
@@ -111,8 +111,8 @@ module {
     // %8 = tosa.exp %7 : (tensor<1x32x40x40xf32>) -> tensor<1x32x40x40xf32>
     // %9 = tosa.reduce_sum %8 {axis = 3 : i32} : (tensor<1x32x40x40xf32>) -> tensor<1x32x40x1xf32>
     %expand_shape_7 = memref.expand_shape %alloc_6 [[0], [1], [2, 3]] output_shape [1, 32, 40, 1]: memref<1x32x40xf32> into memref<1x32x40x1xf32>
-    %alloc_9 = memref.alloc() {alignment = 64 : i64} : memref<1x32x40x40xf32>
-    %alloc_10 = memref.alloc() {alignment = 64 : i64} : memref<1x32x40xf32>
+    %alloc_9 = memref.alloc() alignment = 64 : memref<1x32x40x40xf32>
+    %alloc_10 = memref.alloc() alignment = 64 : memref<1x32x40xf32>
     affine.for %arg4 = 0 to 1 {
       affine.for %arg5 = 0 to 32 {
         affine.for %arg6 = 0 to 40 {
@@ -144,7 +144,7 @@ module {
     // %10 = tosa.reciprocal %9 : (tensor<1x32x40x1xf32>) -> tensor<1x32x40x1xf32>
     // %11 = tosa.mul %8, %10 {shift = 0 : i8} : (tensor<1x32x40x40xf32>, tensor<1x32x40x1xf32>) -> tensor<1x32x40x40xf32>
     %expand_shape_11 = memref.expand_shape %alloc_10 [[0], [1], [2, 3]] output_shape [1, 32, 40, 1]: memref<1x32x40xf32> into memref<1x32x40x1xf32>
-    %alloc_13 = memref.alloc() {alignment = 64 : i64} : memref<1x32x40x40xf32>
+    %alloc_13 = memref.alloc() alignment = 64 : memref<1x32x40x40xf32>
     affine.for %arg4 = 0 to 1 {
       affine.for %arg5 = 0 to 32 {
         affine.for %arg6 = 0 to 40 {
@@ -169,7 +169,7 @@ module {
     // %16 = tosa.add %t3, %15 : (tensor<1x32x40x128xf32>, tensor<1x32x40x128xf32>) -> tensor<1x32x40x128xf32>
     // %17 = tosa.reshape %16 {new_shape = array<i64: 32, 40, 128>} : (tensor<1x32x40x128xf32>) -> tensor<32x40x128xf32>
     %collapse_shape = memref.collapse_shape %alloc_13 [[0, 1], [2], [3]] : memref<1x32x40x40xf32> into memref<32x40x40xf32>
-    %alloc_14 = memref.alloc() {alignment = 64 : i64} : memref<1x32x40x128xf32>
+    %alloc_14 = memref.alloc() alignment = 64 : memref<1x32x40x128xf32>
     // SSA value %0 is from %arg3
     memref.copy %0, %alloc_14 : memref<1x32x40x128xf32, strided<[?, ?, ?, ?], offset: ?>> to memref<1x32x40x128xf32>
     %collapse_shape_15 = memref.collapse_shape %alloc_14 [[0, 1], [2], [3]] : memref<1x32x40x128xf32> into memref<32x40x128xf32>
@@ -177,7 +177,7 @@ module {
     // MatMul
     // %18 = tosa.matmul %14, %17 : (tensor<32x40x40xf32>, tensor<32x40x128xf32>) -> tensor<32x40x128xf32>
     // Allocate space and initialize output.
-    %alloc_16 = memref.alloc() {alignment = 64 : i64} : memref<32x40x128xf32>
+    %alloc_16 = memref.alloc() alignment = 64 : memref<32x40x128xf32>
     affine.for %arg4 = 0 to 32 {
       affine.for %arg5 = 0 to 40 {
         affine.for %arg6 = 0 to 128 {

--- a/examples/BuddyNext/next-attention-loop.mlir
+++ b/examples/BuddyNext/next-attention-loop.mlir
@@ -24,11 +24,11 @@
 
 module {
   func.func private @rtclock() -> f64
-  memref.global "private" constant @__constant_1x32x40x128xf32 : memref<1x32x40x128xf32> = dense<8.000000e+00> {alignment = 64 : i64}
-  memref.global "private" constant @__constant_1x1x40x40xf32 : memref<1x1x40x40xf32> = dense<4.000000e+00> {alignment = 64 : i64}
-  memref.global "private" constant @__constant_32x128x40xf32 : memref<32x128x40xf32> = dense<2.000000e+00> {alignment = 64 : i64}
-  memref.global "private" constant @__constant_32x40x128xf32 : memref<32x40x128xf32> = dense<3.000000e+00> {alignment = 64 : i64}
-  memref.global "private" constant @__constant_1x32x40x40xf32 : memref<1x32x40x40xf32> = dense<11.3137083> {alignment = 64 : i64}
+  memref.global "private" constant @__constant_1x32x40x128xf32 : memref<1x32x40x128xf32> = dense<8.000000e+00> alignment = 64
+  memref.global "private" constant @__constant_1x1x40x40xf32 : memref<1x1x40x40xf32> = dense<4.000000e+00> alignment = 64
+  memref.global "private" constant @__constant_32x128x40xf32 : memref<32x128x40xf32> = dense<2.000000e+00> alignment = 64
+  memref.global "private" constant @__constant_32x40x128xf32 : memref<32x40x128xf32> = dense<3.000000e+00> alignment = 64
+  memref.global "private" constant @__constant_1x32x40x40xf32 : memref<1x32x40x40xf32> = dense<11.3137083> alignment = 64
   func.func @kenerl(%arg0: tensor<32x40x128xf32>, %arg1: tensor<32x128x40xf32>, %arg2: tensor<1x1x40x40xf32>, %arg3: tensor<1x32x40x128xf32>) {
     %t_start = call @rtclock() : () -> f64
     %cst = arith.constant 0.0883883461 : f32
@@ -44,7 +44,7 @@ module {
     // MatMul
     // %0 = tosa.matmul %t0, %t1 : (tensor<32x40x128xf32>, tensor<32x128x40xf32>) -> tensor<32x40x40xf32>
     // Initialize MatMul Output.
-    %alloc = memref.alloc() {alignment = 64 : i64} : memref<32x40x40xf32>
+    %alloc = memref.alloc() alignment = 64 : memref<32x40x40xf32>
     affine.for %arg4 = 0 to 32 {
       affine.for %arg5 = 0 to 40 {
         affine.for %arg6 = 0 to 40 {
@@ -73,7 +73,7 @@ module {
     // %2 = "tosa.const"() <{value = dense<11.3137083> : tensor<1x32x40x40xf32>}> : () -> tensor<1x32x40x40xf32>
     // %3 = tosa.reciprocal %2 : (tensor<1x32x40x40xf32>) -> tensor<1x32x40x40xf32>
     %expand_shape = memref.expand_shape %alloc [[0, 1], [2], [3]] output_shape [1, 32, 40, 40]: memref<32x40x40xf32> into memref<1x32x40x40xf32>
-    %alloc_3 = memref.alloc() {alignment = 64 : i64} : memref<1x32x40x40xf32>
+    %alloc_3 = memref.alloc() alignment = 64 : memref<1x32x40x40xf32>
     affine.for %arg4 = 0 to 1 {
       affine.for %arg5 = 0 to 32 {
         affine.for %arg6 = 0 to 40 {
@@ -86,7 +86,7 @@ module {
 
     // Multiplication
     // %4 = tosa.mul %1, %3 {shift = 0 : i8} : (tensor<1x32x40x40xf32>, tensor<1x32x40x40xf32>) -> tensor<1x32x40x40xf32>
-    %alloc_4 = memref.alloc() {alignment = 64 : i64} : memref<1x32x40x40xf32>
+    %alloc_4 = memref.alloc() alignment = 64 : memref<1x32x40x40xf32>
     affine.for %arg4 = 0 to 1 {
       affine.for %arg5 = 0 to 32 {
         affine.for %arg6 = 0 to 40 {
@@ -102,7 +102,7 @@ module {
 
     // Addition
     // %5 = tosa.add %4, %t2 : (tensor<1x32x40x40xf32>, tensor<1x1x40x40xf32>) -> tensor<1x32x40x40xf32>
-    %alloc_5 = memref.alloc() {alignment = 64 : i64} : memref<1x32x40x40xf32>
+    %alloc_5 = memref.alloc() alignment = 64 : memref<1x32x40x40xf32>
     affine.for %arg4 = 0 to 1 {
       affine.for %arg5 = 0 to 32 {
         affine.for %arg6 = 0 to 40 {
@@ -119,7 +119,7 @@ module {
     // Reduce Max
     // %6 = tosa.reduce_max %5 {axis = 3 : i32} : (tensor<1x32x40x40xf32>) -> tensor<1x32x40x1xf32>
     // Initialize reduce max operation output.
-    %alloc_6 = memref.alloc() {alignment = 64 : i64} : memref<1x32x40xf32>
+    %alloc_6 = memref.alloc() alignment = 64 : memref<1x32x40xf32>
     affine.for %arg4 = 0 to 1 {
       affine.for %arg5 = 0 to 32 {
         affine.for %arg6 = 0 to 40 {
@@ -148,7 +148,7 @@ module {
     // %7 = tosa.sub %5, %6 : (tensor<1x32x40x40xf32>, tensor<1x32x40x1xf32>) -> tensor<1x32x40x40xf32>
     // Allocate space and perform subtraction.
     %expand_shape_7 = memref.expand_shape %alloc_6 [[0], [1], [2, 3]] output_shape [1, 32, 40, 1]: memref<1x32x40xf32> into memref<1x32x40x1xf32>
-    %alloc_8 = memref.alloc() {alignment = 64 : i64} : memref<1x32x40x40xf32>
+    %alloc_8 = memref.alloc() alignment = 64 : memref<1x32x40x40xf32>
     affine.for %arg4 = 0 to 1 {
       affine.for %arg5 = 0 to 32 {
         affine.for %arg6 = 0 to 40 {
@@ -165,7 +165,7 @@ module {
     // Exponentiation
     // %8 = tosa.exp %7 : (tensor<1x32x40x40xf32>) -> tensor<1x32x40x40xf32>
     // Allocate space and perform exponentiation.
-    %alloc_9 = memref.alloc() {alignment = 64 : i64} : memref<1x32x40x40xf32>
+    %alloc_9 = memref.alloc() alignment = 64 : memref<1x32x40x40xf32>
     affine.for %arg4 = 0 to 1 {
       affine.for %arg5 = 0 to 32 {
         affine.for %arg6 = 0 to 40 {
@@ -181,7 +181,7 @@ module {
     // Reduce Sum
     // %9 = tosa.reduce_sum %8 {axis = 3 : i32} : (tensor<1x32x40x40xf32>) -> tensor<1x32x40x1xf32>
     // Allocate space and initialize the output.
-    %alloc_10 = memref.alloc() {alignment = 64 : i64} : memref<1x32x40xf32>
+    %alloc_10 = memref.alloc() alignment = 64 : memref<1x32x40xf32>
     affine.for %arg4 = 0 to 1 {
       affine.for %arg5 = 0 to 32 {
         affine.for %arg6 = 0 to 40 {
@@ -206,7 +206,7 @@ module {
     // Reciprocal
     // %10 = tosa.reciprocal %9 : (tensor<1x32x40x1xf32>) -> tensor<1x32x40x1xf32>
     %expand_shape_11 = memref.expand_shape %alloc_10 [[0], [1], [2, 3]] output_shape [1, 32, 40, 1]: memref<1x32x40xf32> into memref<1x32x40x1xf32>
-    %alloc_12 = memref.alloc() {alignment = 64 : i64} : memref<1x32x40x1xf32>
+    %alloc_12 = memref.alloc() alignment = 64 : memref<1x32x40x1xf32>
     affine.for %arg4 = 0 to 1 {
       affine.for %arg5 = 0 to 32 {
         affine.for %arg6 = 0 to 40 {
@@ -221,7 +221,7 @@ module {
 
     // Multiplication
     // %11 = tosa.mul %8, %10 {shift = 0 : i8} : (tensor<1x32x40x40xf32>, tensor<1x32x40x1xf32>) -> tensor<1x32x40x40xf32>
-    %alloc_13 = memref.alloc() {alignment = 64 : i64} : memref<1x32x40x40xf32>
+    %alloc_13 = memref.alloc() alignment = 64 : memref<1x32x40x40xf32>
     affine.for %arg4 = 0 to 1 {
       affine.for %arg5 = 0 to 32 {
         affine.for %arg6 = 0 to 40 {
@@ -243,7 +243,7 @@ module {
     // %16 = tosa.add %t3, %15 : (tensor<1x32x40x128xf32>, tensor<1x32x40x128xf32>) -> tensor<1x32x40x128xf32>
     // %17 = tosa.reshape %16 {new_shape = array<i64: 32, 40, 128>} : (tensor<1x32x40x128xf32>) -> tensor<32x40x128xf32>
     %collapse_shape = memref.collapse_shape %alloc_13 [[0, 1], [2], [3]] : memref<1x32x40x40xf32> into memref<32x40x40xf32>
-    %alloc_14 = memref.alloc() {alignment = 64 : i64} : memref<1x32x40x128xf32>
+    %alloc_14 = memref.alloc() alignment = 64 : memref<1x32x40x128xf32>
     // SSA value %0 is from %arg3
     memref.copy %0, %alloc_14 : memref<1x32x40x128xf32, strided<[?, ?, ?, ?], offset: ?>> to memref<1x32x40x128xf32>
     %collapse_shape_15 = memref.collapse_shape %alloc_14 [[0, 1], [2], [3]] : memref<1x32x40x128xf32> into memref<32x40x128xf32>
@@ -251,7 +251,7 @@ module {
     // MatMul
     // %18 = tosa.matmul %14, %17 : (tensor<32x40x40xf32>, tensor<32x40x128xf32>) -> tensor<32x40x128xf32>
     // Allocate space and initialize output.
-    %alloc_16 = memref.alloc() {alignment = 64 : i64} : memref<32x40x128xf32>
+    %alloc_16 = memref.alloc() alignment = 64 : memref<32x40x128xf32>
     affine.for %arg4 = 0 to 32 {
       affine.for %arg5 = 0 to 40 {
         affine.for %arg6 = 0 to 128 {

--- a/examples/BuddyNext/next-linalg-matmul-decode.mlir
+++ b/examples/BuddyNext/next-linalg-matmul-decode.mlir
@@ -35,9 +35,9 @@ module {
     %true = arith.constant true
     %cst = arith.constant 4.000000e+00 : f32
     %cst_0 = arith.constant 2.000000e+00 : f32
-    %a = memref.alloc() {alignment = 64 : i64} : memref<1x8960xf32>
+    %a = memref.alloc() alignment = 64 : memref<1x8960xf32>
     linalg.fill ins(%cst_0 : f32) outs(%a : memref<1x8960xf32>)
-    %c = memref.alloc() {alignment = 64 : i64} : memref<1x1536xf32>
+    %c = memref.alloc() alignment = 64 : memref<1x1536xf32>
     linalg.fill ins(%cst : f32) outs(%c : memref<1x1536xf32>)
     %0 = call @rtclock() : () -> f64
 
@@ -55,17 +55,17 @@ module {
     %k = arith.constant 8960 : index
 
     scf.parallel (%n_idx) = (%c0) to (%n) step (%step) {
-      %c_vec = vector.load %c[%c0, %n_idx] {alignment = 64 : i64} : memref<1x1536xf32>, vector<32xf32>
+      %c_vec = vector.load %c[%c0, %n_idx] alignment = 64 : memref<1x1536xf32>, vector<32xf32>
       %sum_iter = scf.for %k_idx = %c0 to %k step %c1 iter_args(%sum_vec = %c_vec) -> (vector<32xf32>) {
         %k_prefetch = arith.addi %k_idx, %prefetch_step : index
         memref.prefetch %b[%k_prefetch, %n_idx], read, locality<0>, data : memref<8960x1536xf32, strided<[?, 1], offset: ?>>
         %a_ele = memref.load %a[%c0, %k_idx] : memref<1x8960xf32>
         %a_vec = vector.broadcast %a_ele : f32 to vector<32xf32>
-        %b_vec = vector.load %b[%k_idx, %n_idx] {alignment = 64 : i64, nontemporal = true} : memref<8960x1536xf32, strided<[?, 1], offset: ?>>, vector<32xf32>
+        %b_vec = vector.load %b[%k_idx, %n_idx] alignment = 64 nontemporal = true : memref<8960x1536xf32, strided<[?, 1], offset: ?>>, vector<32xf32>
         %r_vec = vector.fma %a_vec, %b_vec, %sum_vec : vector<32xf32>
         scf.yield %r_vec : vector<32xf32>
       }
-      vector.store %sum_iter, %c[%c0, %n_idx] {alignment = 64 : i64} : memref<1x1536xf32>, vector<32xf32>
+      vector.store %sum_iter, %c[%c0, %n_idx] alignment = 64 : memref<1x1536xf32>, vector<32xf32>
     }
 
     %5 = call @rtclock() : () -> f64
@@ -77,7 +77,7 @@ module {
   func.func @main() {
     %true = arith.constant true
     %cst = arith.constant 3.000000e+00 : f32
-    %alloc = memref.alloc() {alignment = 64 : i64} : memref<8960x1536xf32>
+    %alloc = memref.alloc() alignment = 64 : memref<8960x1536xf32>
     linalg.fill ins(%cst : f32) outs(%alloc : memref<8960x1536xf32>)
     %cast = memref.cast %alloc : memref<8960x1536xf32> to memref<8960x1536xf32, strided<[?, ?], offset: ?>>
     %0 = call @kernel(%cast) : (memref<8960x1536xf32, strided<[?, ?], offset: ?>>) -> memref<1x1536xf32>

--- a/examples/BuddyNext/next-sgemm-unroll-vec-aligned.mlir
+++ b/examples/BuddyNext/next-sgemm-unroll-vec-aligned.mlir
@@ -93,7 +93,7 @@ module {
             %a_vec_5 = vector.broadcast %a_ele_5 : f32 to vector<32xf32>
             %a_vec_6 = vector.broadcast %a_ele_6 : f32 to vector<32xf32>
             %a_vec_7 = vector.broadcast %a_ele_7 : f32 to vector<32xf32>
-            %b_vec = vector.load %b_aligned[%k_idx, %n_idx] {alignment = 64} : memref<?x?xf32>, vector<32xf32>
+            %b_vec = vector.load %b_aligned[%k_idx, %n_idx] alignment = 64 : memref<?x?xf32>, vector<32xf32>
             %res_sum_vec_0 = vector.fma %a_vec_0, %b_vec, %sum_vec_0 : vector<32xf32>
             %res_sum_vec_1 = vector.fma %a_vec_1, %b_vec, %sum_vec_1 : vector<32xf32>
             %res_sum_vec_2 = vector.fma %a_vec_2, %b_vec, %sum_vec_2 : vector<32xf32>
@@ -107,14 +107,14 @@ module {
                 : vector<32xf32>, vector<32xf32>, vector<32xf32>, vector<32xf32>,
                 vector<32xf32>, vector<32xf32>, vector<32xf32>, vector<32xf32>
         }
-        vector.store %sum_iter_vec_0, %c_aligned[%m_idx, %n_idx] {alignment = 64} : memref<?x?xf32>, vector<32xf32>
-        vector.store %sum_iter_vec_1, %c_aligned[%m_idx_1, %n_idx] {alignment = 64} : memref<?x?xf32>, vector<32xf32>
-        vector.store %sum_iter_vec_2, %c_aligned[%m_idx_2, %n_idx] {alignment = 64} : memref<?x?xf32>, vector<32xf32>
-        vector.store %sum_iter_vec_3, %c_aligned[%m_idx_3, %n_idx] {alignment = 64} : memref<?x?xf32>, vector<32xf32>
-        vector.store %sum_iter_vec_4, %c_aligned[%m_idx_4, %n_idx] {alignment = 64} : memref<?x?xf32>, vector<32xf32>
-        vector.store %sum_iter_vec_5, %c_aligned[%m_idx_5, %n_idx] {alignment = 64} : memref<?x?xf32>, vector<32xf32>
-        vector.store %sum_iter_vec_6, %c_aligned[%m_idx_6, %n_idx] {alignment = 64} : memref<?x?xf32>, vector<32xf32>
-        vector.store %sum_iter_vec_7, %c_aligned[%m_idx_7, %n_idx] {alignment = 64} : memref<?x?xf32>, vector<32xf32>
+        vector.store %sum_iter_vec_0, %c_aligned[%m_idx, %n_idx] alignment = 64 : memref<?x?xf32>, vector<32xf32>
+        vector.store %sum_iter_vec_1, %c_aligned[%m_idx_1, %n_idx] alignment = 64 : memref<?x?xf32>, vector<32xf32>
+        vector.store %sum_iter_vec_2, %c_aligned[%m_idx_2, %n_idx] alignment = 64 : memref<?x?xf32>, vector<32xf32>
+        vector.store %sum_iter_vec_3, %c_aligned[%m_idx_3, %n_idx] alignment = 64 : memref<?x?xf32>, vector<32xf32>
+        vector.store %sum_iter_vec_4, %c_aligned[%m_idx_4, %n_idx] alignment = 64 : memref<?x?xf32>, vector<32xf32>
+        vector.store %sum_iter_vec_5, %c_aligned[%m_idx_5, %n_idx] alignment = 64 : memref<?x?xf32>, vector<32xf32>
+        vector.store %sum_iter_vec_6, %c_aligned[%m_idx_6, %n_idx] alignment = 64 : memref<?x?xf32>, vector<32xf32>
+        vector.store %sum_iter_vec_7, %c_aligned[%m_idx_7, %n_idx] alignment = 64 : memref<?x?xf32>, vector<32xf32>
         %k_next = arith.addi %n_idx, %step : index
         scf.yield %k_next : index
       }
@@ -200,9 +200,9 @@ module {
     %cf2 = arith.constant 2.0 : f32
     %c0 = arith.constant 0.0 : f32
 
-    %A = memref.alloc(%cM, %cK) {alignment = 64} : memref<?x?xf32>
-    %B = memref.alloc(%cK, %cN) {alignment = 64} : memref<?x?xf32>
-    %C = memref.alloc(%cM, %cN) {alignment = 64} : memref<?x?xf32>
+    %A = memref.alloc(%cM, %cK) alignment = 64 : memref<?x?xf32>
+    %B = memref.alloc(%cK, %cN) alignment = 64 : memref<?x?xf32>
+    %C = memref.alloc(%cM, %cN) alignment = 64 : memref<?x?xf32>
 
     linalg.fill
     ins(%cf1 : f32)

--- a/examples/BuddyNext/next-tosa-matmul-manual.mlir
+++ b/examples/BuddyNext/next-tosa-matmul-manual.mlir
@@ -36,7 +36,7 @@ module {
     %a = memref.reinterpret_cast %base_buffer_0 to offset: [%offset_1], sizes: [12, 1, 1024], strides: [%strides_3#0, %strides_3#1, 1] : memref<f32> to memref<12x1x1024xf32, strided<[?, ?, 1], offset: ?>>
     %cst = arith.constant 0.000000e+00 : f32
     %0 = call @rtclock() : () -> f64
-    %output = memref.alloc() {alignment = 64 : i64} : memref<12x1x128xf32>
+    %output = memref.alloc() alignment = 64 : memref<12x1x128xf32>
     linalg.fill ins(%cst : f32) outs(%output : memref<12x1x128xf32>)
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -55,12 +55,12 @@ module {
 
     scf.parallel (%batch_idx) = (%c0) to (%batch_size) step (%c1) {
       scf.for %n_idx = %c0 to %n_size step %c32 {
-        %c_vec = vector.load %output[%batch_idx, %c0, %n_idx] {alignment = 64 : i64} : memref<12x1x128xf32>, vector<64xf32>
+        %c_vec = vector.load %output[%batch_idx, %c0, %n_idx] alignment = 64 : memref<12x1x128xf32>, vector<64xf32>
         %sum_iter = scf.for %k_idx = %c0 to %k_size step %c1 iter_args(%sum_vec = %c_vec) -> (vector<64xf32>) {
           %a_ele = memref.load %a
           [%batch_idx, %c0, %k_idx] : memref<12x1x1024xf32, strided<[?, ?, 1], offset: ?>>
           %a_vec = vector.broadcast %a_ele : f32 to vector<64xf32>
-          %b_vec = vector.load %b[%batch_idx, %k_idx, %n_idx] {alignment = 64 : i64, nontemporal = true} : memref<12x1024x128xf32, strided<[?, ?, 1], offset: ?>>, vector<64xf32>
+          %b_vec = vector.load %b[%batch_idx, %k_idx, %n_idx] alignment = 64 nontemporal = true : memref<12x1024x128xf32, strided<[?, ?, 1], offset: ?>>, vector<64xf32>
           %r_vec = vector.fma %a_vec, %b_vec, %sum_vec : vector<64xf32>
           scf.yield %r_vec : vector<64xf32>
         }
@@ -80,9 +80,9 @@ module {
     %c0 = arith.constant 0 : index
     %cst = arith.constant 4.000000e+00 : f32
     %cst_0 = arith.constant 2.000000e+00 : f32
-    %alloc = memref.alloc() {alignment = 64 : i64} : memref<12x1x1024xf32>
+    %alloc = memref.alloc() alignment = 64 : memref<12x1x1024xf32>
     linalg.fill ins(%cst_0 : f32) outs(%alloc : memref<12x1x1024xf32>)
-    %alloc_1 = memref.alloc() {alignment = 64 : i64} : memref<12x1024x128xf32>
+    %alloc_1 = memref.alloc() alignment = 64 : memref<12x1024x128xf32>
     linalg.fill ins(%cst : f32) outs(%alloc_1 : memref<12x1024x128xf32>)
     scf.for %arg0 = %c0 to %c5 step %c1 {
       %cast = memref.cast %alloc : memref<12x1x1024xf32> to memref<12x1x1024xf32, strided<[?, ?, ?], offset: ?>>

--- a/examples/BuddyNext/next-transpose-vec-manual.mlir
+++ b/examples/BuddyNext/next-transpose-vec-manual.mlir
@@ -24,12 +24,12 @@
 // RUN: | FileCheck %s
 
 module {
-  memref.global "private" constant @__constant_1x32x40x128xf32 : memref<1x32x40x128xf32> = dense<3.000000e+00> {alignment = 64 : i64}
+  memref.global "private" constant @__constant_1x32x40x128xf32 : memref<1x32x40x128xf32> = dense<3.000000e+00> alignment = 64
   func.func private @rtclock() -> f64
   func.func private @printMemrefF32(memref<*xf32>)
   func.func @kernel(%arg0: memref<1x32x40x128xf32>) {
     %0 = call @rtclock() : () -> f64
-    %alloc = memref.alloc() {alignment = 64 : i64} : memref<1x40x32x128xf32>
+    %alloc = memref.alloc() alignment = 64 : memref<1x40x32x128xf32>
     affine.for %arg1 = 0 to 1 {
       affine.for %arg2 = 0 to 40 {
         affine.for %arg3 = 0 to 32 {

--- a/examples/GemminiDialect/tile-matmul-os.mlir
+++ b/examples/GemminiDialect/tile-matmul-os.mlir
@@ -15,10 +15,10 @@ func.func @main() -> i8 {
   %i2I32 = arith.constant 2 : i32
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
-  %aArray = memref.alloc() {alignment = 16} : memref<64x64xi8>
-  %bArray = memref.alloc() {alignment = 16}: memref<64x64xi8>
-  %cArray = memref.alloc() {alignment = 16}: memref<64x64xi8>
-  %dArray = memref.alloc() {alignment = 64} : memref<64x64xi32>
+  %aArray = memref.alloc() alignment = 16 : memref<64x64xi8>
+  %bArray = memref.alloc() alignment = 16: memref<64x64xi8>
+  %cArray = memref.alloc() alignment = 16: memref<64x64xi8>
+  %dArray = memref.alloc() alignment = 64 : memref<64x64xi32>
   %dim = memref.dim %aArray, %c0 : memref<64x64xi8>
   scf.for %i = %c0 to %dim step %c1 {
     scf.for %j = %c0 to %dim step %c1 {

--- a/examples/MLIRVector/vector-extract-strided-slice.mlir
+++ b/examples/MLIRVector/vector-extract-strided-slice.mlir
@@ -27,7 +27,7 @@ func.func @main() -> i32 {
   // o o o o
   // o o o o
   %w0 = vector.extract_strided_slice %base
-    { offsets = [0, 0], sizes = [2, 2], strides = [1, 1] }
+    offsets = [0, 0], sizes = [2, 2], strides = [1, 1]
     : vector<4x4xi32> to vector<2x2xi32>
   // CHECK: ( ( 0, 1 ), ( 10, 11 ) )
   vector.print %w0 : vector<2x2xi32>
@@ -40,13 +40,13 @@ func.func @main() -> i32 {
   //          x x o o    |          o o o o   |         o x x o
   //          o o o o    |          o o o o   |         o o o o
   %w1_0 = vector.extract_strided_slice %base
-    { offsets = [1, 0], sizes = [2, 2], strides = [1, 1] }
+    offsets = [1, 0], sizes = [2, 2], strides = [1, 1]
     : vector<4x4xi32> to vector<2x2xi32>
   %w1_1 = vector.extract_strided_slice %base
-    { offsets = [0, 1], sizes = [2, 2], strides = [1, 1] }
+    offsets = [0, 1], sizes = [2, 2], strides = [1, 1]
     : vector<4x4xi32> to vector<2x2xi32>
   %w1_2 = vector.extract_strided_slice %base
-    { offsets = [1, 1], sizes = [2, 2], strides = [1, 1] }
+    offsets = [1, 1], sizes = [2, 2], strides = [1, 1]
     : vector<4x4xi32> to vector<2x2xi32>
   // CHECK: ( ( 10, 11 ), ( 20, 21 ) )
   vector.print %w1_0 : vector<2x2xi32>
@@ -64,11 +64,11 @@ func.func @main() -> i32 {
   //          x x o o    |          o o o o   |         x o x o
   //          o o o o    |          o o o o   |         o o o o
 
-  // %w2_0 = vector.extract_strided_slice %base { offsets = [0, 0], sizes = [2, 2], strides = [2, 1] }
+  // %w2_0 = vector.extract_strided_slice %base offsets = [0, 0], sizes = [2, 2], strides = [2, 1]
   //   : vector<4x4xi32> to vector<2x2xi32>
-  // %w2_1 = vector.extract_strided_slice %base { offsets = [0, 0], sizes = [2, 2], strides = [1, 2] }
+  // %w2_1 = vector.extract_strided_slice %base offsets = [0, 0], sizes = [2, 2], strides = [1, 2]
   //   : vector<4x4xi32> to vector<2x2xi32>
-  // %w2_2 = vector.extract_strided_slice %base { offsets = [0, 0], sizes = [2, 2], strides = [2, 2] }
+  // %w2_2 = vector.extract_strided_slice %base offsets = [0, 0], sizes = [2, 2], strides = [2, 2]
   //   : vector<4x4xi32> to vector<2x2xi32>
 
   // vector.print %w2_0 : vector<2x2xi32>
@@ -78,14 +78,14 @@ func.func @main() -> i32 {
 
   // vector.extract_strided_slice with any rank can be defined recursively:
 
-  // vector.extract_strided_slice %b { offsets = [o0, ...], sizes = [l0, ...], strides = [s0, ...] }
+  // vector.extract_strided_slice %b offsets = [o0, ...], sizes = [l0, ...], strides = [s0, ...]
   // <==>
   // [
-  //    vector.extract_strided_slice %b[o0 + 0*s0] { offsets = [...], sizes = [...], strides = [...] },
-  //    vector.extract_strided_slice %b[o0 + 1*s0] { offsets = [...], sizes = [...], strides = [...] },
-  //    vector.extract_strided_slice %b[o0 + 2*s0] { offsets = [...], sizes = [...], strides = [...] },
+  //    vector.extract_strided_slice %b[o0 + 0*s0] offsets = [...], sizes = [...], strides = [...],
+  //    vector.extract_strided_slice %b[o0 + 1*s0] offsets = [...], sizes = [...], strides = [...],
+  //    vector.extract_strided_slice %b[o0 + 2*s0] offsets = [...], sizes = [...], strides = [...],
   //    ...
-  //    vector.extract_strided_slice %b[o0 + (l0-1)*s0] { offsets = [...], sizes = [...], strides = [...] }
+  //    vector.extract_strided_slice %b[o0 + (l0-1)*s0] offsets = [...], sizes = [...], strides = [...]
   // ]
 
   %big_base = arith.constant dense<[
@@ -97,7 +97,7 @@ func.func @main() -> i32 {
 
 
   %w3 = vector.extract_strided_slice %big_base
-    { offsets = [1, 0, 0], sizes = [2, 3, 3], strides = [1, 1, 1] }
+    offsets = [1, 0, 0], sizes = [2, 3, 3], strides = [1, 1, 1]
     : vector<4x4x4xi32> to vector<2x3x3xi32>
   // CHECK: ( ( ( 1, 11, 21 ), ( 101, 111, 121 ), ( 201, 211, 221 ) ),
   // CHECK-SAME: ( ( 2, 12, 22 ), ( 102, 112, 122 ), ( 202, 212, 222 ) ) )
@@ -109,17 +109,17 @@ func.func @main() -> i32 {
   // So if we want a lower-rank sub-vector from a bigger one, we can NOT write this:
 
   // %w4_0 = vector.extract_strided_slice %big_base
-  //   { offsets = [1, 0, 0], sizes = [3, 3], strides = [1, 1] }
+  //   offsets = [1, 0, 0], sizes = [3, 3], strides = [1, 1]
   //   : vector<4x4x4xi32> to vector<3x3xi32>
 
   // Instead, we either first extract %big_base[1], or do an extra extract with result:
   %t1 = vector.extract %big_base[1] : vector<4x4xi32> from vector<4x4x4xi32>
   %w4_1 = vector.extract_strided_slice %t1
-    { offsets = [0, 0], sizes = [3, 3], strides = [1, 1] }
+    offsets = [0, 0], sizes = [3, 3], strides = [1, 1]
     : vector<4x4xi32> to vector<3x3xi32>
 
   %t2 = vector.extract_strided_slice %big_base
-    { offsets = [1, 0, 0], sizes = [1, 3, 3], strides = [1, 1, 1] }
+    offsets = [1, 0, 0], sizes = [1, 3, 3], strides = [1, 1, 1]
     : vector<4x4x4xi32> to vector<1x3x3xi32>
   %w4_2 = vector.extract %t2[0] : vector<3x3xi32> from vector<1x3x3xi32>
   // CHECK: ( ( 1, 11, 21 ),

--- a/examples/MLIRVector/vector-fma-alignment.mlir
+++ b/examples/MLIRVector/vector-fma-alignment.mlir
@@ -14,24 +14,24 @@
 // Demonstrate the usage of alignment attribute in vector.load
 func.func @alloc_memref(%in : f32) -> memref<32xf32> {
   %c0 = arith.constant 0 : index
-  %mem = memref.alloc() {alignment = 64} : memref<32xf32>
+  %mem = memref.alloc() alignment = 64 : memref<32xf32>
   %vec = vector.broadcast %in : f32 to vector<32xf32>
-  vector.store %vec, %mem[%c0] {alignment = 64} : memref<32xf32>, vector<32xf32>
+  vector.store %vec, %mem[%c0] alignment = 64 : memref<32xf32>, vector<32xf32>
   return %mem : memref<32xf32>
 }
 
-// Demonstrate usage of memref.assume_alignment and {alignment = 64} attribute
+// Demonstrate usage of memref.assume_alignment and alignment = 64 attribute
 func.func @fma(%mem1 : memref<32xf32>, %mem2 : memref<32xf32>, %mem3 : memref<32xf32>, %output : memref<32xf32>) -> () {
   memref.assume_alignment %mem1, 64 : memref<32xf32>
   memref.assume_alignment %mem2, 64 : memref<32xf32>
   memref.assume_alignment %mem3, 64 : memref<32xf32>
   memref.assume_alignment %output, 64 : memref<32xf32>
   %c0 = arith.constant 0 : index
-  %v1 = vector.load %mem1[%c0] {alignment = 64} : memref<32xf32>, vector<32xf32>
-  %v2 = vector.load %mem2[%c0] {alignment = 64} : memref<32xf32>, vector<32xf32>
-  %v3 = vector.load %mem3[%c0] {alignment = 64} : memref<32xf32>, vector<32xf32>
+  %v1 = vector.load %mem1[%c0] alignment = 64 : memref<32xf32>, vector<32xf32>
+  %v2 = vector.load %mem2[%c0] alignment = 64 : memref<32xf32>, vector<32xf32>
+  %v3 = vector.load %mem3[%c0] alignment = 64 : memref<32xf32>, vector<32xf32>
   %v4 = vector.fma %v1, %v2, %v3 : vector<32xf32>
-  vector.store %v4, %output[%c0] {alignment = 64} : memref<32xf32>, vector<32xf32>
+  vector.store %v4, %output[%c0] alignment = 64 : memref<32xf32>, vector<32xf32>
   return
 }
 
@@ -49,7 +49,7 @@ func.func @main() -> i32 {
   %mem3 = call @alloc_memref(%input3) : (f32) -> memref<32xf32>
   %output = call @alloc_memref(%input) : (f32) -> memref<32xf32>
   call @fma(%mem1, %mem2, %mem3, %output) : (memref<32xf32>, memref<32xf32>, memref<32xf32>, memref<32xf32>) -> ()
-  %v = vector.load %output[%c0] {alignment = 64} : memref<32xf32>, vector<32xf32>
+  %v = vector.load %output[%c0] alignment = 64 : memref<32xf32>, vector<32xf32>
   vector.print %v : vector<32xf32>
   // CHECK: ( 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5 )
 

--- a/examples/MLIRVector/vector-insert-strided-slice.mlir
+++ b/examples/MLIRVector/vector-insert-strided-slice.mlir
@@ -28,7 +28,7 @@ func.func @main() -> i32 {
   // x x o o
   // o o o o
   // o o o o
-  %w0 = vector.insert_strided_slice %val, %base { offsets = [0, 0], strides = [1, 1] }
+  %w0 = vector.insert_strided_slice %val, %base offsets = [0, 0], strides = [1, 1]
     : vector<2x2xi32> into vector<4x4xi32>
   // CHECK:    ( ( 100, 101, 2, 3 ),
   // CHECK-SAME: ( 110, 111, 12, 13 ),
@@ -43,11 +43,11 @@ func.func @main() -> i32 {
   //          x x o o    |          o x x o   |         o x x o
   //          x x o o    |          o o o o   |         o x x o
   //          o o o o    |          o o o o   |         o o o o
-  %w1_0 = vector.insert_strided_slice %val, %base { offsets = [1, 0], strides = [1, 1] }
+  %w1_0 = vector.insert_strided_slice %val, %base offsets = [1, 0], strides = [1, 1]
     : vector<2x2xi32> into vector<4x4xi32>
-  %w1_1 = vector.insert_strided_slice %val, %base { offsets = [0, 1], strides = [1, 1] }
+  %w1_1 = vector.insert_strided_slice %val, %base offsets = [0, 1], strides = [1, 1]
     : vector<2x2xi32> into vector<4x4xi32>
-  %w1_2 = vector.insert_strided_slice %val, %base { offsets = [1, 1], strides = [1, 1] }
+  %w1_2 = vector.insert_strided_slice %val, %base offsets = [1, 1], strides = [1, 1]
     : vector<2x2xi32> into vector<4x4xi32>
   // CHECK:      ( ( 0, 1, 2, 3 ),
   // CHECK-SAME: ( 100, 101, 12, 13 ),
@@ -74,11 +74,11 @@ func.func @main() -> i32 {
   //          x x o o    |          o o o o   |         x o x o
   //          o o o o    |          o o o o   |         o o o o
 
-  // %w2_0 = vector.insert_strided_slice %val, %base { offsets = [0, 0], strides = [2, 1] }
+  // %w2_0 = vector.insert_strided_slice %val, %base offsets = [0, 0], strides = [2, 1]
   //   : vector<2x2xi32> into vector<4x4xi32>
-  // %w2_1 = vector.insert_strided_slice %val, %base { offsets = [0, 0], strides = [1, 2] }
+  // %w2_1 = vector.insert_strided_slice %val, %base offsets = [0, 0], strides = [1, 2]
   //   : vector<2x2xi32> into vector<4x4xi32>
-  // %w2_2 = vector.insert_strided_slice %val, %base { offsets = [0, 0], strides = [2, 2] }
+  // %w2_2 = vector.insert_strided_slice %val, %base offsets = [0, 0], strides = [2, 2]
   //   : vector<2x2xi32> into vector<4x4xi32>
 
   // vector.print %w2_0 : vector<4x4xi32>
@@ -88,14 +88,14 @@ func.func @main() -> i32 {
 
   // vector.insert_strided_slice with any rank can be defined recursively:
 
-  // vector.insert_strided_slice %v, %b { offsets = [o0, ...], strides = [s0, ...] }
+  // vector.insert_strided_slice %v, %b offsets = [o0, ...], strides = [s0, ...]
   // <==>
   // if rank(%v) < rank(%b):
-  //    vector.insert_strided_slice %v, %b[o0] { offsets = [...], strides = [...] }
+  //    vector.insert_strided_slice %v, %b[o0] offsets = [...], strides = [...]
   //
   // if rank(%v) == rank(%b):
   //    for (i = o0; i < dim(%v); i += s0)
-  //      vector.insert_strided_slice %v[i], %b[i] { offsets = [...], strides = [...] }
+  //      vector.insert_strided_slice %v[i], %b[i] offsets = [...], strides = [...]
 
   %big_base = arith.constant dense<[
     [[0, 10, 20, 30], [100, 110, 120, 130], [200, 210, 220, 230], [300, 310, 320, 330]],
@@ -108,7 +108,7 @@ func.func @main() -> i32 {
                                      [1010, 1011, 1012],
                                      [1020, 1021, 1022]]> : vector<3x3xi32>
 
-  %w3 = vector.insert_strided_slice %big_value, %big_base {offsets = [1, 0, 0], strides = [1, 1]}
+  %w3 = vector.insert_strided_slice %big_value, %big_base offsets = [1, 0, 0], strides = [1, 1]
     : vector<3x3xi32> into vector<4x4x4xi32>
   // CHECK:  ( ( ( 0, 10, 20, 30 ), ( 100, 110, 120, 130 ), ( 200, 210, 220, 230 ), ( 300, 310, 320, 330 ) ),
   // CHECK-SMAE: ( ( 1000, 1001, 1002, 31 ), ( 1010, 1011, 1012, 131 ), ( 1020, 1021, 1022, 231 ), ( 301, 311, 321, 331 ) ),

--- a/midend/include/Dialect/BOSCAME/BOSCAME.td
+++ b/midend/include/Dialect/BOSCAME/BOSCAME.td
@@ -859,7 +859,6 @@ class BOSCAME_EleWise2_IntrOp<string mnemonic> : BOSCAME_IntrOpBase<mnemonic>,
 //===----------------------------------------------------------------------===//
 multiclass BOSCAME_EleWise_Int_NoWiden_IntrOp<string prefix> {
   def "Mm_IntrOp"   : BOSCAME_EleWise3_IntrOp<prefix # ".mm">;
-  def "Hbmm_IntrOp" : BOSCAME_EleWise3_IntrOp<prefix # ".hb.mm">;
   def "Bmm_IntrOp"  : BOSCAME_EleWise3_IntrOp<prefix # ".b.mm">;
   def "Hmm_IntrOp"  : BOSCAME_EleWise3_IntrOp<prefix # ".h.mm">;
   def "Wmm_IntrOp"  : BOSCAME_EleWise3_IntrOp<prefix # ".w.mm">;
@@ -868,7 +867,6 @@ multiclass BOSCAME_EleWise_Int_NoWiden_IntrOp<string prefix> {
 
 multiclass BOSCAME_EleWise_Float_NoWiden_IntrOp<string prefix> {
   def "Mm_IntrOp"   : BOSCAME_EleWise3_IntrOp<prefix # ".mm">;
-  def "Cfmm_IntrOp" : BOSCAME_EleWise3_IntrOp<prefix # ".cf.mm">;
   def "Hfmm_IntrOp" : BOSCAME_EleWise3_IntrOp<prefix # ".hf.mm">;
   def "Fmm_IntrOp"  : BOSCAME_EleWise3_IntrOp<prefix # ".f.mm">;
   def "Dmm_IntrOp"  : BOSCAME_EleWise3_IntrOp<prefix # ".d.mm">;
@@ -876,7 +874,6 @@ multiclass BOSCAME_EleWise_Float_NoWiden_IntrOp<string prefix> {
 
 multiclass BOSCAME_EleWise_Int_DoubleWiden_IntrOp<string prefix> {
   def "Mm_IntrOp"   : BOSCAME_EleWise3_IntrOp<prefix # ".mm">;
-  def "Hbmm_IntrOp" : BOSCAME_EleWise3_IntrOp<prefix # ".hb.mm">;
   def "Bmm_IntrOp"  : BOSCAME_EleWise3_IntrOp<prefix # ".b.mm">;
   def "Hmm_IntrOp"  : BOSCAME_EleWise3_IntrOp<prefix # ".h.mm">;
   def "Wmm_IntrOp"  : BOSCAME_EleWise3_IntrOp<prefix # ".w.mm">;
@@ -884,17 +881,15 @@ multiclass BOSCAME_EleWise_Int_DoubleWiden_IntrOp<string prefix> {
 
 multiclass BOSCAME_EleWise_Float_DoubleWiden_IntrOp<string prefix> {
   def "Mm_IntrOp"   : BOSCAME_EleWise3_IntrOp<prefix # ".mm">;
-  def "Cfmm_IntrOp" : BOSCAME_EleWise3_IntrOp<prefix # ".cf.mm">;
   def "Hfmm_IntrOp" : BOSCAME_EleWise3_IntrOp<prefix # ".hf.mm">;
   def "Fmm_IntrOp"  : BOSCAME_EleWise3_IntrOp<prefix # ".f.mm">;
 }
 
 multiclass BOSCAME_EleWise_Unary_Float_IntrOp<string prefix> {
-  def "Mm_IntrOp"   : BOSCAME_EleWise2_IntrOp<prefix # ".mm">;
-  def "Cfmm_IntrOp" : BOSCAME_EleWise2_IntrOp<prefix # ".cf.mm">;
-  def "Hfmm_IntrOp" : BOSCAME_EleWise2_IntrOp<prefix # ".hf.mm">;
-  def "Fmm_IntrOp"  : BOSCAME_EleWise2_IntrOp<prefix # ".f.mm">;
-  def "Dmm_IntrOp"  : BOSCAME_EleWise2_IntrOp<prefix # ".d.mm">;
+  def "M_IntrOp"   : BOSCAME_EleWise2_IntrOp<prefix # ".m">;
+  def "HfM_IntrOp" : BOSCAME_EleWise2_IntrOp<prefix # ".hf.m">;
+  def "FM_IntrOp"  : BOSCAME_EleWise2_IntrOp<prefix # ".f.m">;
+  def "DM_IntrOp"  : BOSCAME_EleWise2_IntrOp<prefix # ".d.m">;
 }
 
 //===----------------------------------------------------------------------===//
@@ -1066,7 +1061,6 @@ def BOSCAME_MswmaHmm_IntrOp  : BOSCAME_MMA_IntrOp<"mswma.h.mm">;
 def BOSCAME_MswmaWmm_IntrOp  : BOSCAME_MMA_IntrOp<"mswma.w.mm">;
 // float point
 def BOSCAME_MfwmaMm_IntrOp   : BOSCAME_MMA_IntrOp<"mfwma.mm">;
-def BOSCAME_MfwmaCfmm_IntrOp : BOSCAME_MMA_IntrOp<"mfwma.cf.mm">;
 def BOSCAME_MfwmaHfmm_IntrOp : BOSCAME_MMA_IntrOp<"mfwma.hf.mm">;
 def BOSCAME_MfwmaFmm_IntrOp  : BOSCAME_MMA_IntrOp<"mfwma.f.mm">;
 
@@ -1087,22 +1081,17 @@ def BOSCAME_MsqmaMm_IntrOp  : BOSCAME_MMA_IntrOp<"msqma.mm">;
 def BOSCAME_MsqmaBmm_IntrOp : BOSCAME_MMA_IntrOp<"msqma.b.mm">;
 // float point
 def BOSCAME_MfqmaMm_IntrOp   : BOSCAME_MMA_IntrOp<"mfqma.mm">;
-def BOSCAME_MfqmaCfmm_IntrOp : BOSCAME_MMA_IntrOp<"mfqma.cf.mm">;
 
 //===--------------------------------------------------------------------===//
 // 4. Oct-widen matrix multiply-accumulate
 //===--------------------------------------------------------------------===//
 // uint
 def BOSCAME_MomauMm_IntrOp   : BOSCAME_MMA_IntrOp<"momau.mm">;
-def BOSCAME_MomauHbmm_IntrOp : BOSCAME_MMA_IntrOp<"momau.hb.mm">;
 // uint, saturated
 def BOSCAME_MsomauMm_IntrOp   : BOSCAME_MMA_IntrOp<"msomau.mm">;
-def BOSCAME_MsomauHbmm_IntrOp : BOSCAME_MMA_IntrOp<"msomau.hb.mm">;
 // int
 def BOSCAME_MomaMm_IntrOp   : BOSCAME_MMA_IntrOp<"moma.mm">;
-def BOSCAME_MomaHbmm_IntrOp : BOSCAME_MMA_IntrOp<"moma.hb.mm">;
 // int, saturated
 def BOSCAME_MsomaMm_IntrOp   : BOSCAME_MMA_IntrOp<"msoma.mm">;
-def BOSCAME_MsomaHbmm_IntrOp : BOSCAME_MMA_IntrOp<"msoma.hb.mm">;
 
 #endif // BOSCAME_DIALECT

--- a/midend/lib/Conversion/LowerVectorExp/LowerVectorExpPass.cpp
+++ b/midend/lib/Conversion/LowerVectorExp/LowerVectorExpPass.cpp
@@ -63,28 +63,24 @@ public:
     for (mlir::Operation &innerOp : configBlock.getOperations()) {
       //
       if (isa<arith::AddFOp>(innerOp)) {
-        Type resultType = cast<arith::AddFOp>(innerOp).getResult().getType();
-        Value result = LLVM::VPFAddOp::create(
-            rewriter, loc, resultType, cast<arith::AddFOp>(innerOp).getLhs(),
-            cast<arith::AddFOp>(innerOp).getRhs(), op.getMask(), op.getVl());
+        Value result = LLVM::FAddOp::create(
+            rewriter, loc, cast<arith::AddFOp>(innerOp).getLhs(),
+            cast<arith::AddFOp>(innerOp).getRhs());
         rewriter.replaceOp(op, result);
       } else if (isa<arith::MulFOp>(innerOp)) {
-        Type resultType = cast<arith::MulFOp>(innerOp).getResult().getType();
-        Value result = LLVM::VPFMulOp::create(
-            rewriter, loc, resultType, cast<arith::MulFOp>(innerOp).getLhs(),
-            cast<arith::MulFOp>(innerOp).getRhs(), op.getMask(), op.getVl());
+        Value result = LLVM::FMulOp::create(
+            rewriter, loc, cast<arith::MulFOp>(innerOp).getLhs(),
+            cast<arith::MulFOp>(innerOp).getRhs());
         rewriter.replaceOp(op, result);
       } else if (isa<arith::AddIOp>(innerOp)) {
-        Type resultType = cast<arith::AddIOp>(innerOp).getResult().getType();
-        Value result = LLVM::VPAddOp::create(
-            rewriter, loc, resultType, cast<arith::AddIOp>(innerOp).getLhs(),
-            cast<arith::AddIOp>(innerOp).getRhs(), op.getMask(), op.getVl());
+        Value result = LLVM::AddOp::create(
+            rewriter, loc, cast<arith::AddIOp>(innerOp).getLhs(),
+            cast<arith::AddIOp>(innerOp).getRhs());
         rewriter.replaceOp(op, result);
       } else if (isa<arith::MulIOp>(innerOp)) {
-        Type resultType = cast<arith::MulIOp>(innerOp).getResult().getType();
-        Value result = LLVM::VPMulOp::create(
-            rewriter, loc, resultType, cast<arith::MulIOp>(innerOp).getLhs(),
-            cast<arith::MulIOp>(innerOp).getRhs(), op.getMask(), op.getVl());
+        Value result = LLVM::MulOp::create(
+            rewriter, loc, cast<arith::MulIOp>(innerOp).getLhs(),
+            cast<arith::MulIOp>(innerOp).getRhs());
         rewriter.replaceOp(op, result);
       } else if (isa<vector::LoadOp>(innerOp)) {
         vector::LoadOp loadOp = cast<vector::LoadOp>(innerOp);


### PR DESCRIPTION
## Summary

- Upgrade the llvm submodule to 2d26d272a0ff74b8c81eac0607b07f98b82ecc46.
- Update downstream MLIR examples and BOSCAME lowering code for the LLVM/MLIR API changes.

## Verification

- LLVM, Clang, and OpenMP configure, build, and test checks passed.
- Buddy configure and full build passed.
- ninja -C build check-buddy: 224 passed, 2 unsupported, 2 failed.
  - Two BOSCAME codegen tests fail because the target LLVM revision now requires vector-typed overloaded intrinsics while Buddy still emits the legacy void(i64, ...) forms.

