### PR TITLE
[ci] Limit psutil to 7.2.2 to avoid glibc detection failures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,9 @@ librosa; platform_machine != "riscv64"
 PyYAML
 certifi
 idna
+# Keep psutil at a known-good version; newer releases can break glibc
+# detection on x86 CI runners.
+psutil<=7.2.2
 diffusers
 pre-commit
 nanobind>=2.9,<3.0


### PR DESCRIPTION
## Summary

- Briefly describe the purpose of this pull request.
- Describe how reviewers can verify and test this change. Include command-line instructions if applicable.

## Checklist

- [ ] The code builds successfully
- [ ] Existing tests pass
- [ ] New tests are added where appropriate
- [ ] Code follows the project coding style
- [ ] Documentation is updated if needed
