### PR TITLE
[frontend] Preserve template output order

### DIFF
--- a/frontend/Python/graph/partitioned_graph_driver.py
+++ b/frontend/Python/graph/partitioned_graph_driver.py
@@ -1747,11 +1747,6 @@ class TemplatePartitionedGraphDriver:
                     original_output, self._graph.node_table
                 )
             )
-        if output_remap is None:
-            body_positions = {
-                op: index for index, op in enumerate(self._graph.body)
-            }
-            final_outputs.sort(key=lambda value: body_positions[value.op])
         resolved_outputs = []
         for value in final_outputs:
             if value.op in self._plan.parameter_indices:

--- a/models/qwen3_vl/codegen/qwen3_vl_codegen.py
+++ b/models/qwen3_vl/codegen/qwen3_vl_codegen.py
@@ -370,6 +370,7 @@ def import_graph(
     prefix,
     *example_inputs,
     template_partitioned=False,
+    output_remap=None,
 ):
     import numpy
     from buddy.compiler.frontend import DynamoCompiler
@@ -442,7 +443,9 @@ def import_graph(
             "w",
         ) as module_file:
             print(
-                driver.construct_template_combined_main_graph(True),
+                driver.construct_template_combined_main_graph(
+                    True, output_remap=output_remap
+                ),
                 file=module_file,
             )
 
@@ -535,6 +538,8 @@ def cmd_import_vision(args):
             "experimental_template_partitioned",
             False,
         ),
+        # Preserve the existing vision ABI: (ds0, ds1, ds2, pooled).
+        output_remap=[1, 2, 3, 0],
     )
     print(
         f"[import] OK -> {VISION_DIR}/vision_forward.mlir weights={weight_count}"

--- a/models/whisper/codegen/import-whisper.py
+++ b/models/whisper/codegen/import-whisper.py
@@ -155,7 +155,10 @@ if args.experimental_template_partitioned:
 
     with open(os.path.join(partition_dir, "forward.mlir"), "w") as module_file:
         print(
-            driver.construct_template_combined_main_graph(True),
+            # Preserve the existing runtime ABI: (encoder output, decoder logits).
+            driver.construct_template_combined_main_graph(
+                True, output_remap=[1, 0]
+            ),
             file=module_file,
         )
 

--- a/tests/Python/test_template_partitioned_graph_driver.py
+++ b/tests/Python/test_template_partitioned_graph_driver.py
@@ -496,7 +496,7 @@ assert "func.func @forward_decode_128" in str(tiered_combined)
 
 # Output remapping changes only the public forward return order.
 remap_graph, _, _ = five_region_graph(
-    "forward_prefill", output_indices=(0, 2, 4)
+    "forward_prefill", output_indices=(4, 0, 2)
 )
 remap_analysis, remap_plan = materialization_analysis(remap_graph)
 ordered_outputs_before = [
@@ -513,9 +513,9 @@ default_output = next(
     op for op in remap_driver.combined_graph.body if isinstance(op, OutputOp)
 )
 assert default_output.args == [
+    default_calls[4].name,
     default_calls[0].name,
     default_calls[2].name,
-    default_calls[4].name,
 ]
 remap_driver.construct_template_combined_main_graph(output_remap=[2, 0, 1])
 remapped_calls = [
@@ -525,9 +525,9 @@ remapped_output = next(
     op for op in remap_driver.combined_graph.body if isinstance(op, OutputOp)
 )
 assert remapped_output.args == [
+    remapped_calls[2].name,
     remapped_calls[4].name,
     remapped_calls[0].name,
-    remapped_calls[2].name,
 ]
 assert ordered_outputs_before == [
     tuple(region.interface.ordered_outputs)


### PR DESCRIPTION
## Summary

This PR fixes the output ordering behavior of
`TemplatePartitionedGraphDriver` and makes model-specific runtime ABI
compatibility explicit.

Previously, when `output_remap` was not provided,
`construct_template_combined_main_graph()` reordered graph outputs by the
position of their producers in `graph.body`.

That behavior happened to match the historical output ordering of the legacy
`GraphDriver` for some models, but it also silently changed the semantic output
order represented by the graph `OutputOp`.

This PR:

- preserves the original graph output order by default in
  `TemplatePartitionedGraphDriver`;
- uses explicit `output_remap` for Qwen3-VL Vision to preserve its existing
  runtime ABI;
- uses explicit `output_remap` for Whisper to preserve its existing runtime
  ABI;
- adds a regression case whose graph output order is intentionally different
  from producer order.

## Background

The legacy `GraphDriver` and `TemplatePartitionedGraphDriver` construct the
combined forward graph differently.

The legacy `GraphDriver` is primarily organized around fused `op_groups`.
Outputs are naturally collected while traversing those groups, so the final
output order can follow producer/group traversal order rather than the operand
order of the original graph `OutputOp`.

The template-partitioned driver has a different structure. It materializes
reusable template subgraphs, invokes their concrete region instances in graph
order, and maintains mappings from original graph values to materialized SSA
values. Therefore, after computation is materialized, it can resolve public
outputs directly according to the original `OutputOp` order.

The previous implementation nevertheless sorted these resolved outputs again
by producer position when no explicit `output_remap` was supplied. This made a
legacy implementation detail part of the generic template driver's behavior.