### PR TITLE
[ MODEL ]add BGE-M3 embedding backend to buddy-server

### DIFF
--- a/midend/include/Dialect/RHAL/RHALOps.td
+++ b/midend/include/Dialect/RHAL/RHALOps.td
@@ -36,6 +36,7 @@ class RHAL_Op<string mnemonic, list<Trait> traits = []> :
 //                                  vocab_uri = "...",
 //                                  runner_library = "...",
 //                                  serving_library = "...",
+//                                  embedding_library = "...",
 //                                  runner_uri = "..."} {
 //     ... rhal.constant, rhal.codeobj, rhal.buffer, rhal.func ops ...
 //   }
@@ -48,7 +49,7 @@ def RHAL_ModuleOp : RHAL_Op<"module", [
   let description = [{
     Top-level container op that declares all model resources and functions.
     Attributes carry module-level metadata (version, model_name, vocab_uri,
-    runner_library, serving_library).
+    runner_library, serving_library, embedding_library).
   }];
 
   let arguments = (ins
@@ -58,6 +59,7 @@ def RHAL_ModuleOp : RHAL_Op<"module", [
     OptionalAttr<StrAttr>:$vocab_uri,
     OptionalAttr<StrAttr>:$runner_library,
     OptionalAttr<StrAttr>:$serving_library,
+    OptionalAttr<StrAttr>:$embedding_library,
     OptionalAttr<StrAttr>:$runner_uri,
     OptionalAttr<StrAttr>:$artifacts_uri,
     OptionalAttr<StrAttr>:$tokenizer_uri,

--- a/models/bge_m3/BgeM3EmbeddingModel.cpp
+++ b/models/bge_m3/BgeM3EmbeddingModel.cpp
@@ -1,0 +1,93 @@
+//===- BgeM3EmbeddingModel.cpp - Resident BGE-M3 embedding adapter --------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/models/BgeM3EmbeddingModel.h"
+#include "buddy/runtime/models/BgeM3Runtime.h"
+
+#include <stdexcept>
+
+namespace buddy {
+namespace runtime {
+BgeM3EmbeddingModel::BgeM3EmbeddingModel() {
+  modelStatus.backend = "cpu";
+  modelStatus.modelName = "bge_m3";
+}
+BgeM3EmbeddingModel::~BgeM3EmbeddingModel() = default;
+
+void BgeM3EmbeddingModel::load(const EmbeddingModelConfig &cfg) {
+  std::lock_guard<std::mutex> lock(mutex);
+  modelStatus = ModelStatus{};
+  modelStatus.state = ModelLoadState::Loading;
+  modelStatus.backend = "cpu";
+  modelStatus.modelName = cfg.modelName.empty() ? "bge_m3" : cfg.modelName;
+  try {
+    if (!cfg.raxPath.empty()) {
+      runtime = BgeM3Runtime::loadFromRax(cfg.raxPath);
+    } else {
+      if (cfg.modelSoPath.empty())
+        throw std::runtime_error(
+            "BgeM3EmbeddingModel: model shared library path is empty");
+      if (cfg.weightPaths.empty())
+        throw std::runtime_error("BgeM3EmbeddingModel: no weights specified");
+      if (cfg.vocabPath.empty())
+        throw std::runtime_error(
+            "BgeM3EmbeddingModel: tokenizer path is empty");
+      if (cfg.weightPaths.size() != 1)
+        throw std::runtime_error("BgeM3EmbeddingModel: legacy mode accepts "
+                                 "exactly one weights file");
+      runtime = BgeM3Runtime::loadLegacy(
+          cfg.modelSoPath, cfg.weightPaths.front(), cfg.vocabPath, 512, 8194,
+          1024, modelStatus.modelName);
+    }
+    modelStatus.state = ModelLoadState::Ready;
+    modelStatus.modelName = runtime->modelName();
+    modelStatus.contextLength = static_cast<int>(runtime->contextLength());
+    modelStatus.message.clear();
+  } catch (const std::exception &ex) {
+    runtime.reset();
+    modelStatus.state = ModelLoadState::Error;
+    modelStatus.message = ex.what();
+    throw;
+  }
+}
+
+ModelStatus BgeM3EmbeddingModel::status() const {
+  std::lock_guard<std::mutex> lock(mutex);
+  return modelStatus;
+}
+
+EmbeddingResult BgeM3EmbeddingModel::embed(const EmbeddingRequest &request) {
+  std::lock_guard<std::mutex> lock(mutex);
+  if (!runtime || modelStatus.state != ModelLoadState::Ready)
+    throw std::runtime_error("BgeM3EmbeddingModel: model is not loaded");
+  if (request.input.empty())
+    throw std::runtime_error("BgeM3EmbeddingModel: input text is empty");
+  if (!request.model.empty() && request.model != modelStatus.modelName)
+    throw std::runtime_error("BgeM3EmbeddingModel: requested model '" +
+                             request.model + "' does not match loaded model '" +
+                             modelStatus.modelName + "'");
+
+  size_t tokenCount = 0;
+  EmbeddingResult result;
+  result.model = modelStatus.modelName;
+  result.embedding = runtime->embed(request.input, &tokenCount);
+  result.promptTokens = tokenCount;
+  result.totalTokens = tokenCount;
+  return result;
+}
+
+} // namespace runtime
+} // namespace buddy

--- a/models/bge_m3/BgeM3EmbeddingModelPlugin.cpp
+++ b/models/bge_m3/BgeM3EmbeddingModelPlugin.cpp
@@ -1,0 +1,28 @@
+//===- BgeM3EmbeddingModelPlugin.cpp - BGE-M3 embedding plugin ABI --------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/models/BgeM3EmbeddingModel.h"
+
+extern "C" buddy::runtime::EmbeddingModel *buddy_create_embedding_model_v1() {
+  return new buddy::runtime::BgeM3EmbeddingModel();
+}
+
+extern "C" void
+buddy_destroy_embedding_model_v1(buddy::runtime::EmbeddingModel *model) {
+  delete model;
+}
+
+extern "C" const char *buddy_embedding_model_type_v1() { return "bge_m3"; }

--- a/models/bge_m3/BgeM3Runner.cpp
+++ b/models/bge_m3/BgeM3Runner.cpp
@@ -1,4 +1,4 @@
-//===- BgeM3Runner.cpp - BGE-M3 dense embedding runner -------------------===//
+//===- BgeM3Runner.cpp - BGE-M3 embedding runner --------------------------===//
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,195 +15,47 @@
 //===----------------------------------------------------------------------===//
 
 #include "buddy/runtime/models/BgeM3Runner.h"
-#include "buddy/runtime/core/ModelManifest.h"
-#include "buddy/runtime/models/BgeM3Tokenizer.h"
+#include "buddy/runtime/models/BgeM3Runtime.h"
 
-#include "buddy/Core/Container.h"
-
-#include <algorithm>
 #include <chrono>
-#include <cmath>
-#include <cstdlib>
-#include <cstring>
-#include <dlfcn.h>
-#include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <stdexcept>
-#include <string>
-#include <vector>
 
 namespace buddy {
 namespace runtime {
 
-namespace {
-
-constexpr size_t kDefaultMaxSeqLen = 512;
-constexpr size_t kDefaultMaxPositionEmbeddings = 8194;
-constexpr size_t kDefaultHiddenSize = 1024;
-
-using ForwardFn = void (*)(MemRef<float, 3> *, MemRef<float, 1> *,
-                           MemRef<int64_t, 1> *, MemRef<int64_t, 2> *,
-                           MemRef<int64_t, 2> *);
-
-void printLog(const std::string &msg, bool suppress) {
-  if (!suppress)
-    std::cerr << "\033[34;1m[Log] \033[0m" << msg << "\n";
-}
-
-size_t parseSizeAttr(const ModelManifest &manifest, const char *key,
-                     size_t fallback) {
-  auto it = manifest.moduleAttrs.find(key);
-  if (it == manifest.moduleAttrs.end() || it->second.empty())
-    return fallback;
-  return static_cast<size_t>(std::stoull(it->second));
-}
-
-std::string findConstantPath(const ModelManifest &manifest,
-                             const std::string &name) {
-  for (const auto &constant : manifest.constants) {
-    if (constant.name == name)
-      return constant.path;
-  }
-  return "";
-}
-
-void loadWeights(const std::string &weightsPath, MemRef<float, 1> &params) {
-  std::ifstream paramFile(weightsPath, std::ios::in | std::ios::binary);
-  if (!paramFile)
-    throw std::runtime_error("BgeM3Runner: failed to open weights: " +
-                             weightsPath);
-  paramFile.read(reinterpret_cast<char *>(params.getData()),
-                 sizeof(float) * params.getSize());
-  if (!paramFile)
-    throw std::runtime_error("BgeM3Runner: error reading weights: " +
-                             weightsPath);
-}
-
-} // namespace
-
 void BgeM3Runner::run(const RunConfig &cfg) {
-  namespace fs = std::filesystem;
-  const bool suppress = cfg.suppressStats;
-
   if (cfg.prompt.empty() && cfg.prompts.empty())
     throw std::runtime_error("BgeM3Runner: pass --prompt or --prompt-file");
   if (cfg.prompts.size() > 1)
-    throw std::runtime_error("BgeM3Runner: only single-prompt inference is "
-                             "implemented for BGE-M3");
+    throw std::runtime_error(
+        "BgeM3Runner: only single-prompt inference is implemented for BGE-M3");
+  const std::string prompt =
+      cfg.prompts.empty() ? cfg.prompt : cfg.prompts.front();
 
-  std::string soPath;
-  std::string weightsPath;
-  std::string tokenizerPath;
-  size_t maxSeqLen = kDefaultMaxSeqLen;
-  size_t maxPositionEmbeddings = kDefaultMaxPositionEmbeddings;
-  size_t hiddenSize = kDefaultHiddenSize;
-
+  std::unique_ptr<BgeM3Runtime> runtime;
   if (!cfg.raxPath.empty()) {
-    ModelManifest manifest = ModelManifest::loadFromRax(cfg.raxPath);
-    soPath = manifest.soPath;
-    weightsPath = findConstantPath(manifest, "params");
-    if (weightsPath.empty() && !manifest.weightPaths.empty())
-      weightsPath = manifest.weightPaths.front();
-    if (weightsPath.empty())
-      throw std::runtime_error("BgeM3Runner: manifest has no weight file");
-    // manifest.vocabPath is payload-resolved (extracted from the embedded
-    // .rax payload if needed), unlike the raw "tokenizer_uri" module attr
-    // which rax-pack never rewrites to payload:* and would break once the
-    // .rax ships without the build tree next to it.
-    tokenizerPath = manifest.vocabPath;
-    maxSeqLen = parseSizeAttr(manifest, "max_seq_len", maxSeqLen);
-    maxPositionEmbeddings = parseSizeAttr(manifest, "max_position_embeddings",
-                                          maxPositionEmbeddings);
-    hiddenSize = parseSizeAttr(manifest, "hidden_size", hiddenSize);
+    runtime = BgeM3Runtime::loadFromRax(cfg.raxPath);
   } else {
     if (cfg.modelSoPath.empty() || cfg.weightsPath.empty() ||
         cfg.vocabPath.empty())
       throw std::runtime_error("BgeM3Runner: legacy mode requires --model-so, "
                                "--weights, and --vocab");
-    soPath = cfg.modelSoPath;
-    weightsPath = cfg.weightsPath;
-    tokenizerPath = cfg.vocabPath;
-    maxSeqLen = cfg.promptLength > 0 ? static_cast<size_t>(cfg.promptLength)
-                                     : maxSeqLen;
+    const size_t maxSeqLen =
+        cfg.promptLength > 0 ? static_cast<size_t>(cfg.promptLength) : 512;
+    runtime = BgeM3Runtime::loadLegacy(cfg.modelSoPath, cfg.weightsPath,
+                                       cfg.vocabPath, maxSeqLen);
   }
-
-  if (tokenizerPath.empty())
-    throw std::runtime_error("BgeM3Runner: tokenizer path is empty");
-
-  const std::string prompt =
-      !cfg.prompts.empty() ? cfg.prompts.front() : cfg.prompt;
-
-  printLog("Model .so : " + soPath, suppress);
-  printLog("Weights   : " + weightsPath, suppress);
-  printLog("Tokenizer : " + tokenizerPath, suppress);
-
-  BgeM3Tokenizer tokenizer = BgeM3Tokenizer::loadFromFile(tokenizerPath);
-  std::vector<int64_t> inputIdVec, attentionMaskVec;
-  tokenizer.encode(prompt, maxSeqLen, inputIdVec, attentionMaskVec);
-  printLog("Tokenization complete", suppress);
-
-  printLog("Loading model shared library", suppress);
-  void *handle = dlopen(soPath.c_str(), RTLD_NOW | RTLD_LOCAL);
-  if (!handle)
-    throw std::runtime_error("BgeM3Runner: dlopen failed: " + soPath + ": " +
-                             dlerror());
-  dlerror();
-  auto forward =
-      reinterpret_cast<ForwardFn>(dlsym(handle, "_mlir_ciface_forward"));
-  if (const char *err = dlerror()) {
-    dlclose(handle);
-    throw std::runtime_error("BgeM3Runner: missing _mlir_ciface_forward in " +
-                             soPath + ": " + std::string(err));
-  }
-
-  const auto weightBytes = fs::file_size(weightsPath);
-  if (weightBytes % sizeof(float) != 0) {
-    dlclose(handle);
-    throw std::runtime_error("BgeM3Runner: weight file is not f32-aligned");
-  }
-  printLog("Loading weights", suppress);
-  MemRef<float, 1> paramsContainer({weightBytes / sizeof(float)});
-  loadWeights(weightsPath, paramsContainer);
-  printLog("Weights loaded", suppress);
-
-  MemRef<int64_t, 2> inputIds({1, maxSeqLen});
-  MemRef<int64_t, 2> attentionMask({1, maxSeqLen});
-  MemRef<int64_t, 1> tokenTypeIds({maxPositionEmbeddings});
-  std::copy(inputIdVec.begin(), inputIdVec.end(), inputIds.getData());
-  std::copy(attentionMaskVec.begin(), attentionMaskVec.end(),
-            attentionMask.getData());
-  std::fill(tokenTypeIds.getData(),
-            tokenTypeIds.getData() + tokenTypeIds.getSize(), 0);
-
-  MemRef<float, 3> resultContainer[1] = {
-      MemRef<float, 3>({1, maxSeqLen, hiddenSize}, false, 0),
-  };
 
   const auto t0 = std::chrono::high_resolution_clock::now();
-  printLog("Calling _mlir_ciface_forward", suppress);
-  forward(resultContainer, &paramsContainer, &tokenTypeIds, &inputIds,
-          &attentionMask);
+  size_t tokenCount = 0;
+  std::vector<float> embedding = runtime->embed(prompt, &tokenCount);
   const auto t1 = std::chrono::high_resolution_clock::now();
-  printLog("Forward complete", suppress);
 
-  std::vector<float> embedding(hiddenSize);
-  const float *cls = resultContainer[0].getData();
-  float norm = 0.0f;
-  for (size_t i = 0; i < hiddenSize; ++i) {
-    embedding[i] = cls[i];
-    norm += embedding[i] * embedding[i];
-  }
-  norm = std::sqrt(norm);
-  if (norm > 0.0f) {
-    for (float &v : embedding)
-      v /= norm;
-  }
-
-  if (!suppress) {
+  if (!cfg.suppressStats) {
     const double seconds = std::chrono::duration<double>(t1 - t0).count();
     std::cerr << "\033[33;1mBGE-M3 Dense Embedding\033[0m\n";
-    std::cerr << "  dim: " << hiddenSize << "\n";
+    std::cerr << "  dim: " << embedding.size() << "\n";
     std::cerr << "  time: " << seconds << "s\n";
   }
 
@@ -214,9 +66,6 @@ void BgeM3Runner::run(const RunConfig &cfg) {
     std::cout << embedding[i];
   }
   std::cout << "]\n";
-
-  free(resultContainer[0].release());
-  dlclose(handle);
 }
 
 } // namespace runtime

--- a/models/bge_m3/BgeM3Runtime.cpp
+++ b/models/bge_m3/BgeM3Runtime.cpp
@@ -1,0 +1,275 @@
+//===- BgeM3Runtime.cpp - Reusable BGE-M3 inference runtime ---------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/models/BgeM3Runtime.h"
+#include "buddy/Core/Container.h"
+#include "buddy/runtime/core/ModelManifest.h"
+#include "buddy/runtime/models/BgeM3Tokenizer.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <dlfcn.h>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <utility>
+
+namespace buddy {
+namespace runtime {
+
+namespace {
+using ForwardFn = void (*)(MemRef<float, 3> *, MemRef<float, 1> *,
+                           MemRef<int64_t, 1> *, MemRef<int64_t, 2> *,
+                           MemRef<int64_t, 2> *);
+
+size_t parseSizeAttr(const ModelManifest &manifest, const char *key,
+                     size_t fallback) {
+  auto it = manifest.moduleAttrs.find(key);
+  if (it == manifest.moduleAttrs.end() || it->second.empty())
+    return fallback;
+  try {
+    return static_cast<size_t>(std::stoull(it->second));
+  } catch (const std::exception &) {
+    throw std::runtime_error(std::string("BgeM3Runtime: invalid manifest ") +
+                             key + " attribute");
+  }
+}
+
+std::string findConstantPath(const ModelManifest &manifest,
+                             const std::string &name) {
+  for (const auto &constant : manifest.constants)
+    if (constant.name == name)
+      return constant.path;
+  return "";
+}
+
+void loadWeights(const std::string &path, MemRef<float, 1> &params) {
+  std::ifstream input(path, std::ios::binary);
+  if (!input)
+    throw std::runtime_error("BgeM3Runtime: failed to open weights: " + path);
+  input.read(reinterpret_cast<char *>(params.getData()),
+             static_cast<std::streamsize>(sizeof(float) * params.getSize()));
+  if (!input)
+    throw std::runtime_error("BgeM3Runtime: error reading weights: " + path);
+}
+
+void closeHandle(void *&handle) {
+  if (handle) {
+    dlclose(handle);
+    handle = nullptr;
+  }
+}
+} // namespace
+
+struct BgeM3Runtime::Impl {
+  std::string name;
+  size_t maxSeqLen = 512;
+  size_t maxPositionEmbeddings = 8194;
+  size_t hiddenSize = 1024;
+  BgeM3Tokenizer tokenizer;
+  std::vector<void *> dependentHandles;
+  void *modelHandle = nullptr;
+  ForwardFn forward = nullptr;
+  std::unique_ptr<MemRef<float, 1>> params;
+  std::unique_ptr<MemRef<int64_t, 2>> inputIds;
+  std::unique_ptr<MemRef<int64_t, 2>> attentionMask;
+  std::unique_ptr<MemRef<int64_t, 1>> tokenTypeIds;
+
+  ~Impl() {
+    closeHandle(modelHandle);
+    for (auto it = dependentHandles.rbegin(); it != dependentHandles.rend();
+         ++it)
+      closeHandle(*it);
+  }
+};
+
+BgeM3Runtime::~BgeM3Runtime() = default;
+
+std::unique_ptr<BgeM3Runtime>
+BgeM3Runtime::load(const std::string &modelSoPath,
+                   const std::string &weightsPath, const std::string &vocabPath,
+                   size_t maxSeqLen, size_t maxPositionEmbeddings,
+                   size_t hiddenSize, const std::string &modelName,
+                   const std::vector<std::string> &deps) {
+  namespace fs = std::filesystem;
+  if (modelSoPath.empty())
+    throw std::runtime_error(
+        "BgeM3Runtime: model shared library path is empty");
+  if (weightsPath.empty())
+    throw std::runtime_error("BgeM3Runtime: weights path is empty");
+  if (vocabPath.empty())
+    throw std::runtime_error("BgeM3Runtime: tokenizer path is empty");
+  if (maxSeqLen < 2)
+    throw std::runtime_error("BgeM3Runtime: max_seq_len must be >= 2");
+  if (maxPositionEmbeddings == 0)
+    throw std::runtime_error(
+        "BgeM3Runtime: max_position_embeddings must be > 0");
+  if (hiddenSize == 0)
+    throw std::runtime_error("BgeM3Runtime: embedding dimension must be > 0");
+  if (!fs::exists(modelSoPath))
+    throw std::runtime_error("BgeM3Runtime: model shared library not found: " +
+                             modelSoPath);
+  if (!fs::exists(weightsPath))
+    throw std::runtime_error("BgeM3Runtime: weights file not found: " +
+                             weightsPath);
+
+  auto runtime = std::unique_ptr<BgeM3Runtime>(new BgeM3Runtime());
+  runtime->impl = std::make_unique<Impl>();
+  Impl &impl = *runtime->impl;
+  impl.name = modelName.empty() ? "bge_m3" : modelName;
+  impl.maxSeqLen = maxSeqLen;
+  impl.maxPositionEmbeddings = maxPositionEmbeddings;
+  impl.hiddenSize = hiddenSize;
+  impl.tokenizer = BgeM3Tokenizer::loadFromFile(vocabPath);
+
+  try {
+    for (const std::string &dep : deps) {
+      if (dep.empty())
+        continue;
+      void *depHandle = dlopen(dep.c_str(), RTLD_NOW | RTLD_GLOBAL);
+      if (!depHandle)
+        throw std::runtime_error("BgeM3Runtime: dlopen dependency failed: " +
+                                 dep + ": " + dlerror());
+      impl.dependentHandles.push_back(depHandle);
+    }
+    impl.modelHandle = dlopen(modelSoPath.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (!impl.modelHandle)
+      throw std::runtime_error("BgeM3Runtime: dlopen model failed: " +
+                               modelSoPath + ": " + dlerror());
+    dlerror();
+    impl.forward = reinterpret_cast<ForwardFn>(
+        dlsym(impl.modelHandle, "_mlir_ciface_forward"));
+    if (const char *err = dlerror())
+      throw std::runtime_error(
+          "BgeM3Runtime: missing _mlir_ciface_forward in " + modelSoPath +
+          ": " + err);
+
+    const uintmax_t bytes = fs::file_size(weightsPath);
+    if (bytes == 0 || bytes % sizeof(float) != 0)
+      throw std::runtime_error("BgeM3Runtime: weight file is not f32-aligned");
+    impl.params = std::make_unique<MemRef<float, 1>>(
+        std::vector<size_t>{static_cast<size_t>(bytes / sizeof(float))});
+    loadWeights(weightsPath, *impl.params);
+    impl.inputIds = std::make_unique<MemRef<int64_t, 2>>(
+        std::vector<size_t>{1, maxSeqLen}, int64_t(0));
+    impl.attentionMask = std::make_unique<MemRef<int64_t, 2>>(
+        std::vector<size_t>{1, maxSeqLen}, int64_t(0));
+    impl.tokenTypeIds = std::make_unique<MemRef<int64_t, 1>>(
+        std::vector<size_t>{maxPositionEmbeddings}, int64_t(0));
+  } catch (...) {
+    runtime.reset();
+    throw;
+  }
+  return runtime;
+}
+
+std::unique_ptr<BgeM3Runtime>
+BgeM3Runtime::loadFromRax(const std::string &raxPath) {
+  if (raxPath.empty())
+    throw std::runtime_error("BgeM3Runtime: .rax path is empty");
+  ModelManifest manifest = ModelManifest::loadFromRax(raxPath);
+  std::string weights = findConstantPath(manifest, "params");
+  if (weights.empty() && !manifest.weightPaths.empty())
+    weights = manifest.weightPaths.front();
+  if (weights.empty())
+    throw std::runtime_error("BgeM3Runtime: manifest has no weight file");
+  const size_t maxSeqLen = parseSizeAttr(manifest, "max_seq_len", 512);
+  const size_t maxPos =
+      parseSizeAttr(manifest, "max_position_embeddings", 8194);
+  const size_t hidden = parseSizeAttr(manifest, "hidden_size", 1024);
+  return load(manifest.soPath, weights, manifest.vocabPath, maxSeqLen, maxPos,
+              hidden,
+              manifest.modelName.empty() ? "bge_m3" : manifest.modelName,
+              manifest.dependentSoPaths);
+}
+
+std::unique_ptr<BgeM3Runtime>
+BgeM3Runtime::loadLegacy(const std::string &modelSoPath,
+                         const std::string &weightsPath,
+                         const std::string &vocabPath, size_t maxSeqLen,
+                         size_t maxPositionEmbeddings, size_t hiddenSize,
+                         const std::string &modelName) {
+  return load(modelSoPath, weightsPath, vocabPath, maxSeqLen,
+              maxPositionEmbeddings, hiddenSize, modelName);
+}
+
+std::vector<float> BgeM3Runtime::embed(const std::string &text,
+                                       size_t *tokenCountOut) {
+  if (!impl)
+    throw std::runtime_error("BgeM3Runtime: runtime is not loaded");
+  if (text.empty())
+    throw std::runtime_error("BgeM3Runtime: input text is empty");
+
+  std::vector<int64_t> ids, mask;
+  impl->tokenizer.encode(text, impl->maxSeqLen, ids, mask);
+  if (ids.size() != impl->maxSeqLen || mask.size() != impl->maxSeqLen)
+    throw std::runtime_error(
+        "BgeM3Runtime: tokenizer returned invalid sequence length");
+  if (tokenCountOut)
+    *tokenCountOut =
+        static_cast<size_t>(std::count(mask.begin(), mask.end(), int64_t(1)));
+  std::copy(ids.begin(), ids.end(), impl->inputIds->getData());
+  std::copy(mask.begin(), mask.end(), impl->attentionMask->getData());
+
+  MemRef<float, 3> output(
+      std::vector<size_t>{1, impl->maxSeqLen, impl->hiddenSize}, false, 0);
+  impl->forward(&output, impl->params.get(), impl->tokenTypeIds.get(),
+                impl->inputIds.get(), impl->attentionMask.get());
+  float *data = output.getData();
+  if (!data)
+    throw std::runtime_error("BgeM3Runtime: forward returned no output");
+
+  std::vector<float> embedding(impl->hiddenSize);
+  float normSquared = 0.0f;
+  for (size_t i = 0; i < impl->hiddenSize; ++i) {
+    embedding[i] = data[i];
+    normSquared += data[i] * data[i];
+  }
+  if (!(normSquared > 0.0f) || !std::isfinite(normSquared)) {
+    free(output.release());
+    throw std::runtime_error(
+        "BgeM3Runtime: forward returned zero/invalid CLS vector");
+  }
+  const float invNorm = 1.0f / std::sqrt(normSquared);
+  for (float &value : embedding)
+    value *= invNorm;
+  free(output.release());
+  return embedding;
+}
+
+const std::string &BgeM3Runtime::modelName() const {
+  static const std::string unloaded = "";
+  return impl ? impl->name : unloaded;
+}
+
+size_t BgeM3Runtime::contextLength() const {
+  return impl ? impl->maxSeqLen : 0;
+}
+
+size_t BgeM3Runtime::embeddingDimension() const {
+  return impl ? impl->hiddenSize : 0;
+}
+
+size_t BgeM3Runtime::tokenCount(const std::string &text) const {
+  if (!impl)
+    throw std::runtime_error("BgeM3Runtime: runtime is not loaded");
+  const size_t raw = impl->tokenizer.tokenCount(text);
+  return std::min(raw, impl->maxSeqLen - 2) + 2;
+}
+
+} // namespace runtime
+} // namespace buddy

--- a/models/bge_m3/CMakeLists.txt
+++ b/models/bge_m3/CMakeLists.txt
@@ -18,6 +18,8 @@ buddy_add_model(
   SPEC "${BUDDY_BGE_M3_SPEC}"
   RUNNER_SRC BgeM3Runner.cpp
   RUNNER_PLUGIN_SRC BgeM3RunnerPlugin.cpp
+  EXTRA_SRCS BgeM3Runtime.cpp BgeM3EmbeddingModel.cpp
+  EMBEDDING_PLUGIN_SRC BgeM3EmbeddingModelPlugin.cpp
   LOCAL_MODEL "${BUDDY_BGE_M3_MODEL_PATH}"
   LOCAL_MODEL_ENV BUDDY_LOCAL_MODEL_PATH
   IMPORT_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/codegen/import-bge-m3.py"

--- a/models/bge_m3/README.md
+++ b/models/bge_m3/README.md
@@ -33,7 +33,7 @@ the kernels, builds the runner plugin, and stages `bge_m3.rax`:
 
 ```bash
 cd buddy-mlir
-conda activate buddy
+conda activate buddy-mlir
 
 python3 tools/buddy-codegen/build_model.py \
   --spec models/bge_m3/specs/base.json \
@@ -90,3 +90,28 @@ The output is a JSON-like dense embedding vector with dimension `1024`.
   `AutoModel.from_pretrained(<local BGE-M3 snapshot>)` using the same tokenizer
   settings: padding to `max_length`, truncation enabled, and `max_length = 512`.
   The dense embedding should match the normalized HF CLS vector closely.
+
+## buddy-server embeddings API
+
+BGE-M3 is an embedding API, not a chat-completion model. The build now emits an
+independent `bge_m3_embedding.so` plugin in addition to the CLI
+`bge_m3_runner.so`; the generated manifest carries
+`embedding_library = "file:bge_m3_embedding.so"`. Start `buddy-server` directly
+from the package (the plugin is discovered from the `.rax`):
+
+```bash
+./build/bin/buddy-server \
+  --model ./build/models/bge_m3/bge_m3.rax \
+  --port 8080
+
+curl http://127.0.0.1:8080/v1/embeddings \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"bge_m3_base","input":"hello world"}'
+```
+
+The response is OpenAI-compatible (`data[0].embedding` is a JSON array and
+`data[0].index` is `0`) with tokenizer prompt usage. The initial server
+implementation accepts one string `input` only; arrays and batch requests are
+rejected explicitly. `tokenizer.json`, weights, model kernels, and the
+embedding plugin are embedded in `--embed-payload` RAX packages, so the
+package can be moved without the source tree or Python runtime.

--- a/models/bge_m3/codegen/gen_bge_m3_manifest.py
+++ b/models/bge_m3/codegen/gen_bge_m3_manifest.py
@@ -33,7 +33,9 @@ def normalize_uri(raw: str) -> str:
     return f"file:{s}"
 
 
-def gen_manifest(spec: dict, runner_library: str) -> str:
+def gen_manifest(
+    spec: dict, runner_library: str, embedding_library: str | None = None
+) -> str:
     model_id = spec.get("model_id", f"{spec['model_family']}_{spec['variant']}")
     params_size = int(spec["params_size"])
     max_seq_len = int(spec["max_seq_len"])
@@ -52,7 +54,14 @@ def gen_manifest(spec: dict, runner_library: str) -> str:
     p(f'    max_seq_len = "{max_seq_len}",')
     p(f'    max_position_embeddings = "{max_position_embeddings}",')
     p(f'    hidden_size = "{hidden_size}",')
-    p(f'    runner_library = "{runner_library}"}} {{')
+    p(
+        f'    runner_library = "{runner_library}"'
+        + ("," if embedding_library else "")
+    )
+    if embedding_library:
+        p(f'    embedding_library = "{normalize_uri(embedding_library)}"}} {{')
+    else:
+        lines[-1] += "} {"
     p("")
     p('  rhal.constant @params {id = 1 : i32, storage = "external",')
     p(f"                         type = tensor<{params_size}xf32>,")
@@ -101,6 +110,11 @@ def main() -> int:
         help="Runner plugin library URI/name for module attrs.",
     )
     parser.add_argument(
+        "--embedding-library",
+        default=None,
+        help="Embedding plugin library URI/name for module attrs.",
+    )
+    parser.add_argument(
         "-o", "--output", default="-", help="Output path (- for stdout)"
     )
     args = parser.parse_args()
@@ -108,7 +122,9 @@ def main() -> int:
     with open(args.spec) as f:
         spec = json.load(f)
 
-    text = gen_manifest(spec, normalize_uri(args.runner_library))
+    text = gen_manifest(
+        spec, normalize_uri(args.runner_library), args.embedding_library
+    )
 
     if args.output == "-":
         sys.stdout.write(text)

--- a/models/bge_m3/include/buddy/runtime/models/BgeM3EmbeddingModel.h
+++ b/models/bge_m3/include/buddy/runtime/models/BgeM3EmbeddingModel.h
@@ -1,0 +1,48 @@
+//===- BgeM3EmbeddingModel.h - Resident BGE-M3 embedding adapter ----------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_MODELS_BGEM3EMBEDDINGMODEL_H
+#define BUDDY_RUNTIME_MODELS_BGEM3EMBEDDINGMODEL_H
+
+#include "buddy/runtime/core/EmbeddingModel.h"
+
+#include <memory>
+#include <mutex>
+
+namespace buddy {
+namespace runtime {
+
+class BgeM3Runtime;
+
+class BgeM3EmbeddingModel final : public EmbeddingModel {
+public:
+  BgeM3EmbeddingModel();
+  ~BgeM3EmbeddingModel() override;
+
+  void load(const EmbeddingModelConfig &cfg) override;
+  ModelStatus status() const override;
+  EmbeddingResult embed(const EmbeddingRequest &request) override;
+
+private:
+  mutable std::mutex mutex;
+  std::unique_ptr<BgeM3Runtime> runtime;
+  ModelStatus modelStatus;
+};
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_MODELS_BGEM3EMBEDDINGMODEL_H

--- a/models/bge_m3/include/buddy/runtime/models/BgeM3Runtime.h
+++ b/models/bge_m3/include/buddy/runtime/models/BgeM3Runtime.h
@@ -1,0 +1,64 @@
+//===- BgeM3Runtime.h - Reusable BGE-M3 inference runtime -----------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_MODELS_BGEM3RUNTIME_H
+#define BUDDY_RUNTIME_MODELS_BGEM3RUNTIME_H
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace buddy {
+namespace runtime {
+
+class BgeM3Runtime {
+public:
+  static std::unique_ptr<BgeM3Runtime> loadFromRax(const std::string &raxPath);
+  static std::unique_ptr<BgeM3Runtime>
+  loadLegacy(const std::string &modelSoPath, const std::string &weightsPath,
+             const std::string &vocabPath, size_t maxSeqLen = 512,
+             size_t maxPositionEmbeddings = 8194, size_t hiddenSize = 1024,
+             const std::string &modelName = "bge_m3");
+
+  ~BgeM3Runtime();
+  BgeM3Runtime(const BgeM3Runtime &) = delete;
+  BgeM3Runtime &operator=(const BgeM3Runtime &) = delete;
+
+  std::vector<float> embed(const std::string &text,
+                           size_t *tokenCount = nullptr);
+  const std::string &modelName() const;
+  size_t contextLength() const;
+  size_t embeddingDimension() const;
+  size_t tokenCount(const std::string &text) const;
+
+private:
+  BgeM3Runtime() = default;
+  struct Impl;
+  std::unique_ptr<Impl> impl;
+
+  static std::unique_ptr<BgeM3Runtime>
+  load(const std::string &modelSoPath, const std::string &weightsPath,
+       const std::string &vocabPath, size_t maxSeqLen,
+       size_t maxPositionEmbeddings, size_t hiddenSize,
+       const std::string &modelName,
+       const std::vector<std::string> &dependentSoPaths = {});
+};
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_MODELS_BGEM3RUNTIME_H

--- a/models/bge_m3/include/buddy/runtime/models/BgeM3Tokenizer.h
+++ b/models/bge_m3/include/buddy/runtime/models/BgeM3Tokenizer.h
@@ -82,6 +82,10 @@ public:
   // Reproduces AutoTokenizer(text, padding="max_length", truncation=True,
   // max_length=maxSeqLen): [bos, content..., eos], content truncated so the
   // wrapped sequence fits maxSeqLen, right-padded with padId_ / mask 0.
+  size_t tokenCount(const std::string &text) const {
+    return tokenize(text).size();
+  }
+
   void encode(const std::string &text, size_t maxSeqLen,
               std::vector<int64_t> &inputIds,
               std::vector<int64_t> &attentionMask) const {

--- a/runtime/include/buddy/runtime/core/EmbeddingModel.h
+++ b/runtime/include/buddy/runtime/core/EmbeddingModel.h
@@ -1,0 +1,42 @@
+//===- EmbeddingModel.h - Long-lived embedding model interface ------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_CORE_EMBEDDINGMODEL_H
+#define BUDDY_RUNTIME_CORE_EMBEDDINGMODEL_H
+
+#include "buddy/runtime/core/EmbeddingTypes.h"
+
+namespace buddy {
+namespace runtime {
+
+class EmbeddingModel {
+public:
+  virtual ~EmbeddingModel() = default;
+  EmbeddingModel(const EmbeddingModel &) = delete;
+  EmbeddingModel &operator=(const EmbeddingModel &) = delete;
+
+  virtual void load(const EmbeddingModelConfig &cfg) = 0;
+  virtual ModelStatus status() const = 0;
+  virtual EmbeddingResult embed(const EmbeddingRequest &request) = 0;
+
+protected:
+  EmbeddingModel() = default;
+};
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_CORE_EMBEDDINGMODEL_H

--- a/runtime/include/buddy/runtime/core/EmbeddingModelPlugin.h
+++ b/runtime/include/buddy/runtime/core/EmbeddingModelPlugin.h
@@ -1,0 +1,32 @@
+//===- EmbeddingModelPlugin.h - Embedding model plugin C ABI --------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_CORE_EMBEDDINGMODELPLUGIN_H
+#define BUDDY_RUNTIME_CORE_EMBEDDINGMODELPLUGIN_H
+
+#include "buddy/runtime/core/EmbeddingModel.h"
+
+namespace buddy {
+namespace runtime {
+
+using CreateEmbeddingModelFn = EmbeddingModel *(*)();
+using DestroyEmbeddingModelFn = void (*)(EmbeddingModel *);
+using EmbeddingModelTypeFn = const char *(*)();
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_CORE_EMBEDDINGMODELPLUGIN_H

--- a/runtime/include/buddy/runtime/core/EmbeddingTypes.h
+++ b/runtime/include/buddy/runtime/core/EmbeddingTypes.h
@@ -1,0 +1,52 @@
+//===- EmbeddingTypes.h - Embedding serving data types -------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_CORE_EMBEDDINGTYPES_H
+#define BUDDY_RUNTIME_CORE_EMBEDDINGTYPES_H
+
+#include "buddy/runtime/core/ServingTypes.h"
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace buddy {
+namespace runtime {
+
+struct EmbeddingModelConfig {
+  std::string raxPath;
+  std::string modelSoPath;
+  std::vector<std::string> weightPaths;
+  std::string vocabPath;
+  std::string modelName;
+};
+
+struct EmbeddingRequest {
+  std::string model;
+  std::string input;
+};
+
+struct EmbeddingResult {
+  std::string model;
+  std::vector<float> embedding;
+  std::size_t promptTokens = 0;
+  std::size_t totalTokens = 0;
+};
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_CORE_EMBEDDINGTYPES_H

--- a/runtime/include/buddy/runtime/core/ModelManifest.h
+++ b/runtime/include/buddy/runtime/core/ModelManifest.h
@@ -24,6 +24,7 @@
 //   HostSharedLib URIs module_attrs["vocab_uri"] → vocab file URI         (e.g.
 //   "file:vocab.txt") module_attrs["runner_library"] → runner plugin URI
 //   module_attrs["serving_library"] → resident serving plugin URI
+//   module_attrs["embedding_library"] → embedding plugin URI
 //   module_attrs["model_name"]→ model identifier      (e.g.
 //   "deepseek_r1_fp32")
 //
@@ -111,6 +112,8 @@ struct ModelManifest {
   std::string runnerLibraryPath;
   // absolute path to the resident serving plugin shared library.
   std::string servingLibraryPath;
+  // absolute path to the embedding model plugin shared library.
+  std::string embeddingLibraryPath;
   // Raw module attrs plus URI-resolved variants for attrs whose value is a URI.
   std::unordered_map<std::string, std::string> moduleAttrs;
   std::unordered_map<std::string, std::string> resolvedModuleAttrs;
@@ -555,6 +558,10 @@ struct ModelManifest {
         else if (key == "serving_library" && kv->value() &&
                  kv->value()->size() > 0)
           out.servingLibraryPath = resolveUri(kv->value(), "serving_library");
+        else if (key == "embedding_library" && kv->value() &&
+                 kv->value()->size() > 0)
+          out.embeddingLibraryPath =
+              resolveUri(kv->value(), "embedding_library");
         else if (key == "model_name" && kv->value() && kv->value()->size() > 0)
           out.modelName = value;
       }

--- a/tools/buddy-codegen/cmake/buddy_model.cmake
+++ b/tools/buddy-codegen/cmake/buddy_model.cmake
@@ -80,6 +80,8 @@ endif()
 #   [RUNNER_HDR   <file.h>]                 model-specific runner header
 #   [SERVING_PLUGIN_SRC <file.cpp>]         resident model plugin wrapper source
 #   [SERVING_LIBRARY <URI_OR_NAME>]         optional resident serving plugin URI
+#   [EMBEDDING_PLUGIN_SRC <file.cpp>]       embedding model plugin wrapper source
+#   [EMBEDDING_LIBRARY <URI_OR_NAME>]       optional embedding plugin URI
 #   [EXTRA_SRCS <file.cpp>...]              optional model runtime sources
 #   [HF_CONFIG    <config.json>]            optional HuggingFace config path
 #   [LOCAL_MODEL  <dir>]                    optional: HF snapshot dir for import
@@ -159,7 +161,7 @@ function(buddy_add_model)
   cmake_parse_arguments(
     MDL                                      # prefix
     ""                                       # flags
-    "NAME;SPEC;RUNNER_SRC;RUNNER_PLUGIN_SRC;RUNNER_HDR;SERVING_PLUGIN_SRC;SERVING_LIBRARY;HF_CONFIG;LOCAL_MODEL;BUILD_DIR;MLIR_DIR;NUM_THREADS;LLC_ATTRS;COMPILE_JOBS;TIERED_KV_CACHE;MODEL_KIND;IMPORT_SCRIPT;MANIFEST_SCRIPT;LOCAL_MODEL_ENV;MODEL_SO_NAME;TEMPLATE_PARTITION_CAPABLE"
+    "NAME;SPEC;RUNNER_SRC;RUNNER_PLUGIN_SRC;RUNNER_HDR;SERVING_PLUGIN_SRC;SERVING_LIBRARY;EMBEDDING_PLUGIN_SRC;EMBEDDING_LIBRARY;HF_CONFIG;LOCAL_MODEL;BUILD_DIR;MLIR_DIR;NUM_THREADS;LLC_ATTRS;COMPILE_JOBS;TIERED_KV_CACHE;MODEL_KIND;IMPORT_SCRIPT;MANIFEST_SCRIPT;LOCAL_MODEL_ENV;MODEL_SO_NAME;TEMPLATE_PARTITION_CAPABLE"
     "EXTRA_SRCS;TIERED_CACHE_SIZES;ASSET_FILES;RUNTIME_LINK_LIBS" # multi-value
     ${ARGN}
   )
@@ -260,6 +262,13 @@ function(buddy_add_model)
     list(APPEND MDL_GEN_MANIFEST_ARGS
       --serving-library "${MDL_SERVING_LIBRARY}")
   endif()
+  if(MDL_EMBEDDING_PLUGIN_SRC AND NOT MDL_EMBEDDING_LIBRARY)
+    set(MDL_EMBEDDING_LIBRARY "${MDL_NAME}_embedding.so")
+  endif()
+  if(MDL_EMBEDDING_LIBRARY)
+    list(APPEND MDL_GEN_MANIFEST_ARGS
+      --embedding-library "${MDL_EMBEDDING_LIBRARY}")
+  endif()
 
   if(IS_RVV_CROSSCOMPILE)
     if(NOT RISCV_GNU_TOOLCHAIN)
@@ -332,6 +341,7 @@ function(buddy_add_model)
   set(RUNNER_PLUGIN_NAME "${MDL_NAME}_runner.so")
   set(IMPORT_STAMP "${BIN}/.buddy_import_done")
   set(SERVING_PLUGIN_TARGET "")
+  set(EMBEDDING_PLUGIN_TARGET "")
 
   # ── gen_config.py ─────────────────────────────────────────────────────────
   if(MDL_MODEL_KIND STREQUAL "single_forward")
@@ -654,6 +664,22 @@ function(buddy_add_model)
     )
     target_link_libraries(${SERVING_PLUGIN_TARGET} PRIVATE ${LIB_TARGET})
     target_compile_features(${SERVING_PLUGIN_TARGET} PRIVATE cxx_std_17)
+  endif()
+
+  if(MDL_EMBEDDING_PLUGIN_SRC)
+    set(EMBEDDING_PLUGIN_TARGET "buddy_models_${MDL_NAME}_embedding")
+    add_library(${EMBEDDING_PLUGIN_TARGET} SHARED
+      "${CMAKE_CURRENT_SOURCE_DIR}/${MDL_EMBEDDING_PLUGIN_SRC}"
+    )
+    set_target_properties(${EMBEDDING_PLUGIN_TARGET} PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY "${BIN}"
+      RUNTIME_OUTPUT_DIRECTORY "${BIN}"
+      OUTPUT_NAME "${MDL_NAME}_embedding"
+      PREFIX ""
+    )
+    target_link_libraries(${EMBEDDING_PLUGIN_TARGET} PRIVATE ${LIB_TARGET})
+    target_compile_features(${EMBEDDING_PLUGIN_TARGET} PRIVATE cxx_std_17)
+    install(TARGETS ${EMBEDDING_PLUGIN_TARGET} EXPORT BuddyMLIRTargets COMPONENT buddy_runtime)
   endif()
 
   # ════════════════════════════════════════════════════════════════════════════
@@ -1147,6 +1173,7 @@ function(buddy_add_model)
     "${GEN_RHAL}"
     "${MODEL_SO}"
     ${RUNNER_PLUGIN_TARGET}
+    ${EMBEDDING_PLUGIN_TARGET}
     ${MDL_ASSET_DSTS})
   if(MDL_MODEL_KIND STREQUAL "single_forward")
     list(APPEND MDL_STAGE4_DEPS "${BIN}/arg0.data")

--- a/tools/buddy-codegen/gen_manifest.py
+++ b/tools/buddy-codegen/gen_manifest.py
@@ -45,6 +45,7 @@ def gen_manifest(
     dep_shared_libs: list[str] | None = None,
     runner_library: str | None = None,
     serving_library: str | None = None,
+    embedding_library: str | None = None,
 ) -> str:
     """Generate the complete RHAL .mlir manifest text."""
     out = StringIO()
@@ -78,6 +79,9 @@ def gen_manifest(
     serving_uri = (
         _normalize_dep_uri(serving_library) if serving_library else None
     )
+    embedding_uri = (
+        _normalize_dep_uri(embedding_library) if embedding_library else None
+    )
 
     dep_uris: list[str] = []
     for item in dep_shared_libs or []:
@@ -91,7 +95,15 @@ def gen_manifest(
     p(f'    runner_library = "{runner_uri}"', end="")
     if serving_uri:
         p(",")
-        p(f'    serving_library = "{serving_uri}"}} {{')
+        p(f'    serving_library = "{serving_uri}"', end="")
+        if embedding_uri:
+            p(",")
+            p(f'    embedding_library = "{embedding_uri}"}} {{')
+        else:
+            p("} {")
+    elif embedding_uri:
+        p(",")
+        p(f'    embedding_library = "{embedding_uri}"}} {{')
     else:
         p("} {")
     p()
@@ -242,6 +254,15 @@ def main():
             "attrs. If no scheme is given, file: is assumed."
         ),
     )
+    parser.add_argument(
+        "--embedding-library",
+        default=None,
+        metavar="URI_OR_NAME",
+        help=(
+            "Embedding plugin library URI/name to place into module attrs. "
+            "If no scheme is given, file: is assumed."
+        ),
+    )
     args = parser.parse_args()
 
     with open(args.config) as f:
@@ -253,6 +274,7 @@ def main():
             dep_shared_libs=args.dep_shared_lib,
             runner_library=args.runner_library,
             serving_library=args.serving_library,
+            embedding_library=args.embedding_library,
         )
     except (ValueError, RuntimeError, OSError) as e:
         print(f"error: {e}", file=sys.stderr)

--- a/tools/buddy-server/CMakeLists.txt
+++ b/tools/buddy-server/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(buddy-server
   buddy-server.cpp
   JsonCodec.cpp
   ResidentModelPluginHandle.cpp
+  EmbeddingModelPluginHandle.cpp
   SimpleHttpServer.cpp
 )
 
@@ -44,6 +45,7 @@ if(BUDDY_ENABLE_TESTS)
   )
   target_link_libraries(buddy-server-json-codec-test PRIVATE
     buddy_runtime_core
+    ${CMAKE_DL_LIBS}
     buddy_runtime_llm
     LLVMSupport
   )
@@ -63,5 +65,26 @@ if(BUDDY_ENABLE_TESTS)
     COMMAND $<TARGET_FILE:buddy-server> --help
     DEPENDS buddy-server
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+endif()
+
+if(BUDDY_ENABLE_TESTS)
+  add_executable(buddy-server-embedding-plugin-handle-test
+    EmbeddingModelPluginHandleTest.cpp
+    EmbeddingModelPluginHandle.cpp
+  )
+  target_compile_features(buddy-server-embedding-plugin-handle-test PRIVATE cxx_std_17)
+  target_include_directories(buddy-server-embedding-plugin-handle-test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+  target_link_libraries(buddy-server-embedding-plugin-handle-test PRIVATE
+    buddy_runtime_core
+    ${CMAKE_DL_LIBS}
+  )
+  add_test(NAME buddy-server-embedding-plugin-handle
+    COMMAND buddy-server-embedding-plugin-handle-test
+  )
+  set_tests_properties(buddy-server-embedding-plugin-handle PROPERTIES
+    PASS_REGULAR_EXPRESSION "EmbeddingModelPluginHandle tests passed"
   )
 endif()

--- a/tools/buddy-server/EmbeddingModelPluginHandle.cpp
+++ b/tools/buddy-server/EmbeddingModelPluginHandle.cpp
@@ -1,0 +1,91 @@
+//===- EmbeddingModelPluginHandle.cpp - Embedding plugin loader -----------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include "EmbeddingModelPluginHandle.h"
+
+#include <dlfcn.h>
+#include <stdexcept>
+
+namespace buddy {
+namespace server {
+
+namespace {
+template <typename Fn>
+Fn lookupRequired(void *handle, const std::string &path, const char *symbol) {
+  dlerror();
+  void *raw = dlsym(handle, symbol);
+  if (const char *err = dlerror())
+    throw std::runtime_error("buddy-server: embedding plugin " + path +
+                             " missing " + symbol + ": " + err);
+  return reinterpret_cast<Fn>(raw);
+}
+
+template <typename Fn> Fn lookupOptional(void *handle, const char *symbol) {
+  dlerror();
+  void *raw = dlsym(handle, symbol);
+  if (dlerror())
+    return nullptr;
+  return reinterpret_cast<Fn>(raw);
+}
+} // namespace
+
+EmbeddingModelPluginHandle::EmbeddingModelPluginHandle(
+    const std::string &pluginPath)
+    : pluginPath(pluginPath) {
+  if (pluginPath.empty())
+    throw std::runtime_error("buddy-server: --embedding-so path is empty");
+  handle = dlopen(pluginPath.c_str(), RTLD_NOW | RTLD_LOCAL);
+  if (!handle)
+    throw std::runtime_error("buddy-server: dlopen embedding plugin failed: " +
+                             pluginPath + ": " + dlerror());
+  try {
+    create = lookupRequired<buddy::runtime::CreateEmbeddingModelFn>(
+        handle, pluginPath, "buddy_create_embedding_model_v1");
+    destroy = lookupRequired<buddy::runtime::DestroyEmbeddingModelFn>(
+        handle, pluginPath, "buddy_destroy_embedding_model_v1");
+    auto type = lookupOptional<buddy::runtime::EmbeddingModelTypeFn>(
+        handle, "buddy_embedding_model_type_v1");
+    if (type) {
+      if (const char *name = type())
+        pluginModelType = name;
+    }
+  } catch (...) {
+    dlclose(handle);
+    handle = nullptr;
+    throw;
+  }
+}
+
+EmbeddingModelPluginHandle::~EmbeddingModelPluginHandle() {
+  if (handle)
+    dlclose(handle);
+}
+
+EmbeddingModelPluginHandle::ModelPtr
+EmbeddingModelPluginHandle::createModel() const {
+  buddy::runtime::EmbeddingModel *model = create();
+  if (!model)
+    throw std::runtime_error(
+        "buddy-server: embedding plugin returned null model: " + pluginPath);
+  return ModelPtr(model,
+                  [destroy = destroy](buddy::runtime::EmbeddingModel *m) {
+                    if (m)
+                      destroy(m);
+                  });
+}
+
+} // namespace server
+} // namespace buddy

--- a/tools/buddy-server/EmbeddingModelPluginHandle.h
+++ b/tools/buddy-server/EmbeddingModelPluginHandle.h
@@ -1,0 +1,56 @@
+//===- EmbeddingModelPluginHandle.h - Embedding plugin loader -------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_TOOLS_BUDDY_SERVER_EMBEDDINGMODELPLUGINHANDLE_H
+#define BUDDY_TOOLS_BUDDY_SERVER_EMBEDDINGMODELPLUGINHANDLE_H
+
+#include "buddy/runtime/core/EmbeddingModelPlugin.h"
+
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace buddy {
+namespace server {
+
+class EmbeddingModelPluginHandle {
+public:
+  using ModelPtr =
+      std::unique_ptr<buddy::runtime::EmbeddingModel,
+                      std::function<void(buddy::runtime::EmbeddingModel *)>>;
+
+  explicit EmbeddingModelPluginHandle(const std::string &pluginPath);
+  ~EmbeddingModelPluginHandle();
+
+  EmbeddingModelPluginHandle(const EmbeddingModelPluginHandle &) = delete;
+  EmbeddingModelPluginHandle &
+  operator=(const EmbeddingModelPluginHandle &) = delete;
+
+  ModelPtr createModel() const;
+  const std::string &modelType() const { return pluginModelType; }
+
+private:
+  std::string pluginPath;
+  std::string pluginModelType;
+  void *handle = nullptr;
+  buddy::runtime::CreateEmbeddingModelFn create = nullptr;
+  buddy::runtime::DestroyEmbeddingModelFn destroy = nullptr;
+};
+
+} // namespace server
+} // namespace buddy
+
+#endif // BUDDY_TOOLS_BUDDY_SERVER_EMBEDDINGMODELPLUGINHANDLE_H

--- a/tools/buddy-server/EmbeddingModelPluginHandleTest.cpp
+++ b/tools/buddy-server/EmbeddingModelPluginHandleTest.cpp
@@ -1,0 +1,38 @@
+//===- EmbeddingModelPluginHandleTest.cpp - Embedding loader tests --------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include "EmbeddingModelPluginHandle.h"
+
+#include <cassert>
+#include <iostream>
+#include <stdexcept>
+#include <type_traits>
+
+int main() {
+  static_assert(std::is_same_v<buddy::runtime::CreateEmbeddingModelFn,
+                               buddy::runtime::EmbeddingModel *(*)()>);
+  static_assert(std::is_same_v<buddy::runtime::DestroyEmbeddingModelFn,
+                               void (*)(buddy::runtime::EmbeddingModel *)>);
+  bool failed = false;
+  try {
+    buddy::server::EmbeddingModelPluginHandle handle("");
+  } catch (const std::runtime_error &) {
+    failed = true;
+  }
+  assert(failed);
+  std::cout << "EmbeddingModelPluginHandle tests passed\n";
+  return 0;
+}

--- a/tools/buddy-server/JsonCodec.cpp
+++ b/tools/buddy-server/JsonCodec.cpp
@@ -256,6 +256,33 @@ DecodedCompletionRequest parseCompletionRequest(const std::string &body) {
   return decoded;
 }
 
+DecodedEmbeddingRequest parseEmbeddingRequest(const std::string &body) {
+  json::Value value = parseValue(body);
+  const json::Object &obj = asObject(value);
+
+  DecodedEmbeddingRequest decoded;
+  if (auto model = obj.getString("model"))
+    decoded.request.model = model->str();
+  else if (obj.find("model") != obj.end())
+    throw JsonCodecError("model must be a string");
+
+  auto inputIt = obj.find("input");
+  if (inputIt == obj.end())
+    throw JsonCodecError("missing required field: input");
+  if (auto stream = obj.getBoolean("stream"); stream && *stream)
+    throw JsonCodecError("streaming embeddings are not supported");
+  if (auto input = inputIt->second.getAsString()) {
+    decoded.request.input = input->str();
+    if (decoded.request.input.empty())
+      throw JsonCodecError("input must not be empty");
+  } else if (inputIt->second.getAsArray()) {
+    throw JsonCodecError("input arrays are not supported; provide one string");
+  } else {
+    throw JsonCodecError("input must be a string");
+  }
+  return decoded;
+}
+
 DecodedChatRequest parseChatCompletionRequest(const std::string &body) {
   json::Value value = parseValue(body);
   const json::Object &obj = asObject(value);
@@ -332,6 +359,26 @@ std::string toJson(const CompletionResult &result) {
                    {"stop_reason", finishReason(result.finishReason)},
                    {"usage", usageJson(result.usage)},
                    {"timings", timingsJson(result.timings)}});
+}
+
+std::string toOpenAIEmbeddingJson(const EmbeddingResult &result) {
+  json::Array embedding;
+  embedding.reserve(result.embedding.size());
+  for (float value : result.embedding)
+    embedding.emplace_back(value);
+
+  json::Array data;
+  data.emplace_back(json::Object{{"object", "embedding"},
+                                 {"embedding", std::move(embedding)},
+                                 {"index", 0}});
+  return serialize(json::Object{
+      {"object", "list"},
+      {"data", std::move(data)},
+      {"model", result.model},
+      {"usage",
+       json::Object{
+           {"prompt_tokens", static_cast<int64_t>(result.promptTokens)},
+           {"total_tokens", static_cast<int64_t>(result.totalTokens)}}}});
 }
 
 std::string toOpenAIChatJson(const CompletionResult &result) {

--- a/tools/buddy-server/JsonCodec.h
+++ b/tools/buddy-server/JsonCodec.h
@@ -17,6 +17,7 @@
 #ifndef BUDDY_TOOLS_BUDDY_SERVER_JSONCODEC_H
 #define BUDDY_TOOLS_BUDDY_SERVER_JSONCODEC_H
 
+#include "buddy/runtime/core/EmbeddingTypes.h"
 #include "buddy/runtime/core/ServingTypes.h"
 
 #include <stdexcept>
@@ -41,12 +42,19 @@ struct DecodedChatRequest {
   bool stream = false;
 };
 
+struct DecodedEmbeddingRequest {
+  buddy::runtime::EmbeddingRequest request;
+};
+
 DecodedCompletionRequest parseCompletionRequest(const std::string &body);
 DecodedChatRequest parseChatCompletionRequest(const std::string &body);
+DecodedEmbeddingRequest parseEmbeddingRequest(const std::string &body);
 buddy::runtime::TokenizeRequest parseTokenizeRequest(const std::string &body);
 
 std::string toJson(const buddy::runtime::ModelStatus &status);
 std::string toJson(const buddy::runtime::CompletionResult &result);
+std::string
+toOpenAIEmbeddingJson(const buddy::runtime::EmbeddingResult &result);
 std::string toOpenAIChatJson(const buddy::runtime::CompletionResult &result);
 std::string toJson(const buddy::runtime::TokenizeResult &result,
                    bool countOnly);

--- a/tools/buddy-server/JsonCodecTest.cpp
+++ b/tools/buddy-server/JsonCodecTest.cpp
@@ -23,6 +23,8 @@
 
 using buddy::server::parseChatCompletionRequest;
 using buddy::server::parseCompletionRequest;
+using buddy::server::parseEmbeddingRequest;
+using buddy::server::toOpenAIEmbeddingJson;
 
 namespace {
 
@@ -72,6 +74,30 @@ int main() {
     parseChatCompletionRequest(
         R"({"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,AA=="}}]}]})");
   });
+
+  auto embedding =
+      parseEmbeddingRequest(R"({"model":"bge_m3_base","input":"hello world"})");
+  assert(embedding.request.model == "bge_m3_base");
+  assert(embedding.request.input == "hello world");
+  expectFailure([] { parseEmbeddingRequest(R"({"model":"bge_m3_base"})"); });
+  expectFailure([] {
+    parseEmbeddingRequest(R"({"model":"bge_m3_base","input":["a","b"]})");
+  });
+  expectFailure(
+      [] { parseEmbeddingRequest(R"({"model":"bge_m3_base","input":3})"); });
+  expectFailure([] {
+    parseEmbeddingRequest(
+        R"({"model":"bge_m3_base","input":"a","stream":true})");
+  });
+  buddy::runtime::EmbeddingResult result;
+  result.model = "bge_m3_base";
+  result.embedding = {0.5f, -0.5f};
+  result.promptTokens = 2;
+  result.totalTokens = 2;
+  const std::string json = toOpenAIEmbeddingJson(result);
+  assert(json.find("\"object\":\"list\"") != std::string::npos);
+  assert(json.find("\"index\":0") != std::string::npos);
+  assert(json.find("\"prompt_tokens\":2") != std::string::npos);
 
   std::cout << "JsonCodec tests passed\n";
   return 0;

--- a/tools/buddy-server/README.md
+++ b/tools/buddy-server/README.md
@@ -295,3 +295,48 @@ Completion and chat requests support:
 - The HTTP layer is a minimal POSIX socket implementation, not a full-featured
   production HTTP framework.
 - SSE streaming uses `data: ...` chunks and finishes with `data: [DONE]`.
+
+## BGE-M3 embedding backend
+
+Build BGE-M3 and its independent server plugin with the `buddy-mlir` conda
+environment (a local HuggingFace snapshot is required for the import step):
+
+```bash
+conda run -n buddy-mlir cmake -S . -B build \
+  -DBUDDY_BUILD_BGE_M3_MODEL=ON \
+  -DBUDDY_BGE_M3_MODEL_PATH=/path/to/bge-m3
+conda run -n buddy-mlir cmake --build build --target bge_m3_rax
+```
+
+The resulting package contains `bge_m3.rax`, `bge_m3_model.so`,
+`bge_m3_runner.so`, and `bge_m3_embedding.so`. Start the embedding backend:
+
+```bash
+./build/bin/buddy-server \
+  --model ./build/models/bge_m3/bge_m3.rax \
+  --host 127.0.0.1 --port 8080
+```
+
+The server discovers `embedding_library` from the manifest. If a manifest
+contains both `serving_library` and `embedding_library`, pass exactly one of
+`--serving-so` or `--embedding-so` to select the backend explicitly. The plugin
+ABI is independent from `ResidentModel`:
+
+```cpp
+extern "C" buddy::runtime::EmbeddingModel *buddy_create_embedding_model_v1();
+extern "C" void buddy_destroy_embedding_model_v1(buddy::runtime::EmbeddingModel *);
+```
+
+`POST /v1/embeddings` (also `/embeddings`) accepts only one non-empty string:
+
+```bash
+curl http://127.0.0.1:8080/v1/embeddings \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"bge_m3_base","input":"hello world"}'
+```
+
+The response contains `data[0].embedding`, `data[0].index`, `model`, and
+`usage.prompt_tokens`/`usage.total_tokens`. Input arrays are rejected with a
+400 unsupported-input error. Embedding mode returns a 400
+`unsupported_endpoint` error for completion, chat completion, and tokenize;
+DeepSeek/Qwen resident behavior and SSE remain unchanged.

--- a/tools/buddy-server/buddy-server.cpp
+++ b/tools/buddy-server/buddy-server.cpp
@@ -14,10 +14,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "EmbeddingModelPluginHandle.h"
 #include "JsonCodec.h"
 #include "ResidentModelPluginHandle.h"
 #include "SimpleHttpServer.h"
 
+#include "buddy/runtime/core/EmbeddingModel.h"
+#include "buddy/runtime/core/EmbeddingTypes.h"
 #include "buddy/runtime/core/ModelManifest.h"
 #include "buddy/runtime/core/ResidentModel.h"
 #include "buddy/runtime/core/ServingTypes.h"
@@ -29,8 +32,9 @@
 #include <mutex>
 #include <string>
 #include <thread>
-#include <vector>
 
+using buddy::runtime::EmbeddingModel;
+using buddy::runtime::EmbeddingModelConfig;
 using buddy::runtime::ModelLoadState;
 using buddy::runtime::ModelStatus;
 using buddy::runtime::ResidentModel;
@@ -42,15 +46,10 @@ using buddy::server::SimpleHttpServer;
 
 namespace {
 
-enum ServerLoadState {
-  Loading = 0,
-  Ready = 1,
-  Error = 2,
-};
+enum ServerLoadState { Loading = 0, Ready = 1, Error = 2 };
 
 void usage(const char *prog, std::ostream &os = std::cout) {
-  os << "Usage: " << prog << " [options]\n"
-     << "\n"
+  os << "Usage: " << prog << " [options]\n\n"
      << "Model source (one required):\n"
      << "  --model      <path.rax>  Model manifest (recommended)\n"
      << "  --model-so   <path.so>   Model shared library (legacy mode)\n"
@@ -58,14 +57,12 @@ void usage(const char *prog, std::ostream &os = std::cout) {
      << "  --vocab      <path>      Vocabulary file (legacy mode)\n"
      << "  --model-type <name>      Model type/name override for status\n"
      << "  --serving-so <path.so>   Resident model plugin shared library\n"
-     << "\n"
+     << "  --embedding-so <path.so> Embedding model plugin shared library\n\n"
      << "Server:\n"
      << "  --host       <addr>      Bind address (default 127.0.0.1)\n"
-     << "  --port       <port>      Bind port (default 8080)\n"
-     << "\n"
+     << "  --port       <port>      Bind port (default 8080)\n\n"
      << "Chat:\n"
-     << "  --chat-template <path>   Path to chat template JSON config\n"
-     << "\n"
+     << "  --chat-template <path>   Path to chat template JSON config\n\n"
      << "Other:\n"
      << "  --help / -h\n";
 }
@@ -94,6 +91,13 @@ template <typename Fn> void withJsonErrors(ResponseWriter &writer, Fn fn) {
   } catch (const std::exception &ex) {
     sendError(writer, 500, ex.what(), "internal_error");
   }
+}
+
+void handleUnsupported(ResponseWriter &writer, const char *endpoint) {
+  sendError(writer, 400,
+            std::string(endpoint) +
+                " is not supported by the embedding backend",
+            "unsupported_endpoint");
 }
 
 void handleCompletion(ResidentModel &model, const std::atomic<int> &loadState,
@@ -170,12 +174,37 @@ void handleTokenize(ResidentModel &model, const std::atomic<int> &loadState,
   });
 }
 
+void handleEmbedding(EmbeddingModel &model, const std::atomic<int> &loadState,
+                     const HttpRequest &request, ResponseWriter &writer) {
+  if (!isReady(loadState)) {
+    sendError(writer, 503, "model is not loaded", "model_not_ready");
+    return;
+  }
+
+  withJsonErrors(writer, [&] {
+    auto decoded = buddy::server::parseEmbeddingRequest(request.body);
+    const ModelStatus status = model.status();
+    if (!decoded.request.model.empty() &&
+        decoded.request.model != status.modelName) {
+      sendError(writer, 400,
+                "model '" + decoded.request.model +
+                    "' does not match loaded model '" + status.modelName + "'",
+                "model_not_found");
+      return;
+    }
+    auto result = model.embed(decoded.request);
+    writer.sendResponse(buddy::server::jsonResponse(
+        200, buddy::server::toOpenAIEmbeddingJson(result)));
+  });
+}
+
 } // namespace
 
 int main(int argc, char **argv) {
   ResidentModelConfig modelConfig;
   std::string modelType;
   std::string servingSoPath;
+  std::string embeddingSoPath;
   std::string host = "127.0.0.1";
   int port = 8080;
 
@@ -193,6 +222,8 @@ int main(int argc, char **argv) {
       modelType = argv[++i];
     else if (arg == "--serving-so" && i + 1 < argc)
       servingSoPath = argv[++i];
+    else if (arg == "--embedding-so" && i + 1 < argc)
+      embeddingSoPath = argv[++i];
     else if (arg == "--chat-template" && i + 1 < argc)
       modelConfig.chatTemplatePath = argv[++i];
     else if (arg == "--host" && i + 1 < argc)
@@ -227,46 +258,102 @@ int main(int argc, char **argv) {
     usage(argv[0], std::cerr);
     return 2;
   }
+  if (!servingSoPath.empty() && !embeddingSoPath.empty()) {
+    std::cerr
+        << "buddy-server: choose one of --serving-so or --embedding-so.\n";
+    return 2;
+  }
 
-  if (!modelConfig.raxPath.empty() && servingSoPath.empty()) {
+  bool embeddingMode = !embeddingSoPath.empty();
+  if (!modelConfig.raxPath.empty()) {
     try {
       auto manifest =
           buddy::runtime::ModelManifest::loadFromRax(modelConfig.raxPath);
-      servingSoPath = manifest.servingLibraryPath;
+      if (servingSoPath.empty() && embeddingSoPath.empty()) {
+        const bool hasServing = !manifest.servingLibraryPath.empty();
+        const bool hasEmbedding = !manifest.embeddingLibraryPath.empty();
+        if (hasServing == hasEmbedding) {
+          if (hasServing)
+            std::cerr << "buddy-server: manifest provides both serving_library "
+                         "and embedding_library; pass --serving-so or "
+                         "--embedding-so explicitly.\n";
+          else
+            std::cerr << "buddy-server: manifest has neither serving_library "
+                         "nor embedding_library.\n";
+          return 1;
+        }
+        if (hasEmbedding) {
+          embeddingSoPath = manifest.embeddingLibraryPath;
+          embeddingMode = true;
+        } else {
+          servingSoPath = manifest.servingLibraryPath;
+        }
+      }
     } catch (const std::exception &ex) {
       std::cerr << "buddy-server: failed to read model manifest: " << ex.what()
                 << "\n";
       return 1;
     }
   }
-  if (servingSoPath.empty()) {
-    std::cerr << "buddy-server: no resident serving plugin specified.\n";
-    if (!modelConfig.raxPath.empty()) {
-      std::cerr << "The .rax manifest has no serving_library; pass "
-                   "--serving-so <path.so> or rebuild the .rax with "
-                   "serving_library.\n";
-    } else {
-      std::cerr << "Pass --serving-so <path.so> for legacy --model-so mode.\n";
+
+  std::unique_ptr<buddy::server::ResidentModelPluginHandle> residentPlugin;
+  std::unique_ptr<buddy::server::EmbeddingModelPluginHandle> embeddingPlugin;
+  buddy::server::ResidentModelPluginHandle::ModelPtr residentModel(
+      nullptr, [](ResidentModel *m) { delete m; });
+  buddy::server::EmbeddingModelPluginHandle::ModelPtr embeddingModel(
+      nullptr, [](EmbeddingModel *m) { delete m; });
+
+  if (embeddingMode) {
+    if (embeddingSoPath.empty()) {
+      std::cerr << "buddy-server: no embedding plugin specified.\n";
+      return 1;
     }
-    return 1;
+    try {
+      embeddingPlugin =
+          std::make_unique<buddy::server::EmbeddingModelPluginHandle>(
+              embeddingSoPath);
+      if (modelType.empty()) {
+        const std::string pluginType = embeddingPlugin->modelType();
+        modelType = pluginType.empty() ? "embedding" : pluginType;
+      }
+      embeddingModel = embeddingPlugin->createModel();
+    } catch (const std::exception &ex) {
+      std::cerr << ex.what() << "\n";
+      return 1;
+    }
+  } else {
+    if (servingSoPath.empty()) {
+      std::cerr << "buddy-server: no resident serving plugin specified.\n";
+      if (!modelConfig.raxPath.empty())
+        std::cerr
+            << "The .rax manifest has no serving_library; pass --serving-so "
+               "<path.so> or rebuild the .rax with serving_library.\n";
+      else
+        std::cerr
+            << "Pass --serving-so <path.so> for legacy --model-so mode.\n";
+      return 1;
+    }
+    try {
+      residentPlugin =
+          std::make_unique<buddy::server::ResidentModelPluginHandle>(
+              servingSoPath);
+      if (modelType.empty()) {
+        const std::string pluginType = residentPlugin->modelType();
+        modelType = pluginType.empty() ? "plugin" : pluginType;
+      }
+      residentModel = residentPlugin->createModel();
+    } catch (const std::exception &ex) {
+      std::cerr << ex.what() << "\n";
+      return 1;
+    }
   }
 
-  std::unique_ptr<buddy::server::ResidentModelPluginHandle> pluginHandle;
-  buddy::server::ResidentModelPluginHandle::ModelPtr model(
-      nullptr, [](ResidentModel *m) { delete m; });
-  try {
-    pluginHandle = std::make_unique<buddy::server::ResidentModelPluginHandle>(
-        servingSoPath);
-    if (modelType.empty()) {
-      const std::string pluginType = pluginHandle->modelType();
-      modelType = pluginType.empty() ? "plugin" : pluginType;
-    }
-    model = pluginHandle->createModel();
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n";
-    return 1;
-  }
-  ResidentModel &residentModel = *model;
+  EmbeddingModelConfig embeddingConfig;
+  embeddingConfig.raxPath = modelConfig.raxPath;
+  embeddingConfig.modelSoPath = modelConfig.modelSoPath;
+  embeddingConfig.weightPaths = modelConfig.weightPaths;
+  embeddingConfig.vocabPath = modelConfig.vocabPath;
+  embeddingConfig.modelName = modelConfig.modelName;
 
   std::atomic<int> loadState{Loading};
   std::mutex loadErrorMutex;
@@ -276,14 +363,17 @@ int main(int argc, char **argv) {
   server.get("/health", [&](const HttpRequest &, ResponseWriter &writer) {
     const int state = loadState.load(std::memory_order_acquire);
     if (state == Ready) {
-      writer.sendResponse(buddy::server::jsonResponse(
-          200, buddy::server::toJson(residentModel.status())));
+      ModelStatus status =
+          embeddingMode ? embeddingModel->status() : residentModel->status();
+      writer.sendResponse(
+          buddy::server::jsonResponse(200, buddy::server::toJson(status)));
       return;
     }
 
     ModelStatus status;
     status.modelName =
         modelConfig.modelName.empty() ? modelType : modelConfig.modelName;
+    status.backend = embeddingMode ? "cpu" : "";
     if (state == Error) {
       status.state = ModelLoadState::Error;
       std::lock_guard<std::mutex> lock(loadErrorMutex);
@@ -295,35 +385,88 @@ int main(int argc, char **argv) {
     writer.sendResponse(
         buddy::server::jsonResponse(200, buddy::server::toJson(status)));
   });
-  server.post("/completion",
-              [&](const HttpRequest &request, ResponseWriter &writer) {
-                handleCompletion(residentModel, loadState, request, writer);
-              });
-  server.post("/v1/chat/completions",
-              [&](const HttpRequest &request, ResponseWriter &writer) {
-                handleChat(residentModel, loadState, request, writer);
-              });
-  server.post("/tokenize",
-              [&](const HttpRequest &request, ResponseWriter &writer) {
-                handleTokenize(residentModel, loadState, request, writer);
-              });
 
-  std::thread loadThread([&residentModel, modelConfig, &loadState, &loadError,
-                          &loadErrorMutex] {
-    try {
-      std::cerr << "[buddy-server] loading model...\n";
-      residentModel.load(modelConfig);
-      loadState.store(Ready, std::memory_order_release);
-      std::cerr << "[buddy-server] model loaded\n";
-    } catch (const std::exception &ex) {
-      {
-        std::lock_guard<std::mutex> lock(loadErrorMutex);
-        loadError = ex.what();
+  if (embeddingMode) {
+    server.post("/v1/embeddings",
+                [&](const HttpRequest &request, ResponseWriter &writer) {
+                  handleEmbedding(*embeddingModel, loadState, request, writer);
+                });
+    server.post("/embeddings",
+                [&](const HttpRequest &request, ResponseWriter &writer) {
+                  handleEmbedding(*embeddingModel, loadState, request, writer);
+                });
+    server.post("/completion",
+                [&](const HttpRequest &, ResponseWriter &writer) {
+                  handleUnsupported(writer, "/completion");
+                });
+    server.post("/v1/chat/completions",
+                [&](const HttpRequest &, ResponseWriter &writer) {
+                  handleUnsupported(writer, "/v1/chat/completions");
+                });
+    server.post("/tokenize", [&](const HttpRequest &, ResponseWriter &writer) {
+      handleUnsupported(writer, "/tokenize");
+    });
+  } else {
+    server.post("/completion",
+                [&](const HttpRequest &request, ResponseWriter &writer) {
+                  handleCompletion(*residentModel, loadState, request, writer);
+                });
+    server.post("/v1/chat/completions",
+                [&](const HttpRequest &request, ResponseWriter &writer) {
+                  handleChat(*residentModel, loadState, request, writer);
+                });
+    server.post("/tokenize",
+                [&](const HttpRequest &request, ResponseWriter &writer) {
+                  handleTokenize(*residentModel, loadState, request, writer);
+                });
+    server.post("/v1/embeddings",
+                [&](const HttpRequest &, ResponseWriter &writer) {
+                  handleUnsupported(writer, "/v1/embeddings");
+                });
+    server.post("/embeddings",
+                [&](const HttpRequest &, ResponseWriter &writer) {
+                  handleUnsupported(writer, "/embeddings");
+                });
+  }
+
+  std::thread loadThread;
+  if (embeddingMode) {
+    loadThread = std::thread([&embeddingModel, &embeddingConfig, &loadState,
+                              &loadError, &loadErrorMutex] {
+      try {
+        std::cerr << "[buddy-server] loading embedding model...\n";
+        embeddingModel->load(embeddingConfig);
+        loadState.store(Ready, std::memory_order_release);
+        std::cerr << "[buddy-server] embedding model loaded\n";
+      } catch (const std::exception &ex) {
+        {
+          std::lock_guard<std::mutex> lock(loadErrorMutex);
+          loadError = ex.what();
+        }
+        loadState.store(Error, std::memory_order_release);
+        std::cerr << "[buddy-server] failed to load embedding model: "
+                  << ex.what() << "\n";
       }
-      loadState.store(Error, std::memory_order_release);
-      std::cerr << "[buddy-server] failed to load model: " << ex.what() << "\n";
-    }
-  });
+    });
+  } else {
+    loadThread = std::thread([&residentModel, &modelConfig, &loadState,
+                              &loadError, &loadErrorMutex] {
+      try {
+        std::cerr << "[buddy-server] loading model...\n";
+        residentModel->load(modelConfig);
+        loadState.store(Ready, std::memory_order_release);
+        std::cerr << "[buddy-server] model loaded\n";
+      } catch (const std::exception &ex) {
+        {
+          std::lock_guard<std::mutex> lock(loadErrorMutex);
+          loadError = ex.what();
+        }
+        loadState.store(Error, std::memory_order_release);
+        std::cerr << "[buddy-server] failed to load model: " << ex.what()
+                  << "\n";
+      }
+    });
+  }
 
   try {
     server.listen(host, port);
@@ -335,6 +478,5 @@ int main(int argc, char **argv) {
   }
   if (loadThread.joinable())
     loadThread.join();
-
   return 0;
 }

--- a/tools/rax-pack/rax-pack.cpp
+++ b/tools/rax-pack/rax-pack.cpp
@@ -66,6 +66,7 @@ enum class PayloadKind : uint16_t {
   CodeObject = 2,
   Vocab = 3,
   ServingPlugin = 4,
+  EmbeddingPlugin = 5,
 };
 
 struct PayloadInput {
@@ -383,6 +384,7 @@ int main(int argc, char **argv) {
     std::string vocabUriAttr;
     std::string runnerLibraryAttr;
     std::string servingLibraryAttr;
+    std::string embeddingLibraryAttr;
     std::vector<std::pair<std::string, std::string>> extraModuleAttrs;
     if (auto v = rhalMod.getModelName())
       modelNameAttr = v->str();
@@ -392,12 +394,14 @@ int main(int argc, char **argv) {
       runnerLibraryAttr = v->str();
     if (auto v = rhalMod.getServingLibrary())
       servingLibraryAttr = v->str();
+    if (auto v = rhalMod.getEmbeddingLibrary())
+      embeddingLibraryAttr = v->str();
 
     for (auto namedAttr : rhalMod->getAttrs()) {
       const std::string key = namedAttr.getName().str();
       if (key == "sym_name" || key == "version" || key == "model_name" ||
           key == "vocab_uri" || key == "runner_library" ||
-          key == "serving_library")
+          key == "serving_library" || key == "embedding_library")
         continue;
       if (auto stringAttr =
               mlir::dyn_cast<mlir::StringAttr>(namedAttr.getValue()))
@@ -557,6 +561,9 @@ int main(int argc, char **argv) {
     if (!servingLibraryAttr.empty())
       registerPayload(PayloadKind::ServingPlugin, servingLibraryAttr,
                       "module attr serving_library");
+    if (!embeddingLibraryAttr.empty())
+      registerPayload(PayloadKind::EmbeddingPlugin, embeddingLibraryAttr,
+                      "module attr embedding_library");
 
     // ── Build FlatBuffer ──────────────────────────────────────────────────
 
@@ -577,6 +584,9 @@ int main(int argc, char **argv) {
     if (!servingLibraryAttr.empty())
       modAttrs.push_back(CreateKV(b, b.CreateString("serving_library"),
                                   b.CreateString(servingLibraryAttr)));
+    if (!embeddingLibraryAttr.empty())
+      modAttrs.push_back(CreateKV(b, b.CreateString("embedding_library"),
+                                  b.CreateString(embeddingLibraryAttr)));
     for (const auto &attr : extraModuleAttrs)
       modAttrs.push_back(
           CreateKV(b, b.CreateString(attr.first), b.CreateString(attr.second)));


### PR DESCRIPTION
  - Add standalone EmbeddingModel types, runtime interface, plugin ABI, and loader.
  - Extract reusable BgeM3Runtime for tokenization, model loading, forward execution, CLS pooling, and L2 normalization.
  - Add the thread-safe BgeM3EmbeddingModel and bge_m3_embedding.so plugin.
  - Support embedding_library and file:/payload: URIs in RHAL, ModelManifest, rax-pack, manifest generation, and buddy_add_model.
  - Add --embedding-so, automatic plugin discovery, /v1/embeddings, and /embeddings to buddy-server.
  - Return OpenAI-compatible embedding responses with token usage.
  - Reject array inputs, streaming, and unsupported completion/chat/tokenize endpoints explicitly.
  - Add JSON codec and plugin loader tests, design documentation, and usage examples.
  - Preserve the existing resident model ABI and leave tools/buddy-cli unchanged.

Assisted-by: OpenAI codex

## Summary

- buddy_server supports BGE-M3 model .
- Testing method : 
```bash
./build/bin/buddy-server \
  --model ./build/models/bge_m3/bge_m3.rax \
  --port 8080

curl http://127.0.0.1:8080/v1/embeddings \
  -H 'Content-Type: application/json' \
  -d '{"model":"bge_m3_base","input":"hello world"}'
```

## Checklist

- [ x] The code builds successfully
- [x ] Existing tests pass
- [x ] New tests are added where appropriate
- [x ] Code follows the project coding style
- [x ] Documentation is updated if needed
