### PR TITLE
feat(buddy-server): add Qwen3-VL resident serving support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,11 +198,10 @@ option(BUDDY_BUILD_WHISPER_MODEL
   "Build models/whisper (whisper_model.so, whisper.rax, whisper_runner.so)"
   OFF)
 
-# Qwen3-VL (self-contained, vision-language). Off by default. Currently builds
-# only the runner stub library/plugin; the MLIR import/compile pipeline is added
-# after the feasibility spikes pass (see models/qwen3_vl/).
+# Qwen3-VL (self-contained, vision-language). Off by default. Builds the
+# multimodal runner and resident serving plugin when enabled.
 option(BUDDY_BUILD_QWEN3_VL_MODEL
-  "Build models/qwen3_vl (buddy_models_qwen3_vl runner plugin)"
+  "Build models/qwen3_vl (runner and buddy-server serving plugin)"
   OFF)
 
 set(_buddy_require_jpeg OFF)

--- a/models/qwen3_vl/CMakeLists.txt
+++ b/models/qwen3_vl/CMakeLists.txt
@@ -24,6 +24,8 @@ buddy_add_model(
   SPEC "${BUDDY_QWEN3_VL_SPEC}"
   RUNNER_SRC Qwen3VLRunner.cpp
   RUNNER_PLUGIN_SRC Qwen3VLRunnerPlugin.cpp
+  SERVING_PLUGIN_SRC Qwen3VLResidentModelPlugin.cpp
+  EXTRA_SRCS Qwen3VLRuntime.cpp Qwen3VLResidentModel.cpp
   LOCAL_MODEL "${BUDDY_QWEN3_VL_MODEL_PATH}"
   NUM_THREADS "${BUDDY_QWEN3_VL_NUM_THREADS}"
   LLC_ATTRS "${BUDDY_QWEN3_VL_LLC_ATTRS}"

--- a/models/qwen3_vl/Qwen3VLResidentModel.cpp
+++ b/models/qwen3_vl/Qwen3VLResidentModel.cpp
@@ -1,0 +1,231 @@
+//===- Qwen3VLResidentModel.cpp - Qwen3-VL serving model ------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/models/Qwen3VLResidentModel.h"
+
+#include "Qwen3VLRuntime.h"
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace buddy {
+namespace runtime {
+namespace {
+
+std::string nextCompletionId() {
+  static std::atomic<unsigned long long> nextId{1};
+  return "qwen-cmpl-" + std::to_string(nextId.fetch_add(1));
+}
+
+std::string renderMessages(const ChatCompletionRequest &request) {
+  if (!request.messages.empty()) {
+    std::string prompt;
+    for (const ChatMessage &message : request.messages) {
+      if (message.content.empty())
+        continue;
+      if (!prompt.empty())
+        prompt += "\n";
+      prompt += message.content;
+    }
+    if (!prompt.empty())
+      return prompt;
+  }
+  if (!request.input.empty())
+    return request.input;
+  throw std::runtime_error("qwen3_vl: chat request has no text content");
+}
+
+std::vector<ImageInput> imagesForRequest(const ChatCompletionRequest &request) {
+  std::vector<ImageInput> images = request.images;
+  if (images.size() > 1)
+    throw std::runtime_error("qwen3_vl: only one image is supported");
+
+  for (const ChatMessage &message : request.messages) {
+    if (!message.images.empty() && message.role != "user")
+      throw std::runtime_error(
+          "qwen3_vl: image content is only supported in user messages");
+    for (const ImageInput &image : message.images) {
+      if (images.empty())
+        images.push_back(image);
+      else if (images.front().uri != image.uri ||
+               images.front().bytes != image.bytes)
+        throw std::runtime_error("qwen3_vl: only one image is supported");
+    }
+  }
+  if (images.size() > 1)
+    throw std::runtime_error("qwen3_vl: only one image is supported");
+  return images;
+}
+
+} // namespace
+
+class Qwen3VLResidentModel::Impl {
+public:
+  void load(const ResidentModelConfig &config) {
+    std::lock_guard<std::mutex> loadLock(loadMutex);
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      statusValue.state = ModelLoadState::Loading;
+      statusValue.backend = "cpu";
+      statusValue.modelName =
+          config.modelName.empty() ? "qwen3_vl" : config.modelName;
+      statusValue.message = "model is loading";
+    }
+
+    try {
+      if (config.raxPath.empty())
+        throw std::runtime_error(
+            "qwen3_vl: --model <path.rax> is required for serving");
+
+      auto candidate = std::make_shared<Qwen3VLRuntime>();
+      candidate->load(config.raxPath);
+
+      ModelStatus ready;
+      ready.state = ModelLoadState::Ready;
+      ready.backend = "cpu";
+      ready.modelName =
+          config.modelName.empty() ? candidate->modelName() : config.modelName;
+      ready.contextLength = candidate->contextLength();
+      ready.message = "model loaded";
+
+      std::lock_guard<std::mutex> lock(mutex);
+      runtime = std::move(candidate);
+      statusValue = std::move(ready);
+    } catch (const std::exception &ex) {
+      std::lock_guard<std::mutex> lock(mutex);
+      runtime.reset();
+      statusValue.state = ModelLoadState::Error;
+      statusValue.backend = "cpu";
+      statusValue.message = ex.what();
+      throw;
+    }
+  }
+
+  ModelStatus status() const {
+    std::lock_guard<std::mutex> lock(mutex);
+    return statusValue;
+  }
+
+  std::string renderChat(const ChatCompletionRequest &request) const {
+    (void)snapshotRuntime();
+    return renderMessages(request);
+  }
+
+  TokenizeResult tokenize(const TokenizeRequest &request) const {
+    return snapshotRuntime()->tokenize(request.content, request.countOnly);
+  }
+
+  CompletionResult complete(const CompletionRequest &request) const {
+    return completeStream(request, {});
+  }
+
+  CompletionResult
+  completeStream(const CompletionRequest &request,
+                 const CompletionStreamCallback &callback) const {
+    auto model = snapshotRuntime();
+    const std::string responseModel = status().modelName;
+    CompletionResult result = model->generate(request.prompt, request.images,
+                                              request.sampling, callback);
+    if (result.id.empty())
+      result.id = nextCompletionId();
+    result.model = responseModel;
+    if (callback) {
+      CompletionChunk done;
+      done.id = result.id;
+      done.model = result.model;
+      done.done = true;
+      done.finishReason = result.finishReason;
+      done.usage = result.usage;
+      done.timings = result.timings;
+      (void)callback(done);
+    }
+    return result;
+  }
+
+  CompletionResult chat(const ChatCompletionRequest &request) const {
+    return chatStream(request, {});
+  }
+
+  CompletionResult chatStream(const ChatCompletionRequest &request,
+                              const CompletionStreamCallback &callback) const {
+    CompletionRequest completion;
+    completion.prompt = renderMessages(request);
+    completion.images = imagesForRequest(request);
+    completion.sampling = request.sampling;
+    return completeStream(completion, callback);
+  }
+
+private:
+  std::shared_ptr<Qwen3VLRuntime> snapshotRuntime() const {
+    std::lock_guard<std::mutex> lock(mutex);
+    if (!runtime || !runtime->isLoaded())
+      throw std::runtime_error("qwen3_vl: model is not loaded");
+    return runtime;
+  }
+
+  mutable std::mutex loadMutex;
+  mutable std::mutex mutex;
+  std::shared_ptr<Qwen3VLRuntime> runtime;
+  ModelStatus statusValue;
+};
+
+Qwen3VLResidentModel::Qwen3VLResidentModel() : impl(std::make_unique<Impl>()) {}
+
+Qwen3VLResidentModel::~Qwen3VLResidentModel() = default;
+
+void Qwen3VLResidentModel::load(const ResidentModelConfig &config) {
+  impl->load(config);
+}
+
+ModelStatus Qwen3VLResidentModel::status() const { return impl->status(); }
+
+std::string
+Qwen3VLResidentModel::renderChat(const ChatCompletionRequest &request) {
+  return impl->renderChat(request);
+}
+
+TokenizeResult Qwen3VLResidentModel::tokenize(const TokenizeRequest &request) {
+  return impl->tokenize(request);
+}
+
+CompletionResult
+Qwen3VLResidentModel::complete(const CompletionRequest &request) {
+  return impl->complete(request);
+}
+
+CompletionResult
+Qwen3VLResidentModel::completeStream(const CompletionRequest &request,
+                                     const CompletionStreamCallback &callback) {
+  return impl->completeStream(request, callback);
+}
+
+CompletionResult
+Qwen3VLResidentModel::chat(const ChatCompletionRequest &request) {
+  return impl->chat(request);
+}
+
+CompletionResult
+Qwen3VLResidentModel::chatStream(const ChatCompletionRequest &request,
+                                 const CompletionStreamCallback &callback) {
+  return impl->chatStream(request, callback);
+}
+
+} // namespace runtime
+} // namespace buddy

--- a/models/qwen3_vl/Qwen3VLResidentModelPlugin.cpp
+++ b/models/qwen3_vl/Qwen3VLResidentModelPlugin.cpp
@@ -1,0 +1,29 @@
+//===- Qwen3VLResidentModelPlugin.cpp - Qwen3-VL serving plugin -----------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/core/ResidentModelPlugin.h"
+#include "buddy/runtime/models/Qwen3VLResidentModel.h"
+
+extern "C" buddy::runtime::ResidentModel *buddy_create_resident_model_v1() {
+  return new buddy::runtime::Qwen3VLResidentModel();
+}
+
+extern "C" void
+buddy_destroy_resident_model_v1(buddy::runtime::ResidentModel *model) {
+  delete model;
+}
+
+extern "C" const char *buddy_resident_model_type_v1() { return "qwen3_vl"; }

--- a/models/qwen3_vl/Qwen3VLRuntime.cpp
+++ b/models/qwen3_vl/Qwen3VLRuntime.cpp
@@ -1,0 +1,496 @@
+//===- Qwen3VLRuntime.cpp - Resident Qwen3-VL runtime ---------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Qwen3VLRuntime.h"
+
+#define STB_IMAGE_IMPLEMENTATION
+#include "ImagePreprocess.h"
+#include "buddy/LLM/TextContainer.h"
+#include "buddy/runtime/core/ModelManifest.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+namespace buddy {
+namespace runtime {
+namespace {
+
+using VisionFn = void (*)(const float *, long, const float *, float *, float *,
+                          float *, float *);
+using DecoderFn = void (*)(const float *, long, const float *, const float *,
+                           const float *, const float *, const float *,
+                           const float *, const float *, float *, long, long,
+                           long, long);
+
+struct MappedFloats {
+  const float *data = nullptr;
+  std::size_t count = 0;
+  void *base = nullptr;
+  std::size_t bytes = 0;
+  ~MappedFloats() {
+    if (base && base != MAP_FAILED)
+      munmap(base, bytes);
+  }
+};
+
+struct MappedI64 {
+  const int64_t *data = nullptr;
+  std::size_t count = 0;
+  void *base = nullptr;
+  std::size_t bytes = 0;
+
+  ~MappedI64() {
+    if (base && base != MAP_FAILED)
+      munmap(base, bytes);
+  }
+};
+void mapFloats(const std::string &path, MappedFloats &out) {
+  int fd = open(path.c_str(), O_RDONLY);
+  if (fd < 0)
+    throw std::runtime_error("qwen3_vl: cannot open " + path);
+  struct stat st;
+  if (fstat(fd, &st) != 0) {
+    close(fd);
+    throw std::runtime_error("qwen3_vl: fstat failed " + path);
+  }
+  out.bytes = static_cast<std::size_t>(st.st_size);
+  if (out.bytes == 0 || out.bytes % sizeof(float) != 0) {
+    close(fd);
+    throw std::runtime_error("qwen3_vl: invalid float file size: " + path);
+  }
+  out.base = mmap(nullptr, out.bytes, PROT_READ, MAP_PRIVATE, fd, 0);
+  close(fd);
+  if (out.base == MAP_FAILED) {
+    out.base = nullptr;
+    throw std::runtime_error("qwen3_vl: mmap failed " + path);
+  }
+  out.data = reinterpret_cast<const float *>(out.base);
+  out.count = out.bytes / sizeof(float);
+}
+
+void mapI64(const std::string &path, MappedI64 &out) {
+  int fd = open(path.c_str(), O_RDONLY);
+  if (fd < 0)
+    throw std::runtime_error("qwen3_vl: cannot open " + path);
+  struct stat st;
+  if (fstat(fd, &st) != 0) {
+    close(fd);
+    throw std::runtime_error("qwen3_vl: fstat failed " + path);
+  }
+  out.bytes = static_cast<std::size_t>(st.st_size);
+  if (out.bytes == 0 || out.bytes % sizeof(int64_t) != 0) {
+    close(fd);
+    throw std::runtime_error("qwen3_vl: invalid int64 file size: " + path);
+  }
+  out.base = mmap(nullptr, out.bytes, PROT_READ, MAP_PRIVATE, fd, 0);
+  close(fd);
+  if (out.base == MAP_FAILED) {
+    out.base = nullptr;
+    throw std::runtime_error("qwen3_vl: mmap failed " + path);
+  }
+
+  out.data = reinterpret_cast<const int64_t *>(out.base);
+  out.count = out.bytes / sizeof(int64_t);
+}
+std::vector<float> readFloats(const std::string &path, std::size_t expected) {
+  std::ifstream f(path, std::ios::binary | std::ios::ate);
+  if (!f)
+    throw std::runtime_error("qwen3_vl: cannot open " + path);
+  const std::streamoff end = f.tellg();
+  if (end < 0 || static_cast<std::size_t>(end) % sizeof(float) != 0)
+    throw std::runtime_error("qwen3_vl: invalid float file size: " + path);
+  const std::size_t count = static_cast<std::size_t>(end) / sizeof(float);
+  if (expected != 0 && count != expected)
+    throw std::runtime_error("qwen3_vl: unexpected float count in " + path);
+  f.seekg(0);
+  std::vector<float> values(count);
+  f.read(reinterpret_cast<char *>(values.data()),
+         static_cast<std::streamsize>(count * sizeof(float)));
+  if (!f)
+    throw std::runtime_error("qwen3_vl: short read from " + path);
+  return values;
+}
+
+std::size_t checkedMul(std::size_t a, std::size_t b, const char *what) {
+  if (a != 0 && b > std::numeric_limits<std::size_t>::max() / a)
+    throw std::runtime_error(std::string("qwen3_vl: size overflow: ") + what);
+  return a * b;
+}
+
+void *openLocal(const std::string &path) {
+  void *handle = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);
+  if (!handle)
+    throw std::runtime_error("qwen3_vl: dlopen " + path + ": " + dlerror());
+  return handle;
+}
+
+template <typename Fn>
+Fn lookup(void *handle, const std::string &path, const char *symbol) {
+  dlerror();
+  void *raw = dlsym(handle, symbol);
+  const char *error = dlerror();
+  if (error)
+    throw std::runtime_error("qwen3_vl: missing " + std::string(symbol) +
+                             " in " + path + ": " + error);
+  return reinterpret_cast<Fn>(raw);
+}
+
+std::string nextId() {
+  static std::atomic<unsigned long long> id{1};
+  return "qwen-cmpl-" + std::to_string(id.fetch_add(1));
+}
+
+std::string resourcePath(const ModelManifest &manifest, const char *name) {
+  for (const auto &constant : manifest.constants)
+    if (constant.name == name)
+      return constant.path;
+  throw std::runtime_error("qwen3_vl: manifest missing constant " +
+                           std::string(name));
+}
+
+std::string codePath(const ModelManifest &manifest, const char *name) {
+  for (const auto &code : manifest.codeObjects)
+    if (code.name == name)
+      return code.path;
+  throw std::runtime_error("qwen3_vl: manifest missing code object " +
+                           std::string(name));
+}
+
+} // namespace
+
+class Qwen3VLRuntime::Impl {
+public:
+  ~Impl() {
+    if (visionHandle)
+      dlclose(visionHandle);
+    if (decoderHandle)
+      dlclose(decoderHandle);
+  }
+
+  TokenizeResult tokenize(const std::string &prompt, bool countOnly) const;
+  CompletionResult generate(const std::string &prompt,
+                            const std::vector<ImageInput> &images,
+                            const SamplingParams &sampling,
+                            const CompletionStreamCallback &callback);
+
+  void load(const std::string &raxPath) {
+    if (raxPath.empty())
+      throw std::runtime_error("qwen3_vl: raxPath is required");
+    if (loadAttempted)
+      throw std::runtime_error("qwen3_vl: runtime load was already attempted");
+    loadAttempted = true;
+    if (visionHandle || decoderHandle)
+      throw std::runtime_error("qwen3_vl: runtime is already loaded");
+
+    manifest = ModelManifest::loadFromRax(raxPath);
+    modelName = manifest.modelName.empty() ? "qwen3_vl" : manifest.modelName;
+    vocabPath = manifest.vocabPath;
+    if (vocabPath.empty())
+      throw std::runtime_error("qwen3_vl: manifest has no vocab_uri");
+
+    mapFloats(resourcePath(manifest, "vision_weights"), visionWeights);
+    mapFloats(resourcePath(manifest, "decoder_weights"), decoderWeights);
+    mapFloats(resourcePath(manifest, "embed_table"), embedTable);
+    mapI64(resourcePath(manifest, "img_pos"), imagePositions);
+    cos = readFloats(resourcePath(manifest, "cos"), 0);
+    sin = readFloats(resourcePath(manifest, "sin"), 0);
+    causalMask = readFloats(resourcePath(manifest, "cmask"), 0);
+
+    std::ifstream meta(resourcePath(manifest, "meta"));
+    if (!meta)
+      throw std::runtime_error("qwen3_vl: cannot read meta resource");
+    std::size_t ignoredPrompt = 0;
+    if (!(meta >> ignoredPrompt >> N >> NIMG >> HID >> VOCAB))
+      throw std::runtime_error("qwen3_vl: invalid meta resource");
+    packagedPromptLength = ignoredPrompt;
+    if (N == 0 || NIMG != 98 || HID == 0 || VOCAB == 0)
+      throw std::runtime_error("qwen3_vl: unsupported dimensions in meta");
+    if (imagePositions.count != NIMG)
+      throw std::runtime_error("qwen3_vl: img_pos count does not match meta");
+    if (cos.size() != checkedMul(N, kHeadDim, "cos") ||
+        sin.size() != checkedMul(N, kHeadDim, "sin") ||
+        causalMask.size() != checkedMul(N, N, "cmask"))
+      throw std::runtime_error("qwen3_vl: positional resource shape mismatch");
+    if (embedTable.count < checkedMul(VOCAB, HID, "embed_table"))
+      throw std::runtime_error("qwen3_vl: embed table is too small");
+    for (std::size_t i = 0; i < imagePositions.count; ++i)
+      if (imagePositions.data[i] < 0 ||
+          static_cast<std::size_t>(imagePositions.data[i]) >= N)
+        throw std::runtime_error("qwen3_vl: image position is out of range");
+
+    const std::string visionPath = codePath(manifest, "vision_kernels");
+    const std::string decoderPath = codePath(manifest, "decoder_kernels");
+    try {
+      visionHandle = openLocal(visionPath);
+      decoderHandle = openLocal(decoderPath);
+      vision = lookup<VisionFn>(visionHandle, visionPath, "qwen3vl_vision");
+      decoder =
+          lookup<DecoderFn>(decoderHandle, decoderPath, "qwen3vl_decoder");
+    } catch (...) {
+      if (decoderHandle) {
+        dlclose(decoderHandle);
+        decoderHandle = nullptr;
+      }
+      if (visionHandle) {
+        dlclose(visionHandle);
+        visionHandle = nullptr;
+      }
+      throw;
+    }
+    loaded = true;
+  }
+
+  static constexpr std::size_t kHeadDim = 128;
+  ModelManifest manifest;
+  std::string modelName;
+  std::string vocabPath;
+  std::size_t packagedPromptLength = 0;
+  std::size_t N = 0, NIMG = 0, HID = 0, VOCAB = 0;
+  MappedFloats visionWeights, decoderWeights, embedTable;
+  MappedI64 imagePositions;
+  std::vector<float> cos, sin, causalMask;
+  void *visionHandle = nullptr;
+  void *decoderHandle = nullptr;
+  VisionFn vision = nullptr;
+  DecoderFn decoder = nullptr;
+  mutable std::mutex kernelMutex;
+  bool loadAttempted = false;
+  bool loaded = false;
+};
+
+TokenizeResult Qwen3VLRuntime::Impl::tokenize(const std::string &prompt,
+                                              bool countOnly) const {
+  if (!loaded)
+    throw std::runtime_error("qwen3_vl: runtime is not loaded");
+  Text<size_t, 2> tokens(prompt);
+  tokens.tokenizeQwen3VL(vocabPath, N, NIMG);
+  TokenizeResult result;
+  result.count = tokens.getTokenCnt();
+  if (!countOnly) {
+    result.tokens.reserve(result.count);
+    for (std::size_t i = 0; i < result.count; ++i)
+      result.tokens.push_back(static_cast<int>(tokens.getData()[i]));
+  }
+  return result;
+}
+
+CompletionResult Qwen3VLRuntime::Impl::generate(
+    const std::string &prompt, const std::vector<ImageInput> &images,
+    const SamplingParams &sampling, const CompletionStreamCallback &callback) {
+  if (!loaded)
+    throw std::runtime_error("qwen3_vl: runtime is not loaded");
+  if (images.size() > 1)
+    throw std::runtime_error("qwen3_vl: only one image is supported");
+  if (!images.empty() && !images.front().bytes.empty())
+    throw std::runtime_error(
+        "qwen3_vl: in-memory image bytes are not supported");
+
+  CompletionResult result;
+  result.id = nextId();
+  result.model = modelName;
+
+  Text<size_t, 2> promptTokens(prompt);
+  promptTokens.tokenizeQwen3VL(vocabPath, N, NIMG);
+  const std::size_t promptCount = promptTokens.getTokenCnt();
+  if (promptCount == 0 || promptCount > N)
+    throw std::runtime_error("qwen3_vl: invalid tokenized prompt length");
+  if (packagedPromptLength != 0 && promptCount != packagedPromptLength)
+    throw std::runtime_error("qwen3_vl: prompt token length " +
+                             std::to_string(promptCount) +
+                             " differs from packaged static RoPE length " +
+                             std::to_string(packagedPromptLength) +
+                             "; rebuild positional constants for this prompt");
+
+  std::vector<float> pixel;
+  const bool bundled = images.empty() || images.front().uri.empty() ||
+                       images.front().uri == "bundled";
+  const auto prefillStart = std::chrono::high_resolution_clock::now();
+  if (bundled) {
+    pixel = readFloats(resourcePath(manifest, "pixel_values"), 392u * 1536u);
+  } else {
+    std::error_code fileError;
+    const auto fileBytes = fs::file_size(images.front().uri, fileError);
+    if (!fileError && fileBytes > 64u * 1024u * 1024u)
+      throw std::runtime_error("qwen3_vl: image file is too large");
+    qwen3vl_image::preprocessImage(images.front().uri, pixel);
+  }
+  if (pixel.size() != 392u * 1536u)
+    throw std::runtime_error("qwen3_vl: pixel_values has unexpected size");
+
+  std::vector<float> pooled(NIMG * HID);
+  std::vector<float> ds0(NIMG * HID), ds1(NIMG * HID), ds2(NIMG * HID);
+  {
+    std::lock_guard<std::mutex> lock(kernelMutex);
+    vision(visionWeights.data, static_cast<long>(visionWeights.count),
+           pixel.data(), ds0.data(), ds1.data(), ds2.data(), pooled.data());
+  }
+  result.timings.prefillMs =
+      std::chrono::duration<double, std::milli>(
+          std::chrono::high_resolution_clock::now() - prefillStart)
+          .count();
+
+  std::vector<int64_t> inputIds(promptCount);
+  for (std::size_t i = 0; i < promptCount; ++i)
+    inputIds[i] = static_cast<int64_t>(promptTokens.getData()[i]);
+  auto embedRow = [&](int64_t token) {
+    if (token < 0 || static_cast<std::size_t>(token) >= VOCAB)
+      throw std::runtime_error("qwen3_vl: prompt token is out of range");
+    return embedTable.data + static_cast<std::size_t>(token) * HID;
+  };
+  std::vector<float> inputs(N * HID, 0.0f);
+  for (std::size_t i = 0; i < promptCount; ++i)
+    std::copy(embedRow(inputIds[i]), embedRow(inputIds[i]) + HID,
+              inputs.begin() + i * HID);
+  for (std::size_t i = 0; i < imagePositions.count; ++i) {
+    const std::size_t off =
+        static_cast<std::size_t>(imagePositions.data[i]) * HID;
+    std::copy(pooled.begin() + i * HID, pooled.begin() + (i + 1) * HID,
+              inputs.begin() + off);
+  }
+  std::vector<float> full0(N * HID, 0.0f), full1(N * HID, 0.0f),
+      full2(N * HID, 0.0f);
+  for (std::size_t i = 0; i < imagePositions.count; ++i) {
+    const std::size_t off =
+        static_cast<std::size_t>(imagePositions.data[i]) * HID;
+    std::copy(ds0.begin() + i * HID, ds0.begin() + (i + 1) * HID,
+              full0.begin() + off);
+    std::copy(ds1.begin() + i * HID, ds1.begin() + (i + 1) * HID,
+              full1.begin() + off);
+    std::copy(ds2.begin() + i * HID, ds2.begin() + (i + 1) * HID,
+              full2.begin() + off);
+  }
+
+  Text<size_t, 2> output;
+  output.loadVocab(vocabPath);
+  std::vector<float> logits(N * VOCAB);
+  const std::size_t contextNew = N - promptCount;
+  const std::size_t maxNew =
+      sampling.maxTokens <= 0
+          ? contextNew
+          : (sampling.maxTokens > static_cast<int>(promptCount)
+                 ? std::min<std::size_t>(contextNew, static_cast<std::size_t>(
+                                                         sampling.maxTokens) -
+                                                         promptCount)
+                 : 0);
+  bool stopped = false;
+  bool cancelled = false;
+  std::size_t generated = 0;
+  double decodeMs = 0.0;
+  std::string streamedText;
+  for (std::size_t t = promptCount - 1; t + 1 < N && generated < maxNew; ++t) {
+    const auto stepStart = std::chrono::high_resolution_clock::now();
+    {
+      std::lock_guard<std::mutex> lock(kernelMutex);
+      decoder(decoderWeights.data, static_cast<long>(decoderWeights.count),
+              inputs.data(), cos.data(), sin.data(), causalMask.data(),
+              full0.data(), full1.data(), full2.data(), logits.data(),
+              static_cast<long>(N), static_cast<long>(VOCAB),
+              static_cast<long>(HID), static_cast<long>(kHeadDim));
+    }
+    decodeMs += std::chrono::duration<double, std::milli>(
+                    std::chrono::high_resolution_clock::now() - stepStart)
+                    .count();
+    const float *row = logits.data() + t * VOCAB;
+    int token = 0;
+    for (std::size_t j = 1; j < VOCAB; ++j)
+      if (row[j] > row[token])
+        token = static_cast<int>(j);
+    if (token == 151645 || token == 151643 ||
+        std::find(sampling.stopTokenIds.begin(), sampling.stopTokenIds.end(),
+                  static_cast<long long>(token)) !=
+            sampling.stopTokenIds.end()) {
+      stopped = true;
+      break;
+    }
+    output.appendTokenIdx(static_cast<std::size_t>(token));
+    ++generated;
+    const std::string current = output.revertQwen3();
+    std::string delta;
+    if (current.size() > streamedText.size())
+      delta.assign(current.data() + streamedText.size(),
+                   current.size() - streamedText.size());
+    streamedText = current;
+    if (callback) {
+      CompletionChunk chunk;
+      chunk.id = result.id;
+      chunk.model = result.model;
+      chunk.delta = std::move(delta);
+      chunk.tokenId = token;
+      if (!callback(chunk)) {
+        cancelled = true;
+        break;
+      }
+    }
+    std::copy(embedRow(token), embedRow(token) + HID,
+              inputs.begin() + (t + 1) * HID);
+  }
+  result.content = output.revertQwen3();
+  result.usage.promptTokens = static_cast<int>(promptCount);
+  result.usage.completionTokens = static_cast<int>(generated);
+  result.usage.totalTokens =
+      result.usage.promptTokens + result.usage.completionTokens;
+  result.timings.decodeMs = decodeMs;
+  result.timings.tokensPerSecond =
+      decodeMs > 0.0 ? static_cast<double>(generated) / (decodeMs / 1000.0)
+                     : 0.0;
+  if (cancelled)
+    result.finishReason = FinishReason::Cancelled;
+  else if (stopped)
+    result.finishReason = FinishReason::Stop;
+  else
+    result.finishReason = FinishReason::Length;
+  return result;
+}
+
+Qwen3VLRuntime::Qwen3VLRuntime() : impl(std::make_unique<Impl>()) {}
+Qwen3VLRuntime::~Qwen3VLRuntime() = default;
+
+void Qwen3VLRuntime::load(const std::string &raxPath) { impl->load(raxPath); }
+bool Qwen3VLRuntime::isLoaded() const { return impl->loaded; }
+int Qwen3VLRuntime::contextLength() const { return static_cast<int>(impl->N); }
+std::size_t Qwen3VLRuntime::imageTokenCount() const { return impl->NIMG; }
+const std::string &Qwen3VLRuntime::modelName() const { return impl->modelName; }
+
+TokenizeResult Qwen3VLRuntime::tokenize(const std::string &prompt,
+                                        bool countOnly) const {
+  return impl->tokenize(prompt, countOnly);
+}
+
+CompletionResult Qwen3VLRuntime::generate(
+    const std::string &prompt, const std::vector<ImageInput> &images,
+    const SamplingParams &sampling, const CompletionStreamCallback &callback) {
+  return impl->generate(prompt, images, sampling, callback);
+}
+
+} // namespace runtime
+} // namespace buddy

--- a/models/qwen3_vl/Qwen3VLRuntime.h
+++ b/models/qwen3_vl/Qwen3VLRuntime.h
@@ -1,0 +1,54 @@
+//===- Qwen3VLRuntime.h - Resident Qwen3-VL runtime -----------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_MODELS_QWEN3VLRUNTIME_H
+#define BUDDY_RUNTIME_MODELS_QWEN3VLRUNTIME_H
+
+#include "buddy/runtime/core/ServingTypes.h"
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace buddy {
+namespace runtime {
+
+class Qwen3VLRuntime {
+public:
+  class Impl;
+  Qwen3VLRuntime();
+  ~Qwen3VLRuntime();
+  Qwen3VLRuntime(const Qwen3VLRuntime &) = delete;
+  Qwen3VLRuntime &operator=(const Qwen3VLRuntime &) = delete;
+
+  void load(const std::string &raxPath);
+  bool isLoaded() const;
+  int contextLength() const;
+  std::size_t imageTokenCount() const;
+  const std::string &modelName() const;
+  TokenizeResult tokenize(const std::string &prompt, bool countOnly) const;
+  CompletionResult generate(const std::string &prompt,
+                            const std::vector<ImageInput> &images,
+                            const SamplingParams &sampling,
+                            const CompletionStreamCallback &callback = {});
+
+private:
+  std::unique_ptr<Impl> impl;
+};
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_MODELS_QWEN3VLRUNTIME_H

--- a/models/qwen3_vl/README.md
+++ b/models/qwen3_vl/README.md
@@ -70,16 +70,47 @@ Qwen-3-VL 0.0
 2026
 ```
 
+Qwen3-VL packages also contain `qwen3_vl_serving.so`, referenced by the
+manifest `serving_library` attribute. Start the resident HTTP model with:
+
+```bash
+./build/bin/buddy-server \
+  --model ./build/models/qwen3_vl/qwen3_vl.rax \
+  --host 127.0.0.1 --port 8080
+```
+
+The server accepts one local image through `image_path`, or an OpenAI-style
+chat content array:
+
+```json
+{
+  "messages": [{
+    "role": "user",
+    "content": [
+      {"type": "text", "text": "Read all text in the image."},
+      {"type": "image_url", "image_url": {"url": "file:/tmp/input.png"}}
+    ]
+  }],
+  "stream": false
+}
+```
+
+Only local paths/file URIs and one fixed-grid image are currently supported;
+omitting the image uses the packaged test image.
+Remote URLs, data URIs, in-memory image bytes, multiple images, video and
+non-greedy sampling are rejected or unsupported. Decoder RoPE tables are
+packaged for the build-time prompt length; requests with another tokenized
+prompt length are rejected rather than producing silently incorrect results.
+String stop sequences are not applied; `stop_token_ids` and the model EOS
+ids are honored.
+The HTTP resident path is implemented separately from `Qwen3VLRunner`, so
+the existing buddy-cli interface and output behavior remain unchanged.
+
 ## Notes
 
-- The `.rax` and other artifacts live in the **build** directory
-  (`build/models/qwen3_vl/`), not in the source tree. Use the `build/` prefix in
-  the `--model` path.
-- Per-query preprocessing (image resize/patchify, prompt tokenization, MRoPE
-  positions) is delegated to the HuggingFace processor via a small Python helper
-  the runner invokes; the model forward itself runs entirely on the compiled
-  kernels. A pure-C++ preprocessing path is future work.
+- The `.rax` and other artifacts live in `build/models/qwen3_vl/`.
+- Runtime image decoding, resize and patchification use the pure-C++
+  `ImagePreprocess.h` implementation; Python is only used while building the
+  package and its fixed positional constants.
 - Greedy decode uses fixed-max-length recompute (no KV cache), and the image
   resolution is pinned at import time (no dynamic resolution / crop modes yet).
-- The first run loads the HuggingFace processor once and memory-maps the weight
-  blobs (~8 GB), so expect ~1–2 minutes end-to-end on CPU.

--- a/models/qwen3_vl/codegen/qwen3_vl_codegen.py
+++ b/models/qwen3_vl/codegen/qwen3_vl_codegen.py
@@ -732,6 +732,9 @@ def cmd_stage(args):
         "QWEN3_VL_RUNNER_SO", os.path.join(PKG_DIR, "qwen3_vl_runner.so")
     )
     vocab = os.path.join(REPO, "examples", "BuddyQwen3", "vocab.txt")
+    serving_so = os.environ.get("QWEN3_VL_SERVING_SO", "")
+    if serving_so:
+        stage_file(serving_so, os.path.join(PKG_DIR, "qwen3_vl_serving.so"))
 
     stage_file(
         os.path.join(VISION_DIR, "vision_shim.so"),
@@ -807,6 +810,11 @@ def cmd_stage(args):
         ("cmask", "cmask.bin"),
         ("meta", "meta.txt"),
     ]
+    serving_attr = (
+        ',\n    serving_library = "file:qwen3_vl_serving.so"'
+        if serving_so
+        else ""
+    )
     constants = "".join(
         rhal_file_constant(idx, name, os.path.join(PKG_DIR, filename))
         for idx, (name, filename) in enumerate(resources, start=1)
@@ -815,7 +823,7 @@ def cmd_stage(args):
     version = "0.1.0",
     model_name = "qwen3_vl",
     vocab_uri = "file:vocab.txt",
-    runner_library = "file:qwen3_vl_runner.so"}} {{
+    runner_library = "file:qwen3_vl_runner.so"{serving_attr}}} {{
 {constants}  rhal.codeobj @vision_kernels {{id = 1 : i32, kind = "host_shared_lib",
                                 backend = "cpu", uri = "file:vision_shim.so"}}
   rhal.codeobj @decoder_kernels {{id = 2 : i32, kind = "host_shared_lib",

--- a/models/qwen3_vl/include/buddy/runtime/models/Qwen3VLResidentModel.h
+++ b/models/qwen3_vl/include/buddy/runtime/models/Qwen3VLResidentModel.h
@@ -1,0 +1,56 @@
+//===- Qwen3VLResidentModel.h - Resident Qwen3-VL model -------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_MODELS_QWEN3VLRESIDENTMODEL_H
+#define BUDDY_RUNTIME_MODELS_QWEN3VLRESIDENTMODEL_H
+
+#include "buddy/runtime/core/ResidentModel.h"
+
+#include <memory>
+#include <string>
+
+namespace buddy {
+namespace runtime {
+class Qwen3VLRuntime;
+
+class Qwen3VLResidentModel final : public ResidentModel {
+public:
+  Qwen3VLResidentModel();
+  ~Qwen3VLResidentModel() override;
+  Qwen3VLResidentModel(const Qwen3VLResidentModel &) = delete;
+  Qwen3VLResidentModel &operator=(const Qwen3VLResidentModel &) = delete;
+
+  void load(const ResidentModelConfig &cfg) override;
+  ModelStatus status() const override;
+  std::string renderChat(const ChatCompletionRequest &request) override;
+  TokenizeResult tokenize(const TokenizeRequest &request) override;
+  CompletionResult complete(const CompletionRequest &request) override;
+  CompletionResult
+  completeStream(const CompletionRequest &request,
+                 const CompletionStreamCallback &callback) override;
+  CompletionResult chat(const ChatCompletionRequest &request) override;
+  CompletionResult
+  chatStream(const ChatCompletionRequest &request,
+             const CompletionStreamCallback &callback) override;
+
+private:
+  class Impl;
+  std::unique_ptr<Impl> impl;
+};
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_MODELS_QWEN3VLRESIDENTMODEL_H

--- a/runtime/include/buddy/runtime/core/ServingTypes.h
+++ b/runtime/include/buddy/runtime/core/ServingTypes.h
@@ -29,6 +29,7 @@
 #include "buddy/runtime/llm/Sampler.h"
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>
@@ -97,17 +98,30 @@ struct SamplingParams {
   /// Optional token-id stops merged with model/template default stop ids.
   std::vector<long long> stopTokenIds;
 };
+/// One image supplied with a multimodal request.
+///
+/// The current Qwen3-VL server path accepts one local file URI/path. `bytes`
+/// is reserved for a future in-memory transport and is intentionally optional.
+/// A resident plugin and buddy-server must be rebuilt together if this DTO is
+/// changed because the resident plugin boundary uses the C++ runtime ABI.
+struct ImageInput {
+  std::string uri;
+  std::string mimeType;
+  std::vector<uint8_t> bytes;
+};
 
 /// Completion request with a fully rendered prompt.
 struct CompletionRequest {
   std::string prompt;
   SamplingParams sampling;
+  std::vector<ImageInput> images;
 };
 
 /// Chat message before model-specific template rendering.
 struct ChatMessage {
   std::string role;    // "system", "user", "assistant"
   std::string content; // Plain message text.
+  std::vector<ImageInput> images;
 };
 
 /// Chat completion request. If messages is empty, input is treated as a single
@@ -117,6 +131,7 @@ struct ChatCompletionRequest {
   std::vector<ChatMessage> messages;
   std::string input;
   SamplingParams sampling;
+  std::vector<ImageInput> images;
 };
 
 /// Tokenization request.

--- a/tools/buddy-codegen/cmake/buddy_model.cmake
+++ b/tools/buddy-codegen/cmake/buddy_model.cmake
@@ -450,6 +450,25 @@ function(buddy_add_model)
   target_link_libraries(${RUNNER_PLUGIN_TARGET} PRIVATE ${LIB_TARGET})
   target_compile_features(${RUNNER_PLUGIN_TARGET} PRIVATE cxx_std_17)
 
+  # Qwen3-VL has a custom packaging path, so create the resident plugin before
+  if(MDL_CUSTOM_QWEN3_VL)
+    # that path returns instead of relying on the generic branch below.
+    set(SERVING_PLUGIN_TARGET "")
+    if(MDL_SERVING_PLUGIN_SRC)
+      set(SERVING_PLUGIN_TARGET "buddy_models_${MDL_NAME}_serving")
+      add_library(${SERVING_PLUGIN_TARGET} SHARED
+        "${CMAKE_CURRENT_SOURCE_DIR}/${MDL_SERVING_PLUGIN_SRC}")
+      set_target_properties(${SERVING_PLUGIN_TARGET} PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY "${BIN}"
+        RUNTIME_OUTPUT_DIRECTORY "${BIN}"
+        OUTPUT_NAME "${MDL_NAME}_serving"
+        PREFIX "")
+      target_link_libraries(${SERVING_PLUGIN_TARGET} PRIVATE ${LIB_TARGET})
+      target_compile_features(${SERVING_PLUGIN_TARGET} PRIVATE cxx_std_17)
+      install(TARGETS ${SERVING_PLUGIN_TARGET} EXPORT BuddyMLIRTargets COMPONENT buddy_runtime)
+    endif()
+
+  endif()
   if(MDL_CUSTOM_QWEN3_VL)
     set(_Q_CG  "${CMAKE_CURRENT_SOURCE_DIR}/codegen")
     set(_Q_CODEGEN "${_Q_CG}/qwen3_vl_codegen.py")
@@ -478,6 +497,10 @@ function(buddy_add_model)
       QWEN3_VL_SPEC=${MDL_SPEC}
       BUDDY_RAX_EMBED_PAYLOAD=${_Q_RAX_EMBED_PAYLOAD}
       QWEN3_VL_MODEL_PATH=${MDL_LOCAL_MODEL})
+
+    if(SERVING_PLUGIN_TARGET)
+      list(APPEND _Q_ENV QWEN3_VL_SERVING_SO=$<TARGET_FILE:${SERVING_PLUGIN_TARGET}>)
+    endif()
 
     set(_Q_IMPORT_ARGS)
     if(MDL_LAYER_PARTITION)
@@ -608,6 +631,7 @@ function(buddy_add_model)
               ${_Q_VIS}/vision_shim.so ${_Q_DEC}/decoder_shim.so
               ${_Q_VIS}/vision_arg0.data ${_Q_DEC}/decoder_arg0.data
               ${_Q_DEC}/embed_table.bin ${RUNNER_PLUGIN_TARGET} rax-pack
+              ${SERVING_PLUGIN_TARGET}
       COMMENT "[${MDL_NAME}] Stage 4: packing ${MDL_NAME}.rax"
       VERBATIM)
 

--- a/tools/buddy-server/CMakeLists.txt
+++ b/tools/buddy-server/CMakeLists.txt
@@ -34,6 +34,27 @@ if(BUDDY_ENABLE_TESTS)
   add_test(NAME buddy-server-help
     COMMAND buddy-server --help
   )
+  add_executable(buddy-server-json-codec-test
+    JsonCodecTest.cpp
+    JsonCodec.cpp
+  )
+  target_compile_features(buddy-server-json-codec-test PRIVATE cxx_std_17)
+  target_include_directories(buddy-server-json-codec-test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+  target_link_libraries(buddy-server-json-codec-test PRIVATE
+    buddy_runtime_core
+    buddy_runtime_llm
+    LLVMSupport
+  )
+  target_link_directories(buddy-server-json-codec-test PRIVATE ${LLVM_LIBRARY_DIR})
+  add_test(NAME buddy-server-json-codec
+    COMMAND buddy-server-json-codec-test
+  )
+  set_tests_properties(buddy-server-json-codec PROPERTIES
+    PASS_REGULAR_EXPRESSION "JsonCodec tests passed"
+  )
+
   set_tests_properties(buddy-server-help PROPERTIES
     PASS_REGULAR_EXPRESSION "Usage:.*buddy-server"
   )

--- a/tools/buddy-server/JsonCodec.cpp
+++ b/tools/buddy-server/JsonCodec.cpp
@@ -40,15 +40,14 @@ std::string serialize(json::Value value) {
 json::Value parseValue(const std::string &body) {
   auto parsed = json::parse(body);
   if (!parsed)
-    throw std::runtime_error("invalid JSON: " +
-                             llvm::toString(parsed.takeError()));
+    throw JsonCodecError("invalid JSON: " + llvm::toString(parsed.takeError()));
   return std::move(*parsed);
 }
 
 const json::Object &asObject(const json::Value &value) {
   const auto *obj = value.getAsObject();
   if (!obj)
-    throw std::runtime_error("JSON root must be an object");
+    throw JsonCodecError("JSON root must be an object");
   return *obj;
 }
 
@@ -76,6 +75,91 @@ uint64_t getUInt64(const json::Object &obj, llvm::StringRef key,
   if (auto value = obj.getInteger(key))
     return static_cast<uint64_t>(*value);
   return fallback;
+}
+
+ImageInput parseImageUri(const std::string &raw, const std::string &field) {
+  if (raw.empty())
+    throw JsonCodecError("image URI is empty: " + field);
+  if (raw.size() > 4096)
+    throw JsonCodecError("image URI is too long: " + field);
+  if (raw.find('\0') != std::string::npos)
+    throw JsonCodecError("image URI contains NUL: " + field);
+
+  std::string uri = raw;
+  if (uri.rfind("file:", 0) == 0)
+    uri = uri.substr(5);
+  if (uri.empty())
+    throw JsonCodecError("image file URI is empty: " + field);
+  if (uri.rfind("http://", 0) == 0 || uri.rfind("https://", 0) == 0)
+    throw JsonCodecError("remote image URLs are not supported: " + field);
+  if (uri.rfind("data:", 0) == 0)
+    throw JsonCodecError("data URI images are not supported: " + field);
+
+  ImageInput image;
+  image.uri = std::move(uri);
+  return image;
+}
+
+ImageInput parseImageValue(const json::Value &value, const std::string &field) {
+  std::string uri;
+  if (auto s = value.getAsString()) {
+    uri = s->str();
+  } else if (const auto *obj = value.getAsObject()) {
+    uri = getString(*obj, "url", getString(*obj, "uri"));
+  } else {
+    throw JsonCodecError("image value must be a string or object: " + field);
+  }
+  return parseImageUri(uri, field);
+}
+
+void appendImage(std::vector<ImageInput> &images, ImageInput image,
+                 const std::string &field) {
+  if (!images.empty())
+    throw JsonCodecError("only one image is supported: " + field);
+  images.push_back(std::move(image));
+}
+
+void parseMessageContent(const json::Value &value, ChatMessage &message,
+                         const std::string &field) {
+  if (auto text = value.getAsString()) {
+    message.content = text->str();
+    return;
+  }
+
+  const auto *parts = value.getAsArray();
+  if (!parts)
+    throw JsonCodecError("message content must be a string or array: " + field);
+
+  for (std::size_t i = 0; i < parts->size(); ++i) {
+    const auto *part = (*parts)[i].getAsObject();
+    if (!part)
+      throw JsonCodecError("content entries must be objects: " + field);
+    const std::string type = getString(*part, "type");
+    if (type == "text") {
+      const std::string text = getString(*part, "text");
+      if (text.empty())
+        throw JsonCodecError("text content part is empty: " + field);
+      if (!message.content.empty())
+        message.content += "\n";
+      message.content += text;
+      continue;
+    } else if (type == "image_url" || type == "image") {
+      const json::Value *imageValue = nullptr;
+      if (auto it = part->find("image_url"); it != part->end())
+        imageValue = &it->second;
+      else if (auto it = part->find("image"); it != part->end())
+        imageValue = &it->second;
+      else if (auto it = part->find("url"); it != part->end())
+        imageValue = &it->second;
+      if (!imageValue)
+        throw JsonCodecError("image content part requires image_url: " + field);
+      appendImage(message.images,
+                  parseImageValue(*imageValue, field + ".image_url"), field);
+      continue;
+    }
+    throw JsonCodecError("unsupported content part type '" + type +
+                         "': " + field);
+  }
 }
 
 float getFloat(const json::Object &obj, llvm::StringRef key, float fallback) {
@@ -162,7 +246,11 @@ DecodedCompletionRequest parseCompletionRequest(const std::string &body) {
   DecodedCompletionRequest decoded;
   decoded.request.prompt = getString(obj, "prompt");
   if (decoded.request.prompt.empty())
-    throw std::runtime_error("missing required field: prompt");
+    throw JsonCodecError("missing required field: prompt");
+  if (auto imagePath = obj.getString("image_path"))
+    appendImage(decoded.request.images,
+                parseImageUri(imagePath->str(), "image_path"), "image_path");
+
   fillSampling(obj, decoded.request.sampling);
   decoded.stream = getBool(obj, "stream", false);
   return decoded;
@@ -180,18 +268,31 @@ DecodedChatRequest parseChatCompletionRequest(const std::string &body) {
     for (const auto &messageValue : *messages) {
       const auto *messageObj = messageValue.getAsObject();
       if (!messageObj)
-        throw std::runtime_error("messages entries must be objects");
+        throw JsonCodecError("messages entries must be objects");
       ChatMessage msg;
       msg.role = getString(*messageObj, "role");
-      msg.content = getString(*messageObj, "content");
-      if (msg.role.empty() || msg.content.empty())
-        throw std::runtime_error("chat message requires role and content");
+      if (msg.role.empty())
+        throw JsonCodecError("chat message requires role");
+      auto contentIt = messageObj->find("content");
+      if (contentIt != messageObj->end())
+        parseMessageContent(
+            contentIt->second, msg,
+            "messages[" + std::to_string(decoded.request.messages.size()) +
+                "].content");
+      if (msg.content.empty() && msg.images.empty())
+        throw JsonCodecError("chat message requires content or image");
+      for (const auto &image : msg.images)
+        appendImage(decoded.request.images, image, "messages");
       decoded.request.messages.push_back(std::move(msg));
     }
   }
+  if (auto imagePath = obj.getString("image_path"))
+    appendImage(decoded.request.images,
+                parseImageUri(imagePath->str(), "image_path"), "image_path");
 
-  if (decoded.request.messages.empty() && decoded.request.input.empty())
-    throw std::runtime_error("missing messages or input");
+  if (decoded.request.messages.empty() && decoded.request.input.empty() &&
+      decoded.request.images.empty())
+    throw JsonCodecError("missing messages or input");
 
   fillSampling(obj, decoded.request.sampling);
   decoded.stream = getBool(obj, "stream", false);
@@ -205,7 +306,7 @@ TokenizeRequest parseTokenizeRequest(const std::string &body) {
   TokenizeRequest request;
   request.content = getString(obj, "content", getString(obj, "text"));
   if (request.content.empty())
-    throw std::runtime_error("missing required field: content");
+    throw JsonCodecError("missing required field: content");
   request.addSpecial = getBool(obj, "add_special", request.addSpecial);
   request.countOnly = getBool(obj, "count_only", request.countOnly);
   return request;

--- a/tools/buddy-server/JsonCodec.h
+++ b/tools/buddy-server/JsonCodec.h
@@ -19,10 +19,17 @@
 
 #include "buddy/runtime/core/ServingTypes.h"
 
+#include <stdexcept>
 #include <string>
 
 namespace buddy {
 namespace server {
+
+class JsonCodecError : public std::runtime_error {
+public:
+  explicit JsonCodecError(const std::string &message)
+      : std::runtime_error(message) {}
+};
 
 struct DecodedCompletionRequest {
   buddy::runtime::CompletionRequest request;

--- a/tools/buddy-server/JsonCodecTest.cpp
+++ b/tools/buddy-server/JsonCodecTest.cpp
@@ -1,0 +1,78 @@
+//===- JsonCodecTest.cpp - buddy-server JSON codec tests -----------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include "JsonCodec.h"
+
+#include <cassert>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+using buddy::server::parseChatCompletionRequest;
+using buddy::server::parseCompletionRequest;
+
+namespace {
+
+template <typename Fn> void expectFailure(Fn &&fn) {
+  bool failed = false;
+  try {
+    fn();
+  } catch (const std::exception &) {
+    failed = true;
+  }
+  assert(failed);
+}
+
+} // namespace
+
+int main() {
+  auto completion = parseCompletionRequest(
+      R"({"prompt":"read","image_path":"file:/tmp/a.png"})");
+  assert(completion.request.prompt == "read");
+  assert(completion.request.images.size() == 1);
+  assert(completion.request.images.front().uri == "/tmp/a.png");
+
+  auto textChat = parseChatCompletionRequest(
+      R"({"messages":[{"role":"user","content":"hello"}]})");
+  assert(textChat.request.messages.size() == 1);
+  assert(textChat.request.messages.front().content == "hello");
+  assert(textChat.request.images.empty());
+
+  auto multimodal = parseChatCompletionRequest(
+      R"({"messages":[{"role":"user","content":[{"type":"text","text":"read"},{"type":"image_url","image_url":{"url":"/tmp/a.png"}}]}]})");
+  assert(multimodal.request.messages.front().content == "read");
+  assert(multimodal.request.images.size() == 1);
+  assert(multimodal.request.messages.front().images.size() == 1);
+  assert(multimodal.request.messages.front().images.front().uri ==
+         "/tmp/a.png");
+  assert(multimodal.request.images.front().uri == "/tmp/a.png");
+
+  expectFailure([] {
+    parseChatCompletionRequest(
+        R"({"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"http://example/a.png"}},{"type":"image_url","image_url":{"url":"/tmp/b.png"}}]}]})");
+  });
+  expectFailure([] {
+    parseChatCompletionRequest(
+        R"({"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"/tmp/a.png"}},{"type":"image_url","image_url":{"url":"/tmp/b.png"}}]}]})");
+  });
+  expectFailure([] {
+    parseChatCompletionRequest(
+        R"({"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,AA=="}}]}]})");
+  });
+
+  std::cout << "JsonCodec tests passed\n";
+  return 0;
+}

--- a/tools/buddy-server/buddy-server.cpp
+++ b/tools/buddy-server/buddy-server.cpp
@@ -89,8 +89,10 @@ void sendError(ResponseWriter &writer, int status, const std::string &message,
 template <typename Fn> void withJsonErrors(ResponseWriter &writer, Fn fn) {
   try {
     fn();
-  } catch (const std::exception &ex) {
+  } catch (const buddy::server::JsonCodecError &ex) {
     sendError(writer, 400, ex.what(), "bad_request");
+  } catch (const std::exception &ex) {
+    sendError(writer, 500, ex.what(), "internal_error");
   }
 }
 
@@ -306,8 +308,8 @@ int main(int argc, char **argv) {
                 handleTokenize(residentModel, loadState, request, writer);
               });
 
-  std::thread([&residentModel, modelConfig, &loadState, &loadError,
-               &loadErrorMutex] {
+  std::thread loadThread([&residentModel, modelConfig, &loadState, &loadError,
+                          &loadErrorMutex] {
     try {
       std::cerr << "[buddy-server] loading model...\n";
       residentModel.load(modelConfig);
@@ -321,14 +323,18 @@ int main(int argc, char **argv) {
       loadState.store(Error, std::memory_order_release);
       std::cerr << "[buddy-server] failed to load model: " << ex.what() << "\n";
     }
-  }).detach();
+  });
 
   try {
     server.listen(host, port);
   } catch (const std::exception &ex) {
     std::cerr << "[buddy-server] " << ex.what() << "\n";
+    if (loadThread.joinable())
+      loadThread.join();
     return 1;
   }
+  if (loadThread.joinable())
+    loadThread.join();
 
   return 0;
 }


### PR DESCRIPTION
- Add ImageInput to ServingTypes for text-plus-image requests.
- Extend JsonCodec with image_path and OpenAI-style multimodal content parsing.
- Reject remote URLs, data URIs, empty/oversized URIs, and multiple images.
- Add Qwen3VLRuntime for .rax resource loading, mmap weights, local shim loading, C++ image preprocessing, vision/deepstack execution, greedy decoding, and streaming cancellation.
- Add Qwen3VLResidentModel and resident plugin with the v1 C ABI.
- Integrate the Qwen serving plugin into CMake, staging, and RAX serving_library metadata.
- Preserve existing buddy-cli and Qwen3VLRunner behavior.
- Return HTTP 400 for JSON errors and 500 for model/runtime errors.
- Join the model loading thread when the server exits.
- Add JSON codec tests and update Qwen3-VL serving documentation.

## Summary

- Briefly describe the purpose of this pull request.
- Describe how reviewers can verify and test this change. Include command-line instructions if applicable.

## Checklist

- [x ] The code builds successfully
- [ x] Existing tests pass
- [x ] New tests are added where appropriate
- [x ] Code follows the project coding style
- [ x] Documentation is updated if needed
