### PR TITLE
[ci] Add pytorch 2.14 test for X86

### DIFF
--- a/.github/workflows/TestBuild.yml
+++ b/.github/workflows/TestBuild.yml
@@ -82,13 +82,19 @@ jobs:
       - name: Run check-buddy
         continue-on-error: ${{ matrix.arch == 'arm64' }}
         run: |
+          # Newest first: the latest torch releases break most often, so fail
+          # fast before spending time on the older, stable ones.
           if [ "${{ matrix.arch }}" = "riscv64" ]; then
             # The Ruyi torch 2.12 riscv64 wheel omits the top-level functorch
             # compatibility package still imported by torch._dynamo.
             # https://ruyirepo.ruyicommunity.cn/pypi/simple/torch/
-            torch_versions=(2.10 2.11 2.12 2.13)
+            # That index carries torch 2.14.0 for x86_64/aarch64 but its newest
+            # riscv64 build is still 2.13.0, so keep 2.14 off riscv64 until it
+            # shows up.
+            torch_versions=(2.13 2.12 2.11 2.10)
           else
-            torch_versions=(2.10 2.11 2.12 2.13)
+            # torch 2.14.0 is on the CPU index and on PyPI, including cp312.
+            torch_versions=(2.14 2.13 2.12 2.11 2.10)
           fi
 
           for torch_version in "${torch_versions[@]}"; do
@@ -114,5 +120,16 @@ jobs:
               import torch
               print("torch:", torch.__version__)
             """))'
-            ninja -C build check-buddy
+            # Only the newest version needs the whole suite: of the 590 cases
+            # check-buddy runs, the 268 that import torch while running all live
+            # in check-tests, plus the matmul roundtrip in examples/BuddyJIT; the
+            # rest consume .mlir checked into the tree, so swapping the wheel
+            # cannot show up in them. Measured per version: check-examples costs
+            # 57s on x64 and 587-707s on riscv64, check-tests 34s and 150-190s,
+            # and the BuddyJIT case is a single test out of those 239.
+            if [ "${torch_version}" = "${torch_versions[0]}" ]; then
+              ninja -C build check-buddy
+            else
+              ninja -C build check-tests check-buddy-examples-buddyjit
+            fi
           done

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -102,5 +102,9 @@ if(BUDDY_ENABLE_TESTS)
     )
   set_target_properties(check-examples PROPERTIES FOLDER "Examples")
 
-  add_lit_testsuites(BUDDY-EXAMPLES ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${BUDDY_EXAMPLES_DEPENDS})
+  # See tests/CMakeLists.txt: BINARY_DIR keeps the check-buddy-examples-*
+  # targets on the build tree, where lit.site.cfg.py is.
+  add_lit_testsuites(BUDDY-EXAMPLES ${CMAKE_CURRENT_SOURCE_DIR}
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${BUDDY_EXAMPLES_DEPENDS})
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,7 +42,13 @@ add_lit_testsuite(check-tests "Running the buddy regression tests..."
   )
 set_target_properties(check-tests PROPERTIES FOLDER "Tests")
 
-add_lit_testsuites(BUDDY ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${BUDDY_TEST_DEPENDS})
+# BINARY_DIR lets the per-directory check-buddy-* targets run lit on the build
+# tree with --filter=<subdir>. Pointing lit at the source tree instead makes it
+# load lit.cfg.py without the generated lit.site.cfg.py in front of it, and that
+# config dies on config.buddy_mlir_enable_python_packages.
+add_lit_testsuites(BUDDY ${CMAKE_CURRENT_SOURCE_DIR}
+  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${BUDDY_TEST_DEPENDS})
 
 #------------------------------------------------------------------------------------
 #    E2E test module
@@ -73,6 +79,8 @@ if(BUDDY_ENABLE_E2E_TESTS)
     )
   set_target_properties(check-e2e PROPERTIES FOLDER "Tests")
 
-  add_lit_testsuites(BUDDY_MODELS ${CMAKE_CURRENT_SOURCE_DIR}/Models DEPENDS ${BUDDY_MODELS_TEST_DEPENDS})
+  add_lit_testsuites(BUDDY_MODELS ${CMAKE_CURRENT_SOURCE_DIR}/Models
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/Models
+    DEPENDS ${BUDDY_MODELS_TEST_DEPENDS})
 
 endif()


### PR DESCRIPTION
## What

* Test torch **2.14** on x64/arm64. It is on `download.pytorch.org/whl/cpu` and on PyPI (`torch-2.14.0-cp312`), so no index change is needed.
* Keep **riscv64 at 2.13**: the Ruyi index already publishes `torch-2.14.0` for x86_64/aarch64, but its newest riscv64 build is still `torch-2.13.0-...-manylinux_2_38_riscv64.whl`.
* Walk the versions **newest first** -- the newest releases break most often, so 2.14 should fail before we spend a full pass on the older, stable ones.
* Only the newest version runs the whole `check-buddy`; the older ones run `check-buddy-python` + `check-buddy-examples-buddyjit`.

## Why the loop can be cheap

`check-buddy` runs 590 lit cases, but only **269 import torch while running**: 268 in `tests/Python` plus `examples/BuddyJIT/pytorch_matrix_multiplication.py`. The other 321 consume `.mlir` checked into the tree (IME, BuddyNext, MLIRVector, Gemmini, Conversion, Dialect, ...), so swapping the wheel cannot show up in them -- and the model importers that *would* notice are behind `BUDDY_*_EXAMPLES=OFF` in this workflow anyway.

Per version, measured on run 3573 with an LLVM cache hit:

| suite | cases | x64 | riscv64 |
|---|---|---|---|
| `check-examples` | 239 (1 torch) | 88s | 587-707s |
| `check-tests` | 351 (268 torch) | 32s | 150-190s |

So the loop drops from 8.3 to ~5min on x64 and from 52 to ~27min on riscv64, which pays for the new 2.14 entry.

## Notes

* Coverage lost for the older versions: the 238 non-torch cases in `check-examples`, and 1 torch case there is kept via `check-buddy-examples-buddyjit`. Full coverage for the newest version, and still every version runs all 279 `tests/Python` cases.
* Both suites are pre-existing lit targets; no CMake change (verified against a CI-like configure: `-DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON -DBUDDY_BUILD_DEEPSEEK_R1_MODEL=OFF`).

Expect this to be the first real run of torch 2.14 against the frontend.