### PR TITLE
[Models] feat(proteinglm): add masked-LM buddy-server backend

### DIFF
--- a/models/proteinglm/CMakeLists.txt
+++ b/models/proteinglm/CMakeLists.txt
@@ -23,6 +23,8 @@ buddy_add_model(
   SPEC "${BUDDY_PROTEINGLM_SPEC}"
   RUNNER_SRC ProteinGLMRunner.cpp
   RUNNER_PLUGIN_SRC ProteinGLMRunnerPlugin.cpp
+  MASKED_LM_PLUGIN_SRC ProteinGLMMaskedLMModelPlugin.cpp
+  EXTRA_SRCS ProteinGLMMaskedLMModel.cpp
   RUNNER_HDR include/buddy/runtime/models/ProteinGLMRunner.h
   LOCAL_MODEL "${BUDDY_PROTEINGLM_MODEL_PATH}"
   LOCAL_MODEL_ENV PROTEINGLM_MODEL_PATH
@@ -34,3 +36,14 @@ buddy_add_model(
     "${BUDDY_PROTEINGLM_MODEL_PATH}/tokenizer_config.json"
     "${BUDDY_PROTEINGLM_MODEL_PATH}/special_tokens_map.json"
 )
+
+if(BUDDY_ENABLE_TESTS)
+  add_executable(proteinglm-masked-lm-runtime-test
+    ProteinGLMMaskedLMModelTest.cpp)
+  target_compile_features(proteinglm-masked-lm-runtime-test PRIVATE cxx_std_17)
+  target_link_libraries(proteinglm-masked-lm-runtime-test PRIVATE buddy_models_proteinglm)
+  add_test(NAME proteinglm-masked-lm-runtime
+    COMMAND proteinglm-masked-lm-runtime-test)
+  set_tests_properties(proteinglm-masked-lm-runtime PROPERTIES
+    PASS_REGULAR_EXPRESSION "ProteinGLM masked-LM runtime tests passed")
+endif()

--- a/models/proteinglm/ProteinGLMMaskedLMModel.cpp
+++ b/models/proteinglm/ProteinGLMMaskedLMModel.cpp
@@ -1,0 +1,273 @@
+//===- ProteinGLMMaskedLMModel.cpp - ProteinGLM masked-LM model ----------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/models/ProteinGLMMaskedLMModel.h"
+#include "buddy/Core/Container.h"
+#include "buddy/runtime/core/ModelManifest.h"
+
+#include <algorithm>
+#include <cctype>
+#include <dlfcn.h>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace buddy {
+namespace runtime {
+namespace {
+using ForwardFn = void (*)(MemRef<float, 3> *, MemRef<float, 1> *,
+                           MemRef<int64_t, 2> *, MemRef<int64_t, 2> *,
+                           MemRef<int64_t, 2> *);
+struct Tokenizer {
+  std::vector<std::string> idToToken;
+  std::unordered_map<std::string, int64_t> tokenToId;
+  int64_t padId = 0, unkId = 35, eosId = 34, maskId = 28;
+};
+Tokenizer loadTokenizer(const std::string &path) {
+  std::ifstream in(path);
+  if (!in)
+    throw std::runtime_error(
+        "ProteinGLM masked-LM: failed to open tokenizer: " + path);
+  Tokenizer t;
+  std::string line;
+  while (std::getline(in, line)) {
+    if (!line.empty() && line.back() == '\r')
+      line.pop_back();
+    int64_t id = static_cast<int64_t>(t.idToToken.size());
+    t.tokenToId[line] = id;
+    t.idToToken.push_back(line);
+  }
+  auto idOf = [&](const char *s, int64_t fallback) {
+    auto it = t.tokenToId.find(s);
+    return it == t.tokenToId.end() ? fallback : it->second;
+  };
+  t.padId = idOf("<pad>", t.padId);
+  t.unkId = idOf("<unk>", t.unkId);
+  t.eosId = idOf("<eos>", t.eosId);
+  t.maskId = idOf("<mask>", t.maskId);
+  return t;
+}
+std::vector<std::string> pieces(const std::string &s) {
+  std::vector<std::string> out;
+  for (size_t i = 0; i < s.size();) {
+    if (std::isspace(static_cast<unsigned char>(s[i]))) {
+      ++i;
+      continue;
+    }
+    if (s[i] == '<') {
+      size_t e = s.find('>', i + 1);
+      if (e != std::string::npos) {
+        out.push_back(s.substr(i, e - i + 1));
+        i = e + 1;
+        continue;
+      }
+    }
+    out.emplace_back(1, s[i++]);
+  }
+  return out;
+}
+size_t attrSize(const ModelManifest &m, const char *key, size_t fallback) {
+  auto it = m.moduleAttrs.find(key);
+  if (it == m.moduleAttrs.end() || it->second.empty())
+    return fallback;
+  return static_cast<size_t>(std::stoull(it->second));
+}
+std::string constantPath(const ModelManifest &m) {
+  for (const auto &c : m.constants)
+    if (c.name == "params")
+      return c.path;
+  return m.weightPaths.empty() ? std::string() : m.weightPaths.front();
+}
+} // namespace
+
+struct ProteinGLMMaskedLMModel::Impl {
+  mutable std::mutex mutex;
+  ModelStatus status;
+  MaskedLMModelConfig config;
+  Tokenizer tokenizer;
+  std::string soPath, weightsPath;
+  size_t maxSeqLen = 1024, vocabSize = 128, defaultTopK = 5;
+  void *soHandle = nullptr;
+  ForwardFn forward = nullptr;
+  std::unique_ptr<MemRef<float, 1>> params;
+  ~Impl() {
+    params.reset();
+    if (soHandle)
+      dlclose(soHandle);
+  }
+};
+
+ProteinGLMMaskedLMModel::ProteinGLMMaskedLMModel() : impl(new Impl) {}
+ProteinGLMMaskedLMModel::~ProteinGLMMaskedLMModel() = default;
+
+void ProteinGLMMaskedLMModel::load(const MaskedLMModelConfig &cfg) {
+  std::lock_guard<std::mutex> lock(impl->mutex);
+  impl->params.reset();
+  if (impl->soHandle) {
+    dlclose(impl->soHandle);
+    impl->soHandle = nullptr;
+    impl->forward = nullptr;
+  }
+  impl->status = ModelStatus{};
+  impl->status.state = ModelLoadState::Loading;
+  impl->config = cfg;
+  try {
+    if (!cfg.raxPath.empty()) {
+      auto m = ModelManifest::loadFromRax(cfg.raxPath);
+      impl->soPath = m.soPath;
+      impl->weightsPath = constantPath(m);
+      impl->config.modelName =
+          cfg.modelName.empty() ? m.modelName : cfg.modelName;
+      if (impl->config.modelName.empty())
+        impl->config.modelName = "proteinglm";
+      impl->tokenizer =
+          loadTokenizer(cfg.vocabPath.empty() ? m.vocabPath : cfg.vocabPath);
+      impl->maxSeqLen = cfg.contextLength
+                            ? cfg.contextLength
+                            : attrSize(m, "max_seq_len", impl->maxSeqLen);
+      impl->vocabSize = attrSize(m, "vocab_size", impl->vocabSize);
+      impl->defaultTopK =
+          cfg.topK ? cfg.topK : attrSize(m, "top_k", impl->defaultTopK);
+    } else {
+      if (cfg.modelSoPath.empty() || cfg.weightPaths.empty() ||
+          cfg.vocabPath.empty())
+        throw std::runtime_error(
+            "masked-LM legacy mode requires model, weights and vocab");
+      impl->soPath = cfg.modelSoPath;
+      impl->weightsPath = cfg.weightPaths.front();
+      impl->config.modelName =
+          cfg.modelName.empty() ? "proteinglm" : cfg.modelName;
+      impl->tokenizer = loadTokenizer(cfg.vocabPath);
+      impl->defaultTopK = cfg.topK ? cfg.topK : 5;
+      if (cfg.contextLength)
+        impl->maxSeqLen = cfg.contextLength;
+    }
+    if (impl->soPath.empty() || impl->weightsPath.empty() ||
+        impl->tokenizer.idToToken.empty())
+      throw std::runtime_error("masked-LM model resources are incomplete");
+    impl->soHandle = dlopen(impl->soPath.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (!impl->soHandle)
+      throw std::runtime_error(std::string("masked-LM dlopen failed: ") +
+                               dlerror());
+    dlerror();
+    impl->forward = reinterpret_cast<ForwardFn>(
+        dlsym(impl->soHandle, "_mlir_ciface_forward"));
+    if (const char *e = dlerror())
+      throw std::runtime_error(
+          std::string("masked-LM kernel symbol missing: ") + e);
+    std::ifstream wf(impl->weightsPath, std::ios::binary | std::ios::ate);
+    if (!wf)
+      throw std::runtime_error("masked-LM weights cannot be opened");
+    auto bytes = static_cast<size_t>(wf.tellg());
+    if (bytes % sizeof(float))
+      throw std::runtime_error("masked-LM weights are not f32-aligned");
+    impl->params = std::make_unique<MemRef<float, 1>>(
+        std::vector<size_t>{bytes / sizeof(float)});
+    wf.seekg(0);
+    wf.read(reinterpret_cast<char *>(impl->params->getData()), bytes);
+    if (!wf)
+      throw std::runtime_error("masked-LM weights read failed");
+    impl->status.state = ModelLoadState::Ready;
+    impl->status.modelName = impl->config.modelName;
+    impl->status.backend = "cpu";
+    impl->status.contextLength = static_cast<int>(impl->maxSeqLen);
+    impl->status.message.clear();
+  } catch (...) {
+    impl->status.state = ModelLoadState::Error;
+    try {
+      throw;
+    } catch (const std::exception &e) {
+      impl->status.message = e.what();
+    }
+    throw;
+  }
+}
+
+ModelStatus ProteinGLMMaskedLMModel::status() const {
+  std::lock_guard<std::mutex> lock(impl->mutex);
+  return impl->status;
+}
+
+MaskedLMResult ProteinGLMMaskedLMModel::predict(const MaskedLMRequest &req) {
+  std::lock_guard<std::mutex> lock(impl->mutex);
+  if (impl->status.state != ModelLoadState::Ready)
+    throw std::runtime_error("masked-LM model is not ready");
+  if (req.input.empty())
+    throw std::invalid_argument("input must not be empty");
+  if (!req.model.empty() && req.model != impl->status.modelName)
+    throw std::invalid_argument("model name does not match loaded model");
+  size_t topK = req.topK ? req.topK : impl->defaultTopK;
+  if (topK == 0)
+    throw std::invalid_argument("top_k must be positive");
+  topK = std::min(topK, impl->vocabSize);
+  std::vector<int64_t> ids(impl->maxSeqLen, impl->tokenizer.padId);
+  std::vector<size_t> masks;
+  size_t real = 0;
+  for (const auto &p : pieces(req.input)) {
+    if (real + 1 >= impl->maxSeqLen)
+      throw std::invalid_argument("input exceeds context length");
+    auto it = impl->tokenizer.tokenToId.find(p);
+    ids[real] = it == impl->tokenizer.tokenToId.end() ? impl->tokenizer.unkId
+                                                      : it->second;
+    if (ids[real] == impl->tokenizer.maskId)
+      masks.push_back(real);
+    ++real;
+  }
+  if (real < impl->maxSeqLen)
+    ids[real++] = impl->tokenizer.eosId;
+  if (masks.empty())
+    throw std::invalid_argument("input must contain at least one <mask>");
+  MemRef<int64_t, 2> input({1, impl->maxSeqLen}),
+      attention({1, impl->maxSeqLen}), position({1, impl->maxSeqLen});
+  std::copy(ids.begin(), ids.end(), input.getData());
+  for (size_t i = 0; i < impl->maxSeqLen; ++i) {
+    attention.getData()[i] = i < real;
+    position.getData()[i] = static_cast<int64_t>(i);
+  }
+  MemRef<float, 3> output({1, impl->maxSeqLen, impl->vocabSize});
+  impl->forward(&output, impl->params.get(), &input, &attention, &position);
+  MaskedLMResult result;
+  result.model = impl->status.modelName;
+  result.sequenceLength = real;
+  result.promptTokens = real;
+  for (size_t pos : masks) {
+    std::vector<size_t> order(impl->vocabSize);
+    for (size_t i = 0; i < order.size(); ++i)
+      order[i] = i;
+    const float *row = output.getData() + pos * impl->vocabSize;
+    std::partial_sort(order.begin(), order.begin() + topK, order.end(),
+                      [&](size_t a, size_t b) { return row[a] > row[b]; });
+    MaskedLMPrediction pred;
+    pred.position = pos;
+    for (size_t i = 0; i < topK; ++i) {
+      size_t id = order[i];
+      pred.tokens.push_back(MaskedLMToken{static_cast<int64_t>(id),
+                                          id < impl->tokenizer.idToToken.size()
+                                              ? impl->tokenizer.idToToken[id]
+                                              : "?",
+                                          row[id]});
+    }
+    result.predictions.push_back(std::move(pred));
+  }
+  return result;
+}
+
+} // namespace runtime
+} // namespace buddy

--- a/models/proteinglm/ProteinGLMMaskedLMModelPlugin.cpp
+++ b/models/proteinglm/ProteinGLMMaskedLMModelPlugin.cpp
@@ -1,0 +1,28 @@
+//===- ProteinGLMMaskedLMModelPlugin.cpp - ProteinGLM masked-LM plugin ---===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/models/ProteinGLMMaskedLMModel.h"
+
+extern "C" buddy::runtime::MaskedLMModel *buddy_create_masked_lm_model_v1() {
+  return new buddy::runtime::ProteinGLMMaskedLMModel();
+}
+
+extern "C" void
+buddy_destroy_masked_lm_model_v1(buddy::runtime::MaskedLMModel *model) {
+  delete model;
+}
+
+extern "C" const char *buddy_masked_lm_model_type_v1() { return "proteinglm"; }

--- a/models/proteinglm/ProteinGLMMaskedLMModelTest.cpp
+++ b/models/proteinglm/ProteinGLMMaskedLMModelTest.cpp
@@ -1,0 +1,43 @@
+//===- ProteinGLMMaskedLMModelTest.cpp - ProteinGLM masked-LM tests ------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/models/ProteinGLMMaskedLMModel.h"
+
+#include <cassert>
+#include <iostream>
+#include <stdexcept>
+
+int main() {
+  buddy::runtime::ProteinGLMMaskedLMModel model;
+  bool loadFailed = false;
+  try {
+    model.load(buddy::runtime::MaskedLMModelConfig{});
+  } catch (const std::exception &) {
+    loadFailed = true;
+  }
+  assert(loadFailed);
+  assert(model.status().state == buddy::runtime::ModelLoadState::Error);
+
+  bool predictFailed = false;
+  try {
+    model.predict(buddy::runtime::MaskedLMRequest{});
+  } catch (const std::exception &) {
+    predictFailed = true;
+  }
+  assert(predictFailed);
+  std::cout << "ProteinGLM masked-LM runtime tests passed\n";
+  return 0;
+}

--- a/models/proteinglm/README.md
+++ b/models/proteinglm/README.md
@@ -79,6 +79,44 @@ position 1:
   C (20): ...
 ```
 
+## Masked-LM server
+
+The package also exposes a non-streaming masked-LM endpoint. Build
+`buddy-server` with the model target, then start it with the `.rax` manifest;
+the `masked_lm_library` attribute is discovered automatically.
+
+```bash
+conda run -n buddy-mlir cmake --build build --target proteinglm_rax buddy-server
+./build/bin/buddy-server --model build/models/proteinglm/proteinglm.rax \
+  --host 127.0.0.1 --port 8080
+curl http://127.0.0.1:8080/v1/masked-lm \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"proteinglm_1b_mlm","input":"A <mask> C","top_k":5}'
+```
+
+`prompt` is accepted as an alias for `input`. Multiple `<mask>` tokens produce
+one prediction entry per position; `top_k` overrides the manifest default.
+Input arrays and SSE streaming are not supported.
+
+## Masked-LM server
+
+The same package exposes a non-streaming masked-LM endpoint. Build
+`buddy-server` together with the model target, then start it with the `.rax`
+manifest (the `masked_lm_library` attr is discovered automatically):
+
+```bash
+conda run -n buddy-mlir cmake --build build --target proteinglm_rax buddy-server
+./build/bin/buddy-server --model build/models/proteinglm/proteinglm.rax \
+  --host 127.0.0.1 --port 8080
+curl http://127.0.0.1:8080/v1/masked-lm \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"proteinglm_1b_mlm","input":"A <mask> C","top_k":5}'
+```
+
+`prompt` is accepted as an alias for `input`. Multiple `<mask>` tokens produce
+one prediction entry per position; `top_k` overrides the manifest default.
+Input arrays and SSE streaming are not supported.
+
 ## Implementation Notes
 
 ProteinGLM is built as `MODEL_KIND single_forward`, not as an autoregressive
@@ -106,4 +144,8 @@ runner and packer are updated to resolve it portably.
 - `ProteinGLMRunner.cpp`: runtime loading, tokenization, forward call, top-k
   printing
 - `ProteinGLMRunnerPlugin.cpp`: `InferenceRunner` plugin C ABI exports
+- `ProteinGLMMaskedLMModel.cpp` and `ProteinGLMMaskedLMModelPlugin.cpp`:
+  masked-LM runtime and `buddy-server` plugin ABI
+- `ProteinGLMMaskedLMModel.cpp` and `ProteinGLMMaskedLMModelPlugin.cpp`:
+  masked-LM runtime and `buddy-server` plugin ABI
 - `CMakeLists.txt`: `buddy_add_model` integration

--- a/models/proteinglm/codegen/gen_proteinglm_manifest.py
+++ b/models/proteinglm/codegen/gen_proteinglm_manifest.py
@@ -14,7 +14,12 @@ def normalize_uri(raw: str) -> str:
     return f"file:{s}"
 
 
-def gen_manifest(spec: dict, params_size: int, runner_library: str) -> str:
+def gen_manifest(
+    spec: dict,
+    params_size: int,
+    runner_library: str,
+    masked_lm_library: str = "",
+) -> str:
     model_id = spec.get("model_id", f"{spec['model_family']}_{spec['variant']}")
     max_seq_len = int(spec["max_seq_len"])
     vocab_size = int(spec["vocab_size"])
@@ -32,7 +37,11 @@ def gen_manifest(spec: dict, params_size: int, runner_library: str) -> str:
     p(f'    max_seq_len = "{max_seq_len}",')
     p(f'    vocab_size = "{vocab_size}",')
     p(f'    top_k = "{top_k}",')
-    p(f'    runner_library = "{runner_library}"}} {{')
+    if masked_lm_library:
+        p(f'    runner_library = "{runner_library}",')
+        p(f'    masked_lm_library = "{masked_lm_library}"}} {{')
+    else:
+        p(f'    runner_library = "{runner_library}"}} {{')
     p("")
     p('  rhal.constant @params {id = 1 : i32, storage = "external",')
     p(f"                         type = tensor<{params_size}xf32>,")
@@ -82,6 +91,7 @@ def main() -> int:
     )
     parser.add_argument("--spec", required=True)
     parser.add_argument("--runner-library", default="proteinglm_runner.so")
+    parser.add_argument("--masked-lm-library", default="")
     parser.add_argument("-o", "--output", default="-")
     args = parser.parse_args()
 
@@ -98,7 +108,10 @@ def main() -> int:
         raise RuntimeError(f"weight file is not f32-aligned: {params_file}")
 
     text = gen_manifest(
-        spec, params_bytes // 4, normalize_uri(args.runner_library)
+        spec,
+        params_bytes // 4,
+        normalize_uri(args.runner_library),
+        normalize_uri(args.masked_lm_library) if args.masked_lm_library else "",
     )
     if args.output == "-":
         sys.stdout.write(text)

--- a/models/proteinglm/include/buddy/runtime/models/ProteinGLMMaskedLMModel.h
+++ b/models/proteinglm/include/buddy/runtime/models/ProteinGLMMaskedLMModel.h
@@ -1,0 +1,42 @@
+//===- ProteinGLMMaskedLMModel.h - ProteinGLM masked-LM model ------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_MODELS_PROTEINGLM_MASKEDLMMODEL_H
+#define BUDDY_RUNTIME_MODELS_PROTEINGLM_MASKEDLMMODEL_H
+
+#include "buddy/runtime/core/MaskedLMModel.h"
+#include <memory>
+
+namespace buddy {
+namespace runtime {
+
+class ProteinGLMMaskedLMModel final : public MaskedLMModel {
+public:
+  ProteinGLMMaskedLMModel();
+  ~ProteinGLMMaskedLMModel() override;
+  void load(const MaskedLMModelConfig &config) override;
+  ModelStatus status() const override;
+  MaskedLMResult predict(const MaskedLMRequest &request) override;
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl;
+};
+
+} // namespace runtime
+} // namespace buddy
+
+#endif

--- a/runtime/include/buddy/runtime/core/MaskedLMModel.h
+++ b/runtime/include/buddy/runtime/core/MaskedLMModel.h
@@ -1,0 +1,41 @@
+//===- MaskedLMModel.h - Masked language model interface -----------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_CORE_MASKEDLMMODEL_H
+#define BUDDY_RUNTIME_CORE_MASKEDLMMODEL_H
+
+#include "buddy/runtime/core/MaskedLMTypes.h"
+
+namespace buddy {
+namespace runtime {
+
+class MaskedLMModel {
+public:
+  virtual ~MaskedLMModel() = default;
+  MaskedLMModel(const MaskedLMModel &) = delete;
+  MaskedLMModel &operator=(const MaskedLMModel &) = delete;
+  virtual void load(const MaskedLMModelConfig &config) = 0;
+  virtual ModelStatus status() const = 0;
+  virtual MaskedLMResult predict(const MaskedLMRequest &request) = 0;
+
+protected:
+  MaskedLMModel() = default;
+};
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_CORE_MASKEDLMMODEL_H

--- a/runtime/include/buddy/runtime/core/MaskedLMModelPlugin.h
+++ b/runtime/include/buddy/runtime/core/MaskedLMModelPlugin.h
@@ -1,0 +1,32 @@
+//===- MaskedLMModelPlugin.h - Masked-LM plugin C ABI --------------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_CORE_MASKEDLMMODELPLUGIN_H
+#define BUDDY_RUNTIME_CORE_MASKEDLMMODELPLUGIN_H
+
+#include "buddy/runtime/core/MaskedLMModel.h"
+
+namespace buddy {
+namespace runtime {
+
+using CreateMaskedLMModelFn = MaskedLMModel *(*)();
+using DestroyMaskedLMModelFn = void (*)(MaskedLMModel *);
+using MaskedLMModelTypeFn = const char *(*)();
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_CORE_MASKEDLMMODELPLUGIN_H

--- a/runtime/include/buddy/runtime/core/MaskedLMTypes.h
+++ b/runtime/include/buddy/runtime/core/MaskedLMTypes.h
@@ -1,0 +1,66 @@
+//===- MaskedLMTypes.h - Masked language model serving DTOs --------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_CORE_MASKEDLMTYPES_H
+#define BUDDY_RUNTIME_CORE_MASKEDLMTYPES_H
+
+#include "buddy/runtime/core/ServingTypes.h"
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace buddy {
+namespace runtime {
+
+struct MaskedLMModelConfig {
+  std::string raxPath;
+  std::string modelSoPath;
+  std::vector<std::string> weightPaths;
+  std::string vocabPath;
+  std::string modelName;
+  std::size_t topK = 5;
+  std::size_t contextLength = 0;
+};
+
+struct MaskedLMRequest {
+  std::string model;
+  std::string input;
+  std::size_t topK = 0; // zero means use the manifest default
+};
+
+struct MaskedLMToken {
+  std::int64_t tokenId = 0;
+  std::string token;
+  float score = 0.0f;
+};
+
+struct MaskedLMPrediction {
+  std::size_t position = 0;
+  std::vector<MaskedLMToken> tokens;
+};
+
+struct MaskedLMResult {
+  std::string model;
+  std::size_t sequenceLength = 0;
+  std::vector<MaskedLMPrediction> predictions;
+  std::size_t promptTokens = 0;
+};
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_CORE_MASKEDLMTYPES_H

--- a/runtime/include/buddy/runtime/core/ModelManifest.h
+++ b/runtime/include/buddy/runtime/core/ModelManifest.h
@@ -25,6 +25,7 @@
 //   "file:vocab.txt") module_attrs["runner_library"] → runner plugin URI
 //   module_attrs["serving_library"] → resident serving plugin URI
 //   module_attrs["embedding_library"] → embedding plugin URI
+//   module_attrs["masked_lm_library"] → masked-LM plugin URI
 //   module_attrs["model_name"]→ model identifier      (e.g.
 //   "deepseek_r1_fp32")
 //
@@ -114,6 +115,8 @@ struct ModelManifest {
   std::string servingLibraryPath;
   // absolute path to the embedding model plugin shared library.
   std::string embeddingLibraryPath;
+  // absolute path to the masked language model plugin shared library.
+  std::string maskedLMLibraryPath;
   // Raw module attrs plus URI-resolved variants for attrs whose value is a URI.
   std::unordered_map<std::string, std::string> moduleAttrs;
   std::unordered_map<std::string, std::string> resolvedModuleAttrs;
@@ -548,7 +551,7 @@ struct ModelManifest {
         std::string value = kv->value()->str();
         out.moduleAttrs[key] = value;
         if (hasPrefix(value, "file:") || hasPrefix(value, "payload:") ||
-            hasSuffix(key, "_uri"))
+            hasSuffix(key, "_uri") || key == "masked_lm_library")
           out.resolvedModuleAttrs[key] = resolveUri(kv->value(), key.c_str());
         if (key == "vocab_uri" && kv->value() && kv->value()->size() > 0)
           out.vocabPath = out.resolvedModuleAttrs[key];
@@ -562,6 +565,10 @@ struct ModelManifest {
                  kv->value()->size() > 0)
           out.embeddingLibraryPath =
               resolveUri(kv->value(), "embedding_library");
+        else if (key == "masked_lm_library" && kv->value() &&
+                 kv->value()->size() > 0)
+          out.maskedLMLibraryPath =
+              resolveUri(kv->value(), "masked_lm_library");
         else if (key == "model_name" && kv->value() && kv->value()->size() > 0)
           out.modelName = value;
       }

--- a/tools/buddy-codegen/cmake/buddy_model.cmake
+++ b/tools/buddy-codegen/cmake/buddy_model.cmake
@@ -82,6 +82,8 @@ endif()
 #   [SERVING_LIBRARY <URI_OR_NAME>]         optional resident serving plugin URI
 #   [EMBEDDING_PLUGIN_SRC <file.cpp>]       embedding model plugin wrapper source
 #   [EMBEDDING_LIBRARY <URI_OR_NAME>]       optional embedding plugin URI
+#   [MASKED_LM_PLUGIN_SRC <file.cpp>]       masked-LM plugin wrapper source
+#   [MASKED_LM_LIBRARY <URI_OR_NAME>]       optional masked-LM plugin URI
 #   [EXTRA_SRCS <file.cpp>...]              optional model runtime sources
 #   [HF_CONFIG    <config.json>]            optional HuggingFace config path
 #   [LOCAL_MODEL  <dir>]                    optional: HF snapshot dir for import
@@ -161,7 +163,7 @@ function(buddy_add_model)
   cmake_parse_arguments(
     MDL                                      # prefix
     ""                                       # flags
-    "NAME;SPEC;RUNNER_SRC;RUNNER_PLUGIN_SRC;RUNNER_HDR;SERVING_PLUGIN_SRC;SERVING_LIBRARY;EMBEDDING_PLUGIN_SRC;EMBEDDING_LIBRARY;HF_CONFIG;LOCAL_MODEL;BUILD_DIR;MLIR_DIR;NUM_THREADS;LLC_ATTRS;COMPILE_JOBS;TIERED_KV_CACHE;MODEL_KIND;IMPORT_SCRIPT;MANIFEST_SCRIPT;LOCAL_MODEL_ENV;MODEL_SO_NAME;TEMPLATE_PARTITION_CAPABLE"
+    "NAME;SPEC;RUNNER_SRC;RUNNER_PLUGIN_SRC;RUNNER_HDR;SERVING_PLUGIN_SRC;SERVING_LIBRARY;EMBEDDING_PLUGIN_SRC;EMBEDDING_LIBRARY;MASKED_LM_PLUGIN_SRC;MASKED_LM_LIBRARY;HF_CONFIG;LOCAL_MODEL;BUILD_DIR;MLIR_DIR;NUM_THREADS;LLC_ATTRS;COMPILE_JOBS;TIERED_KV_CACHE;MODEL_KIND;IMPORT_SCRIPT;MANIFEST_SCRIPT;LOCAL_MODEL_ENV;MODEL_SO_NAME;TEMPLATE_PARTITION_CAPABLE"
     "EXTRA_SRCS;TIERED_CACHE_SIZES;ASSET_FILES;RUNTIME_LINK_LIBS" # multi-value
     ${ARGN}
   )
@@ -269,6 +271,13 @@ function(buddy_add_model)
     list(APPEND MDL_GEN_MANIFEST_ARGS
       --embedding-library "${MDL_EMBEDDING_LIBRARY}")
   endif()
+  if(MDL_MASKED_LM_PLUGIN_SRC AND NOT MDL_MASKED_LM_LIBRARY)
+    set(MDL_MASKED_LM_LIBRARY "${MDL_NAME}_masked_lm.so")
+  endif()
+  if(MDL_MASKED_LM_LIBRARY)
+    list(APPEND MDL_GEN_MANIFEST_ARGS
+      --masked-lm-library "${MDL_MASKED_LM_LIBRARY}")
+  endif()
 
   if(IS_RVV_CROSSCOMPILE)
     if(NOT RISCV_GNU_TOOLCHAIN)
@@ -342,6 +351,7 @@ function(buddy_add_model)
   set(IMPORT_STAMP "${BIN}/.buddy_import_done")
   set(SERVING_PLUGIN_TARGET "")
   set(EMBEDDING_PLUGIN_TARGET "")
+  set(MASKED_LM_PLUGIN_TARGET "")
 
   # ── gen_config.py ─────────────────────────────────────────────────────────
   if(MDL_MODEL_KIND STREQUAL "single_forward")
@@ -680,6 +690,20 @@ function(buddy_add_model)
     target_link_libraries(${EMBEDDING_PLUGIN_TARGET} PRIVATE ${LIB_TARGET})
     target_compile_features(${EMBEDDING_PLUGIN_TARGET} PRIVATE cxx_std_17)
     install(TARGETS ${EMBEDDING_PLUGIN_TARGET} EXPORT BuddyMLIRTargets COMPONENT buddy_runtime)
+  endif()
+
+  if(MDL_MASKED_LM_PLUGIN_SRC)
+    set(MASKED_LM_PLUGIN_TARGET "buddy_models_${MDL_NAME}_masked_lm")
+    add_library(${MASKED_LM_PLUGIN_TARGET} SHARED
+      "${CMAKE_CURRENT_SOURCE_DIR}/${MDL_MASKED_LM_PLUGIN_SRC}")
+    set_target_properties(${MASKED_LM_PLUGIN_TARGET} PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY "${BIN}"
+      RUNTIME_OUTPUT_DIRECTORY "${BIN}"
+      OUTPUT_NAME "${MDL_NAME}_masked_lm"
+      PREFIX "")
+    target_link_libraries(${MASKED_LM_PLUGIN_TARGET} PRIVATE ${LIB_TARGET})
+    target_compile_features(${MASKED_LM_PLUGIN_TARGET} PRIVATE cxx_std_17)
+    install(TARGETS ${MASKED_LM_PLUGIN_TARGET} EXPORT BuddyMLIRTargets COMPONENT buddy_runtime)
   endif()
 
   # ════════════════════════════════════════════════════════════════════════════
@@ -1174,6 +1198,7 @@ function(buddy_add_model)
     "${MODEL_SO}"
     ${RUNNER_PLUGIN_TARGET}
     ${EMBEDDING_PLUGIN_TARGET}
+    ${MASKED_LM_PLUGIN_TARGET}
     ${MDL_ASSET_DSTS})
   if(MDL_MODEL_KIND STREQUAL "single_forward")
     list(APPEND MDL_STAGE4_DEPS "${BIN}/arg0.data")

--- a/tools/buddy-codegen/gen_manifest.py
+++ b/tools/buddy-codegen/gen_manifest.py
@@ -46,6 +46,7 @@ def gen_manifest(
     runner_library: str | None = None,
     serving_library: str | None = None,
     embedding_library: str | None = None,
+    masked_lm_library: str | None = None,
 ) -> str:
     """Generate the complete RHAL .mlir manifest text."""
     out = StringIO()
@@ -82,6 +83,9 @@ def gen_manifest(
     embedding_uri = (
         _normalize_dep_uri(embedding_library) if embedding_library else None
     )
+    masked_lm_uri = (
+        _normalize_dep_uri(masked_lm_library) if masked_lm_library else None
+    )
 
     dep_uris: list[str] = []
     for item in dep_shared_libs or []:
@@ -98,14 +102,16 @@ def gen_manifest(
         p(f'    serving_library = "{serving_uri}"', end="")
         if embedding_uri:
             p(",")
-            p(f'    embedding_library = "{embedding_uri}"}} {{')
+            p(f'    embedding_library = "{embedding_uri}"', end="")
         else:
-            p("} {")
+            pass
     elif embedding_uri:
         p(",")
-        p(f'    embedding_library = "{embedding_uri}"}} {{')
-    else:
-        p("} {")
+        p(f'    embedding_library = "{embedding_uri}"', end="")
+    if masked_lm_uri:
+        p(",")
+        p(f'    masked_lm_library = "{masked_lm_uri}"', end="")
+    p("} {")
     p()
 
     # -- External constants (weight blobs) -------------------------------------
@@ -263,6 +269,12 @@ def main():
             "If no scheme is given, file: is assumed."
         ),
     )
+    parser.add_argument(
+        "--masked-lm-library",
+        default=None,
+        metavar="URI_OR_NAME",
+        help=("Masked-LM plugin library URI/name to place into module attrs."),
+    )
     args = parser.parse_args()
 
     with open(args.config) as f:
@@ -275,6 +287,7 @@ def main():
             runner_library=args.runner_library,
             serving_library=args.serving_library,
             embedding_library=args.embedding_library,
+            masked_lm_library=args.masked_lm_library,
         )
     except (ValueError, RuntimeError, OSError) as e:
         print(f"error: {e}", file=sys.stderr)

--- a/tools/buddy-server/CMakeLists.txt
+++ b/tools/buddy-server/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(buddy-server
   JsonCodec.cpp
   ResidentModelPluginHandle.cpp
   EmbeddingModelPluginHandle.cpp
+  MaskedLMModelPluginHandle.cpp
   SimpleHttpServer.cpp
 )
 
@@ -87,4 +88,18 @@ if(BUDDY_ENABLE_TESTS)
   set_tests_properties(buddy-server-embedding-plugin-handle PROPERTIES
     PASS_REGULAR_EXPRESSION "EmbeddingModelPluginHandle tests passed"
   )
+
+  add_executable(buddy-server-masked-lm-plugin-handle-test
+    MaskedLMModelPluginHandleTest.cpp
+    MaskedLMModelPluginHandle.cpp
+  )
+  target_compile_features(buddy-server-masked-lm-plugin-handle-test PRIVATE cxx_std_17)
+  target_include_directories(buddy-server-masked-lm-plugin-handle-test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR})
+  target_link_libraries(buddy-server-masked-lm-plugin-handle-test PRIVATE
+    buddy_runtime_core ${CMAKE_DL_LIBS})
+  add_test(NAME buddy-server-masked-lm-plugin-handle
+    COMMAND buddy-server-masked-lm-plugin-handle-test)
+  set_tests_properties(buddy-server-masked-lm-plugin-handle PROPERTIES
+    PASS_REGULAR_EXPRESSION "MaskedLMModelPluginHandle tests passed")
 endif()

--- a/tools/buddy-server/JsonCodec.cpp
+++ b/tools/buddy-server/JsonCodec.cpp
@@ -283,6 +283,40 @@ DecodedEmbeddingRequest parseEmbeddingRequest(const std::string &body) {
   return decoded;
 }
 
+DecodedMaskedLMRequest parseMaskedLMRequest(const std::string &body) {
+  json::Value value = parseValue(body);
+  const json::Object &obj = asObject(value);
+  DecodedMaskedLMRequest decoded;
+  if (auto model = obj.getString("model"))
+    decoded.request.model = model->str();
+  else if (obj.find("model") != obj.end())
+    throw JsonCodecError("model must be a string");
+  const bool hasInput = obj.find("input") != obj.end();
+  const bool hasPrompt = obj.find("prompt") != obj.end();
+  if (hasInput && hasPrompt)
+    throw JsonCodecError("provide only one of input or prompt");
+  const char *key = hasInput ? "input" : "prompt";
+  if (!hasInput && !hasPrompt)
+    throw JsonCodecError("missing required field: input");
+  auto it = obj.find(key);
+  auto input = it->second.getAsString();
+  if (!input)
+    throw JsonCodecError("input must be a string");
+  decoded.request.input = input->str();
+  if (decoded.request.input.empty())
+    throw JsonCodecError("input must not be empty");
+  if (auto top = obj.getInteger("top_k")) {
+    if (*top <= 0)
+      throw JsonCodecError("top_k must be positive");
+    decoded.request.topK = static_cast<std::size_t>(*top);
+  } else if (obj.find("top_k") != obj.end()) {
+    throw JsonCodecError("top_k must be a positive integer");
+  }
+  if (auto stream = obj.getBoolean("stream"); stream && *stream)
+    throw JsonCodecError("streaming masked-LM is not supported");
+  return decoded;
+}
+
 DecodedChatRequest parseChatCompletionRequest(const std::string &body) {
   json::Value value = parseValue(body);
   const json::Object &obj = asObject(value);
@@ -379,6 +413,27 @@ std::string toOpenAIEmbeddingJson(const EmbeddingResult &result) {
        json::Object{
            {"prompt_tokens", static_cast<int64_t>(result.promptTokens)},
            {"total_tokens", static_cast<int64_t>(result.totalTokens)}}}});
+}
+
+std::string toJson(const MaskedLMResult &result) {
+  json::Array predictions;
+  for (const auto &prediction : result.predictions) {
+    json::Array tokens;
+    for (const auto &token : prediction.tokens)
+      tokens.emplace_back(json::Object{{"token_id", token.tokenId},
+                                       {"token", token.token},
+                                       {"score", token.score}});
+    predictions.emplace_back(
+        json::Object{{"position", static_cast<int64_t>(prediction.position)},
+                     {"tokens", std::move(tokens)}});
+  }
+  return serialize(json::Object{
+      {"object", "masked_lm"},
+      {"model", result.model},
+      {"sequence_length", static_cast<int64_t>(result.sequenceLength)},
+      {"predictions", std::move(predictions)},
+      {"usage", json::Object{{"prompt_tokens",
+                              static_cast<int64_t>(result.promptTokens)}}}});
 }
 
 std::string toOpenAIChatJson(const CompletionResult &result) {

--- a/tools/buddy-server/JsonCodec.h
+++ b/tools/buddy-server/JsonCodec.h
@@ -18,6 +18,7 @@
 #define BUDDY_TOOLS_BUDDY_SERVER_JSONCODEC_H
 
 #include "buddy/runtime/core/EmbeddingTypes.h"
+#include "buddy/runtime/core/MaskedLMTypes.h"
 #include "buddy/runtime/core/ServingTypes.h"
 
 #include <stdexcept>
@@ -45,16 +46,21 @@ struct DecodedChatRequest {
 struct DecodedEmbeddingRequest {
   buddy::runtime::EmbeddingRequest request;
 };
+struct DecodedMaskedLMRequest {
+  buddy::runtime::MaskedLMRequest request;
+};
 
 DecodedCompletionRequest parseCompletionRequest(const std::string &body);
 DecodedChatRequest parseChatCompletionRequest(const std::string &body);
 DecodedEmbeddingRequest parseEmbeddingRequest(const std::string &body);
+DecodedMaskedLMRequest parseMaskedLMRequest(const std::string &body);
 buddy::runtime::TokenizeRequest parseTokenizeRequest(const std::string &body);
 
 std::string toJson(const buddy::runtime::ModelStatus &status);
 std::string toJson(const buddy::runtime::CompletionResult &result);
 std::string
 toOpenAIEmbeddingJson(const buddy::runtime::EmbeddingResult &result);
+std::string toJson(const buddy::runtime::MaskedLMResult &result);
 std::string toOpenAIChatJson(const buddy::runtime::CompletionResult &result);
 std::string toJson(const buddy::runtime::TokenizeResult &result,
                    bool countOnly);

--- a/tools/buddy-server/JsonCodecTest.cpp
+++ b/tools/buddy-server/JsonCodecTest.cpp
@@ -24,6 +24,7 @@
 using buddy::server::parseChatCompletionRequest;
 using buddy::server::parseCompletionRequest;
 using buddy::server::parseEmbeddingRequest;
+using buddy::server::parseMaskedLMRequest;
 using buddy::server::toOpenAIEmbeddingJson;
 
 namespace {
@@ -98,6 +99,22 @@ int main() {
   assert(json.find("\"object\":\"list\"") != std::string::npos);
   assert(json.find("\"index\":0") != std::string::npos);
   assert(json.find("\"prompt_tokens\":2") != std::string::npos);
+
+  auto masked = parseMaskedLMRequest(
+      R"({"model":"proteinglm_1b_mlm","prompt":"A <mask> C","top_k":3,"extra":true})");
+  assert(masked.request.model == "proteinglm_1b_mlm");
+  assert(masked.request.input == "A <mask> C");
+  assert(masked.request.topK == 3);
+  expectFailure([] { parseMaskedLMRequest(R"({"input":"x","prompt":"y"})"); });
+  expectFailure([] { parseMaskedLMRequest(R"({"input":"x","top_k":0})"); });
+  buddy::runtime::MaskedLMResult maskedResult;
+  maskedResult.model = "proteinglm_1b_mlm";
+  maskedResult.sequenceLength = 4;
+  maskedResult.promptTokens = 4;
+  maskedResult.predictions.push_back({1, {{3, "G", 12.3f}}});
+  const std::string maskedJson = buddy::server::toJson(maskedResult);
+  assert(maskedJson.find("\"object\":\"masked_lm\"") != std::string::npos);
+  assert(maskedJson.find("\"position\":1") != std::string::npos);
 
   std::cout << "JsonCodec tests passed\n";
   return 0;

--- a/tools/buddy-server/MaskedLMModelPluginHandle.cpp
+++ b/tools/buddy-server/MaskedLMModelPluginHandle.cpp
@@ -1,0 +1,87 @@
+//===- MaskedLMModelPluginHandle.cpp - Masked-LM plugin loader -----------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include "MaskedLMModelPluginHandle.h"
+#include <dlfcn.h>
+#include <stdexcept>
+
+namespace buddy {
+namespace server {
+namespace {
+template <typename Fn>
+Fn required(void *h, const std::string &p, const char *s) {
+  dlerror();
+  void *raw = dlsym(h, s);
+  if (const char *e = dlerror())
+    throw std::runtime_error("buddy-server: masked-LM plugin " + p +
+                             " missing " + s + ": " + e);
+  return reinterpret_cast<Fn>(raw);
+}
+template <typename Fn> Fn optional(void *h, const char *s) {
+  dlerror();
+  void *raw = dlsym(h, s);
+  if (dlerror())
+    return nullptr;
+  return reinterpret_cast<Fn>(raw);
+}
+} // namespace
+MaskedLMModelPluginHandle::MaskedLMModelPluginHandle(const std::string &p)
+    : pluginPath(p) {
+  if (p.empty())
+    throw std::runtime_error("buddy-server: --masked-lm-so path is empty");
+  handle = dlopen(p.c_str(), RTLD_NOW | RTLD_LOCAL);
+  if (!handle)
+    throw std::runtime_error(
+        std::string("buddy-server: dlopen masked-LM plugin failed: ") +
+        dlerror());
+  lifetime = std::shared_ptr<void>(handle, [](void *library) {
+    if (library)
+      dlclose(library);
+  });
+  try {
+    create = required<buddy::runtime::CreateMaskedLMModelFn>(
+        handle, p, "buddy_create_masked_lm_model_v1");
+    destroy = required<buddy::runtime::DestroyMaskedLMModelFn>(
+        handle, p, "buddy_destroy_masked_lm_model_v1");
+    if (auto type = optional<buddy::runtime::MaskedLMModelTypeFn>(
+            handle, "buddy_masked_lm_model_type_v1"))
+      if (const char *n = type())
+        pluginModelType = n;
+  } catch (...) {
+    lifetime.reset();
+    handle = nullptr;
+    throw;
+  }
+}
+MaskedLMModelPluginHandle::~MaskedLMModelPluginHandle() {
+  lifetime.reset();
+  handle = nullptr;
+}
+MaskedLMModelPluginHandle::ModelPtr
+MaskedLMModelPluginHandle::createModel() const {
+  auto *m = create();
+  if (!m)
+    throw std::runtime_error(
+        "buddy-server: masked-LM plugin returned null model: " + pluginPath);
+  auto keepAlive = lifetime;
+  return ModelPtr(
+      m, [destroy = destroy, keepAlive](buddy::runtime::MaskedLMModel *p) {
+        if (p)
+          destroy(p);
+      });
+}
+} // namespace server
+} // namespace buddy

--- a/tools/buddy-server/MaskedLMModelPluginHandle.h
+++ b/tools/buddy-server/MaskedLMModelPluginHandle.h
@@ -1,0 +1,50 @@
+//===- MaskedLMModelPluginHandle.h - Masked-LM plugin loader -------------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_TOOLS_BUDDY_SERVER_MASKEDLMMODELPLUGINHANDLE_H
+#define BUDDY_TOOLS_BUDDY_SERVER_MASKEDLMMODELPLUGINHANDLE_H
+
+#include "buddy/runtime/core/MaskedLMModelPlugin.h"
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace buddy {
+namespace server {
+class MaskedLMModelPluginHandle {
+public:
+  using ModelPtr =
+      std::unique_ptr<buddy::runtime::MaskedLMModel,
+                      std::function<void(buddy::runtime::MaskedLMModel *)>>;
+  explicit MaskedLMModelPluginHandle(const std::string &path);
+  ~MaskedLMModelPluginHandle();
+  MaskedLMModelPluginHandle(const MaskedLMModelPluginHandle &) = delete;
+  MaskedLMModelPluginHandle &
+  operator=(const MaskedLMModelPluginHandle &) = delete;
+  ModelPtr createModel() const;
+  const std::string &modelType() const { return pluginModelType; }
+
+private:
+  std::string pluginPath, pluginModelType;
+  void *handle = nullptr;
+  std::shared_ptr<void> lifetime;
+  buddy::runtime::CreateMaskedLMModelFn create = nullptr;
+  buddy::runtime::DestroyMaskedLMModelFn destroy = nullptr;
+};
+} // namespace server
+} // namespace buddy
+
+#endif

--- a/tools/buddy-server/MaskedLMModelPluginHandleTest.cpp
+++ b/tools/buddy-server/MaskedLMModelPluginHandleTest.cpp
@@ -1,0 +1,39 @@
+//===- MaskedLMModelPluginHandleTest.cpp - Masked-LM loader tests --------===//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include "MaskedLMModelPluginHandle.h"
+#include <cassert>
+#include <iostream>
+#include <stdexcept>
+int main() {
+  bool failed = false;
+  try {
+    buddy::server::MaskedLMModelPluginHandle handle("");
+  } catch (const std::runtime_error &) {
+    failed = true;
+  }
+  assert(failed);
+  failed = false;
+  try {
+    buddy::server::MaskedLMModelPluginHandle handle(
+        "/definitely/missing/masked_lm_plugin.so");
+  } catch (const std::runtime_error &) {
+    failed = true;
+  }
+  assert(failed);
+  std::cout << "MaskedLMModelPluginHandle tests passed\n";
+  return 0;
+}

--- a/tools/buddy-server/README.md
+++ b/tools/buddy-server/README.md
@@ -4,6 +4,11 @@
 models. The server binary is built by default and is decoupled from concrete
 model implementations through resident model plugins.
 
+It also supports the independent masked-LM backend with `--masked-lm-so`.
+Choose at most one of `--serving-so`, `--embedding-so` and `--masked-lm-so`;
+when a `.rax` manifest is supplied, exactly one corresponding module attribute
+is discovered automatically.
+
 ## Build
 
 `buddy-server` is built by default:
@@ -340,3 +345,25 @@ The response contains `data[0].embedding`, `data[0].index`, `model`, and
 400 unsupported-input error. Embedding mode returns a 400
 `unsupported_endpoint` error for completion, chat completion, and tokenize;
 DeepSeek/Qwen resident behavior and SSE remain unchanged.
+
+## ProteinGLM masked-LM backend
+
+ProteinGLM uses a single forward pass and is served independently from the
+resident completion API. Build the package with a local snapshot, then start
+the server using the manifest's `masked_lm_library` (or pass
+`--masked-lm-so` explicitly):
+
+```bash
+conda run -n buddy-mlir cmake --build build --target proteinglm_rax buddy-server
+./build/bin/buddy-server --model ./build/models/proteinglm/proteinglm.rax \
+  --host 127.0.0.1 --port 8080
+curl http://127.0.0.1:8080/v1/masked-lm \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"proteinglm_1b_mlm","input":"A <mask> C","top_k":5}'
+```
+
+`/masked-lm` is an alias. `prompt` may replace `input`; multiple masks return
+multiple prediction entries and `top_k` overrides the manifest default. The
+endpoint is non-streaming and accepts only a single string input. Completion,
+chat, tokenize and embedding routes return `unsupported_endpoint` in this
+mode.

--- a/tools/buddy-server/buddy-server.cpp
+++ b/tools/buddy-server/buddy-server.cpp
@@ -16,11 +16,14 @@
 
 #include "EmbeddingModelPluginHandle.h"
 #include "JsonCodec.h"
+#include "MaskedLMModelPluginHandle.h"
 #include "ResidentModelPluginHandle.h"
 #include "SimpleHttpServer.h"
 
 #include "buddy/runtime/core/EmbeddingModel.h"
 #include "buddy/runtime/core/EmbeddingTypes.h"
+#include "buddy/runtime/core/MaskedLMModel.h"
+#include "buddy/runtime/core/MaskedLMTypes.h"
 #include "buddy/runtime/core/ModelManifest.h"
 #include "buddy/runtime/core/ResidentModel.h"
 #include "buddy/runtime/core/ServingTypes.h"
@@ -35,6 +38,8 @@
 
 using buddy::runtime::EmbeddingModel;
 using buddy::runtime::EmbeddingModelConfig;
+using buddy::runtime::MaskedLMModel;
+using buddy::runtime::MaskedLMModelConfig;
 using buddy::runtime::ModelLoadState;
 using buddy::runtime::ModelStatus;
 using buddy::runtime::ResidentModel;
@@ -58,6 +63,7 @@ void usage(const char *prog, std::ostream &os = std::cout) {
      << "  --model-type <name>      Model type/name override for status\n"
      << "  --serving-so <path.so>   Resident model plugin shared library\n"
      << "  --embedding-so <path.so> Embedding model plugin shared library\n\n"
+     << "  --masked-lm-so <path.so> Masked-LM plugin shared library\n\n"
      << "Server:\n"
      << "  --host       <addr>      Bind address (default 127.0.0.1)\n"
      << "  --port       <port>      Bind port (default 8080)\n\n"
@@ -88,6 +94,8 @@ template <typename Fn> void withJsonErrors(ResponseWriter &writer, Fn fn) {
     fn();
   } catch (const buddy::server::JsonCodecError &ex) {
     sendError(writer, 400, ex.what(), "bad_request");
+  } catch (const std::invalid_argument &ex) {
+    sendError(writer, 400, ex.what(), "bad_request");
   } catch (const std::exception &ex) {
     sendError(writer, 500, ex.what(), "internal_error");
   }
@@ -95,9 +103,31 @@ template <typename Fn> void withJsonErrors(ResponseWriter &writer, Fn fn) {
 
 void handleUnsupported(ResponseWriter &writer, const char *endpoint) {
   sendError(writer, 400,
-            std::string(endpoint) +
-                " is not supported by the embedding backend",
+            std::string(endpoint) + " is not supported by the selected backend",
             "unsupported_endpoint");
+}
+
+void handleMaskedLM(MaskedLMModel &model, const std::atomic<int> &loadState,
+                    const HttpRequest &request, ResponseWriter &writer) {
+  if (!isReady(loadState)) {
+    sendError(writer, 503, "model is not loaded", "model_not_ready");
+    return;
+  }
+  withJsonErrors(writer, [&] {
+    auto decoded = buddy::server::parseMaskedLMRequest(request.body);
+    const ModelStatus status = model.status();
+    if (!decoded.request.model.empty() &&
+        decoded.request.model != status.modelName) {
+      sendError(writer, 400,
+                "model '" + decoded.request.model +
+                    "' does not match loaded model '" + status.modelName + "'",
+                "model_not_found");
+      return;
+    }
+    auto result = model.predict(decoded.request);
+    writer.sendResponse(
+        buddy::server::jsonResponse(200, buddy::server::toJson(result)));
+  });
 }
 
 void handleCompletion(ResidentModel &model, const std::atomic<int> &loadState,
@@ -205,6 +235,7 @@ int main(int argc, char **argv) {
   std::string modelType;
   std::string servingSoPath;
   std::string embeddingSoPath;
+  std::string maskedLMSoPath;
   std::string host = "127.0.0.1";
   int port = 8080;
 
@@ -224,6 +255,8 @@ int main(int argc, char **argv) {
       servingSoPath = argv[++i];
     else if (arg == "--embedding-so" && i + 1 < argc)
       embeddingSoPath = argv[++i];
+    else if (arg == "--masked-lm-so" && i + 1 < argc)
+      maskedLMSoPath = argv[++i];
     else if (arg == "--chat-template" && i + 1 < argc)
       modelConfig.chatTemplatePath = argv[++i];
     else if (arg == "--host" && i + 1 < argc)
@@ -258,33 +291,41 @@ int main(int argc, char **argv) {
     usage(argv[0], std::cerr);
     return 2;
   }
-  if (!servingSoPath.empty() && !embeddingSoPath.empty()) {
+  if ((!servingSoPath.empty() && !embeddingSoPath.empty()) ||
+      (!servingSoPath.empty() && !maskedLMSoPath.empty()) ||
+      (!embeddingSoPath.empty() && !maskedLMSoPath.empty())) {
     std::cerr
-        << "buddy-server: choose one of --serving-so or --embedding-so.\n";
+        << "buddy-server: choose at most one of --serving-so, --embedding-so, "
+           "--masked-lm-so.\n";
     return 2;
   }
 
   bool embeddingMode = !embeddingSoPath.empty();
+  bool maskedLMMode = !maskedLMSoPath.empty();
   if (!modelConfig.raxPath.empty()) {
     try {
       auto manifest =
           buddy::runtime::ModelManifest::loadFromRax(modelConfig.raxPath);
-      if (servingSoPath.empty() && embeddingSoPath.empty()) {
+      if (servingSoPath.empty() && embeddingSoPath.empty() &&
+          maskedLMSoPath.empty()) {
         const bool hasServing = !manifest.servingLibraryPath.empty();
         const bool hasEmbedding = !manifest.embeddingLibraryPath.empty();
-        if (hasServing == hasEmbedding) {
-          if (hasServing)
-            std::cerr << "buddy-server: manifest provides both serving_library "
-                         "and embedding_library; pass --serving-so or "
-                         "--embedding-so explicitly.\n";
-          else
-            std::cerr << "buddy-server: manifest has neither serving_library "
-                         "nor embedding_library.\n";
+        const bool hasMasked = !manifest.maskedLMLibraryPath.empty();
+        const int backends = static_cast<int>(hasServing) +
+                             static_cast<int>(hasEmbedding) +
+                             static_cast<int>(hasMasked);
+        if (backends != 1) {
+          std::cerr << "buddy-server: manifest must provide exactly one of "
+                       "serving_library, embedding_library, masked_lm_library; "
+                       "pass an explicit plugin option.\n";
           return 1;
         }
         if (hasEmbedding) {
           embeddingSoPath = manifest.embeddingLibraryPath;
           embeddingMode = true;
+        } else if (hasMasked) {
+          maskedLMSoPath = manifest.maskedLMLibraryPath;
+          maskedLMMode = true;
         } else {
           servingSoPath = manifest.servingLibraryPath;
         }
@@ -298,12 +339,29 @@ int main(int argc, char **argv) {
 
   std::unique_ptr<buddy::server::ResidentModelPluginHandle> residentPlugin;
   std::unique_ptr<buddy::server::EmbeddingModelPluginHandle> embeddingPlugin;
+  std::unique_ptr<buddy::server::MaskedLMModelPluginHandle> maskedLMPlugin;
   buddy::server::ResidentModelPluginHandle::ModelPtr residentModel(
       nullptr, [](ResidentModel *m) { delete m; });
   buddy::server::EmbeddingModelPluginHandle::ModelPtr embeddingModel(
       nullptr, [](EmbeddingModel *m) { delete m; });
+  buddy::server::MaskedLMModelPluginHandle::ModelPtr maskedLMModel(
+      nullptr, [](MaskedLMModel *m) { delete m; });
 
-  if (embeddingMode) {
+  if (maskedLMMode) {
+    try {
+      maskedLMPlugin =
+          std::make_unique<buddy::server::MaskedLMModelPluginHandle>(
+              maskedLMSoPath);
+      if (modelType.empty()) {
+        const std::string pluginType = maskedLMPlugin->modelType();
+        modelType = pluginType.empty() ? "masked_lm" : pluginType;
+      }
+      maskedLMModel = maskedLMPlugin->createModel();
+    } catch (const std::exception &ex) {
+      std::cerr << ex.what() << "\n";
+      return 1;
+    }
+  } else if (embeddingMode) {
     if (embeddingSoPath.empty()) {
       std::cerr << "buddy-server: no embedding plugin specified.\n";
       return 1;
@@ -354,6 +412,12 @@ int main(int argc, char **argv) {
   embeddingConfig.weightPaths = modelConfig.weightPaths;
   embeddingConfig.vocabPath = modelConfig.vocabPath;
   embeddingConfig.modelName = modelConfig.modelName;
+  MaskedLMModelConfig maskedConfig;
+  maskedConfig.raxPath = modelConfig.raxPath;
+  maskedConfig.modelSoPath = modelConfig.modelSoPath;
+  maskedConfig.weightPaths = modelConfig.weightPaths;
+  maskedConfig.vocabPath = modelConfig.vocabPath;
+  maskedConfig.modelName = modelConfig.modelName;
 
   std::atomic<int> loadState{Loading};
   std::mutex loadErrorMutex;
@@ -363,8 +427,10 @@ int main(int argc, char **argv) {
   server.get("/health", [&](const HttpRequest &, ResponseWriter &writer) {
     const int state = loadState.load(std::memory_order_acquire);
     if (state == Ready) {
-      ModelStatus status =
-          embeddingMode ? embeddingModel->status() : residentModel->status();
+      ModelStatus status = maskedLMMode
+                               ? maskedLMModel->status()
+                               : (embeddingMode ? embeddingModel->status()
+                                                : residentModel->status());
       writer.sendResponse(
           buddy::server::jsonResponse(200, buddy::server::toJson(status)));
       return;
@@ -373,7 +439,7 @@ int main(int argc, char **argv) {
     ModelStatus status;
     status.modelName =
         modelConfig.modelName.empty() ? modelType : modelConfig.modelName;
-    status.backend = embeddingMode ? "cpu" : "";
+    status.backend = maskedLMMode ? "cpu" : (embeddingMode ? "cpu" : "");
     if (state == Error) {
       status.state = ModelLoadState::Error;
       std::lock_guard<std::mutex> lock(loadErrorMutex);
@@ -386,7 +452,35 @@ int main(int argc, char **argv) {
         buddy::server::jsonResponse(200, buddy::server::toJson(status)));
   });
 
-  if (embeddingMode) {
+  if (maskedLMMode) {
+    server.post("/v1/masked-lm",
+                [&](const HttpRequest &request, ResponseWriter &writer) {
+                  handleMaskedLM(*maskedLMModel, loadState, request, writer);
+                });
+    server.post("/masked-lm",
+                [&](const HttpRequest &request, ResponseWriter &writer) {
+                  handleMaskedLM(*maskedLMModel, loadState, request, writer);
+                });
+    server.post("/completion",
+                [&](const HttpRequest &, ResponseWriter &writer) {
+                  handleUnsupported(writer, "/completion");
+                });
+    server.post("/v1/chat/completions",
+                [&](const HttpRequest &, ResponseWriter &writer) {
+                  handleUnsupported(writer, "/v1/chat/completions");
+                });
+    server.post("/tokenize", [&](const HttpRequest &, ResponseWriter &writer) {
+      handleUnsupported(writer, "/tokenize");
+    });
+    server.post("/v1/embeddings",
+                [&](const HttpRequest &, ResponseWriter &writer) {
+                  handleUnsupported(writer, "/v1/embeddings");
+                });
+    server.post("/embeddings",
+                [&](const HttpRequest &, ResponseWriter &writer) {
+                  handleUnsupported(writer, "/embeddings");
+                });
+  } else if (embeddingMode) {
     server.post("/v1/embeddings",
                 [&](const HttpRequest &request, ResponseWriter &writer) {
                   handleEmbedding(*embeddingModel, loadState, request, writer);
@@ -430,7 +524,25 @@ int main(int argc, char **argv) {
   }
 
   std::thread loadThread;
-  if (embeddingMode) {
+  if (maskedLMMode) {
+    loadThread = std::thread([&maskedLMModel, &maskedConfig, &loadState,
+                              &loadError, &loadErrorMutex] {
+      try {
+        std::cerr << "[buddy-server] loading masked-LM model...\n";
+        maskedLMModel->load(maskedConfig);
+        loadState.store(Ready, std::memory_order_release);
+        std::cerr << "[buddy-server] masked-LM model loaded\n";
+      } catch (const std::exception &ex) {
+        {
+          std::lock_guard<std::mutex> lock(loadErrorMutex);
+          loadError = ex.what();
+        }
+        loadState.store(Error, std::memory_order_release);
+        std::cerr << "[buddy-server] failed to load masked-LM model: "
+                  << ex.what() << "\n";
+      }
+    });
+  } else if (embeddingMode) {
     loadThread = std::thread([&embeddingModel, &embeddingConfig, &loadState,
                               &loadError, &loadErrorMutex] {
       try {

--- a/tools/rax-pack/rax-pack.cpp
+++ b/tools/rax-pack/rax-pack.cpp
@@ -67,6 +67,7 @@ enum class PayloadKind : uint16_t {
   Vocab = 3,
   ServingPlugin = 4,
   EmbeddingPlugin = 5,
+  MaskedLMPlugin = 6,
 };
 
 struct PayloadInput {
@@ -385,6 +386,7 @@ int main(int argc, char **argv) {
     std::string runnerLibraryAttr;
     std::string servingLibraryAttr;
     std::string embeddingLibraryAttr;
+    std::string maskedLMLibraryAttr;
     std::vector<std::pair<std::string, std::string>> extraModuleAttrs;
     if (auto v = rhalMod.getModelName())
       modelNameAttr = v->str();
@@ -396,12 +398,16 @@ int main(int argc, char **argv) {
       servingLibraryAttr = v->str();
     if (auto v = rhalMod.getEmbeddingLibrary())
       embeddingLibraryAttr = v->str();
+    if (auto attr = rhalMod->getAttr("masked_lm_library"))
+      if (auto v = mlir::dyn_cast<mlir::StringAttr>(attr))
+        maskedLMLibraryAttr = v.getValue().str();
 
     for (auto namedAttr : rhalMod->getAttrs()) {
       const std::string key = namedAttr.getName().str();
       if (key == "sym_name" || key == "version" || key == "model_name" ||
           key == "vocab_uri" || key == "runner_library" ||
-          key == "serving_library" || key == "embedding_library")
+          key == "serving_library" || key == "embedding_library" ||
+          key == "masked_lm_library")
         continue;
       if (auto stringAttr =
               mlir::dyn_cast<mlir::StringAttr>(namedAttr.getValue()))
@@ -564,6 +570,9 @@ int main(int argc, char **argv) {
     if (!embeddingLibraryAttr.empty())
       registerPayload(PayloadKind::EmbeddingPlugin, embeddingLibraryAttr,
                       "module attr embedding_library");
+    if (!maskedLMLibraryAttr.empty())
+      registerPayload(PayloadKind::MaskedLMPlugin, maskedLMLibraryAttr,
+                      "module attr masked_lm_library");
 
     // ── Build FlatBuffer ──────────────────────────────────────────────────
 
@@ -587,6 +596,9 @@ int main(int argc, char **argv) {
     if (!embeddingLibraryAttr.empty())
       modAttrs.push_back(CreateKV(b, b.CreateString("embedding_library"),
                                   b.CreateString(embeddingLibraryAttr)));
+    if (!maskedLMLibraryAttr.empty())
+      modAttrs.push_back(CreateKV(b, b.CreateString("masked_lm_library"),
+                                  b.CreateString(maskedLMLibraryAttr)));
     for (const auto &attr : extraModuleAttrs)
       modAttrs.push_back(
           CreateKV(b, b.CreateString(attr.first), b.CreateString(attr.second)));


### PR DESCRIPTION
  - Add MaskedLM runtime types, interfaces, and C ABI plugin contract.
  - Implement ProteinGLM masked-LM runtime with tokenizer, multi-mask top-k prediction, fixed-shape forward, model state, and parameter validation.
  - Extend buddy-server with masked-LM plugin loading, manifest discovery, `/v1/masked-lm` and `/masked-lm` endpoints, backend validation, and loading/ready/error states.
  - Add masked-LM JSON codec and plugin loader tests.
  - Extend ModelManifest, rax-pack, manifest generation, and buddy_model.cmake to support masked_lm_library and embedded payloads.
  - Add buddy-server documentation and runtime tests.

Assisted-by: OpenAI codex

## Summary

- Add buddy_server support to the Proteinlm model
- test
```
cmake --build build --target proteinglm_rax buddy-server
./build/bin/buddy-server --model build/models/proteinglm/proteinglm.rax \
  --host 127.0.0.1 --port 8080
curl http://127.0.0.1:8080/v1/masked-lm \
  -H 'Content-Type: application/json' \
  -d '{"model":"proteinglm_1b_mlm","input":"A <mask> C","top_k":5}'
```

## Checklist

- [x] The code builds successfully
- [x] Existing tests pass
- [x] New tests are added where appropriate
- [x] Code follows the project coding style
- [x] Documentation is updated if needed
