### PR TITLE
[RAX] Add distributed execution and DeepSeek TP=2 integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,9 @@ set(BUDDY_ENABLE_OPENCV OFF CACHE BOOL "Enable OpenCV support.")
 option(BUDDY_BUILD_DEEPSEEK_R1_MODEL
   "Build models/deepseek_r1 (buddy_models_deepseek_r1, .so, .rax)"
   OFF)
+option(BUDDY_BUILD_DEEPSEEK_R1_TP2_MODEL
+  "Build the independent models/deepseek_r1_tp2 MPI/RAX package"
+  OFF)
 option(BUDDY_BUILD_LLAMA31_TT_MODEL
   "Build models/llama31_tt and link the Tenstorrent Llama 3.1 runner into buddy-cli"
   OFF)
@@ -380,6 +383,9 @@ endif()
 
 add_subdirectory(midend)
 add_subdirectory(tools)
+if(BUDDY_BUILD_DEEPSEEK_R1_TP2_MODEL)
+  add_dependencies(deepseek_r1_tp2_rax buddy-cli)
+endif()
 get_property(_buddy_llama_tt_rax_targets_set GLOBAL PROPERTY
              BUDDY_LLAMA_TT_RAX_TARGETS SET)
 if(_buddy_llama_tt_rax_targets_set)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ option(LLVM_INCLUDE_TOOLS "Generate build targets for the LLVM tools." ON)
 option(LLVM_BUILD_TOOLS "Build the LLVM tools. If OFF, just generate build targets." ON)
 option(BUDDY_MLIR_OUT_OF_TREE_BUILD "Specifies an out of tree build" OFF)
 option(BUDDY_ENABLE_TESTS "Enable buddy-mlir test targets." ON)
+option(BUDDY_RUNTIME_ENABLE_MPI "Build the Buddy Runtime MPI communicator" OFF)
 
 #-------------------------------------------------------------------------------
 # MLIR/LLVM Configuration

--- a/docs/RaxDistributedExecution.md
+++ b/docs/RaxDistributedExecution.md
@@ -1,0 +1,488 @@
+# RAX Distributed Execution
+
+This document describes distributed execution support in RAX, including
+collective communication, Transformer parallel planning and rank-local
+materialization, and the currently validated DeepSeek R1 tensor-parallel
+example.
+
+The distributed path extends the existing RAX execution model rather than
+introducing a model-specific communication runtime. The frontend derives
+rank-local computation and communication from tensor layouts, RHAL represents
+the resulting ordered schedule, and the RAX runtime delegates collective
+operations to a communicator backend.
+
+DeepSeek R1 with tensor parallelism of size 2 is the current end-to-end
+integration used to validate this path.
+
+## Overview
+
+The distributed compilation and execution flow is:
+
+```text
+PyTorch / FX Graph
+        │
+        ▼
+Transformer structure and template analysis
+        │
+        ▼
+TransformerParallelPlan
+  - parameter shards
+  - value layouts
+  - operation rewrites
+  - collective boundaries
+  - compute segments
+        │
+        ▼
+ParallelTemplatePartitionedGraphDriver
+  - rank-local subgraphs
+  - rank-local wrappers
+  - rank parameter packs
+  - ordered runtime plans
+        │
+        ▼
+rankN_forward_prefill.json
+rankN_forward_decode.json
+        │
+        ▼
+gen_manifest.py
+        │
+        ▼
+rankN.rhal.mlir
+  dispatch → collective → dispatch → ...
+        │
+        ▼
+rax-pack
+        │
+        ▼
+rankN.rax
+        │
+        ▼
+RaxExecutor
+        │
+        ▼
+Communicator
+        │
+        ▼
+MpiCommunicator
+        │
+        ▼
+MPI
+```
+
+Each distributed process executes one rank-local RAX package. Compute and
+communication remain explicit in the RAX schedule, while the model runner
+continues to provide the higher-level inference loop such as tokenization,
+prefill, KV-cache management, and decode.
+
+## RAX Communication Model
+
+### Ordered RHAL Functions
+
+The original RHAL function form describes a single dispatch through
+attributes:
+
+```mlir
+rhal.func @forward {
+  inputs = ["input"],
+  outputs = ["output"],
+  dispatch = "model_kernels",
+  args = ["input", "output"]
+}
+```
+
+This form remains supported.
+
+For multi-step execution, `rhal.func` can instead contain an ordered body of
+`rhal.dispatch` and `rhal.collective` operations:
+
+```mlir
+rhal.func @forward {
+  inputs = ["input"],
+  outputs = ["output"]
+} body {
+  rhal.dispatch @stage0 [@params, @input, @scratch]
+
+  rhal.collective [@scratch] {
+    kind = "all_reduce",
+    reduction = "sum"
+  }
+
+  rhal.dispatch @stage1 [@params, @scratch, @output]
+}
+```
+
+Operations in a body-form `rhal.func` form an ordered runtime schedule.
+`rax-pack` serializes the schedule into the RAX FlatBuffer representation, and
+`RaxExecutor` executes the operations in the same order.
+
+The legacy attribute-only form and the ordered body form coexist so existing
+single-dispatch RAX packages do not need to use the distributed execution
+path.
+
+### Supported Collectives
+
+The runtime communication interface currently provides the following
+collectives:
+
+| Collective    | Current behavior                                    |
+| ------------- | --------------------------------------------------- |
+| Broadcast     | In-place broadcast from a specified root rank       |
+| AllReduce     | F32 reduction with `sum`                            |
+| AllGatherV    | Variable-size gather into an explicit output buffer |
+| ReduceScatter | F32 `sum` reduction into an explicit output buffer  |
+
+For example:
+
+```mlir
+rhal.collective [@input] {
+  kind = "all_gatherv",
+  output_buffers = [@output],
+  recv_counts = array<i64: 2, 3>,
+  displacements = array<i64: 0, 2>
+}
+```
+
+and:
+
+```mlir
+rhal.collective [@input] {
+  kind = "reduce_scatter",
+  output_buffers = [@output],
+  recv_counts = array<i64: 2, 2>,
+  reduction = "sum"
+}
+```
+
+The RHAL verifier checks properties that can be validated statically from the
+IR. Communicator size, rank, and other execution-dependent properties are
+validated by the runtime where required.
+
+### Runtime Execution
+
+Distributed execution is split between a generic executor and a communication
+backend:
+
+```text
+RaxExecutionSession
+        │
+        ▼
+RaxExecutor
+  ├─ Dispatch
+  │    └─ host shared library
+  │
+  └─ Collective
+       └─ Communicator
+            └─ MpiCommunicator
+                 └─ MPI
+```
+
+`RaxExecutor` does not call MPI directly. It operates on the abstract
+`Communicator` interface, which provides rank information and collective
+operations.
+
+`MpiCommunicator` is the MPI implementation of this interface. It maps RAX
+collectives to the corresponding MPI operations.
+
+MPI support is optional at build time and is controlled by:
+
+```text
+BUDDY_RUNTIME_ENABLE_MPI
+```
+
+When the option is disabled, the generic RAX execution library can still be
+built without MPI.
+
+## Frontend Parallel Planning
+
+### Parallel Plan
+
+Transformer parallelization is represented explicitly in the frontend before
+rank-local MLIR is materialized.
+
+The existing Transformer structure and template analysis first produces a
+`TransformerPartitionPlan`. Parallel analysis then constructs a
+`TransformerParallelPlan`.
+
+The main parallel-plan objects are:
+
+```text
+ParameterShardSpec
+ValueLayoutSpec
+OpRewriteSpec
+CollectiveBoundary
+ComputeSegment
+```
+
+A `ParameterShardSpec` describes how a parameter is divided between ranks.
+A `ValueLayoutSpec` describes the distributed layout of an intermediate value.
+An `OpRewriteSpec` records rank-specific shape or operand rewrites.
+A `CollectiveBoundary` represents communication required between compute
+regions. A `ComputeSegment` groups consecutive operations that can execute
+locally on a rank.
+
+The current configuration is represented by `TransformerParallelConfig`.
+Tensor parallelism of size 2 is the currently validated configuration used by
+the DeepSeek integration.
+
+### Layout-Driven Collectives
+
+Parallel communication is derived from tensor-layout transitions rather than
+from model layer indices.
+
+The frontend tracks three layout kinds:
+
+* `REPLICATED`: every rank holds the complete value;
+* `SHARDED(axis)`: the value is partitioned along a tensor axis;
+* `PARTIAL`: each rank holds a partial contribution that must be reduced before
+  some consumers can use the value.
+
+When a consumer requires a different layout, the planner inserts a collective
+boundary. Important transitions include:
+
+| Producer layout | Required layout | Collective    |
+| --------------- | --------------- | ------------- |
+| `PARTIAL`       | `REPLICATED`    | AllReduce     |
+| `PARTIAL`       | `SHARDED(axis)` | ReduceScatter |
+| `SHARDED(axis)` | `REPLICATED`    | AllGatherV    |
+
+For example, a row-parallel projection can produce a partial result on each
+rank. If the next operation requires the complete value on every rank, the
+planner represents the transition as an AllReduce boundary.
+
+This keeps the communication decision in the parallel data-layout analysis
+instead of hard-coding communication after particular DeepSeek layers.
+
+### Rank-Local Materialization
+
+`ParallelTemplatePartitionedGraphDriver` consumes the parallel plan for one
+rank and materializes the local program.
+
+For each rank it produces:
+
+* rank-local template subgraphs;
+* rank-local compute-segment wrappers;
+* rank-local tensor shapes;
+* a rank-global parameter pack;
+* an ordered runtime plan containing dispatch and collective operations.
+
+A rank-global parameter pack is shared by the wrappers belonging to the same
+rank. Individual wrappers use static offsets into that pack for the parameters
+they consume.
+
+The generated runtime plans are JSON files such as:
+
+```text
+layer_partitioned/runtime/
+├── rank0_forward_prefill.json
+├── rank0_forward_decode.json
+├── rank1_forward_prefill.json
+└── rank1_forward_decode.json
+```
+
+Each runtime plan describes the resources and ordered operations for one
+function on one rank.
+
+`gen_manifest.py` converts the prefill and decode runtime plans of a rank into
+one body-form RHAL module. The module is then serialized by `rax-pack`, producing
+one RAX package for each rank.
+
+## DeepSeek R1 TP=2 Example
+
+DeepSeek R1 is the currently validated end-to-end integration of the
+distributed RAX path.
+
+The TP=2 package is separate from the normal single-rank
+`models/deepseek_r1` build. It generates two sets of parameters and runtime
+plans, two RHAL schedules, and two rank-local RAX packages.
+
+The example below uses the f32 DeepSeek R1 Distill Qwen 1.5B configuration.
+
+### MPI / MPICH
+
+The communication runtime uses the standard MPI C++ interface through CMake
+`FindMPI`.
+
+MPICH is the MPI implementation currently validated for the DeepSeek TP=2
+flow. Make sure that the MPI compiler and launcher come from the same MPI
+installation.
+
+For a system MPICH installation, verify:
+
+```bash
+mpicxx --version
+mpiexec --version
+```
+
+For a custom MPICH installation:
+
+```bash
+export MPI_HOME=/path/to/mpich-install
+export PATH="$MPI_HOME/bin:$PATH"
+export LD_LIBRARY_PATH="$MPI_HOME/lib:$LD_LIBRARY_PATH"
+```
+
+If CMake does not automatically select the intended MPI compiler, it can be
+specified through `build_model.py`:
+
+```bash
+--cmake-args=-DMPI_CXX_COMPILER="$MPI_HOME/bin/mpicxx"
+```
+
+The TP=2 build automatically enables `BUDDY_RUNTIME_ENABLE_MPI`.
+
+### Build
+
+Run the build from the repository root:
+
+```bash
+cd buddy-mlir
+```
+
+Build the f32 DeepSeek TP=2 package:
+
+```bash
+python3 tools/buddy-codegen/build_model.py \
+  --spec models/deepseek_r1/specs/f32.json \
+  --build-dir build \
+  --tensor-parallel-size 2
+```
+
+For an existing local HuggingFace-format model directory:
+
+```bash
+python3 tools/buddy-codegen/build_model.py \
+  --spec models/deepseek_r1/specs/f32.json \
+  --build-dir build \
+  --local-model /path/to/DeepSeek-R1-Distill-Qwen-1.5B \
+  --tensor-parallel-size 2
+```
+
+If a custom MPICH installation must be selected explicitly:
+
+```bash
+python3 tools/buddy-codegen/build_model.py \
+  --spec models/deepseek_r1/specs/f32.json \
+  --build-dir build \
+  --local-model /path/to/DeepSeek-R1-Distill-Qwen-1.5B \
+  --tensor-parallel-size 2 \
+  --cmake-args=-DMPI_CXX_COMPILER="$MPI_HOME/bin/mpicxx"
+```
+
+For `--tensor-parallel-size 2`, `build_model.py` automatically enables:
+
+```text
+BUDDY_BUILD_DEEPSEEK_R1_TP2_MODEL=ON
+BUDDY_RUNTIME_ENABLE_MPI=ON
+BUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON
+```
+
+and builds the `deepseek_r1_tp2_rax` target.
+
+The TP=2 model has its own CMake build graph under:
+
+```text
+models/deepseek_r1_tp2/
+```
+
+It intentionally does not use the normal single-model `buddy_add_model()`
+pipeline because distributed compilation produces rank-local runtime plans,
+parameter packs, RHAL modules, and RAX packages instead of one ordinary model
+artifact.
+
+### Generated Artifacts
+
+After a successful build, the main artifacts are under:
+
+```text
+build/models/deepseek_r1_tp2/
+```
+
+The important files include:
+
+```text
+build/models/deepseek_r1_tp2/
+├── rank0.rax
+├── rank1.rax
+├── rank0.rhal.mlir
+├── rank1.rhal.mlir
+├── rank0_params_float32.data
+├── rank1_params_float32.data
+├── deepseek_r1_tp2_model.so
+├── deepseek_r1_tp2_runner.so
+├── vocab.txt
+├── generated/
+│   └── RaxShims.cpp
+└── layer_partitioned/
+    ├── rank0/
+    ├── rank1/
+    └── runtime/
+        ├── rank0_forward_prefill.json
+        ├── rank0_forward_decode.json
+        ├── rank1_forward_prefill.json
+        └── rank1_forward_decode.json
+```
+
+`rank0.rax` and `rank1.rax` are the two runtime entry packages. Each one
+contains the schedule and resource metadata for its rank and refers to its
+rank-local parameter pack.
+
+`deepseek_r1_tp2_model.so` contains the compiled rank-local compute kernels and
+the generated RAX ABI shims.
+
+`deepseek_r1_tp2_runner.so` implements the DeepSeek TP=2 inference runner used
+by `buddy-cli`.
+
+If payload embedding is enabled in the RAX build, runtime libraries referenced
+by the RAX package are embedded by `rax-pack` and extracted by the runtime when
+the package is loaded.
+
+### Run
+
+Run two MPI processes and use the rank placeholder in the RAX path:
+
+```bash
+mpiexec -n 2 \
+  ./build/bin/buddy-cli \
+  --model "./build/models/deepseek_r1_tp2/rank{rank}.rax" \
+  --prompt "Hello" \
+  --temperature 0 \
+  --max-tokens 2 \
+  --no-stats
+```
+
+Under the validated MPICH launch path, each process receives `PMI_RANK`.
+When the `--model` path contains `{rank}`, `buddy-cli` replaces the placeholder
+with `PMI_RANK` before reading the RAX manifest.
+
+The two MPI processes therefore resolve the same command line as:
+
+```text
+rank 0 → build/models/deepseek_r1_tp2/rank0.rax
+rank 1 → build/models/deepseek_r1_tp2/rank1.rax
+```
+
+The `{rank}` handling is generic in `buddy-cli`; the CLI does not need a
+DeepSeek-specific tensor-parallel option at runtime.
+
+Each process loads its own RAX package and executes the same inference loop.
+Collective operations inside the prefill and decode schedules synchronize the
+rank-local computations through `MpiCommunicator`.
+
+Only the designated output rank emits generated text, while all ranks
+participate in the distributed computation.
+
+## Current Limitations
+
+The distributed RAX infrastructure is designed independently of DeepSeek, but
+the current end-to-end integration has the following limitations:
+
+* DeepSeek R1 with tensor parallelism of size 2 is the currently validated
+  model configuration.
+* The DeepSeek TP=2 package is currently validated for native builds and is not
+  enabled for RVV cross-compilation.
+* The current runtime collective data type is F32, and reduction collectives
+  currently use `sum`.
+* Each distributed process executes one rank-local RAX package.
+* The current frontend entry point exposes the validated TP=2 configuration;
+  broader distributed configurations require additional validation before
+  being exposed through the model build interface.

--- a/frontend/Python/graph/__init__.py
+++ b/frontend/Python/graph/__init__.py
@@ -23,6 +23,9 @@ from .graph import NodeType as NodeType
 from .graph_driver import GraphDriver as GraphDriver
 from .operation import *
 from .partitioned_graph_driver import (
+    ParallelTemplatePartitionedGraphDriver as ParallelTemplatePartitionedGraphDriver,
+)
+from .partitioned_graph_driver import (
     PartitionedGraphDriver as PartitionedGraphDriver,
 )
 from .partitioned_graph_driver import (
@@ -36,7 +39,16 @@ from .transformer_partition import (
 )
 from .transformer_partition import TemplateUnit as TemplateUnit
 from .transformer_partition import (
+    TransformerParallelConfig as TransformerParallelConfig,
+)
+from .transformer_partition import (
+    TransformerParallelPlan as TransformerParallelPlan,
+)
+from .transformer_partition import (
     TransformerPartitionPlan as TransformerPartitionPlan,
+)
+from .transformer_partition import (
+    build_transformer_parallel_plan as build_transformer_parallel_plan,
 )
 from .transformer_partition import (
     build_transformer_partition_plan as build_transformer_partition_plan,

--- a/frontend/Python/graph/graph.py
+++ b/frontend/Python/graph/graph.py
@@ -1143,7 +1143,12 @@ class GraphImporter:
             if self._param_pack_offsets is None:
                 offset = self._current_param_pack_offset[dtype]
             else:
-                offset = self._param_pack_offsets[str(node.name)]
+                param_name = str(node.name)
+                if param_name not in self._param_pack_offsets:
+                    raise ValueError(
+                        f"param_pack_offsets is missing placeholder {param_name!r}"
+                    )
+                offset = self._param_pack_offsets[param_name]
             placeholder_name = self._ops_registry["param.extract"](
                 node, offset, pack_of_dtype
             ).result

--- a/frontend/Python/graph/graph.py
+++ b/frontend/Python/graph/graph.py
@@ -631,20 +631,29 @@ class Graph:
         for transform_func in func_list:
             transform_func(self)
 
-    def lower_to_top_level_ir(self):
+    def lower_to_top_level_ir(
+        self,
+        do_param_pack: bool = False,
+        param_pack_sizes=None,
+        param_pack_offsets=None,
+    ):
         """
         Lowers the graph to top-level MLIR dialects.
 
         Parameters:
-        - do_params_pack: bool, optional (default=False)
+        - do_param_pack: bool, optional (default=False)
             Flag indicating whether to perform parameters packing to one memref.
+        - param_pack_sizes: dict, optional
+            Explicit total element count for each dtype pack.
+        - param_pack_offsets: dict, optional
+            Explicit element offset for each parameter placeholder name.
 
         Returns:
         None
 
         Example:
         graph_instance = Graph(inputs, fake_params, ops_registry, func_name)
-        graph_instance.lower_to_top_level_ir(do_params_pack=True)
+        graph_instance.lower_to_top_level_ir(do_param_pack=True)
         # The graph is now lowered to top-level MLIR dialects
         """
         with ir.Location.unknown(self._ctx):
@@ -654,20 +663,30 @@ class Graph:
                 self.inputs_shapes,
                 self._func_name,
                 self._ops_registry,
-                False,
+                do_param_pack,
                 self.device,
                 verbose=self._verbose,
                 verbose_path=self._verbose_path,
                 enable_external_calls=self._enable_external_calls,
+                param_pack_sizes=param_pack_sizes,
+                param_pack_offsets=param_pack_offsets,
             )
-            self._imported_module = fx_importer.import_graph()
+            self._imported_module = (
+                fx_importer.import_main_graph()
+                if do_param_pack
+                else fx_importer.import_graph()
+            )
             outputs = fx_importer.get_output_nodes()
             self._outputs = outputs
         self._output_memref = []
         output_ranks = []
         output_dtypes = []
         for out_node in outputs:
-            out_type = ir.RankedTensorType(out_node.type)
+            out_type = (
+                ir.MemRefType(out_node.type)
+                if do_param_pack
+                else ir.RankedTensorType(out_node.type)
+            )
             shape = list(out_type.shape)
             dtype = out_type.element_type
             match str(dtype):
@@ -830,6 +849,8 @@ class GraphImporter:
         verbose=False,
         verbose_path: str | Path | None = None,
         enable_external_calls: bool = False,
+        param_pack_sizes=None,
+        param_pack_offsets=None,
     ):
         """
         Initializes the buddy Graph importer.
@@ -862,6 +883,13 @@ class GraphImporter:
         self._ops_registry = ops_registry
         self._current_param_pack_offset = None
         self._enable_external_calls = enable_external_calls
+        if (param_pack_sizes is None) != (param_pack_offsets is None):
+            raise ValueError(
+                "param_pack_sizes and param_pack_offsets must be provided "
+                "together"
+            )
+        self._param_pack_sizes = param_pack_sizes
+        self._param_pack_offsets = param_pack_offsets
 
     def _verbose_output(self):
         if self._verbose_path is None:
@@ -939,18 +967,26 @@ class GraphImporter:
         graph_instance._pack_params()
         # The parameters of the graph are now packed to one memref.
         """
-        dtypes = list(set([param.dtype for param in self._params_shapes]))
+        if self._param_pack_sizes is not None:
+            dtypes = list(self._param_pack_sizes)
+        else:
+            dtypes = list(set([param.dtype for param in self._params_shapes]))
         dtypes.sort(key=str)
         self._current_param_pack_offset = dict.fromkeys(dtypes, 0)
         for dtype in dtypes:
-            params_of_dtype = [
-                param for param in self._params_shapes if param.dtype == dtype
-            ]
-            param_total_size = 0
-            for param in params_of_dtype:
-                param_total_size += functools.reduce(
-                    lambda x, y: x * y, list(param.shape), 1
-                )
+            if self._param_pack_sizes is not None:
+                param_total_size = self._param_pack_sizes[dtype]
+            else:
+                params_of_dtype = [
+                    param
+                    for param in self._params_shapes
+                    if param.dtype == dtype
+                ]
+                param_total_size = 0
+                for param in params_of_dtype:
+                    param_total_size += functools.reduce(
+                        lambda x, y: x * y, list(param.shape), 1
+                    )
             mlir_dtype = self._str_to_mlir_dtype(dtype)
             self._param_packs.append(
                 ir.MemRefType.get([param_total_size], mlir_dtype)
@@ -1104,12 +1140,19 @@ class GraphImporter:
                 ).element_type == self._str_to_mlir_dtype(dtype):
                     pack_of_dtype = pack
                     break
+            if self._param_pack_offsets is None:
+                offset = self._current_param_pack_offset[dtype]
+            else:
+                offset = self._param_pack_offsets[str(node.name)]
             placeholder_name = self._ops_registry["param.extract"](
-                node, self._current_param_pack_offset[dtype], pack_of_dtype
+                node, offset, pack_of_dtype
             ).result
-            self._current_param_pack_offset[dtype] += functools.reduce(
-                lambda x, y: x * y, list(node.tensor_meta["shape"]), 1
-            )
+            if self._param_pack_offsets is None:
+                self._current_param_pack_offset[dtype] += functools.reduce(
+                    lambda x, y: x * y,
+                    list(node.tensor_meta["shape"]),
+                    1,
+                )
         elif self._do_param_pack:
             if len(self._params_shapes) > 0:
                 placeholder_name = args_list[

--- a/frontend/Python/graph/partitioned_graph_driver.py
+++ b/frontend/Python/graph/partitioned_graph_driver.py
@@ -57,7 +57,9 @@ from .transformer_partition import (
     GraphValueRef,
     RegionInputKind,
     RegionInputRef,
+    RewriteTarget,
     TemplateInstanceBinding,
+    TransformerParallelPlan,
     TransformerPartitionPlan,
     _operand_dict_items,
     _resolve_operand_node_reference,
@@ -1816,3 +1818,462 @@ class TemplatePartitionedGraphDriver:
                 verbose_path=main_graph._verbose_path,
             )
             return importer.import_main_graph()
+
+
+class ParallelTemplatePartitionedGraphDriver(TemplatePartitionedGraphDriver):
+    """Materialize rank-local compute segments from a Stage 1 parallel plan."""
+
+    def __init__(
+        self,
+        graph: Graph,
+        partition_plan: TransformerPartitionPlan,
+        parallel_plan: TransformerParallelPlan,
+        rank: int,
+    ) -> None:
+        super().__init__(graph, partition_plan)
+        if rank < 0 or rank >= parallel_plan.world_size:
+            raise ValueError(
+                f"rank {rank} is outside [0, {parallel_plan.world_size})"
+            )
+        if parallel_plan.graph_name != graph._func_name:
+            raise ValueError("parallel plan graph_name does not match Graph")
+        expected_ids = tuple(
+            unit.template_id for unit in partition_plan.templates
+        )
+        actual_ids = tuple(unit.template_id for unit in parallel_plan.templates)
+        if actual_ids != expected_ids:
+            raise ValueError(
+                "parallel plan template id/order does not match partition plan"
+            )
+        self._parallel_plan = parallel_plan
+        self._rank = rank
+        self._parallel_segment_wrappers = {}
+        self._wrapper_parameter_bindings = {}
+        self._rank_parameter_layout = {}
+
+    @property
+    def subgraphs(self):
+        if not self._subgraphs:
+            return []
+        return [
+            self._subgraphs[(template.template_id, segment.segment_index)]
+            for template in self._parallel_plan.templates
+            for segment in template.segments
+        ]
+
+    def parallel_template_symbol(
+        self, template_id: int, segment_index: int
+    ) -> str:
+        return f"{self.template_symbol(template_id)}_seg{segment_index}"
+
+    def _collective_ingress_map(self, template) -> dict:
+        ingress = {}
+        for segment in template.segments:
+            nodes = set(segment.ordered_nodes)
+            uses_by_value = defaultdict(set)
+            for op in segment.ordered_nodes:
+                for value, path in iter_op_input_references(
+                    op, self._graph.node_table, with_paths=True
+                ):
+                    uses_by_value[value].add((op, path))
+            for value in segment.ordered_inputs:
+                uses = uses_by_value[value]
+                boundaries = []
+                for boundary in template.collectives:
+                    if boundary.producer != value:
+                        continue
+                    boundary_uses = {
+                        (use.consumer, use.operand_path)
+                        for use in boundary.consumers
+                        if use.consumer in nodes
+                    }
+                    if not boundary_uses:
+                        continue
+                    if boundary_uses != uses:
+                        raise ValueError(
+                            f"segment {segment.segment_index} input "
+                            f"{value.op.name!r}:{value.result_index} has ambiguous "
+                            "collective ingress"
+                        )
+                    boundaries.append(boundary)
+                if len(boundaries) > 1:
+                    raise ValueError(
+                        f"segment {segment.segment_index} input "
+                        f"{value.op.name!r}:{value.result_index} has ambiguous "
+                        "collective ingress"
+                    )
+                if boundaries:
+                    ingress[(segment.segment_index, value)] = boundaries[0]
+        return ingress
+
+    def _rank_tensor_meta(self, value: GraphValueRef, shape) -> TensorMeta:
+        meta = graph_value_tensor_meta(value)
+        return TensorMeta(tuple(shape), meta.dtype)
+
+    def _localize_result_metadata(self, op, clone, layouts) -> None:
+        meta = op.tensor_meta
+        shape = (
+            meta.shape if isinstance(meta, TensorMeta) else meta.get("shape")
+        )
+        if shape is None:
+            raise ValueError(f"operation {op.name!r} has no result metadata")
+        is_multi_result = (
+            isinstance(shape, (list, tuple))
+            and bool(shape)
+            and isinstance(shape[0], (list, tuple, torch.Size))
+        )
+        result_count = len(shape) if is_multi_result else 1
+        local_shapes = []
+        for result_index in range(result_count):
+            value = GraphValueRef(op, result_index)
+            try:
+                spec = layouts[value]
+            except KeyError as error:
+                raise ValueError(
+                    f"result {op.name!r}:{result_index} has no value layout"
+                ) from error
+            local_shapes.append(tuple(spec.local_shapes[self._rank]))
+        clone._tensor_meta["shape"] = (
+            local_shapes if is_multi_result else local_shapes[0]
+        )
+
+    def _apply_op_rewrite(self, clone, spec) -> None:
+        value = tuple(spec.rank_values[self._rank])
+        if spec.target is RewriteTarget.NEW_SHAPE:
+            if spec.operand_path is not None:
+                raise ValueError(
+                    "NEW_SHAPE rewrite must not have an operand path"
+                )
+            clone._newshape = value
+            return
+        if spec.target is RewriteTarget.OPERAND:
+            if spec.operand_path != ("args", 1):
+                raise ValueError(
+                    f"unsupported operand rewrite path {spec.operand_path!r}"
+                )
+            if len(clone._arguments) <= 1:
+                raise ValueError("operand rewrite path does not exist on clone")
+            clone._arguments[1] = value
+            return
+        raise ValueError(f"unsupported rewrite target {spec.target!r}")
+
+    def build_parallel_template_subgraphs(self):
+        if self._subgraphs:
+            return self.subgraphs
+        materialized = {}
+        for template in self._parallel_plan.templates:
+            layouts = {spec.value: spec for spec in template.value_layouts}
+            rewrites = defaultdict(list)
+            for spec in template.op_rewrites:
+                rewrites[spec.op].append(spec)
+            ingress = self._collective_ingress_map(template)
+            for segment in template.segments:
+                subgraph = Graph(
+                    self._graph._ops_registry,
+                    self.parallel_template_symbol(
+                        template.template_id, segment.segment_index
+                    ),
+                    self._graph.device,
+                    verbose=self._graph._verbose,
+                    verbose_path=self._graph._verbose_path,
+                )
+                local_nodes = set(segment.ordered_nodes)
+                bindings = {}
+                for slot, value in enumerate(segment.ordered_inputs):
+                    try:
+                        layout = layouts[value]
+                    except KeyError as error:
+                        raise ValueError(
+                            f"segment input {value.op.name!r}:"
+                            f"{value.result_index} has no value layout"
+                        ) from error
+                    boundary = ingress.get((segment.segment_index, value))
+                    shape = (
+                        boundary.target_local_shapes[self._rank]
+                        if boundary is not None
+                        else layout.local_shapes[self._rank]
+                    )
+                    placeholder = PlaceholderOp()
+                    placeholder.name = f"__segment_arg{slot}"
+                    placeholder.tensor_meta = self._rank_tensor_meta(
+                        value, shape
+                    )
+                    subgraph.add_node(placeholder, NodeType.InputNode)
+                    bindings[value] = placeholder.name
+
+                for op in segment.ordered_nodes:
+                    clone = self._clone_region_node(op, bindings, local_nodes)
+                    self._localize_result_metadata(op, clone, layouts)
+                    for spec in rewrites.get(op, ()):
+                        self._apply_op_rewrite(clone, spec)
+                    subgraph.add_node(clone)
+
+                output = OutputOp()
+                output.name = "output"
+                for slot, value in enumerate(segment.ordered_outputs):
+                    if value.result_index == 0:
+                        output.add_argument(value.op.name)
+                        continue
+                    getitem = GetItemOp()
+                    getitem.name = f"__segment_result{slot}"
+                    getitem.add_argument(value.op.name)
+                    getitem.add_argument(value.result_index)
+                    subgraph.add_node(getitem)
+                    output.add_argument(getitem.name)
+                subgraph.add_node(output)
+                materialized[(template.template_id, segment.segment_index)] = (
+                    subgraph
+                )
+        self._subgraphs = materialized
+        return self.subgraphs
+
+    def construct_parallel_segment_wrappers(self):
+        if self._parallel_segment_wrappers:
+            return list(self._parallel_segment_wrappers.values())
+
+        units = {unit.template_id: unit for unit in self._plan.templates}
+        templates = {
+            template.template_id: template
+            for template in self._parallel_plan.templates
+        }
+        parameter_metadata = {}
+
+        for instance_index, binding in enumerate(self._plan.instance_bindings):
+            unit = units[binding.template_id]
+            template = templates[binding.template_id]
+            layouts = {spec.value: spec for spec in template.value_layouts}
+            ingress = self._collective_ingress_map(template)
+            parameter_inputs = [
+                input_ref
+                for input_ref in unit.representative.interface.ordered_inputs
+                if input_ref.kind is RegionInputKind.PARAMETER
+            ]
+            parameter_slots = {
+                input_ref.value: slot
+                for slot, input_ref in enumerate(parameter_inputs)
+            }
+            shard_specs = {
+                spec.template_parameter_slot: spec
+                for spec in template.parameter_shards
+            }
+
+            for segment in template.segments:
+                region_index = getattr(
+                    binding.region, "layer_index", instance_index
+                )
+                region_label = (
+                    "layer"
+                    if hasattr(binding.region, "layer_index")
+                    else "region"
+                )
+                wrapper = Graph(
+                    self._graph._ops_registry,
+                    f"{self._graph._func_name}_{region_label}"
+                    f"{region_index}_seg{segment.segment_index}",
+                    self._graph.device,
+                    verbose=self._graph._verbose,
+                    verbose_path=self._graph._verbose_path,
+                )
+                placeholders = []
+                input_metas = []
+                parameter_placeholders = []
+                runtime_placeholders = []
+                wrapper_bindings = {}
+
+                for slot, value in enumerate(segment.ordered_inputs):
+                    try:
+                        layout = layouts[value]
+                    except KeyError as error:
+                        raise ValueError(
+                            f"segment input {value.op.name!r}:"
+                            f"{value.result_index} has no value layout"
+                        ) from error
+                    boundary = ingress.get((segment.segment_index, value))
+                    shape = (
+                        boundary.target_local_shapes[self._rank]
+                        if boundary is not None
+                        else layout.local_shapes[self._rank]
+                    )
+                    input_meta = self._rank_tensor_meta(value, shape)
+                    input_metas.append(input_meta)
+                    placeholder = PlaceholderOp()
+                    if value in parameter_slots:
+                        parameter_slot = parameter_slots[value]
+                        actual_parameter_index = binding.parameter_indices[
+                            parameter_slot
+                        ]
+                        actual_parameter = self._graph.params[
+                            actual_parameter_index
+                        ]
+                        placeholder.name = actual_parameter.name
+                        shard_spec = shard_specs.get(parameter_slot)
+                        actual_meta = graph_value_tensor_meta(
+                            GraphValueRef(actual_parameter)
+                        )
+                        actual_shape = list(actual_meta.shape)
+                        if shard_spec is not None:
+                            actual_shape[shard_spec.storage_shard_axis] = (
+                                shard_spec.rank_slices[self._rank].size
+                            )
+                        placeholder.tensor_meta = TensorMeta(
+                            tuple(actual_shape), actual_meta.dtype
+                        )
+                        parameter_placeholders.append(placeholder)
+                        wrapper_bindings[placeholder.name] = (
+                            actual_parameter_index
+                        )
+                        parameter_metadata.setdefault(
+                            actual_parameter_index,
+                            (actual_meta.dtype, tuple(actual_shape)),
+                        )
+                    else:
+                        placeholder.name = f"__wrapper_arg{slot}"
+                        placeholder.tensor_meta = input_meta
+                        runtime_placeholders.append(placeholder)
+                    placeholders.append(placeholder)
+
+                for placeholder in parameter_placeholders:
+                    wrapper.add_node(placeholder, NodeType.FakeNode)
+                for placeholder in runtime_placeholders:
+                    wrapper.add_node(placeholder, NodeType.InputNode)
+
+                declaration = FuncOp()
+                declaration.name = self.parallel_template_symbol(
+                    template.template_id, segment.segment_index
+                )
+                declaration.tensor_meta = {"shape": [], "dtype": []}
+                for input_meta in input_metas:
+                    declaration.add_argument(input_meta)
+                for value in segment.ordered_outputs:
+                    meta = self._rank_tensor_meta(
+                        value, layouts[value].local_shapes[self._rank]
+                    )
+                    declaration.tensor_meta["shape"].append(meta.shape)
+                    declaration.tensor_meta["dtype"].append(meta.dtype)
+                wrapper.add_node(declaration)
+
+                call = CallOp()
+                call.name = "segment_call"
+                call.call_func_name = declaration.name
+                call.tensor_meta = {
+                    "shape": list(declaration.tensor_meta["shape"]),
+                    "dtype": list(declaration.tensor_meta["dtype"]),
+                }
+                for placeholder in placeholders:
+                    call.add_argument(placeholder.name)
+                wrapper.add_node(call)
+
+                output = OutputOp()
+                output.name = "output"
+                for output_index in range(len(segment.ordered_outputs)):
+                    if output_index == 0:
+                        output.add_argument(call.name)
+                        continue
+                    getitem = GetItemOp()
+                    getitem.name = f"__wrapper_result{output_index}"
+                    getitem.add_argument(call.name)
+                    getitem.add_argument(output_index)
+                    wrapper.add_node(getitem)
+                    output.add_argument(getitem.name)
+                wrapper.add_node(output)
+
+                key = (instance_index, segment.segment_index)
+                self._parallel_segment_wrappers[key] = wrapper
+                self._wrapper_parameter_bindings[key] = wrapper_bindings
+
+        dtype_offsets = defaultdict(int)
+        for parameter_index in sorted(parameter_metadata):
+            dtype, shape = parameter_metadata[parameter_index]
+            numel = functools.reduce(lambda x, y: x * y, shape, 1)
+            self._rank_parameter_layout[parameter_index] = {
+                "dtype": dtype,
+                "shape": shape,
+                "offset": dtype_offsets[dtype],
+                "numel": numel,
+            }
+            dtype_offsets[dtype] += numel
+
+        return list(self._parallel_segment_wrappers.values())
+
+    def build_rank_parameter_pack(self, params, output_dir):
+        if not self._rank_parameter_layout:
+            self.construct_parallel_segment_wrappers()
+
+        parameter_shards = {}
+        for template in self._parallel_plan.templates:
+            shard_specs = {
+                spec.template_parameter_slot: spec
+                for spec in template.parameter_shards
+            }
+            for binding in self._plan.instance_bindings:
+                if binding.template_id != template.template_id:
+                    continue
+                for parameter_slot, spec in shard_specs.items():
+                    parameter_shards[
+                        binding.parameter_indices[parameter_slot]
+                    ] = spec
+
+        os.makedirs(output_dir, exist_ok=True)
+        dtypes = {
+            layout["dtype"] for layout in self._rank_parameter_layout.values()
+        }
+        for dtype in sorted(dtypes, key=str):
+            dtype_name = dtype.value
+            filename = os.path.join(
+                output_dir, f"rank{self._rank}_params_{dtype_name}.data"
+            )
+            current_offset = 0
+            with open(filename, "wb") as file:
+                for parameter_index, layout in sorted(
+                    self._rank_parameter_layout.items()
+                ):
+                    if layout["dtype"] != dtype:
+                        continue
+
+                    tensor = params[parameter_index]
+                    spec = parameter_shards.get(parameter_index)
+                    if spec is not None:
+                        rank_slice = spec.rank_slices[self._rank]
+                        slices = [slice(None)] * tensor.ndim
+                        slices[spec.storage_shard_axis] = slice(
+                            rank_slice.offset,
+                            rank_slice.offset + rank_slice.size,
+                        )
+                        local_tensor = tensor[tuple(slices)]
+                    else:
+                        local_tensor = tensor
+
+                    if tuple(local_tensor.shape) != layout["shape"]:
+                        raise ValueError(
+                            f"parameter {parameter_index} rank-local shape "
+                            "does not match _rank_parameter_layout"
+                        )
+                    if current_offset != layout["offset"]:
+                        raise ValueError(
+                            f"parameter {parameter_index} offset does not "
+                            "follow _rank_parameter_layout"
+                        )
+
+                    local_tensor = local_tensor.detach().cpu().contiguous()
+                    tensor_dtype_name = str(local_tensor.dtype).removeprefix(
+                        "torch."
+                    )
+                    if tensor_dtype_name != dtype_name:
+                        raise ValueError(
+                            f"parameter {parameter_index} dtype "
+                            f"{tensor_dtype_name} does not match layout dtype "
+                            f"{dtype_name}"
+                        )
+                    if dtype_name == "bfloat16":
+                        flat = (
+                            local_tensor.view(torch.uint16).numpy().reshape(-1)
+                        )
+                    else:
+                        flat = local_tensor.numpy().reshape(-1)
+                    if flat.size != layout["numel"]:
+                        raise ValueError(
+                            f"parameter {parameter_index} rank-local size "
+                            "does not match _rank_parameter_layout"
+                        )
+                    flat.tofile(file)
+                    current_offset += flat.size

--- a/frontend/Python/graph/partitioned_graph_driver.py
+++ b/frontend/Python/graph/partitioned_graph_driver.py
@@ -22,6 +22,7 @@
 
 import copy
 import functools
+import math
 import os
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
@@ -54,7 +55,9 @@ from .operation import (
     ViewOp,
 )
 from .transformer_partition import (
+    CollectiveKind,
     GraphValueRef,
+    LayoutKind,
     RegionInputKind,
     RegionInputRef,
     RewriteTarget,
@@ -2194,6 +2197,437 @@ class ParallelTemplatePartitionedGraphDriver(TemplatePartitionedGraphDriver):
             dtype_offsets[dtype] += numel
 
         return list(self._parallel_segment_wrappers.values())
+
+    def build_parallel_runtime_plan(
+        self, output_remap: list[int] | None = None
+    ):
+        """Resolve the rank-local ordered program for parallel wrappers."""
+        self.construct_parallel_segment_wrappers()
+
+        units = {unit.template_id: unit for unit in self._plan.templates}
+        templates = {
+            template.template_id: template
+            for template in self._parallel_plan.templates
+        }
+
+        def require_flat_collective_layout(layout, global_shape):
+            if (
+                layout.kind is LayoutKind.SHARDED
+                and math.prod(global_shape[: layout.shard_axis]) != 1
+            ):
+                raise ValueError(
+                    "current flat RAX collective cannot represent that "
+                    "shard layout"
+                )
+
+        resources = {}
+        parameter_packs = []
+        pack_names = {}
+        for dtype in sorted(
+            {
+                layout["dtype"]
+                for layout in self._rank_parameter_layout.values()
+            },
+            key=str,
+        ):
+            name = f"rank{self._rank}_params_{dtype.value}"
+            entries = tuple(
+                {
+                    "parameter_index": parameter_index,
+                    "shape": layout["shape"],
+                    "offset": layout["offset"],
+                    "numel": layout["numel"],
+                }
+                for parameter_index, layout in sorted(
+                    self._rank_parameter_layout.items()
+                )
+                if layout["dtype"] == dtype
+            )
+            numel = sum(entry["numel"] for entry in entries)
+            pack_names[dtype] = name
+            resources[name] = {
+                "shape": (numel,),
+                "dtype": dtype.value,
+                "role": "parameter",
+            }
+            parameter_packs.append(
+                {
+                    "resource": name,
+                    "dtype": dtype.value,
+                    "numel": numel,
+                    "parameters": entries,
+                }
+            )
+
+        input_shapes = {}
+        for binding in self._plan.instance_bindings:
+            unit = units[binding.template_id]
+            template = templates[binding.template_id]
+            layouts = {spec.value: spec for spec in template.value_layouts}
+            for representative, actual in zip(
+                unit.representative.interface.ordered_inputs,
+                binding.ordered_inputs,
+                strict=True,
+            ):
+                if representative.kind not in (
+                    RegionInputKind.DATA,
+                    RegionInputKind.STATE,
+                ):
+                    continue
+                if (
+                    actual.value.op not in self._graph.inputs
+                    or actual.value.result_index != 0
+                ):
+                    continue
+                shape = tuple(
+                    layouts[representative.value].local_shapes[self._rank]
+                )
+                previous = input_shapes.setdefault(actual.value, shape)
+                if previous != shape:
+                    raise ValueError(
+                        f"graph input {actual.value.op.name!r} has "
+                        "inconsistent rank-local shapes"
+                    )
+
+        values = {}
+        value_map = {}
+
+        def add_value(name, value, shape, role, definition):
+            meta = graph_value_tensor_meta(value)
+            values[name] = {
+                "shape": tuple(shape),
+                "dtype": meta.dtype.value,
+                "role": role,
+                "definition": definition,
+                "last_use": definition,
+            }
+            return name
+
+        for input_index, op in enumerate(self._graph.inputs):
+            value = GraphValueRef(op)
+            meta = graph_value_tensor_meta(value)
+            name = f"input{input_index}"
+            value_map[value] = add_value(
+                name,
+                value,
+                input_shapes.get(value, meta.shape),
+                "input",
+                -1,
+            )
+
+        operations = []
+        for instance_index, binding in enumerate(self._plan.instance_bindings):
+            unit = units[binding.template_id]
+            template = templates[binding.template_id]
+            layouts = {spec.value: spec for spec in template.value_layouts}
+            representative_inputs = unit.representative.interface.ordered_inputs
+            parameter_values = {}
+            instance_value_map = {}
+            parameter_offset = 0
+            for representative, actual in zip(
+                representative_inputs, binding.ordered_inputs, strict=True
+            ):
+                if representative.kind is RegionInputKind.PARAMETER:
+                    parameter_values[representative.value] = (
+                        binding.parameter_indices[parameter_offset]
+                    )
+                    parameter_offset += 1
+                elif representative.kind in (
+                    RegionInputKind.DATA,
+                    RegionInputKind.STATE,
+                ):
+                    instance_value_map[representative.value] = value_map[
+                        actual.value
+                    ]
+                elif representative.kind is RegionInputKind.CONSTANT:
+                    raise ValueError(
+                        "external TensorConstant inputs are not supported by "
+                        "parallel runtime planning"
+                    )
+                else:
+                    raise ValueError(
+                        f"unsupported Region input kind {representative.kind!r}"
+                    )
+
+            ingress = self._collective_ingress_map(template)
+            boundary_indices = {
+                boundary: index
+                for index, boundary in enumerate(template.collectives)
+            }
+            collective_results = {}
+            for segment in template.segments:
+                resolved_inputs = []
+                for value in segment.ordered_inputs:
+                    if value in parameter_values:
+                        continue
+                    producer = instance_value_map[value]
+                    boundary = ingress.get((segment.segment_index, value))
+                    if boundary is not None:
+                        boundary_index = boundary_indices[boundary]
+                        if boundary_index not in collective_results:
+                            position = len(operations)
+                            kind = boundary.kind
+                            collective_output = producer
+                            collective = {
+                                "kind": "collective",
+                                "collective": kind.name.lower(),
+                                "input": producer,
+                                "output": producer,
+                            }
+                            if kind is CollectiveKind.ALL_REDUCE:
+                                collective["reduction"] = "sum"
+                            elif kind is CollectiveKind.ALL_GATHERV:
+                                source_layout = layouts[boundary.producer]
+                                require_flat_collective_layout(
+                                    source_layout.layout,
+                                    source_layout.global_shape,
+                                )
+                                counts = tuple(
+                                    math.prod(shape)
+                                    for shape in source_layout.local_shapes
+                                )
+                                displacements = []
+                                offset = 0
+                                for count in counts:
+                                    displacements.append(offset)
+                                    offset += count
+                                collective_output = add_value(
+                                    f"instance{instance_index}_collective"
+                                    f"{boundary_index}",
+                                    boundary.producer,
+                                    boundary.target_local_shapes[self._rank],
+                                    "workspace",
+                                    position,
+                                )
+                                collective["output"] = collective_output
+                                collective["recv_counts"] = counts
+                                collective["displacements"] = tuple(
+                                    displacements
+                                )
+                            elif kind is CollectiveKind.REDUCE_SCATTER:
+                                source_layout = layouts[boundary.producer]
+                                require_flat_collective_layout(
+                                    boundary.target_layout,
+                                    source_layout.global_shape,
+                                )
+                                collective_output = add_value(
+                                    f"instance{instance_index}_collective"
+                                    f"{boundary_index}",
+                                    boundary.producer,
+                                    boundary.target_local_shapes[self._rank],
+                                    "workspace",
+                                    position,
+                                )
+                                collective["output"] = collective_output
+                                collective["recv_counts"] = tuple(
+                                    math.prod(shape)
+                                    for shape in boundary.target_local_shapes
+                                )
+                                collective["reduction"] = "sum"
+                            else:
+                                raise ValueError(
+                                    f"unsupported collective kind {kind!r}"
+                                )
+                            operations.append(collective)
+                            collective_results[boundary_index] = (
+                                collective_output
+                            )
+                        producer = collective_results[boundary_index]
+                    resolved_inputs.append(producer)
+
+                position = len(operations)
+                resolved_outputs = tuple(
+                    add_value(
+                        f"instance{instance_index}_segment"
+                        f"{segment.segment_index}_result{result_index}",
+                        value,
+                        layouts[value].local_shapes[self._rank],
+                        "workspace",
+                        position,
+                    )
+                    for result_index, value in enumerate(
+                        segment.ordered_outputs
+                    )
+                )
+                key = (instance_index, segment.segment_index)
+                wrapper_bindings = self._wrapper_parameter_bindings[key]
+                parameter_bindings = tuple(
+                    {
+                        "name": name,
+                        "parameter_index": parameter_index,
+                        "pack": pack_names[layout["dtype"]],
+                        "dtype": layout["dtype"].value,
+                        "shape": layout["shape"],
+                        "offset": layout["offset"],
+                        "numel": layout["numel"],
+                    }
+                    for name, parameter_index in wrapper_bindings.items()
+                    for layout in (
+                        self._rank_parameter_layout[parameter_index],
+                    )
+                )
+                dispatch_packs = tuple(
+                    pack_names[dtype]
+                    for dtype in sorted(
+                        {
+                            self._rank_parameter_layout[index]["dtype"]
+                            for index in wrapper_bindings.values()
+                        },
+                        key=str,
+                    )
+                )
+                wrapper = self._parallel_segment_wrappers[key]
+                operations.append(
+                    {
+                        "kind": "dispatch",
+                        "instance_index": instance_index,
+                        "template_id": template.template_id,
+                        "segment_index": segment.segment_index,
+                        "wrapper": wrapper._func_name,
+                        "function": self.parallel_template_symbol(
+                            template.template_id, segment.segment_index
+                        ),
+                        "parameter_packs": dispatch_packs,
+                        "parameter_bindings": parameter_bindings,
+                        "inputs": tuple(resolved_inputs),
+                        "outputs": resolved_outputs,
+                        "arguments": (
+                            dispatch_packs
+                            + tuple(resolved_inputs)
+                            + resolved_outputs
+                        ),
+                    }
+                )
+                for value, result in zip(
+                    segment.ordered_outputs, resolved_outputs, strict=True
+                ):
+                    instance_value_map[value] = result
+
+            for representative, actual in zip(
+                unit.representative.interface.ordered_outputs,
+                binding.ordered_outputs,
+                strict=True,
+            ):
+                value_map[actual] = instance_value_map[representative]
+
+        final_values = []
+        for op in self._graph.body:
+            if isinstance(op, OutputOp):
+                final_values.extend(
+                    iter_op_input_references(op, self._graph.node_table)
+                )
+        resolved_outputs = tuple(value_map[value] for value in final_values)
+        if output_remap is not None:
+            if len(output_remap) != len(resolved_outputs):
+                raise ValueError(
+                    "output_remap length must match the number of graph outputs"
+                )
+            if any(
+                index < 0 or index >= len(resolved_outputs)
+                for index in output_remap
+            ):
+                raise ValueError(
+                    "output_remap contains an invalid output index"
+                )
+            resolved_outputs = tuple(
+                resolved_outputs[index] for index in output_remap
+            )
+        for name in resolved_outputs:
+            if values[name]["role"] == "workspace":
+                values[name]["role"] = "output"
+
+        for position, operation in enumerate(operations):
+            inputs = (
+                operation["inputs"]
+                if operation["kind"] == "dispatch"
+                else (operation["input"],)
+            )
+            for name in inputs:
+                values[name]["last_use"] = position
+        for name in resolved_outputs:
+            values[name]["last_use"] = len(operations)
+
+        output_indices = {}
+        for output_index, name in enumerate(resolved_outputs):
+            output_indices.setdefault(name, output_index)
+
+        workspace_slots = []
+        for name, value in values.items():
+            role = value["role"]
+            if role == "input":
+                resource = name
+            elif role == "output":
+                resource = f"output{output_indices[name]}"
+            else:
+                compatible = (
+                    value["dtype"],
+                    value["shape"],
+                    value["role"],
+                )
+                slot = next(
+                    (
+                        item
+                        for item in workspace_slots
+                        if item["compatible"] == compatible
+                        and item["available_after"] < value["definition"]
+                    ),
+                    None,
+                )
+                if slot is None:
+                    slot = {
+                        "resource": f"workspace{len(workspace_slots)}",
+                        "compatible": compatible,
+                        "available_after": value["last_use"],
+                    }
+                    workspace_slots.append(slot)
+                else:
+                    slot["available_after"] = value["last_use"]
+                resource = slot["resource"]
+            value["resource"] = resource
+            resources.setdefault(
+                resource,
+                {
+                    "shape": value["shape"],
+                    "dtype": value["dtype"],
+                    "role": role,
+                },
+            )
+
+        resolved_operations = []
+        for operation in operations:
+            operation = dict(operation)
+            if operation["kind"] == "dispatch":
+                operation["inputs"] = tuple(
+                    values[name]["resource"] for name in operation["inputs"]
+                )
+                operation["outputs"] = tuple(
+                    values[name]["resource"] for name in operation["outputs"]
+                )
+                operation["arguments"] = tuple(
+                    values[name]["resource"] if name in values else name
+                    for name in operation["arguments"]
+                )
+            else:
+                operation["input"] = values[operation["input"]]["resource"]
+                operation["output"] = values[operation["output"]]["resource"]
+            resolved_operations.append(operation)
+
+        return {
+            "graph": self._graph._func_name,
+            "rank": self._rank,
+            "world_size": self._parallel_plan.world_size,
+            "resources": resources,
+            "values": values,
+            "parameter_packs": tuple(parameter_packs),
+            "operations": resolved_operations,
+            "runtime_inputs": tuple(
+                values[value_map[GraphValueRef(op)]]["resource"]
+                for op in self._graph.inputs
+            ),
+            "runtime_outputs": tuple(
+                values[name]["resource"] for name in resolved_outputs
+            ),
+        }
 
     def build_rank_parameter_pack(self, params, output_dir):
         if not self._rank_parameter_layout:

--- a/frontend/Python/graph/transformer_partition.py
+++ b/frontend/Python/graph/transformer_partition.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Any
 
+from . import operation as operation
 from .operation import Op, OutputOp, TensorConstantOp
 from .structure_analysis import (
     ModuleStructureAnalyzer,
@@ -126,38 +127,77 @@ def _resolve_operand_node_reference(
 
 
 def _iter_operand_value_references(
-    value, node_table: dict[str, Op], result_index: int = 0
+    value,
+    node_table: dict[str, Op],
+    result_index: int = 0,
+    path: tuple[int | str, ...] = (),
+    with_paths: bool = False,
 ):
     referenced = _resolve_operand_node_reference(value, node_table)
     if referenced is not None:
-        yield GraphValueRef(referenced, result_index)
+        reference = GraphValueRef(referenced, result_index)
+        yield (reference, path) if with_paths else reference
         return
     if isinstance(value, (list, tuple)):
-        for item in value:
+        for index, item in enumerate(value):
             yield from _iter_operand_value_references(
-                item, node_table, result_index
+                item,
+                node_table,
+                result_index,
+                path + (index,),
+                with_paths,
             )
     elif isinstance(value, dict):
         for key, item in _operand_dict_items(value):
             yield from _iter_operand_value_references(
-                key, node_table, result_index
+                key,
+                node_table,
+                result_index,
+                path + ("key", key),
+                with_paths,
             )
             yield from _iter_operand_value_references(
-                item, node_table, result_index
+                item,
+                node_table,
+                result_index,
+                path + (key,),
+                with_paths,
             )
 
 
-def iter_op_input_references(op: Op, node_table: dict[str, Op]):
+def iter_op_input_references(
+    op: Op, node_table: dict[str, Op], *, with_paths: bool = False
+):
+    """Iterate operand value references, optionally retaining their paths.
+
+    Paths use ``("args", index, ...)`` and ``("kwargs", key, ...)`` and are
+    derived by this same traversal; planning therefore cannot disagree with
+    Region/template analysis about what constitutes an operand reference.
+    """
     for index, value in enumerate(op.args):
         result_index = (
             op._args_index[index] if index < len(op._args_index) else 0
         )
         yield from _iter_operand_value_references(
-            value, node_table, result_index
+            value,
+            node_table,
+            result_index,
+            ("args", index),
+            with_paths,
         )
     for key, value in _operand_dict_items(op.kwargs):
-        yield from _iter_operand_value_references(key, node_table)
-        yield from _iter_operand_value_references(value, node_table)
+        yield from _iter_operand_value_references(
+            key,
+            node_table,
+            path=("kwargs", "key", key),
+            with_paths=with_paths,
+        )
+        yield from _iter_operand_value_references(
+            value,
+            node_table,
+            path=("kwargs", key),
+            with_paths=with_paths,
+        )
 
 
 class RegionBuilder:
@@ -1437,3 +1477,1503 @@ def build_transformer_partition_plan(
     )
     _verify_partition_plan(graph, plan)
     return plan
+
+
+# Transformer tensor/sequence parallel planning (read-only Stage 1).
+
+
+class ParallelPlanError(ValueError):
+    """A graph property required for parallel planning cannot be proven."""
+
+
+class ParameterRole(Enum):
+    Q_WEIGHT = auto()
+    Q_BIAS = auto()
+    K_WEIGHT = auto()
+    K_BIAS = auto()
+    V_WEIGHT = auto()
+    V_BIAS = auto()
+    O_WEIGHT = auto()
+    GATE_WEIGHT = auto()
+    UP_WEIGHT = auto()
+    DOWN_WEIGHT = auto()
+    LM_HEAD_WEIGHT = auto()
+
+
+class FeatureAxis(Enum):
+    INPUT_FEATURE = auto()
+    OUTPUT_FEATURE = auto()
+
+
+class LayoutKind(Enum):
+    REPLICATED = auto()
+    SHARDED = auto()
+    PARTIAL = auto()
+
+
+class CollectiveKind(Enum):
+    ALL_REDUCE = auto()
+    REDUCE_SCATTER = auto()
+    ALL_GATHERV = auto()
+
+
+class RewriteTarget(Enum):
+    NEW_SHAPE = auto()
+    OPERAND = auto()
+
+
+@dataclass(frozen=True)
+class RankSlice:
+    rank: int
+    offset: int
+    size: int
+
+
+@dataclass(frozen=True)
+class TensorLayout:
+    kind: LayoutKind
+    shard_axis: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind is LayoutKind.SHARDED:
+            if not isinstance(self.shard_axis, int):
+                raise ParallelPlanError(
+                    "SHARDED layout requires an integer shard axis"
+                )
+        elif self.shard_axis is not None:
+            raise ParallelPlanError(
+                f"{self.kind.name} layout must not specify a shard axis"
+            )
+
+
+@dataclass(frozen=True)
+class OperandUseRef:
+    consumer: Op
+    operand_path: tuple[int | str, ...]
+
+
+@dataclass(frozen=True)
+class ParameterShardSpec:
+    parameter: GraphValueRef
+    global_parameter_index: int
+    template_parameter_slot: int
+    role: ParameterRole
+    semantic_axis: FeatureAxis
+    consumer_use: OperandUseRef
+    consumer_shard_axis: int
+    storage_shard_axis: int
+    storage_to_consumer_permutation: tuple[int, ...]
+    global_shape: tuple[int, ...]
+    rank_slices: tuple[RankSlice, ...]
+
+
+@dataclass(frozen=True)
+class ValueLayoutSpec:
+    value: GraphValueRef
+    global_shape: tuple[int, ...]
+    local_shapes: tuple[tuple[int, ...], ...]
+    layout: TensorLayout
+
+
+@dataclass(frozen=True)
+class OpRewriteSpec:
+    op: Op
+    target: RewriteTarget
+    operand_path: tuple[int | str, ...] | None
+    rank_values: tuple[tuple[int, ...], ...]
+
+
+@dataclass(frozen=True)
+class CollectiveBoundary:
+    producer: GraphValueRef
+    consumers: tuple[OperandUseRef, ...]
+    kind: CollectiveKind
+    target_layout: TensorLayout
+    target_local_shapes: tuple[tuple[int, ...], ...]
+
+
+@dataclass(frozen=True)
+class ComputeSegment:
+    segment_index: int
+    ordered_nodes: tuple[Op, ...]
+    ordered_inputs: tuple[GraphValueRef, ...]
+    ordered_outputs: tuple[GraphValueRef, ...]
+
+
+@dataclass(frozen=True)
+class TemplateParallelPlan:
+    template_id: int
+    parameter_shards: tuple[ParameterShardSpec, ...]
+    value_layouts: tuple[ValueLayoutSpec, ...]
+    op_rewrites: tuple[OpRewriteSpec, ...]
+    collectives: tuple[CollectiveBoundary, ...]
+    segments: tuple[ComputeSegment, ...]
+
+
+@dataclass(frozen=True)
+class TransformerParallelPlan:
+    graph_name: str
+    world_size: int
+    templates: tuple[TemplateParallelPlan, ...]
+
+
+@dataclass(frozen=True)
+class TransformerParallelConfig:
+    tp_size: int = 2
+    prefill_sequence_parallel: bool = False
+    parallel_lm_head: bool = False
+
+
+_REPLICATED = TensorLayout(LayoutKind.REPLICATED)
+_PARTIAL = TensorLayout(LayoutKind.PARTIAL)
+
+
+def partition_extent(extent: int, world_size: int) -> tuple[RankSlice, ...]:
+    if extent <= 0 or world_size <= 0:
+        raise ParallelPlanError(
+            "partition extent and world size must be positive"
+        )
+    base, remainder = divmod(extent, world_size)
+    offset = 0
+    slices = []
+    for rank in range(world_size):
+        size = base + (1 if rank < remainder else 0)
+        slices.append(RankSlice(rank, offset, size))
+        offset += size
+    return tuple(slices)
+
+
+def _global_shape(value: GraphValueRef) -> tuple[int, ...]:
+    shape = tuple(graph_value_tensor_meta(value).shape)
+    if not all(isinstance(dim, int) and dim >= 0 for dim in shape):
+        raise ParallelPlanError(
+            f"{value.op.name!r} result {value.result_index} has a non-static shape"
+        )
+    return shape
+
+
+def _result_shapes(op: Op) -> tuple[tuple[int, ...], ...]:
+    meta = op.tensor_meta
+    shape = meta.shape if isinstance(meta, TensorMeta) else meta.get("shape")
+    if shape is None:
+        raise ParallelPlanError(f"operation {op.name!r} has no result shape")
+    if (
+        isinstance(shape, (list, tuple))
+        and shape
+        and isinstance(shape[0], (list, tuple))
+    ):
+        return tuple(tuple(item) for item in shape)
+    return (tuple(shape),)
+
+
+def _rank_shapes(
+    shape: tuple[int, ...], axis: int, slices: tuple[RankSlice, ...]
+) -> tuple[tuple[int, ...], ...]:
+    result = []
+    for rank_slice in slices:
+        local = list(shape)
+        local[axis] = rank_slice.size
+        result.append(tuple(local))
+    return tuple(result)
+
+
+def _linear_semantics(op: Op) -> tuple[int, int, int, int | None]:
+    """Return activation, weight, input-feature axis and optional bias slot.
+
+    The feature axes describe the actual mathematical weight operand, before
+    any parameter-side permutation is mapped back to Graph storage.
+    """
+    if isinstance(op, operation.AddMMOp):
+        return 1, 2, 0, 0
+    if isinstance(op, operation.MatmulOp):
+        return 0, 1, 0, None
+    if isinstance(op, operation.TransposeMatmulFusedOp):
+        return 0, 1, 1, None
+    raise ParallelPlanError(
+        f"operation {op.name!r} is not a supported Linear-like compute op"
+    )
+
+
+def _permutation_for_transform(op: Op, rank: int) -> tuple[int, ...]:
+    if isinstance(op, operation.PermuteOp):
+        if len(op.args) < 2 or not isinstance(op.args[1], (list, tuple)):
+            raise ParallelPlanError(
+                f"Permute {op.name!r} has no static permutation"
+            )
+        permutation = tuple(int(item) for item in op.args[1])
+    elif isinstance(op, operation.TransposeOp):
+        if len(op.args) < 3:
+            raise ParallelPlanError(
+                f"Transpose {op.name!r} has no static dimensions"
+            )
+        dim0, dim1 = int(op.args[1]), int(op.args[2])
+        dim0 %= rank
+        dim1 %= rank
+        values = list(range(rank))
+        values[dim0], values[dim1] = values[dim1], values[dim0]
+        permutation = tuple(values)
+    else:
+        raise ParallelPlanError(f"{op.name!r} is not an axis-only transform")
+    if sorted(permutation) != list(range(rank)):
+        raise ParallelPlanError(
+            f"operation {op.name!r} has invalid permutation {permutation}"
+        )
+    return permutation
+
+
+def _trace_parameter_operand(
+    graph: Graph, consumer: Op, operand_slot: int
+) -> tuple[GraphValueRef, tuple[int | str, ...], tuple[int, ...]]:
+    uses = [
+        (value, path)
+        for value, path in iter_op_input_references(
+            consumer, graph.node_table, with_paths=True
+        )
+        if path[:2] == ("args", operand_slot)
+    ]
+    if len(uses) != 1:
+        raise ParallelPlanError(
+            f"Linear operand args[{operand_slot}] of {consumer.name!r} does not "
+            "contain exactly one tensor reference"
+        )
+    value, consumer_path = uses[0]
+    rank = len(_global_shape(value))
+    consumer_to_storage = tuple(range(rank))
+    while value.op not in graph.params:
+        transform = value.op
+        if not isinstance(
+            transform, (operation.PermuteOp, operation.TransposeOp)
+        ):
+            raise ParallelPlanError(
+                f"unsupported parameter-side {type(transform).__name__} "
+                f"{transform.name!r} before Linear {consumer.name!r}"
+            )
+        permutation = _permutation_for_transform(transform, rank)
+        consumer_to_storage = tuple(
+            permutation[axis] for axis in consumer_to_storage
+        )
+        inputs = list(iter_op_input_references(transform, graph.node_table))
+        if len(inputs) != 1:
+            raise ParallelPlanError(
+                f"parameter transform {transform.name!r} is not unary"
+            )
+        value = inputs[0]
+        if len(_global_shape(value)) != rank:
+            raise ParallelPlanError(
+                f"parameter transform {transform.name!r} changes rank"
+            )
+    return value, consumer_path, consumer_to_storage
+
+
+_PROJECTION_ROLES = {
+    "q_proj": (
+        ParameterRole.Q_WEIGHT,
+        ParameterRole.Q_BIAS,
+        FeatureAxis.OUTPUT_FEATURE,
+    ),
+    "k_proj": (
+        ParameterRole.K_WEIGHT,
+        ParameterRole.K_BIAS,
+        FeatureAxis.OUTPUT_FEATURE,
+    ),
+    "v_proj": (
+        ParameterRole.V_WEIGHT,
+        ParameterRole.V_BIAS,
+        FeatureAxis.OUTPUT_FEATURE,
+    ),
+    "o_proj": (
+        ParameterRole.O_WEIGHT,
+        None,
+        FeatureAxis.INPUT_FEATURE,
+    ),
+    "gate_proj": (
+        ParameterRole.GATE_WEIGHT,
+        None,
+        FeatureAxis.OUTPUT_FEATURE,
+    ),
+    "up_proj": (
+        ParameterRole.UP_WEIGHT,
+        None,
+        FeatureAxis.OUTPUT_FEATURE,
+    ),
+    "down_proj": (
+        ParameterRole.DOWN_WEIGHT,
+        None,
+        FeatureAxis.INPUT_FEATURE,
+    ),
+    "lm_head": (
+        ParameterRole.LM_HEAD_WEIGHT,
+        None,
+        FeatureAxis.OUTPUT_FEATURE,
+    ),
+}
+
+
+def _nodes_for_subcomponent(
+    unit: TemplateUnit,
+    partition_plan: TransformerPartitionPlan,
+    subcomponent: str,
+) -> tuple[Op, ...]:
+    region = unit.representative
+    if isinstance(region, LayerRegion):
+        return tuple(region.subcomponent_nodes.get(subcomponent, ()))
+    result = []
+    for op in region.nodes:
+        annotation = partition_plan.structure_index.annotations.get(
+            op, NodeAnnotation()
+        )
+        if annotation.subcomponent == subcomponent or (
+            subcomponent == "lm_head" and annotation.component == "lm_head"
+        ):
+            result.append(op)
+    return tuple(result)
+
+
+def _parameter_shards_for_template(
+    graph: Graph,
+    unit: TemplateUnit,
+    partition_plan: TransformerPartitionPlan,
+    config: TransformerParallelConfig,
+) -> tuple[ParameterShardSpec, ...]:
+    parameter_slots = {
+        item.value.op: slot
+        for slot, item in enumerate(
+            ref
+            for ref in unit.representative.interface.ordered_inputs
+            if ref.kind is RegionInputKind.PARAMETER
+        )
+    }
+    specs = []
+    targets = list(_PROJECTION_ROLES)
+    if not config.parallel_lm_head:
+        targets.remove("lm_head")
+    for subcomponent in targets:
+        nodes = _nodes_for_subcomponent(unit, partition_plan, subcomponent)
+        if not nodes:
+            continue
+        linears = [
+            op
+            for op in nodes
+            if isinstance(
+                op,
+                (
+                    operation.MatmulOp,
+                    operation.AddMMOp,
+                    operation.TransposeMatmulFusedOp,
+                ),
+            )
+        ]
+        if len(linears) != 1:
+            raise ParallelPlanError(
+                f"subcomponent {subcomponent!r} in template {unit.template_id} "
+                f"contains {len(linears)} supported Linear-like operations"
+            )
+        linear = linears[0]
+        _, weight_slot, input_axis, bias_slot = _linear_semantics(linear)
+        weight_role, bias_role, semantic_axis = _PROJECTION_ROLES[subcomponent]
+        consumer_axis = (
+            input_axis
+            if semantic_axis is FeatureAxis.INPUT_FEATURE
+            else 1 - input_axis
+        )
+
+        def add_spec(
+            role, slot, axis, *, linear=linear, semantic_axis=semantic_axis
+        ):
+            parameter, path, consumer_to_storage = _trace_parameter_operand(
+                graph, linear, slot
+            )
+            storage_shape = _global_shape(parameter)
+            operand_values = [
+                value
+                for value, operand_path in iter_op_input_references(
+                    linear, graph.node_table, with_paths=True
+                )
+                if operand_path == path
+            ]
+            if len(operand_values) != 1:
+                raise ParallelPlanError(
+                    f"cannot recover Linear operand {path!r} for {linear.name!r}"
+                )
+            consumer_shape = _global_shape(operand_values[0])
+            expected = tuple(
+                storage_shape[index] for index in consumer_to_storage
+            )
+            if consumer_shape != expected:
+                raise ParallelPlanError(
+                    f"parameter {parameter.op.name!r} permutation maps shape "
+                    f"{storage_shape} to {expected}, not consumer shape "
+                    f"{consumer_shape}"
+                )
+            storage_axis = consumer_to_storage[axis]
+            inverse = [0] * len(consumer_to_storage)
+            for consumer_index, storage_index in enumerate(consumer_to_storage):
+                inverse[storage_index] = consumer_index
+            try:
+                parameter_slot = parameter_slots[parameter.op]
+                parameter_index = partition_plan.parameter_indices[parameter.op]
+            except KeyError as error:
+                raise ParallelPlanError(
+                    f"parameter {parameter.op.name!r} is not a template parameter"
+                ) from error
+            slices = partition_extent(
+                storage_shape[storage_axis], config.tp_size
+            )
+            specs.append(
+                ParameterShardSpec(
+                    parameter=parameter,
+                    global_parameter_index=parameter_index,
+                    template_parameter_slot=parameter_slot,
+                    role=role,
+                    semantic_axis=semantic_axis,
+                    consumer_use=OperandUseRef(linear, path),
+                    consumer_shard_axis=axis,
+                    storage_shard_axis=storage_axis,
+                    storage_to_consumer_permutation=tuple(inverse),
+                    global_shape=storage_shape,
+                    rank_slices=slices,
+                )
+            )
+
+        add_spec(weight_role, weight_slot, consumer_axis)
+        if bias_role is not None and bias_slot is not None:
+            add_spec(bias_role, bias_slot, 0)
+    return tuple(specs)
+
+
+def _prod(shape: tuple[int, ...]) -> int:
+    return math.prod(shape)
+
+
+def _reshape_shard_axis(
+    input_shape: tuple[int, ...], output_shape: tuple[int, ...], axis: int
+) -> int | None:
+    input_suffix = _prod(input_shape[axis:])
+    candidates = [
+        output_axis
+        for output_axis in range(len(output_shape))
+        if _prod(output_shape[output_axis:]) == input_suffix
+    ]
+    if not candidates:
+        return None
+    first, last = candidates[0], candidates[-1]
+    if all(dim == 1 for dim in output_shape[first:last]):
+        return last
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def _broadcast_output_axis(
+    input_shape: tuple[int, ...], output_shape: tuple[int, ...], axis: int
+) -> int:
+    output_axis = len(output_shape) - len(input_shape) + axis
+    if output_axis < 0 or input_shape[axis] != output_shape[output_axis]:
+        raise ParallelPlanError(
+            f"cannot map sharded broadcast axis {axis} from {input_shape} "
+            f"to {output_shape}"
+        )
+    return output_axis
+
+
+@dataclass(frozen=True)
+class _ResolvedUse:
+    value: GraphValueRef
+    use: OperandUseRef
+    global_shape: tuple[int, ...]
+    local_shapes: tuple[tuple[int, ...], ...]
+    layout: TensorLayout
+
+
+@dataclass(frozen=True)
+class _PendingBoundary:
+    producer: GraphValueRef
+    consumer: OperandUseRef
+    kind: CollectiveKind
+    target_layout: TensorLayout
+    target_local_shapes: tuple[tuple[int, ...], ...]
+
+
+class _TemplateParallelPlanner:
+    def __init__(
+        self,
+        graph: Graph,
+        unit: TemplateUnit,
+        partition_plan: TransformerPartitionPlan,
+        config: TransformerParallelConfig,
+    ) -> None:
+        self.graph = graph
+        self.unit = unit
+        self.region = unit.representative
+        self.partition_plan = partition_plan
+        self.config = config
+        self.world_size = config.tp_size
+        self.local_shapes: dict[GraphValueRef, tuple[tuple[int, ...], ...]] = {}
+        self.layouts: dict[GraphValueRef, TensorLayout] = {}
+        self.rewrites: list[OpRewriteSpec] = []
+        self.pending: list[_PendingBoundary] = []
+        self.positions: dict[Op, int] = {}
+        self.op_inputs: dict[Op, tuple[GraphValueRef, ...]] = {}
+        self.value_consumers: dict[GraphValueRef, list[Op]] = {}
+        self.parameter_shards = _parameter_shards_for_template(
+            graph, unit, partition_plan, config
+        )
+        self._required_replicated: set[Op] = set()
+
+    @property
+    def is_prefill_sp(self) -> bool:
+        return self.config.prefill_sequence_parallel and (
+            "prefill" in self.graph._func_name.lower()
+        )
+
+    def _seed(
+        self,
+        value: GraphValueRef,
+        layout: TensorLayout,
+        local_shapes: tuple[tuple[int, ...], ...] | None = None,
+    ) -> None:
+        shape = _global_shape(value)
+        self.layouts[value] = layout
+        self.local_shapes[value] = local_shapes or (shape,) * self.world_size
+
+    def _prepare_sp_policy(self) -> None:
+        if not self.is_prefill_sp:
+            return
+        for name in ("q_proj", "k_proj", "v_proj", "gate_proj", "up_proj"):
+            nodes = _nodes_for_subcomponent(
+                self.unit, self.partition_plan, name
+            )
+            if nodes:
+                self._required_replicated.add(nodes[0])
+        if self.config.parallel_lm_head:
+            nodes = _nodes_for_subcomponent(
+                self.unit, self.partition_plan, "lm_head"
+            )
+            if nodes:
+                self._required_replicated.add(nodes[0])
+
+    def _seed_inputs(self) -> None:
+        sharded_parameters = {
+            spec.parameter: spec for spec in self.parameter_shards
+        }
+        for input_ref in self.region.interface.ordered_inputs:
+            value = input_ref.value
+            spec = sharded_parameters.get(value)
+            if spec is not None:
+                self._seed(
+                    value,
+                    TensorLayout(LayoutKind.SHARDED, spec.storage_shard_axis),
+                    _rank_shapes(
+                        spec.global_shape,
+                        spec.storage_shard_axis,
+                        spec.rank_slices,
+                    ),
+                )
+            else:
+                self._seed(value, _REPLICATED)
+
+        if not self.is_prefill_sp:
+            return
+        seed_nodes = []
+        for name in ("input_layernorm", "final_norm"):
+            seed_nodes.extend(
+                _nodes_for_subcomponent(self.unit, self.partition_plan, name)
+            )
+        internal = set(self.region.nodes)
+        for op in seed_nodes:
+            for value in iter_op_input_references(op, self.graph.node_table):
+                if value.op in internal:
+                    continue
+                shape = _global_shape(value)
+                if len(shape) < 3:
+                    continue
+                axis = len(shape) - 2
+                slices = partition_extent(shape[axis], self.world_size)
+                self._seed(
+                    value,
+                    TensorLayout(LayoutKind.SHARDED, axis),
+                    _rank_shapes(shape, axis, slices),
+                )
+
+    def _resolve_uses(self, op: Op) -> list[_ResolvedUse]:
+        resolved = []
+        input_values = []
+        for value, path in iter_op_input_references(
+            op, self.graph.node_table, with_paths=True
+        ):
+            input_values.append(value)
+            self.value_consumers.setdefault(value, []).append(op)
+            if value not in self.local_shapes or value not in self.layouts:
+                raise ParallelPlanError(
+                    f"input value {value.op.name!r} result {value.result_index} "
+                    f"of operation {op.name!r} has no inferred layout/local shape"
+                )
+            use = OperandUseRef(op, path)
+            shape = _global_shape(value)
+            local = self.local_shapes[value]
+            layout = self.layouts[value]
+            if (
+                op in self._required_replicated
+                and layout.kind is LayoutKind.SHARDED
+                and value.op not in self.graph.params
+            ):
+                target_local = (shape,) * self.world_size
+                self.pending.append(
+                    _PendingBoundary(
+                        value,
+                        use,
+                        CollectiveKind.ALL_GATHERV,
+                        _REPLICATED,
+                        target_local,
+                    )
+                )
+                local, layout = target_local, _REPLICATED
+            resolved.append(_ResolvedUse(value, use, shape, local, layout))
+        self.op_inputs[op] = tuple(input_values)
+        return resolved
+
+    @staticmethod
+    def _arg_use(uses: list[_ResolvedUse], index: int) -> _ResolvedUse | None:
+        matches = [
+            use for use in uses if use.use.operand_path[:2] == ("args", index)
+        ]
+        if not matches:
+            return None
+        if len(matches) != 1:
+            raise ParallelPlanError(
+                f"operand args[{index}] contains multiple tensors"
+            )
+        return matches[0]
+
+    def _record_result(
+        self,
+        value: GraphValueRef,
+        local_shapes: tuple[tuple[int, ...], ...],
+        layout: TensorLayout,
+    ) -> None:
+        if len(local_shapes) != self.world_size:
+            raise ParallelPlanError(
+                f"operation {value.op.name!r} did not produce one shape per rank"
+            )
+        global_shape = _global_shape(value)
+        for local in local_shapes:
+            if len(local) != len(global_shape):
+                raise ParallelPlanError(
+                    f"local rank mismatch for {value.op.name!r}: "
+                    f"global={global_shape}, local={local}"
+                )
+        self.local_shapes[value] = local_shapes
+        self.layouts[value] = layout
+
+    def _materialize_partial(
+        self,
+        partial: _ResolvedUse,
+        target: _ResolvedUse | None,
+    ) -> _ResolvedUse:
+        if target is None or target.layout.kind is LayoutKind.REPLICATED:
+            layout = _REPLICATED
+            local_shapes = (partial.global_shape,) * self.world_size
+            kind = CollectiveKind.ALL_REDUCE
+        elif target.layout.kind is LayoutKind.SHARDED:
+            layout = target.layout
+            local_shapes = target.local_shapes
+            kind = CollectiveKind.REDUCE_SCATTER
+        else:
+            raise ParallelPlanError(
+                f"binary {partial.use.consumer.name!r} has two PARTIAL operands"
+            )
+        self.pending.append(
+            _PendingBoundary(
+                partial.value,
+                partial.use,
+                kind,
+                layout,
+                local_shapes,
+            )
+        )
+        return _ResolvedUse(
+            partial.value,
+            partial.use,
+            partial.global_shape,
+            local_shapes,
+            layout,
+        )
+
+    def _infer_linear(self, op: Op, uses: list[_ResolvedUse]) -> None:
+        activation_slot, weight_slot, input_axis, bias_slot = _linear_semantics(
+            op
+        )
+        activation = self._arg_use(uses, activation_slot)
+        weight = self._arg_use(uses, weight_slot)
+        if activation is None or weight is None:
+            raise ParallelPlanError(
+                f"Linear {op.name!r} has missing tensor operands"
+            )
+        output_value = GraphValueRef(op)
+        output_shape = _global_shape(output_value)
+        output_axis = 1 - input_axis
+        if weight.layout.kind is LayoutKind.SHARDED:
+            if weight.layout.shard_axis == output_axis:
+                local_shapes = []
+                for rank in range(self.world_size):
+                    local = list(output_shape)
+                    local[-1] = weight.local_shapes[rank][output_axis]
+                    local_shapes.append(tuple(local))
+                layout = TensorLayout(LayoutKind.SHARDED, len(output_shape) - 1)
+                if bias_slot is not None:
+                    bias = self._arg_use(uses, bias_slot)
+                    if (
+                        bias is None
+                        or bias.layout.kind is not LayoutKind.SHARDED
+                    ):
+                        raise ParallelPlanError(
+                            f"column-parallel AddMM {op.name!r} requires sharded bias"
+                        )
+                self._record_result(output_value, tuple(local_shapes), layout)
+                return
+            if weight.layout.shard_axis == input_axis:
+                if (
+                    activation.layout.kind is not LayoutKind.SHARDED
+                    or activation.layout.shard_axis
+                    != len(activation.global_shape) - 1
+                ):
+                    raise ParallelPlanError(
+                        f"row-parallel Linear {op.name!r} requires its activation "
+                        "contracting feature to be sharded"
+                    )
+                for rank in range(self.world_size):
+                    if (
+                        activation.local_shapes[rank][-1]
+                        != (weight.local_shapes[rank][input_axis])
+                    ):
+                        raise ParallelPlanError(
+                            f"row-parallel Linear {op.name!r} has incompatible "
+                            "activation and weight contracting dimensions"
+                        )
+                self._record_result(
+                    output_value,
+                    (output_shape,) * self.world_size,
+                    _PARTIAL,
+                )
+                return
+            raise ParallelPlanError(
+                f"Linear {op.name!r} weight is sharded on non-feature axis"
+            )
+        if (
+            weight.layout.kind is LayoutKind.REPLICATED
+            and activation.layout.kind is LayoutKind.REPLICATED
+        ):
+            self._record_result(
+                output_value, (output_shape,) * self.world_size, _REPLICATED
+            )
+            return
+        raise ParallelPlanError(
+            f"unsupported Linear layouts for {op.name!r}: "
+            f"activation={activation.layout}, weight={weight.layout}"
+        )
+
+    def _infer_permute(self, op: Op, uses: list[_ResolvedUse]) -> None:
+        source = self._arg_use(uses, 0)
+        if source is None:
+            raise ParallelPlanError(
+                f"axis transform {op.name!r} has no tensor input"
+            )
+        permutation = _permutation_for_transform(op, len(source.global_shape))
+        local = tuple(
+            tuple(shape[index] for index in permutation)
+            for shape in source.local_shapes
+        )
+        if source.layout.kind is LayoutKind.SHARDED:
+            try:
+                axis = permutation.index(source.layout.shard_axis)
+            except ValueError as error:
+                raise ParallelPlanError(
+                    f"axis transform {op.name!r} loses sharded axis"
+                ) from error
+            layout = TensorLayout(LayoutKind.SHARDED, axis)
+        else:
+            layout = source.layout
+        self._record_result(GraphValueRef(op), local, layout)
+
+    def _infer_reshape_like(
+        self, op: Op, uses: list[_ResolvedUse], rewrite: bool = False
+    ) -> None:
+        source = self._arg_use(uses, 0)
+        if source is None:
+            raise ParallelPlanError(
+                f"reshape-like {op.name!r} has no tensor input"
+            )
+        output = GraphValueRef(op)
+        output_shape = _global_shape(output)
+        if source.layout.kind is LayoutKind.REPLICATED:
+            local = (output_shape,) * self.world_size
+            layout = _REPLICATED
+        elif source.layout.kind is LayoutKind.PARTIAL:
+            local = (output_shape,) * self.world_size
+            layout = _PARTIAL
+        else:
+            axis = None
+            if source.layout.shard_axis is not None:
+                axis = _reshape_shard_axis(
+                    source.global_shape,
+                    output_shape,
+                    source.layout.shard_axis,
+                )
+            if axis is None:
+                raise ParallelPlanError(
+                    f"cannot map sharded axis through reshape-like {op.name!r}: "
+                    f"{source.global_shape} -> {output_shape}"
+                )
+            local_values = []
+            for rank_shape in source.local_shapes:
+                rank_output = list(output_shape)
+                global_suffix = _prod(
+                    source.global_shape[source.layout.shard_axis :]
+                )
+                local_suffix = _prod(rank_shape[source.layout.shard_axis :])
+                inner = _prod(output_shape[axis + 1 :])
+                if local_suffix % inner != 0 or global_suffix % inner != 0:
+                    raise ParallelPlanError(
+                        f"reshape-like {op.name!r} cannot express a rank-local axis"
+                    )
+                rank_output[axis] = local_suffix // inner
+                rank_output = tuple(rank_output)
+                if _prod(rank_output) != _prod(rank_shape):
+                    raise ParallelPlanError(
+                        f"reshape-like {op.name!r} changes rank-local element count"
+                    )
+                local_values.append(rank_output)
+            local = tuple(local_values)
+            layout = TensorLayout(LayoutKind.SHARDED, axis)
+        self._record_result(output, local, layout)
+        if rewrite:
+            self.rewrites.append(
+                OpRewriteSpec(op, RewriteTarget.NEW_SHAPE, None, local)
+            )
+
+    def _infer_expand(self, op: Op, uses: list[_ResolvedUse]) -> None:
+        source = self._arg_use(uses, 0)
+        if source is None:
+            raise ParallelPlanError(f"Expand {op.name!r} has no tensor input")
+        output = GraphValueRef(op)
+        output_shape = _global_shape(output)
+        if source.layout.kind is LayoutKind.PARTIAL:
+            raise ParallelPlanError(
+                f"Expand {op.name!r} cannot consume PARTIAL"
+            )
+        if source.layout.kind is LayoutKind.REPLICATED:
+            local = (output_shape,) * self.world_size
+            layout = _REPLICATED
+        else:
+            padded_axis = (
+                len(output_shape)
+                - len(source.global_shape)
+                + source.layout.shard_axis
+            )
+            if padded_axis < 0:
+                raise ParallelPlanError(
+                    f"Expand {op.name!r} reduces input rank"
+                )
+            local_values = []
+            for rank in range(self.world_size):
+                rank_output = list(output_shape)
+                original = source.global_shape[source.layout.shard_axis]
+                target = output_shape[padded_axis]
+                if target not in (original, 1):
+                    raise ParallelPlanError(
+                        f"Expand {op.name!r} broadcasts a sharded dimension"
+                    )
+                rank_output[padded_axis] = source.local_shapes[rank][
+                    source.layout.shard_axis
+                ]
+                local_values.append(tuple(rank_output))
+            local = tuple(local_values)
+            layout = TensorLayout(LayoutKind.SHARDED, padded_axis)
+        self._record_result(output, local, layout)
+        self.rewrites.append(
+            OpRewriteSpec(op, RewriteTarget.OPERAND, ("args", 1), local)
+        )
+
+    def _infer_unsqueeze(self, op: Op, uses: list[_ResolvedUse]) -> None:
+        source = self._arg_use(uses, 0)
+        if (
+            source is None
+            or len(op.args) < 2
+            or not isinstance(op.args[1], int)
+        ):
+            raise ParallelPlanError(f"Unsqueeze {op.name!r} has no static axis")
+        output = GraphValueRef(op)
+        output_shape = _global_shape(output)
+        axis = op.args[1] % len(output_shape)
+        expected = list(source.global_shape)
+        expected.insert(axis, 1)
+        if tuple(expected) != output_shape:
+            raise ParallelPlanError(
+                f"Unsqueeze {op.name!r} shape is inconsistent with axis {axis}"
+            )
+        local = []
+        for rank_shape in source.local_shapes:
+            rank_output = list(rank_shape)
+            rank_output.insert(axis, 1)
+            local.append(tuple(rank_output))
+        if source.layout.kind is LayoutKind.SHARDED:
+            shard_axis = source.layout.shard_axis + (
+                1 if axis <= source.layout.shard_axis else 0
+            )
+            layout = TensorLayout(LayoutKind.SHARDED, shard_axis)
+        else:
+            layout = source.layout
+        self._record_result(output, tuple(local), layout)
+
+    def _infer_binary(self, op: Op, uses: list[_ResolvedUse]) -> None:
+        tensors = [
+            use
+            for use in uses
+            if use.use.operand_path[:2] in (("args", 0), ("args", 1))
+        ]
+        if not tensors:
+            raise ParallelPlanError(
+                f"binary operation {op.name!r} has no tensor input"
+            )
+        if len(tensors) > 2:
+            raise ParallelPlanError(
+                f"binary operation {op.name!r} has too many inputs"
+            )
+        if len(tensors) == 2:
+            first, second = tensors
+            if first.layout.kind is LayoutKind.PARTIAL:
+                first = self._materialize_partial(first, second)
+            if second.layout.kind is LayoutKind.PARTIAL:
+                second = self._materialize_partial(second, first)
+            tensors = [first, second]
+        elif tensors[0].layout.kind is LayoutKind.PARTIAL:
+            tensors[0] = self._materialize_partial(tensors[0], None)
+
+        output = GraphValueRef(op)
+        output_shape = _global_shape(output)
+        sharded = [
+            use for use in tensors if use.layout.kind is LayoutKind.SHARDED
+        ]
+        if not sharded:
+            layout = _REPLICATED
+            local = (output_shape,) * self.world_size
+        else:
+            axes = {
+                _broadcast_output_axis(
+                    use.global_shape, output_shape, use.layout.shard_axis
+                )
+                for use in sharded
+            }
+            if len(axes) != 1:
+                raise ParallelPlanError(
+                    f"binary operation {op.name!r} has incompatible sharded axes"
+                )
+            axis = axes.pop()
+            local_values = []
+            for rank in range(self.world_size):
+                extents = {
+                    use.local_shapes[rank][use.layout.shard_axis]
+                    for use in sharded
+                }
+                if len(extents) != 1:
+                    raise ParallelPlanError(
+                        f"binary operation {op.name!r} has incompatible local shapes"
+                    )
+                rank_output = list(output_shape)
+                rank_output[axis] = extents.pop()
+                local_values.append(tuple(rank_output))
+            layout = TensorLayout(LayoutKind.SHARDED, axis)
+            local = tuple(local_values)
+        self._record_result(output, local, layout)
+
+    def _infer_reduce(self, op: Op, uses: list[_ResolvedUse]) -> None:
+        source = self._arg_use(uses, 0)
+        if source is None:
+            raise ParallelPlanError(
+                f"reduction {op.name!r} has no tensor input"
+            )
+        if source.layout.kind is LayoutKind.PARTIAL:
+            raise ParallelPlanError(
+                f"reduction {op.name!r} cannot consume PARTIAL"
+            )
+        output = GraphValueRef(op)
+        output_shape = _global_shape(output)
+        if source.layout.kind is LayoutKind.REPLICATED:
+            self._record_result(
+                output, (output_shape,) * self.world_size, _REPLICATED
+            )
+            return
+        axes_value = op.args[1] if len(op.args) > 1 else None
+        if isinstance(axes_value, int):
+            axes = (axes_value % len(source.global_shape),)
+        elif isinstance(axes_value, (list, tuple)):
+            axes = tuple(
+                int(axis) % len(source.global_shape) for axis in axes_value
+            )
+        else:
+            raise ParallelPlanError(f"reduction {op.name!r} has no static axes")
+        if source.layout.shard_axis in axes:
+            raise ParallelPlanError(
+                f"reduction {op.name!r} reduces sharded axis {source.layout.shard_axis}"
+            )
+        keepdim = bool(op.args[2]) if len(op.args) > 2 else False
+        output_axis = source.layout.shard_axis
+        if not keepdim:
+            output_axis -= sum(axis < output_axis for axis in axes)
+        local_values = []
+        for rank in range(self.world_size):
+            rank_output = list(output_shape)
+            rank_output[output_axis] = source.local_shapes[rank][
+                source.layout.shard_axis
+            ]
+            local_values.append(tuple(rank_output))
+        self._record_result(
+            output,
+            tuple(local_values),
+            TensorLayout(LayoutKind.SHARDED, output_axis),
+        )
+
+    def _infer_slice(self, op: Op, uses: list[_ResolvedUse]) -> None:
+        source = self._arg_use(uses, 0)
+        if source is None:
+            raise ParallelPlanError(f"Slice {op.name!r} has no tensor input")
+        output = GraphValueRef(op)
+        output_shape = _global_shape(output)
+        if source.layout.kind is not LayoutKind.SHARDED:
+            self._record_result(
+                output, (output_shape,) * self.world_size, source.layout
+            )
+            return
+        if len(op.args) < 2 or not isinstance(op.args[1], int):
+            raise ParallelPlanError(f"Slice {op.name!r} has no static axis")
+        slice_axis = op.args[1] % len(source.global_shape)
+        if slice_axis == source.layout.shard_axis:
+            raise ParallelPlanError(
+                f"Slice {op.name!r} slices sharded axis {slice_axis}"
+            )
+        local_values = []
+        for rank in range(self.world_size):
+            rank_output = list(output_shape)
+            rank_output[source.layout.shard_axis] = source.local_shapes[rank][
+                source.layout.shard_axis
+            ]
+            local_values.append(tuple(rank_output))
+        self._record_result(output, tuple(local_values), source.layout)
+
+    def _infer_cat(self, op: Op, uses: list[_ResolvedUse]) -> None:
+        tensors = [
+            use for use in uses if use.use.operand_path[:2] == ("args", 0)
+        ]
+        if not tensors:
+            raise ParallelPlanError(f"Cat {op.name!r} has no tensor inputs")
+        output = GraphValueRef(op)
+        output_shape = _global_shape(output)
+        kinds = {use.layout.kind for use in tensors}
+        if kinds == {LayoutKind.REPLICATED}:
+            self._record_result(
+                output, (output_shape,) * self.world_size, _REPLICATED
+            )
+            return
+        if LayoutKind.PARTIAL in kinds:
+            raise ParallelPlanError(f"Cat {op.name!r} cannot consume PARTIAL")
+        if kinds != {LayoutKind.SHARDED}:
+            raise ParallelPlanError(
+                f"Cat {op.name!r} cannot mix REPLICATED and SHARDED inputs"
+            )
+        axes = {use.layout.shard_axis for use in tensors}
+        if len(axes) != 1:
+            raise ParallelPlanError(f"Cat {op.name!r} has incompatible layouts")
+        shard_axis = axes.pop()
+        cat_axis_value = op.args[1] if len(op.args) > 1 else 0
+        cat_axis = int(cat_axis_value) % len(output_shape)
+        if cat_axis == shard_axis:
+            raise ParallelPlanError(
+                f"Cat {op.name!r} concatenates sharded axis"
+            )
+        local_values = []
+        for rank in range(self.world_size):
+            non_cat_shapes = {
+                tuple(
+                    dim
+                    for axis, dim in enumerate(use.local_shapes[rank])
+                    if axis != cat_axis
+                )
+                for use in tensors
+            }
+            if len(non_cat_shapes) != 1:
+                raise ParallelPlanError(
+                    f"Cat {op.name!r} has incompatible local shapes"
+                )
+            rank_output = list(output_shape)
+            rank_output[shard_axis] = tensors[0].local_shapes[rank][shard_axis]
+            local_values.append(tuple(rank_output))
+        self._record_result(
+            output,
+            tuple(local_values),
+            TensorLayout(LayoutKind.SHARDED, shard_axis),
+        )
+
+    def _infer_index_put(self, op: Op, uses: list[_ResolvedUse]) -> None:
+        target = self._arg_use(uses, 0)
+        update = self._arg_use(uses, 2)
+        if target is None or update is None:
+            raise ParallelPlanError(
+                f"IndexPut {op.name!r} has missing operands"
+            )
+        output = GraphValueRef(op)
+        output_shape = _global_shape(output)
+        if update.layout.kind is LayoutKind.PARTIAL:
+            raise ParallelPlanError(
+                f"IndexPut {op.name!r} cannot store PARTIAL"
+            )
+        if update.layout.kind is LayoutKind.REPLICATED:
+            if target.layout.kind is not LayoutKind.REPLICATED:
+                raise ParallelPlanError(
+                    f"IndexPut {op.name!r} mixes incompatible layouts"
+                )
+            self._record_result(
+                output, (output_shape,) * self.world_size, _REPLICATED
+            )
+            return
+        axis = update.layout.shard_axis
+        if len(update.global_shape) != len(output_shape):
+            raise ParallelPlanError(
+                f"IndexPut {op.name!r} update rank does not match its cache"
+            )
+        if update.global_shape[axis] != output_shape[axis]:
+            raise ParallelPlanError(
+                f"IndexPut {op.name!r} cannot map update shard axis to cache"
+            )
+        local_values = []
+        for rank in range(self.world_size):
+            rank_output = list(output_shape)
+            rank_output[axis] = update.local_shapes[rank][axis]
+            local_values.append(tuple(rank_output))
+        local_shapes = tuple(local_values)
+        layout = TensorLayout(LayoutKind.SHARDED, axis)
+        if target.global_shape != output_shape:
+            raise ParallelPlanError(
+                f"IndexPut {op.name!r} output shape does not match its cache"
+            )
+        if target.layout.kind is LayoutKind.REPLICATED:
+            region_inputs = {
+                input_ref.value
+                for input_ref in self.region.interface.ordered_inputs
+            }
+            if target.value not in region_inputs:
+                raise ParallelPlanError(
+                    f"IndexPut {op.name!r} cannot shard an internal replicated cache"
+                )
+            self.local_shapes[target.value] = local_shapes
+            self.layouts[target.value] = layout
+        elif target.layout != layout or target.local_shapes != local_shapes:
+            raise ParallelPlanError(
+                f"IndexPut {op.name!r} cache and update layouts do not match"
+            )
+        self._record_result(
+            output,
+            local_shapes,
+            layout,
+        )
+
+    def _infer_passthrough(self, op: Op, uses: list[_ResolvedUse]) -> None:
+        affected = [
+            use
+            for use in uses
+            if use.layout.kind is not LayoutKind.REPLICATED
+            or any(shape != use.global_shape for shape in use.local_shapes)
+        ]
+        result_shapes = _result_shapes(op)
+        if not affected:
+            for result_index, shape in enumerate(result_shapes):
+                self._record_result(
+                    GraphValueRef(op, result_index),
+                    (shape,) * self.world_size,
+                    _REPLICATED,
+                )
+            return
+        structural_partial = isinstance(op, operation.CloneOp)
+        if (
+            any(use.layout.kind is LayoutKind.PARTIAL for use in affected)
+            and not structural_partial
+        ):
+            raise ParallelPlanError(
+                f"non-structural {type(op).__name__} {op.name!r} cannot consume PARTIAL"
+            )
+        if not structural_partial and op._op_type not in (
+            operation.OpType.ElementwiseType,
+            operation.OpType.GetItemType,
+        ):
+            raise ParallelPlanError(
+                f"unsupported parallel-sensitive {type(op).__name__} {op.name!r}"
+            )
+        for result_index, shape in enumerate(result_shapes):
+            matches = [use for use in affected if use.global_shape == shape]
+            if not matches:
+                prefix_matches = [
+                    use
+                    for use in affected
+                    if len(use.global_shape) > len(shape)
+                    and use.global_shape[: len(shape)] == shape
+                    and (
+                        use.layout.kind is not LayoutKind.SHARDED
+                        or use.layout.shard_axis < len(shape)
+                    )
+                ]
+                prefix_layouts = {use.layout for use in prefix_matches}
+                prefix_locals = {
+                    tuple(
+                        rank_shape[: len(shape)]
+                        for rank_shape in use.local_shapes
+                    )
+                    for use in prefix_matches
+                }
+                if (
+                    prefix_matches
+                    and len(prefix_layouts) == 1
+                    and len(prefix_locals) == 1
+                ):
+                    self._record_result(
+                        GraphValueRef(op, result_index),
+                        prefix_locals.pop(),
+                        prefix_layouts.pop(),
+                    )
+                    continue
+                raise ParallelPlanError(
+                    f"cannot prove {type(op).__name__} {op.name!r} result "
+                    f"{result_index} is shape-preserving"
+                )
+            layouts = {use.layout for use in matches}
+            local_shapes = {use.local_shapes for use in matches}
+            if len(layouts) != 1 or len(local_shapes) != 1:
+                raise ParallelPlanError(
+                    f"shape-preserving {op.name!r} has incompatible parallel inputs"
+                )
+            self._record_result(
+                GraphValueRef(op, result_index),
+                local_shapes.pop(),
+                layouts.pop(),
+            )
+
+    def _infer_op(self, op: Op, uses: list[_ResolvedUse]) -> None:
+        if isinstance(
+            op,
+            (
+                operation.MatmulOp,
+                operation.AddMMOp,
+                operation.TransposeMatmulFusedOp,
+            ),
+        ):
+            self._infer_linear(op, uses)
+        elif isinstance(op, (operation.PermuteOp, operation.TransposeOp)):
+            self._infer_permute(op, uses)
+        elif isinstance(op, (operation.ViewOp, operation.ReshapeOp)):
+            self._infer_reshape_like(op, uses, rewrite=True)
+        elif isinstance(op, operation.ExpandOp):
+            self._infer_expand(op, uses)
+        elif isinstance(op, operation.UnsqueezeOp):
+            self._infer_unsqueeze(op, uses)
+        elif op._op_type is operation.OpType.BroadcastType:
+            self._infer_binary(op, uses)
+        elif isinstance(op, (operation.MeanOp, operation.SumDimOp)):
+            self._infer_reduce(op, uses)
+        elif isinstance(op, operation.SliceOp):
+            self._infer_slice(op, uses)
+        elif isinstance(op, operation.CatOp):
+            self._infer_cat(op, uses)
+        elif isinstance(op, operation.IndexPutOp):
+            self._infer_index_put(op, uses)
+        elif op._op_type is operation.OpType.ReshapeType:
+            self._infer_reshape_like(op, uses)
+        else:
+            self._infer_passthrough(op, uses)
+
+    def _group_boundaries(self) -> tuple[CollectiveBoundary, ...]:
+        grouped: dict[
+            tuple[
+                GraphValueRef,
+                CollectiveKind,
+                TensorLayout,
+                tuple[tuple[int, ...], ...],
+            ],
+            list[OperandUseRef],
+        ] = {}
+        for boundary in self.pending:
+            key = (
+                boundary.producer,
+                boundary.kind,
+                boundary.target_layout,
+                boundary.target_local_shapes,
+            )
+            grouped.setdefault(key, []).append(boundary.consumer)
+        return tuple(
+            CollectiveBoundary(
+                producer=key[0],
+                consumers=tuple(consumers),
+                kind=key[1],
+                target_layout=key[2],
+                target_local_shapes=key[3],
+            )
+            for key, consumers in grouped.items()
+        )
+
+    def _segments(
+        self, collectives: tuple[CollectiveBoundary, ...]
+    ) -> tuple[ComputeSegment, ...]:
+        nodes = tuple(self.region.nodes)
+        cut_positions = sorted(
+            {
+                min(
+                    self.positions[consumer.consumer]
+                    for consumer in boundary.consumers
+                )
+                for boundary in collectives
+            }
+        )
+        effective_cuts = [
+            position for position in cut_positions if position > 0
+        ]
+
+        def segment_at(position: int) -> int:
+            return sum(cut <= position for cut in effective_cuts)
+
+        op_to_segment = {
+            op: segment_at(position) for op, position in self.positions.items()
+        }
+        region_outputs = set(self.region.interface.ordered_outputs)
+        collective_producers = {boundary.producer for boundary in collectives}
+        count = len(effective_cuts) + 1
+        segment_nodes = [[] for _ in range(count)]
+        segment_inputs = [[] for _ in range(count)]
+        segment_outputs = [[] for _ in range(count)]
+        seen_inputs = [set() for _ in range(count)]
+        seen_outputs = [set() for _ in range(count)]
+
+        # Pass 2: one forward traversal; use-def was captured by Pass 1.
+        for position, op in enumerate(nodes):
+            segment_index = segment_at(position)
+            segment_nodes[segment_index].append(op)
+            for value in self.op_inputs[op]:
+                if (
+                    op_to_segment.get(value.op) == segment_index
+                    or value in seen_inputs[segment_index]
+                ):
+                    continue
+                seen_inputs[segment_index].add(value)
+                segment_inputs[segment_index].append(value)
+            for result_index in range(len(_result_shapes(op))):
+                value = GraphValueRef(op, result_index)
+                has_external_user = any(
+                    op_to_segment[consumer] != segment_index
+                    for consumer in self.value_consumers.get(value, ())
+                )
+                if (
+                    has_external_user
+                    or value in region_outputs
+                    or value in collective_producers
+                ) and value not in seen_outputs[segment_index]:
+                    seen_outputs[segment_index].add(value)
+                    segment_outputs[segment_index].append(value)
+
+        segments = tuple(
+            ComputeSegment(
+                segment_index,
+                tuple(segment_nodes[segment_index]),
+                tuple(segment_inputs[segment_index]),
+                tuple(segment_outputs[segment_index]),
+            )
+            for segment_index in range(count)
+        )
+
+        flattened = tuple(
+            op for segment in segments for op in segment.ordered_nodes
+        )
+        if flattened != nodes or len(flattened) != len(set(flattened)):
+            raise ParallelPlanError(
+                f"template {self.unit.template_id} segment coverage/order is invalid"
+            )
+        for boundary in collectives:
+            producer_segment = op_to_segment.get(boundary.producer.op)
+            consumer_segments = {
+                op_to_segment[consumer.consumer]
+                for consumer in boundary.consumers
+            }
+            if len(consumer_segments) != 1:
+                raise ParallelPlanError(
+                    "grouped collective consumers do not share a downstream segment"
+                )
+            if (
+                producer_segment is not None
+                and producer_segment in consumer_segments
+            ):
+                raise ParallelPlanError(
+                    f"collective producer {boundary.producer.op.name!r} remains "
+                    "in its consumer segment"
+                )
+        for segment in segments:
+            for value in segment.ordered_inputs + segment.ordered_outputs:
+                if value not in self.local_shapes:
+                    raise ParallelPlanError(
+                        f"segment ABI value {value.op.name!r}:{value.result_index} "
+                        "has no local shape"
+                    )
+                producer_position = self.positions.get(value.op)
+                if (
+                    value in segment.ordered_inputs
+                    and producer_position is not None
+                ):
+                    if (
+                        producer_position
+                        >= self.positions[segment.ordered_nodes[0]]
+                    ):
+                        raise ParallelPlanError(
+                            "segment input producer order is invalid"
+                        )
+        return segments
+
+    def build(self) -> TemplateParallelPlan:
+        self._prepare_sp_policy()
+        self._seed_inputs()
+        for position, op in enumerate(self.region.nodes):
+            self.positions[op] = position
+            uses = self._resolve_uses(op)
+            self._infer_op(op, uses)
+        collectives = self._group_boundaries()
+        segments = self._segments(collectives)
+        value_layouts = tuple(
+            ValueLayoutSpec(
+                value, _global_shape(value), local, self.layouts[value]
+            )
+            for value, local in self.local_shapes.items()
+        )
+        return TemplateParallelPlan(
+            template_id=self.unit.template_id,
+            parameter_shards=self.parameter_shards,
+            value_layouts=value_layouts,
+            op_rewrites=tuple(self.rewrites),
+            collectives=collectives,
+            segments=segments,
+        )
+
+
+def build_transformer_parallel_plan(
+    graph: Graph,
+    template_plan: TransformerPartitionPlan,
+    config: TransformerParallelConfig,
+) -> TransformerParallelPlan:
+    """Build a read-only TP/SP plan over each unique representative template."""
+    if config.tp_size != 2:
+        raise ParallelPlanError(
+            f"unsupported tp_size={config.tp_size}; Stage 1 supports only tp_size=2"
+        )
+    if template_plan.parameter_indices != {
+        parameter: index for index, parameter in enumerate(graph.params)
+    }:
+        raise ParallelPlanError("partition plan does not belong to this Graph")
+    templates = tuple(
+        _TemplateParallelPlanner(graph, unit, template_plan, config).build()
+        for unit in template_plan.templates
+    )
+    if tuple(plan.template_id for plan in templates) != tuple(
+        unit.template_id for unit in template_plan.templates
+    ):
+        raise ParallelPlanError("parallel plan template order is invalid")
+    return TransformerParallelPlan(graph._func_name, config.tp_size, templates)

--- a/midend/include/Dialect/RHAL/RHALOps.td
+++ b/midend/include/Dialect/RHAL/RHALOps.td
@@ -130,7 +130,8 @@ def RHAL_CodeobjOp : RHAL_Op<"codeobj", [Symbol]> {
     I32Attr:$id,
     StrAttr:$kind,
     StrAttr:$backend,
-    StrAttr:$uri
+    StrAttr:$uri,
+    OptionalAttr<StrAttr>:$entry_symbol
   );
 
   let assemblyFormat = [{
@@ -171,30 +172,88 @@ def RHAL_BufferOp : RHAL_Op<"buffer", [Symbol]> {
 //   rhal.func @name inputs = ["buf1", ...], outputs = ["buf2", ...],
 //                   dispatch = "codeobj_name",
 //                   args = ["buf1", "buf2", ...]
+//   rhal.func @name inputs = ["buf1", ...], outputs = ["buf2", ...] body {
+//     rhal.dispatch @codeobj [@resource1, @resource2, ...]
+//   }
 //===----------------------------------------------------------------------===//
 
-def RHAL_FuncOp : RHAL_Op<"func", [Symbol]> {
+def RHAL_FuncOp : RHAL_Op<"func", [Symbol, NoTerminator, SingleBlock]> {
   let summary = "Model function dispatch declaration.";
   let description = [{
-    Declares a model entry point and its dispatch configuration:
+    Declares a model entry point. The legacy form has an attribute-only
+    dispatch configuration:
     - `inputs`:   buffer names that are function inputs
     - `outputs`:  buffer names that are function outputs
     - `dispatch`: name of the code object that provides this function
     - `args`:     all buffer names passed as arguments to the kernel,
                   in ABI order (inputs + state + outputs)
+
+    The body form instead contains ordered `rhal.dispatch` operations.
   }];
 
   let arguments = (ins
     SymbolNameAttr:$sym_name,
     ArrayAttr:$inputs,
     ArrayAttr:$outputs,
-    StrAttr:$dispatch,
-    ArrayAttr:$args
+    OptionalAttr<StrAttr>:$dispatch,
+    OptionalAttr<ArrayAttr>:$args
+  );
+  let regions = (region MaxSizedRegion<1>:$body);
+
+  let assemblyFormat = [{
+    $sym_name attr-dict (`body` $body^)?
+  }];
+
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// rhal.dispatch — dispatch inside a body-form rhal.func
+//
+// Syntax:
+//   rhal.dispatch @codeobj [@resource1, @resource2, ...]
+//===----------------------------------------------------------------------===//
+
+def RHAL_DispatchOp : RHAL_Op<"dispatch"> {
+  let summary = "Dispatch a code object with ordered resource arguments.";
+
+  let arguments = (ins
+    FlatSymbolRefAttr:$code_object,
+    FlatSymbolRefArrayAttr:$args
   );
 
   let assemblyFormat = [{
-    $sym_name attr-dict
+    $code_object $args attr-dict
   }];
+}
+
+//===----------------------------------------------------------------------===//
+// rhal.collective — collective communication inside a schedule
+//
+// Syntax:
+//   rhal.collective [@buffer1, @buffer2, ...] {
+//     kind = "all_reduce", reduction = "sum"
+//   }
+//===----------------------------------------------------------------------===//
+
+def RHAL_CollectiveOp : RHAL_Op<"collective"> {
+  let summary = "Collective communication over ordered buffer arguments.";
+
+  let arguments = (ins
+    FlatSymbolRefArrayAttr:$buffers,
+    OptionalAttr<FlatSymbolRefArrayAttr>:$output_buffers,
+    StrAttr:$kind,
+    OptionalAttr<StrAttr>:$reduction,
+    OptionalAttr<I32Attr>:$root,
+    OptionalAttr<DenseI64ArrayAttr>:$recv_counts,
+    OptionalAttr<DenseI64ArrayAttr>:$displacements
+  );
+
+  let assemblyFormat = [{
+    $buffers attr-dict
+  }];
+
+  let hasVerifier = 1;
 }
 
 #endif // BUDDY_MIDEND_RHAL_RHALOPS_TD

--- a/midend/lib/Dialect/RHAL/RHALOps.cpp
+++ b/midend/lib/Dialect/RHAL/RHALOps.cpp
@@ -21,3 +21,131 @@
 
 #define GET_OP_CLASSES
 #include "RHAL/RHALOps.cpp.inc"
+
+mlir::LogicalResult buddy::rhal::FuncOp::verify() {
+  bool hasDispatch = (*this)->hasAttr("dispatch");
+  bool hasArgs = (*this)->hasAttr("args");
+
+  if (getBody().empty()) {
+    if (!hasDispatch || !hasArgs)
+      return emitOpError(
+          "legacy form requires 'dispatch' and 'args' attributes");
+  } else if (hasDispatch || hasArgs) {
+    return emitOpError(
+        "body form must not have legacy 'dispatch' or 'args' attributes");
+  }
+
+  return mlir::success();
+}
+
+mlir::LogicalResult buddy::rhal::CollectiveOp::verify() {
+  if (getBuffers().empty())
+    return emitOpError("requires at least one buffer");
+
+  mlir::StringAttr kind = getKindAttr();
+  mlir::StringAttr reduction = getReductionAttr();
+  mlir::IntegerAttr root = getRootAttr();
+  mlir::ArrayAttr outputBuffers = getOutputBuffersAttr();
+  mlir::DenseI64ArrayAttr recvCounts = getRecvCountsAttr();
+  mlir::DenseI64ArrayAttr displacements = getDisplacementsAttr();
+
+  if (kind.getValue() == "all_reduce") {
+    if (!reduction || reduction.getValue() != "sum")
+      return emitOpError("with kind 'all_reduce' requires reduction = \"sum\"");
+    if (outputBuffers)
+      return emitOpError(
+          "with kind 'all_reduce' does not accept an 'output_buffers' "
+          "attribute");
+    if (root)
+      return emitOpError(
+          "with kind 'all_reduce' does not accept a 'root' attribute");
+    if (recvCounts)
+      return emitOpError(
+          "with kind 'all_reduce' does not accept a 'recv_counts' attribute");
+    if (displacements)
+      return emitOpError("with kind 'all_reduce' does not accept a "
+                         "'displacements' attribute");
+    return mlir::success();
+  }
+
+  if (kind.getValue() == "broadcast") {
+    if (!root)
+      return emitOpError("with kind 'broadcast' requires a 'root' attribute");
+    if (root.getInt() < 0)
+      return emitOpError("with kind 'broadcast' requires a non-negative root");
+    if (outputBuffers)
+      return emitOpError(
+          "with kind 'broadcast' does not accept an 'output_buffers' "
+          "attribute");
+    if (reduction)
+      return emitOpError(
+          "with kind 'broadcast' does not accept a 'reduction' attribute");
+    if (recvCounts)
+      return emitOpError(
+          "with kind 'broadcast' does not accept a 'recv_counts' attribute");
+    if (displacements)
+      return emitOpError("with kind 'broadcast' does not accept a "
+                         "'displacements' attribute");
+    return mlir::success();
+  }
+
+  if (kind.getValue() == "all_gatherv") {
+    if (getBuffers().size() != 1)
+      return emitOpError(
+          "with kind 'all_gatherv' requires exactly one input buffer");
+    if (!outputBuffers || outputBuffers.size() != 1)
+      return emitOpError("with kind 'all_gatherv' requires exactly one "
+                         "explicit output buffer");
+    if (!recvCounts || recvCounts.empty())
+      return emitOpError(
+          "with kind 'all_gatherv' requires non-empty 'recv_counts'");
+    if (!displacements)
+      return emitOpError("with kind 'all_gatherv' requires 'displacements'");
+    if (recvCounts.size() != displacements.size())
+      return emitOpError("with kind 'all_gatherv' requires 'recv_counts' and "
+                         "'displacements' to have equal sizes");
+    for (int64_t count : recvCounts.asArrayRef())
+      if (count < 0)
+        return emitOpError(
+            "with kind 'all_gatherv' requires non-negative recv_counts");
+    for (int64_t displacement : displacements.asArrayRef())
+      if (displacement < 0)
+        return emitOpError(
+            "with kind 'all_gatherv' requires non-negative displacements");
+    if (reduction)
+      return emitOpError(
+          "with kind 'all_gatherv' does not accept a 'reduction' attribute");
+    if (root)
+      return emitOpError(
+          "with kind 'all_gatherv' does not accept a 'root' attribute");
+    return mlir::success();
+  }
+
+  if (kind.getValue() == "reduce_scatter") {
+    if (getBuffers().size() != 1)
+      return emitOpError(
+          "with kind 'reduce_scatter' requires exactly one input buffer");
+    if (!outputBuffers || outputBuffers.size() != 1)
+      return emitOpError("with kind 'reduce_scatter' requires exactly one "
+                         "explicit output buffer");
+    if (!recvCounts || recvCounts.empty())
+      return emitOpError(
+          "with kind 'reduce_scatter' requires non-empty 'recv_counts'");
+    for (int64_t count : recvCounts.asArrayRef())
+      if (count < 0)
+        return emitOpError(
+            "with kind 'reduce_scatter' requires non-negative recv_counts");
+    if (!reduction || reduction.getValue() != "sum")
+      return emitOpError(
+          "with kind 'reduce_scatter' requires reduction = \"sum\"");
+    if (displacements)
+      return emitOpError("with kind 'reduce_scatter' does not accept a "
+                         "'displacements' attribute");
+    if (root)
+      return emitOpError(
+          "with kind 'reduce_scatter' does not accept a 'root' attribute");
+    return mlir::success();
+  }
+
+  return emitOpError("has unsupported kind '") << kind.getValue() << "'";
+}

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -2,6 +2,10 @@ if(BUDDY_BUILD_DEEPSEEK_R1_MODEL)
   add_subdirectory(deepseek_r1)
 endif()
 
+if(BUDDY_BUILD_DEEPSEEK_R1_TP2_MODEL)
+  add_subdirectory(deepseek_r1_tp2)
+endif()
+
 if(BUDDY_BUILD_LLAMA31_TT_MODEL OR BUDDY_BUILD_LLAMA32_TT_MODEL)
   add_subdirectory(llama31_tt)
 endif()

--- a/models/deepseek_r1_tp2/CMakeLists.txt
+++ b/models/deepseek_r1_tp2/CMakeLists.txt
@@ -1,0 +1,301 @@
+# DeepSeek R1 tensor-parallel package. This build graph intentionally lives
+# outside buddy_add_model(): TP=2 produces rank-local plans, parameter packs,
+# scheduled RHAL modules, and RAX artifacts rather than one ordinary model.
+
+include(${CMAKE_SOURCE_DIR}/tools/buddy-codegen/cmake/buddy_model.cmake)
+include(ProcessorCount)
+
+if(NOT BUDDY_RUNTIME_ENABLE_MPI)
+  message(FATAL_ERROR
+    "models/deepseek_r1_tp2 requires BUDDY_RUNTIME_ENABLE_MPI=ON")
+endif()
+if(NOT BUDDY_MLIR_ENABLE_PYTHON_PACKAGES)
+  message(FATAL_ERROR
+    "models/deepseek_r1_tp2 requires BUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON")
+endif()
+if(IS_RVV_CROSSCOMPILE)
+  message(FATAL_ERROR
+    "models/deepseek_r1_tp2 has only been validated for native builds")
+endif()
+if(NOT Python3_EXECUTABLE)
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+endif()
+
+ProcessorCount(_BUDDY_DSR1_TP2_DEFAULT_COMPILE_JOBS)
+if(_BUDDY_DSR1_TP2_DEFAULT_COMPILE_JOBS EQUAL 0)
+  set(_BUDDY_DSR1_TP2_DEFAULT_COMPILE_JOBS 1)
+endif()
+
+set(BUDDY_DSR1_TP2_SPEC
+  "${CMAKE_SOURCE_DIR}/models/deepseek_r1/specs/f32.json"
+  CACHE FILEPATH "DeepSeek R1 source model spec reused by the TP=2 package")
+set(BUDDY_DSR1_TP2_HF_CONFIG ""
+  CACHE FILEPATH "Optional HuggingFace config.json for DeepSeek R1 TP=2")
+set(BUDDY_DSR1_TP2_LOCAL_MODEL ""
+  CACHE PATH "Optional local HuggingFace DeepSeek R1 model directory")
+set(BUDDY_DSR1_TP2_COMPILE_JOBS
+  "${_BUDDY_DSR1_TP2_DEFAULT_COMPILE_JOBS}"
+  CACHE STRING "Parallel MLIR compilation jobs for DeepSeek R1 TP=2")
+set(BUDDY_DSR1_TP2_LLC_ATTRS "-mcpu=native"
+  CACHE STRING "llc target attributes for DeepSeek R1 TP=2")
+
+execute_process(
+  COMMAND "${Python3_EXECUTABLE}" -c
+          "import json,sys; v=json.load(open(sys.argv[1]))['variant']; print({'f32':'float32','f16':'float16','bf16':'bfloat16'}.get(v,''))"
+          "${BUDDY_DSR1_TP2_SPEC}"
+  OUTPUT_VARIABLE _BUDDY_DSR1_TP2_PACK_DTYPE
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE _BUDDY_DSR1_TP2_SPEC_RESULT)
+if(NOT _BUDDY_DSR1_TP2_SPEC_RESULT EQUAL 0 OR
+   _BUDDY_DSR1_TP2_PACK_DTYPE STREQUAL "")
+  message(FATAL_ERROR
+    "DeepSeek R1 TP=2 currently supports only plain f32/f16/bf16 specs")
+endif()
+
+set(_TP2_BIN "${CMAKE_CURRENT_BINARY_DIR}")
+set(_TP2_GEN "${_TP2_BIN}/generated")
+set(_TP2_LAYER "${_TP2_BIN}/layer_partitioned")
+set(_TP2_OBJ "${_TP2_BIN}/obj_partitioned")
+set(_TP2_CONFIG "${_TP2_GEN}/config.json")
+set(_TP2_SESSION_H
+  "${_TP2_GEN}/buddy/runtime/models/ModelSession.h")
+set(_TP2_SESSION_CPP "${_TP2_GEN}/ModelSession.cpp")
+set(_TP2_IMPORT_STAMP "${_TP2_BIN}/.buddy_import_done")
+set(_TP2_RAX_SHIMS "${_TP2_GEN}/RaxShims.cpp")
+set(_TP2_MODEL_SO "${_TP2_BIN}/deepseek_r1_tp2_model.so")
+set(_TP2_RUNNER_SO_NAME "deepseek_r1_tp2_runner.so")
+
+set(_TP2_GEN_CONFIG_CMD
+  "${Python3_EXECUTABLE}" "${BUDDY_CODEGEN_DIR}/gen_config.py"
+  --spec "${BUDDY_DSR1_TP2_SPEC}" -o "${_TP2_CONFIG}")
+if(BUDDY_DSR1_TP2_HF_CONFIG)
+  list(APPEND _TP2_GEN_CONFIG_CMD
+    --hf-config "${BUDDY_DSR1_TP2_HF_CONFIG}")
+endif()
+add_custom_command(
+  OUTPUT "${_TP2_CONFIG}"
+  COMMAND "${CMAKE_COMMAND}" -E make_directory "${_TP2_GEN}"
+  COMMAND ${_TP2_GEN_CONFIG_CMD}
+  DEPENDS
+    "${BUDDY_DSR1_TP2_SPEC}"
+    "${BUDDY_CODEGEN_DIR}/gen_config.py"
+  COMMENT "[deepseek_r1_tp2] Generating config.json"
+  VERBATIM)
+
+add_custom_command(
+  OUTPUT "${_TP2_SESSION_H}" "${_TP2_SESSION_CPP}"
+  COMMAND "${Python3_EXECUTABLE}" "${BUDDY_CODEGEN_DIR}/gen_session.py"
+          --config "${_TP2_CONFIG}" --output-dir "${_TP2_GEN}"
+  DEPENDS "${_TP2_CONFIG}" "${BUDDY_CODEGEN_DIR}/gen_session.py"
+  COMMENT "[deepseek_r1_tp2] Generating model constants"
+  VERBATIM)
+
+add_library(buddy_models_deepseek_r1_tp2 STATIC
+  DeepSeekR1TPRunner.cpp
+  DeepSeekR1RaxRunner.cpp
+  DeepSeekR1RaxSession.cpp
+  "${_TP2_SESSION_H}"
+)
+set_target_properties(buddy_models_deepseek_r1_tp2 PROPERTIES
+  POSITION_INDEPENDENT_CODE ON)
+target_include_directories(buddy_models_deepseek_r1_tp2 PUBLIC
+  "${_TP2_GEN}"
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${BUDDY_SOURCE_DIR}/frontend/Interfaces>
+  $<BUILD_INTERFACE:${BUDDY_BINARY_DIR}/frontend/Interfaces>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/buddy-mlir>
+)
+target_compile_features(buddy_models_deepseek_r1_tp2 PUBLIC cxx_std_17)
+target_link_libraries(buddy_models_deepseek_r1_tp2 PUBLIC
+  buddy_runtime_core
+  buddy_runtime_execution
+  buddy_runtime_llm
+  buddy_runtime_mpi
+  ${CMAKE_DL_LIBS}
+  LLVMSupport
+)
+
+add_library(buddy_models_deepseek_r1_tp2_runner SHARED
+  DeepSeekR1TPRunnerPlugin.cpp)
+set_target_properties(buddy_models_deepseek_r1_tp2_runner PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY "${_TP2_BIN}"
+  RUNTIME_OUTPUT_DIRECTORY "${_TP2_BIN}"
+  OUTPUT_NAME "deepseek_r1_tp2_runner"
+  PREFIX "")
+target_link_libraries(buddy_models_deepseek_r1_tp2_runner PRIVATE
+  buddy_models_deepseek_r1_tp2)
+target_compile_features(buddy_models_deepseek_r1_tp2_runner PRIVATE cxx_std_17)
+
+set(_TP2_RUNTIME_PLANS)
+set(_TP2_PARAMETER_PACKS)
+set(_TP2_RUNTIME_PLAN_ARGS)
+foreach(_rank RANGE 0 1)
+  foreach(_phase IN ITEMS forward_prefill forward_decode)
+    set(_plan "${_TP2_LAYER}/runtime/rank${_rank}_${_phase}.json")
+    list(APPEND _TP2_RUNTIME_PLANS "${_plan}")
+    list(APPEND _TP2_RUNTIME_PLAN_ARGS --runtime-plan "${_plan}")
+  endforeach()
+  list(APPEND _TP2_PARAMETER_PACKS
+    "${_TP2_BIN}/rank${_rank}_params_${_BUDDY_DSR1_TP2_PACK_DTYPE}.data")
+endforeach()
+
+set(_TP2_IMPORT_ENV
+  "${CMAKE_COMMAND}" -E env
+  "PYTHONPATH=${CMAKE_BINARY_DIR}/python_packages")
+if(BUDDY_DSR1_TP2_LOCAL_MODEL)
+  list(APPEND _TP2_IMPORT_ENV
+    "DEEPSEEKR1_MODEL_PATH=${BUDDY_DSR1_TP2_LOCAL_MODEL}")
+endif()
+set(_TP2_IMPORT_ARGS
+  --experimental-template-partitioned
+  --skip-full-mlir
+  --tensor-parallel-size 2)
+if(BUDDY_MODEL_REUSE_WEIGHTS)
+  list(APPEND _TP2_IMPORT_ARGS --reuse-existing-weights)
+endif()
+set(_TP2_IMPORT_DEPS
+  "${_TP2_CONFIG}"
+  "${BUDDY_CODEGEN_DIR}/import_model.py")
+if(TARGET python-package-buddy)
+  list(APPEND _TP2_IMPORT_DEPS python-package-buddy)
+endif()
+add_custom_command(
+  OUTPUT
+    "${_TP2_IMPORT_STAMP}"
+    ${_TP2_RUNTIME_PLANS}
+    ${_TP2_PARAMETER_PACKS}
+  BYPRODUCTS
+    "${_TP2_LAYER}/partition_manifest.json"
+    "${_TP2_LAYER}/forward_prefill.mlir"
+    "${_TP2_LAYER}/forward_decode.mlir"
+  COMMAND ${_TP2_IMPORT_ENV}
+          "${Python3_EXECUTABLE}" "${BUDDY_CODEGEN_DIR}/import_model.py"
+          --config "${_TP2_CONFIG}" --output-dir "${_TP2_BIN}"
+          ${_TP2_IMPORT_ARGS}
+  COMMAND "${CMAKE_COMMAND}" -E touch "${_TP2_IMPORT_STAMP}"
+  DEPENDS ${_TP2_IMPORT_DEPS}
+  COMMENT "[deepseek_r1_tp2] Importing rank-local TP=2 artifacts"
+  VERBATIM)
+
+add_custom_command(
+  OUTPUT "${_TP2_RAX_SHIMS}"
+  COMMAND "${Python3_EXECUTABLE}" "${BUDDY_CODEGEN_DIR}/gen_rax_shims.py"
+          ${_TP2_RUNTIME_PLAN_ARGS} -o "${_TP2_RAX_SHIMS}"
+  DEPENDS
+    "${_TP2_IMPORT_STAMP}"
+    ${_TP2_RUNTIME_PLANS}
+    "${BUDDY_CODEGEN_DIR}/gen_rax_shims.py"
+  COMMENT "[deepseek_r1_tp2] Generating RAX ABI shims"
+  VERBATIM)
+
+set(_TP2_OPENMP_ARGS)
+if(BUDDY_OPENMP_RUNTIME_LIBRARY)
+  list(APPEND _TP2_OPENMP_ARGS
+    --openmp-runtime-lib "${BUDDY_OPENMP_RUNTIME_LIBRARY}")
+endif()
+add_custom_command(
+  OUTPUT "${_TP2_MODEL_SO}"
+  COMMAND "${CMAKE_COMMAND}" -E make_directory "${_TP2_OBJ}"
+  COMMAND "${Python3_EXECUTABLE}" "${BUDDY_CODEGEN_DIR}/compile_pipeline.py"
+          --config "${_TP2_CONFIG}"
+          --compile-partitioned
+          --link
+          --mlir-dir "${_TP2_LAYER}"
+          --output-dir "${_TP2_OBJ}"
+          --output-so "${_TP2_MODEL_SO}"
+          --buddy-opt "${BUDDY_BINARY_DIR}/buddy-opt"
+          --llvm-tools-dir "${LLVM_TOOLS_BINARY_DIR}"
+          "--llc-attrs=${BUDDY_DSR1_TP2_LLC_ATTRS}"
+          --cxx "${CMAKE_CXX_COMPILER}"
+          --llvm-lib-dir "${LLVM_LIBRARY_DIR}"
+          ${_TP2_OPENMP_ARGS}
+          ${_TP2_RUNTIME_PLAN_ARGS}
+          --rax-shims "${_TP2_RAX_SHIMS}"
+          -j "${BUDDY_DSR1_TP2_COMPILE_JOBS}"
+  COMMAND "${Python3_EXECUTABLE}" "${BUDDY_CODEGEN_DIR}/gen_rax_shims.py"
+          ${_TP2_RUNTIME_PLAN_ARGS}
+          --validate-library "${_TP2_MODEL_SO}"
+  DEPENDS
+    buddy-opt
+    "${_TP2_CONFIG}"
+    "${_TP2_IMPORT_STAMP}"
+    "${_TP2_RAX_SHIMS}"
+    ${_TP2_RUNTIME_PLANS}
+    "${BUDDY_CODEGEN_DIR}/compile_pipeline.py"
+    "${BUDDY_CODEGEN_DIR}/gen_rax_shims.py"
+  COMMENT "[deepseek_r1_tp2] Compiling deepseek_r1_tp2_model.so"
+  VERBATIM)
+add_custom_target(deepseek_r1_tp2_model_so DEPENDS "${_TP2_MODEL_SO}")
+
+set(_TP2_VOCAB_SRC "${CMAKE_SOURCE_DIR}/examples/BuddyDeepSeekR1/vocab.txt")
+set(_TP2_VOCAB "${_TP2_BIN}/vocab.txt")
+add_custom_command(
+  OUTPUT "${_TP2_VOCAB}"
+  COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+          "${_TP2_VOCAB_SRC}" "${_TP2_VOCAB}"
+  DEPENDS "${_TP2_VOCAB_SRC}"
+  COMMENT "[deepseek_r1_tp2] Copying vocab.txt"
+  VERBATIM)
+
+set(_TP2_RAX_PACK_ARGS)
+if(BUDDY_RAX_EMBED_PAYLOAD)
+  list(APPEND _TP2_RAX_PACK_ARGS --embed-payload)
+endif()
+set(_TP2_RAX_FILES)
+foreach(_rank RANGE 0 1)
+  set(_prefill_plan
+    "${_TP2_LAYER}/runtime/rank${_rank}_forward_prefill.json")
+  set(_decode_plan
+    "${_TP2_LAYER}/runtime/rank${_rank}_forward_decode.json")
+  set(_rank_rhal "${_TP2_BIN}/rank${_rank}.rhal.mlir")
+  set(_rank_rax "${_TP2_BIN}/rank${_rank}.rax")
+  list(GET _TP2_PARAMETER_PACKS ${_rank} _rank_parameter_pack)
+
+  add_custom_command(
+    OUTPUT "${_rank_rhal}"
+    COMMAND "${Python3_EXECUTABLE}" "${BUDDY_CODEGEN_DIR}/gen_manifest.py"
+            --config "${_TP2_CONFIG}"
+            --runtime-plan "forward_prefill=${_prefill_plan}"
+            --runtime-plan "forward_decode=${_decode_plan}"
+            --kernel-library "deepseek_r1_tp2_model.so"
+            --runner-library "${_TP2_RUNNER_SO_NAME}"
+            -o "${_rank_rhal}"
+    DEPENDS
+      "${_TP2_IMPORT_STAMP}"
+      "${_prefill_plan}"
+      "${_decode_plan}"
+      "${_TP2_CONFIG}"
+      "${BUDDY_CODEGEN_DIR}/gen_manifest.py"
+    COMMENT "[deepseek_r1_tp2] Generating rank${_rank}.rhal.mlir"
+    VERBATIM)
+
+  add_custom_command(
+    OUTPUT "${_rank_rax}"
+    COMMAND "$<TARGET_FILE:rax-pack>" "${_rank_rhal}"
+            -o "${_rank_rax}" ${_TP2_RAX_PACK_ARGS}
+    DEPENDS
+      rax-pack
+      "${_rank_rhal}"
+      "${_rank_parameter_pack}"
+      "${_TP2_MODEL_SO}"
+      buddy_models_deepseek_r1_tp2_runner
+      "${_TP2_VOCAB}"
+    WORKING_DIRECTORY "${_TP2_BIN}"
+    COMMENT "[deepseek_r1_tp2] Packing rank${_rank}.rax"
+    VERBATIM)
+  list(APPEND _TP2_RAX_FILES "${_rank_rax}")
+endforeach()
+
+add_custom_target(deepseek_r1_tp2_rax
+  DEPENDS ${_TP2_RAX_FILES} "${_TP2_VOCAB}"
+  COMMENT "DeepSeek R1 TP=2 rank-local RAX package -> ${_TP2_BIN}")
+
+install(FILES
+  include/buddy/runtime/models/DeepSeekR1TPRunner.h
+  include/buddy/runtime/models/DeepSeekR1RaxRunner.h
+  include/buddy/runtime/models/DeepSeekR1RaxSession.h
+  DESTINATION include/buddy-mlir/buddy/runtime/models
+  COMPONENT buddy_runtime)
+install(TARGETS buddy_models_deepseek_r1_tp2
+  EXPORT BuddyMLIRTargets
+  COMPONENT buddy_runtime)

--- a/models/deepseek_r1_tp2/DeepSeekR1RaxRunner.cpp
+++ b/models/deepseek_r1_tp2/DeepSeekR1RaxRunner.cpp
@@ -1,0 +1,72 @@
+//===- DeepSeekR1RaxRunner.cpp - DeepSeek RAX execution entry ------------===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/models/DeepSeekR1RaxRunner.h"
+
+#include "buddy/runtime/communication/MpiCommunicator.h"
+#include "buddy/runtime/models/DeepSeekR1RaxSession.h"
+
+#include <mpi.h>
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace buddy {
+namespace runtime {
+namespace {
+
+void checkMpi(int status, const char *operation) {
+  if (status != MPI_SUCCESS)
+    throw std::runtime_error(std::string("DeepSeekR1RaxRunner: ") + operation +
+                             " failed");
+}
+
+} // namespace
+
+void runDeepSeekR1Rax(const std::string &raxPath,
+                      const DeepSeekR1RaxSessionCallback &callback) {
+  if (raxPath.empty())
+    throw std::runtime_error("DeepSeekR1RaxRunner requires a RAX artifact");
+
+  int finalized = 0;
+  checkMpi(MPI_Finalized(&finalized), "MPI_Finalized");
+  if (finalized)
+    throw std::runtime_error("DeepSeekR1RaxRunner: MPI is already finalized");
+
+  int initialized = 0;
+  checkMpi(MPI_Initialized(&initialized), "MPI_Initialized");
+  const bool ownsMpi = initialized == 0;
+  if (ownsMpi)
+    checkMpi(MPI_Init(nullptr, nullptr), "MPI_Init");
+
+  try {
+    MpiCommunicator communicator(MPI_COMM_WORLD);
+    const int rank = communicator.rank();
+    const int worldSize = communicator.size();
+    if (worldSize != 2)
+      throw std::runtime_error("DeepSeekR1RaxRunner: MPI world size " +
+                               std::to_string(worldSize) + "; expected 2");
+
+    std::cerr << "DeepSeek RAX rank " << rank << '/' << worldSize << ": "
+              << raxPath << '\n';
+
+    DeepSeekR1RaxSession session(raxPath, communicator);
+    callback(session, rank);
+  } catch (...) {
+    if (ownsMpi)
+      MPI_Finalize();
+    throw;
+  }
+
+  if (ownsMpi)
+    checkMpi(MPI_Finalize(), "MPI_Finalize");
+}
+
+} // namespace runtime
+} // namespace buddy

--- a/models/deepseek_r1_tp2/DeepSeekR1RaxSession.cpp
+++ b/models/deepseek_r1_tp2/DeepSeekR1RaxSession.cpp
@@ -1,0 +1,495 @@
+//===- DeepSeekR1RaxSession.cpp - DeepSeek RAX resource session -----------===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/models/DeepSeekR1RaxSession.h"
+
+#include "buddy/runtime/core/RaxExecutionSession.h"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <unordered_map>
+#include <utility>
+
+namespace buddy {
+namespace runtime {
+namespace {
+
+struct MappedRegion {
+  void *data = nullptr;
+  size_t bytes = 0;
+
+  ~MappedRegion() {
+    if (data)
+      munmap(data, bytes);
+  }
+};
+
+std::runtime_error systemError(const std::string &message) {
+  return std::runtime_error(message + ": " + std::strerror(errno));
+}
+
+std::unique_ptr<MappedRegion> mapAnonymous(size_t bytes) {
+  if (bytes == 0)
+    throw std::runtime_error(
+        "DeepSeekR1RaxSession: cannot allocate an empty buffer");
+  int flags = MAP_PRIVATE | MAP_ANONYMOUS;
+#ifdef MAP_NORESERVE
+  flags |= MAP_NORESERVE;
+#endif
+  void *data = mmap(nullptr, bytes, PROT_READ | PROT_WRITE, flags, -1, 0);
+  if (data == MAP_FAILED)
+    throw systemError("DeepSeekR1RaxSession: mmap buffer failed");
+  auto region = std::make_unique<MappedRegion>();
+  region->data = data;
+  region->bytes = bytes;
+  return region;
+}
+
+std::unique_ptr<MappedRegion> mapFile(const std::string &path) {
+  const int fd = open(path.c_str(), O_RDONLY);
+  if (fd < 0)
+    throw systemError("DeepSeekR1RaxSession: cannot open parameter pack " +
+                      path);
+
+  struct stat status{};
+  if (fstat(fd, &status) != 0) {
+    const int savedErrno = errno;
+    close(fd);
+    errno = savedErrno;
+    throw systemError("DeepSeekR1RaxSession: cannot stat parameter pack " +
+                      path);
+  }
+  if (status.st_size <= 0) {
+    close(fd);
+    throw std::runtime_error("DeepSeekR1RaxSession: parameter pack is empty: " +
+                             path);
+  }
+  if (static_cast<uintmax_t>(status.st_size) >
+      static_cast<uintmax_t>(std::numeric_limits<size_t>::max())) {
+    close(fd);
+    throw std::runtime_error(
+        "DeepSeekR1RaxSession: parameter pack is too large: " + path);
+  }
+
+  const size_t bytes = static_cast<size_t>(status.st_size);
+  void *data = mmap(nullptr, bytes, PROT_READ, MAP_PRIVATE, fd, 0);
+  const int savedErrno = errno;
+  close(fd);
+  if (data == MAP_FAILED) {
+    errno = savedErrno;
+    throw systemError("DeepSeekR1RaxSession: mmap parameter pack failed for " +
+                      path);
+  }
+
+  auto region = std::make_unique<MappedRegion>();
+  region->data = data;
+  region->bytes = bytes;
+  return region;
+}
+
+size_t elementBytes(rhal::rax::DType dtype) {
+  switch (dtype) {
+  // The current RAX schema has no i1 value. DeepSeek attention-mask buffers
+  // therefore arrive as Invalid, while their generated shim ABI uses bool.
+  case rhal::rax::DType_Invalid:
+  case rhal::rax::DType_I8:
+  case rhal::rax::DType_U8:
+    return 1;
+  case rhal::rax::DType_I16:
+  case rhal::rax::DType_U16:
+  case rhal::rax::DType_F16:
+  case rhal::rax::DType_BF16:
+    return 2;
+  case rhal::rax::DType_I32:
+  case rhal::rax::DType_U32:
+  case rhal::rax::DType_F32:
+    return 4;
+  case rhal::rax::DType_I64:
+  case rhal::rax::DType_U64:
+  case rhal::rax::DType_F64:
+    return 8;
+  default:
+    throw std::runtime_error("DeepSeekR1RaxSession: unsupported buffer dtype");
+  }
+}
+
+size_t bufferBytes(const ModelManifest::RaxBuffer &buffer) {
+  size_t elements = 1;
+  for (int64_t dimension : buffer.shape) {
+    if (dimension <= 0)
+      throw std::runtime_error("DeepSeekR1RaxSession: buffer " + buffer.name +
+                               " has a non-static shape");
+    if (elements >
+        std::numeric_limits<size_t>::max() / static_cast<size_t>(dimension))
+      throw std::runtime_error("DeepSeekR1RaxSession: buffer " + buffer.name +
+                               " size overflows size_t");
+    elements *= static_cast<size_t>(dimension);
+  }
+  const size_t scalarBytes = elementBytes(buffer.dtype);
+  if (elements > std::numeric_limits<size_t>::max() / scalarBytes)
+    throw std::runtime_error("DeepSeekR1RaxSession: buffer " + buffer.name +
+                             " size overflows size_t");
+  return elements * scalarBytes;
+}
+
+} // namespace
+
+struct DeepSeekR1RaxSession::Impl {
+  explicit Impl(const std::string &raxPath) : execution(raxPath) {
+    initialize();
+  }
+
+  Impl(const std::string &raxPath, Communicator &communicator)
+      : execution(raxPath, communicator) {
+    initialize();
+  }
+
+  void initialize() {
+    const ModelManifest &manifest = execution.manifest();
+    for (const auto &buffer : manifest.buffers) {
+      if (buffers.count(buffer.id) || bufferNames.count(buffer.name))
+        throw std::runtime_error(
+            "DeepSeekR1RaxSession: duplicate buffer resource");
+      auto storage = mapAnonymous(bufferBytes(buffer));
+      execution.bindBuffer(buffer.id, storage->data);
+      bufferNames.emplace(buffer.name, buffer.id);
+      buffers.emplace(buffer.id, std::move(storage));
+    }
+    for (const auto &constant : manifest.constants) {
+      if (constantNames.count(constant.name))
+        throw std::runtime_error(
+            "DeepSeekR1RaxSession: duplicate constant resource");
+      constantNames.emplace(constant.name, constant.id);
+      if (constant.storage == rhal::rax::ConstantStorage_External)
+        bindParameterPack(constant.id, constant.path);
+    }
+  }
+
+  uint32_t bufferId(const std::string &name) const {
+    auto found = bufferNames.find(name);
+    if (found == bufferNames.end())
+      throw std::runtime_error("DeepSeekR1RaxSession: unknown buffer " + name);
+    return found->second;
+  }
+
+  uint32_t constantId(const std::string &name) const {
+    auto found = constantNames.find(name);
+    if (found == constantNames.end())
+      throw std::runtime_error("DeepSeekR1RaxSession: unknown constant " +
+                               name);
+    return found->second;
+  }
+
+  MappedRegion &buffer(uint32_t id) {
+    auto found = buffers.find(id);
+    if (found == buffers.end())
+      throw std::runtime_error("DeepSeekR1RaxSession: unknown buffer ID " +
+                               std::to_string(id));
+    return *found->second;
+  }
+
+  const MappedRegion &buffer(uint32_t id) const {
+    auto found = buffers.find(id);
+    if (found == buffers.end())
+      throw std::runtime_error("DeepSeekR1RaxSession: unknown buffer ID " +
+                               std::to_string(id));
+    return *found->second;
+  }
+
+  bool isRuntimeInput(uint32_t id) const {
+    for (const auto &function : execution.manifest().functions)
+      for (uint32_t input : function.inputs)
+        if (input == id)
+          return true;
+    return false;
+  }
+
+  void copyBuffer(uint32_t id, const void *data, size_t bytes) {
+    MappedRegion &destination = buffer(id);
+    if (bytes > destination.bytes)
+      throw std::runtime_error(
+          "DeepSeekR1RaxSession: source is larger than buffer ID " +
+          std::to_string(id));
+    if (bytes != 0 && !data)
+      throw std::runtime_error("DeepSeekR1RaxSession: null buffer source");
+    if (bytes != 0)
+      std::memcpy(destination.data, data, bytes);
+  }
+
+  const ModelManifest::RaxFunction *function(const std::string &name) const {
+    for (const auto &candidate : execution.manifest().functions)
+      if (candidate.name == name)
+        return &candidate;
+    return nullptr;
+  }
+
+  const ModelManifest::RaxBuffer &bufferMetadata(uint32_t id) const {
+    for (const auto &candidate : execution.manifest().buffers)
+      if (candidate.id == id)
+        return candidate;
+    throw std::runtime_error("DeepSeekR1RaxSession: missing buffer metadata");
+  }
+
+  void initializeGenerationContract() {
+    if (generationContractInitialized)
+      return;
+    const auto *prefill = function("forward_prefill");
+    const auto *decode = function("forward_decode");
+    if (!prefill || prefill->inputs.size() != 1 || prefill->outputs.empty() ||
+        !decode || decode->inputs.size() < 2 || decode->outputs.empty())
+      throw std::runtime_error(
+          "DeepSeekR1RaxSession: unsupported DeepSeek forward signatures");
+
+    prefillInput = prefill->inputs.front();
+    decodeTokenInput = decode->inputs.front();
+    prefillLogits = prefill->outputs.back();
+    decodeLogits = decode->outputs.back();
+
+    const auto &prefillInputMetadata = bufferMetadata(prefillInput);
+    const auto &prefillLogitsMetadata = bufferMetadata(prefillLogits);
+    const auto &decodeLogitsMetadata = bufferMetadata(decodeLogits);
+    if (prefillInputMetadata.dtype != rhal::rax::DType_I64 ||
+        prefillLogitsMetadata.dtype != rhal::rax::DType_F32 ||
+        decodeLogitsMetadata.dtype != rhal::rax::DType_F32 ||
+        prefillLogitsMetadata.shape.empty() ||
+        decodeLogitsMetadata.shape.empty() ||
+        prefillLogitsMetadata.shape.back() <= 0 ||
+        prefillLogitsMetadata.shape.back() != decodeLogitsMetadata.shape.back())
+      throw std::runtime_error(
+          "DeepSeekR1RaxSession: incompatible token or logits metadata");
+    generationVocabSize = static_cast<int>(prefillLogitsMetadata.shape.back());
+    generationContractInitialized = true;
+  }
+
+  void copyBuffer(uint32_t sourceId, uint32_t destinationId) {
+    const MappedRegion &source = buffer(sourceId);
+    MappedRegion &destination = buffer(destinationId);
+    if (source.bytes != destination.bytes)
+      throw std::runtime_error(
+          "DeepSeekR1RaxSession: KV cache buffer sizes do not match");
+    std::memcpy(destination.data, source.data, source.bytes);
+  }
+
+  size_t deepSeekKVLayerCount() const {
+    const auto *prefill = function("forward_prefill");
+    const auto *decode = function("forward_decode");
+    if (!prefill || !decode || decode->inputs.empty() ||
+        (decode->inputs.size() - 1) % 3 != 0)
+      throw std::runtime_error(
+          "DeepSeekR1RaxSession: incompatible DeepSeek KV-cache contract");
+    const size_t layers = (decode->inputs.size() - 1) / 3;
+    if (layers == 0 || prefill->outputs.size() != 2 * layers + 1 ||
+        decode->outputs.size() != 3 * layers + 1)
+      throw std::runtime_error(
+          "DeepSeekR1RaxSession: incompatible DeepSeek KV-cache contract");
+    return layers;
+  }
+
+  void copyPrefillKVCacheToDecodeInputs() {
+    const size_t layers = deepSeekKVLayerCount();
+    const auto *prefill = function("forward_prefill");
+    const auto *decode = function("forward_decode");
+    for (size_t layer = 0; layer < layers; ++layer) {
+      copyBuffer(prefill->outputs[2 * layer], decode->inputs[3 * layer + 2]);
+      copyBuffer(prefill->outputs[2 * layer + 1],
+                 decode->inputs[3 * layer + 3]);
+    }
+  }
+
+  void copyDecodeKVCacheToInputs() {
+    const size_t layers = deepSeekKVLayerCount();
+    const auto *decode = function("forward_decode");
+    for (size_t layer = 0; layer < layers; ++layer) {
+      copyBuffer(decode->outputs[3 * layer + 1], decode->inputs[3 * layer + 2]);
+      copyBuffer(decode->outputs[3 * layer + 2], decode->inputs[3 * layer + 3]);
+    }
+  }
+
+  void bindParameterPack(uint32_t id, const std::string &path) {
+    bool known = false;
+    for (const auto &constant : execution.manifest().constants) {
+      if (constant.id == id) {
+        known = true;
+        break;
+      }
+    }
+    if (!known)
+      throw std::runtime_error("DeepSeekR1RaxSession: unknown constant ID " +
+                               std::to_string(id));
+    auto mapping = mapFile(path);
+    execution.bindConstant(id, mapping->data);
+    constants[id] = std::move(mapping);
+  }
+
+  RaxExecutionSession execution;
+  std::unordered_map<uint32_t, std::unique_ptr<MappedRegion>> buffers;
+  std::unordered_map<uint32_t, std::unique_ptr<MappedRegion>> constants;
+  std::unordered_map<std::string, uint32_t> bufferNames;
+  std::unordered_map<std::string, uint32_t> constantNames;
+  uint32_t prefillInput = 0;
+  uint32_t decodeTokenInput = 0;
+  uint32_t prefillLogits = 0;
+  uint32_t decodeLogits = 0;
+  int generationVocabSize = 0;
+  int position = 0;
+  bool lastLogitsAreDecode = false;
+  bool generationContractInitialized = false;
+};
+
+DeepSeekR1RaxSession::DeepSeekR1RaxSession(const std::string &raxPath)
+    : impl_(std::make_unique<Impl>(raxPath)) {}
+
+DeepSeekR1RaxSession::DeepSeekR1RaxSession(const std::string &raxPath,
+                                           Communicator &communicator)
+    : impl_(std::make_unique<Impl>(raxPath, communicator)) {}
+
+DeepSeekR1RaxSession::~DeepSeekR1RaxSession() = default;
+
+void DeepSeekR1RaxSession::bindParameterPack(uint32_t id,
+                                             const std::string &path) {
+  impl_->bindParameterPack(id, path);
+}
+
+void DeepSeekR1RaxSession::bindParameterPack(const std::string &name,
+                                             const std::string &path) {
+  bindParameterPack(impl_->constantId(name), path);
+}
+
+void DeepSeekR1RaxSession::bindRuntimeInput(uint32_t id, const void *data,
+                                            size_t bytes) {
+  if (!impl_->isRuntimeInput(id))
+    throw std::runtime_error("DeepSeekR1RaxSession: buffer ID " +
+                             std::to_string(id) + " is not a forward input");
+  impl_->copyBuffer(id, data, bytes);
+}
+
+void DeepSeekR1RaxSession::bindRuntimeInput(const std::string &name,
+                                            const void *data, size_t bytes) {
+  bindRuntimeInput(impl_->bufferId(name), data, bytes);
+}
+
+void DeepSeekR1RaxSession::bindKVCacheBuffer(uint32_t id, const void *data,
+                                             size_t bytes) {
+  impl_->copyBuffer(id, data, bytes);
+}
+
+void DeepSeekR1RaxSession::bindKVCacheBuffer(const std::string &name,
+                                             const void *data, size_t bytes) {
+  bindKVCacheBuffer(impl_->bufferId(name), data, bytes);
+}
+
+void DeepSeekR1RaxSession::forwardPrefill() {
+  impl_->execution.execute("forward_prefill");
+  impl_->copyPrefillKVCacheToDecodeInputs();
+}
+
+void DeepSeekR1RaxSession::forwardDecode() {
+  impl_->execution.execute("forward_decode");
+  impl_->copyDecodeKVCacheToInputs();
+}
+
+void DeepSeekR1RaxSession::loadWeights(
+    const std::vector<std::string> &weightPaths) {
+  (void)weightPaths;
+  // External constants are resolved and mapped when the RAX session is built.
+}
+
+void DeepSeekR1RaxSession::prefill(Text<size_t, 2> &tokens) {
+  impl_->initializeGenerationContract();
+  const size_t inputBytes = bufferSize(impl_->prefillInput);
+  if (sizeof(size_t) != sizeof(int64_t) ||
+      tokens.getSize() * sizeof(size_t) != inputBytes)
+    throw std::runtime_error(
+        "DeepSeekR1RaxSession: token input does not match RAX metadata");
+  bindRuntimeInput(impl_->prefillInput, tokens.getData(), inputBytes);
+  forwardPrefill();
+  impl_->position = static_cast<int>(tokens.getTokenCnt());
+  impl_->lastLogitsAreDecode = false;
+}
+
+void DeepSeekR1RaxSession::decode(int tokenId) {
+  impl_->initializeGenerationContract();
+  const auto *decodeFunction = impl_->function("forward_decode");
+  const int64_t token = tokenId;
+  const int64_t position = impl_->position;
+  bindRuntimeInput(impl_->decodeTokenInput, &token, sizeof(token));
+  for (size_t index = 1; index < decodeFunction->inputs.size(); ++index) {
+    const uint32_t input = decodeFunction->inputs[index];
+    const auto &metadata = impl_->bufferMetadata(input);
+    if (metadata.dtype == rhal::rax::DType_I64 &&
+        bufferSize(input) == sizeof(position))
+      bindRuntimeInput(input, &position, sizeof(position));
+  }
+  forwardDecode();
+  ++impl_->position;
+  impl_->lastLogitsAreDecode = true;
+}
+
+void DeepSeekR1RaxSession::resetPosition() {
+  impl_->position = 0;
+  impl_->lastLogitsAreDecode = false;
+}
+
+int DeepSeekR1RaxSession::position() const { return impl_->position; }
+
+const float *DeepSeekR1RaxSession::logitsData(int tokenOffset) const {
+  impl_->initializeGenerationContract();
+  const uint32_t logits =
+      impl_->lastLogitsAreDecode ? impl_->decodeLogits : impl_->prefillLogits;
+  if (tokenOffset < 0)
+    throw std::runtime_error("DeepSeekR1RaxSession: negative logits offset");
+  const size_t offset = static_cast<size_t>(tokenOffset) * vocabSize();
+  if ((offset + static_cast<size_t>(vocabSize())) * sizeof(float) >
+      bufferSize(logits))
+    throw std::runtime_error(
+        "DeepSeekR1RaxSession: logits offset out of range");
+  return static_cast<const float *>(impl_->buffer(logits).data) + offset;
+}
+
+int DeepSeekR1RaxSession::vocabSize() const {
+  impl_->initializeGenerationContract();
+  return impl_->generationVocabSize;
+}
+
+bool DeepSeekR1RaxSession::handleKVCacheOverflow(int keepTokenNum,
+                                                 float ropeTheta) {
+  (void)keepTokenNum;
+  (void)ropeTheta;
+  throw std::runtime_error(
+      "DeepSeekR1RaxSession: KV cache overflow is not supported");
+}
+
+void *DeepSeekR1RaxSession::bufferData(uint32_t id) {
+  return impl_->buffer(id).data;
+}
+
+void *DeepSeekR1RaxSession::bufferData(const std::string &name) {
+  return bufferData(impl_->bufferId(name));
+}
+
+size_t DeepSeekR1RaxSession::bufferSize(uint32_t id) const {
+  return impl_->buffer(id).bytes;
+}
+
+size_t DeepSeekR1RaxSession::bufferSize(const std::string &name) const {
+  return bufferSize(impl_->bufferId(name));
+}
+
+const ModelManifest &DeepSeekR1RaxSession::manifest() const {
+  return impl_->execution.manifest();
+}
+
+} // namespace runtime
+} // namespace buddy

--- a/models/deepseek_r1_tp2/DeepSeekR1TPRunner.cpp
+++ b/models/deepseek_r1_tp2/DeepSeekR1TPRunner.cpp
@@ -1,0 +1,120 @@
+//===- DeepSeekR1TPRunner.cpp - DeepSeek R1 TP=2 inference ----------------===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/models/DeepSeekR1TPRunner.h"
+
+#include "buddy/LLM/ChatTemplate.h"
+#include "buddy/LLM/TextContainer.h"
+#include "buddy/runtime/llm/TextGeneration.h"
+#include "buddy/runtime/models/DeepSeekR1RaxRunner.h"
+#include "buddy/runtime/models/DeepSeekR1RaxSession.h"
+#include "buddy/runtime/models/ModelSession.h"
+
+#include "buddy/Core/Container.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using buddy::Text;
+
+namespace buddy {
+namespace runtime {
+namespace {
+
+static constexpr int kEosToken = 151643; // <|end▁of▁sentence|>
+static constexpr int kEotToken = 151647; // <|EOT|>
+
+} // namespace
+
+void DeepSeekR1TPRunner::run(const RunConfig &cfg) {
+  if (cfg.raxPath.empty())
+    throw std::runtime_error(
+        "DeepSeek R1 TP runner requires --model <rank-local.rax>");
+  if (cfg.interactive)
+    throw std::runtime_error(
+        "DeepSeek R1 tensor-parallel interactive mode is not supported");
+
+  const auto &samplerConfig = cfg.samplerConfig;
+  if (samplerConfig.temperature != 0.0f || samplerConfig.topK != 0 ||
+      samplerConfig.topP != 1.0f || samplerConfig.minP != 0.0f ||
+      samplerConfig.repeatPenalty != 1.0f)
+    throw std::runtime_error(
+        "DeepSeek R1 tensor-parallel execution requires greedy sampling");
+
+  std::vector<long long> stopTokenIds = {kEosToken, kEotToken};
+  std::unique_ptr<buddy::ChatTemplate> chatTemplate;
+  if (!cfg.chatTemplatePath.empty()) {
+    chatTemplate = std::make_unique<buddy::ChatTemplate>(
+        buddy::ChatTemplate::fromFile(cfg.chatTemplatePath));
+    for (int id : chatTemplate->stopTokenIds())
+      if (std::find(stopTokenIds.begin(), stopTokenIds.end(), id) ==
+          stopTokenIds.end())
+        stopTokenIds.push_back(static_cast<long long>(id));
+  }
+
+  TextCodec codec;
+  codec.tokenize = [](Text<size_t, 2> &tokens, const std::string &vocab) {
+    tokens.tokenizeDeepSeekR1(vocab, BUDDY_DSR1_MAX_TOKEN_LEN);
+  };
+  codec.detokenize = [](Text<size_t, 2> &tokens) {
+    return tokens.revertDeepSeekR1();
+  };
+  codec.maxTokenLen = BUDDY_DSR1_MAX_TOKEN_LEN;
+  buddy::Sampler sampler(samplerConfig);
+
+  runDeepSeekR1Rax(cfg.raxPath, [&](DeepSeekR1RaxSession &session, int rank) {
+    const ModelManifest &manifest = session.manifest();
+    const std::string vocabPath =
+        manifest.vocabPath.empty()
+            ? (std::filesystem::path(manifest.soPath).parent_path() /
+               "vocab.txt")
+                  .string()
+            : manifest.vocabPath;
+    const bool emitOutput = rank == 0;
+    const bool suppress = cfg.suppressStats || cfg.streamJsonl || !emitOutput;
+
+    if (!suppress) {
+      std::cerr << "\033[33;1mDeepSeekR1 TP=2 Inference (buddy-cli / "
+                   "BuddyRuntime)\033[0m\n";
+      printLog("Manifest: " + cfg.raxPath, false);
+      printLog("  .so     = " + manifest.soPath, false);
+      for (const auto &path : manifest.weightPaths)
+        printLog("  weights = " + path, false);
+      printLog("  vocab   = " + vocabPath, false);
+    }
+
+    session.loadWeights(manifest.weightPaths);
+    printLog("Weights loaded.", suppress);
+    printLog("Vocab: " + vocabPath, suppress);
+    printLog("KV cache: " + std::to_string(BUDDY_DSR1_KV_LAYERS) + " x {1," +
+                 std::to_string(BUDDY_DSR1_HEAD_NUM) + "," +
+                 std::to_string(BUDDY_DSR1_MAX_TOKEN_LEN) + "," +
+                 std::to_string(BUDDY_DSR1_HIDDEN_SIZE) + "} f32",
+             suppress);
+
+    std::string finalPrompt = cfg.prompt;
+    if (chatTemplate) {
+      std::vector<buddy::Message> messages = {{"user", cfg.prompt}};
+      finalPrompt = chatTemplate->apply(messages);
+    }
+
+    GenerationResult result = runGeneration(
+        finalPrompt, session, vocabPath, cfg.maxNewTokens, stopTokenIds,
+        sampler, codec, suppress, cfg.streamJsonl, emitOutput);
+    if (!suppress)
+      printStats(result, /*verbose=*/true);
+  });
+}
+
+} // namespace runtime
+} // namespace buddy

--- a/models/deepseek_r1_tp2/DeepSeekR1TPRunnerPlugin.cpp
+++ b/models/deepseek_r1_tp2/DeepSeekR1TPRunnerPlugin.cpp
@@ -1,0 +1,18 @@
+//===- DeepSeekR1TPRunnerPlugin.cpp - DeepSeek TP runner plugin -----------===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/models/DeepSeekR1TPRunner.h"
+
+extern "C" buddy::runtime::InferenceRunner *buddy_create_inference_runner_v1() {
+  return new buddy::runtime::DeepSeekR1TPRunner();
+}
+
+extern "C" void
+buddy_destroy_inference_runner_v1(buddy::runtime::InferenceRunner *runner) {
+  delete runner;
+}

--- a/models/deepseek_r1_tp2/include/buddy/runtime/models/DeepSeekR1RaxRunner.h
+++ b/models/deepseek_r1_tp2/include/buddy/runtime/models/DeepSeekR1RaxRunner.h
@@ -1,0 +1,31 @@
+//===- DeepSeekR1RaxRunner.h - DeepSeek RAX execution entry ----*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_MODELS_DEEPSEEKR1RAXRUNNER_H
+#define BUDDY_RUNTIME_MODELS_DEEPSEEKR1RAXRUNNER_H
+
+#include <functional>
+#include <string>
+
+namespace buddy {
+namespace runtime {
+
+class DeepSeekR1RaxSession;
+
+using DeepSeekR1RaxSessionCallback =
+    std::function<void(DeepSeekR1RaxSession &, int rank)>;
+
+/// Run a callback while the rank-local RAX session and MPI world are alive.
+/// Each process opens the supplied rank-local RAX path.
+void runDeepSeekR1Rax(const std::string &raxPath,
+                      const DeepSeekR1RaxSessionCallback &callback);
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_MODELS_DEEPSEEKR1RAXRUNNER_H

--- a/models/deepseek_r1_tp2/include/buddy/runtime/models/DeepSeekR1RaxSession.h
+++ b/models/deepseek_r1_tp2/include/buddy/runtime/models/DeepSeekR1RaxSession.h
@@ -1,0 +1,80 @@
+//===- DeepSeekR1RaxSession.h - DeepSeek RAX resource session ---*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_MODELS_DEEPSEEKR1RAXSESSION_H
+#define BUDDY_RUNTIME_MODELS_DEEPSEEKR1RAXSESSION_H
+
+#include "buddy/runtime/communication/Communicator.h"
+#include "buddy/runtime/core/ModelManifest.h"
+#include "buddy/runtime/llm/LLMSession.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace buddy {
+namespace runtime {
+
+/// Owns the resources needed to execute an existing DeepSeek R1 RAX schedule.
+///
+/// External parameter packs are mapped from the paths resolved by the RAX
+/// manifest. Rank-local buffers are allocated from their manifest shapes and
+/// remain valid for the session lifetime. This class does not implement text
+/// generation policy, tokenization, or sampling.
+class DeepSeekR1RaxSession : public LLMSession {
+public:
+  explicit DeepSeekR1RaxSession(const std::string &raxPath);
+  DeepSeekR1RaxSession(const std::string &raxPath, Communicator &communicator);
+  ~DeepSeekR1RaxSession() override;
+
+  DeepSeekR1RaxSession(const DeepSeekR1RaxSession &) = delete;
+  DeepSeekR1RaxSession &operator=(const DeepSeekR1RaxSession &) = delete;
+
+  /// Replace an automatically resolved parameter pack with an owned mapping.
+  void bindParameterPack(uint32_t id, const std::string &path);
+  void bindParameterPack(const std::string &name, const std::string &path);
+
+  /// Copy call input data into a session-owned RAX input buffer.
+  void bindRuntimeInput(uint32_t id, const void *data, size_t bytes);
+  void bindRuntimeInput(const std::string &name, const void *data,
+                        size_t bytes);
+
+  /// Copy initial or updated KV state into a persistent session buffer.
+  void bindKVCacheBuffer(uint32_t id, const void *data, size_t bytes);
+  void bindKVCacheBuffer(const std::string &name, const void *data,
+                         size_t bytes);
+
+  void forwardPrefill();
+  void forwardDecode();
+
+  void loadWeights(const std::vector<std::string> &weightPaths) override;
+  void prefill(Text<size_t, 2> &tokens) override;
+  void decode(int tokenId) override;
+  void resetPosition() override;
+  int position() const override;
+  const float *logitsData(int tokenOffset = 0) const override;
+  int vocabSize() const override;
+  bool handleKVCacheOverflow(int keepTokenNum,
+                             float ropeTheta = 10000.0f) override;
+
+  void *bufferData(uint32_t id);
+  void *bufferData(const std::string &name);
+  size_t bufferSize(uint32_t id) const;
+  size_t bufferSize(const std::string &name) const;
+  const ModelManifest &manifest() const;
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_MODELS_DEEPSEEKR1RAXSESSION_H

--- a/models/deepseek_r1_tp2/include/buddy/runtime/models/DeepSeekR1TPRunner.h
+++ b/models/deepseek_r1_tp2/include/buddy/runtime/models/DeepSeekR1TPRunner.h
@@ -1,0 +1,26 @@
+//===- DeepSeekR1TPRunner.h - DeepSeek R1 TP=2 runner ---------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_MODELS_DEEPSEEKR1TPRUNNER_H
+#define BUDDY_RUNTIME_MODELS_DEEPSEEKR1TPRUNNER_H
+
+#include "buddy/runtime/core/InferenceRunner.h"
+
+namespace buddy {
+namespace runtime {
+
+/// Runs rank-local DeepSeek R1 RAX schedules through the MPI communicator.
+class DeepSeekR1TPRunner : public InferenceRunner {
+public:
+  void run(const RunConfig &cfg) override;
+};
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_MODELS_DEEPSEEKR1TPRUNNER_H

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -26,5 +26,7 @@ install(TARGETS buddy_runtime_core
         EXPORT BuddyMLIRTargets
         COMPONENT buddy_runtime)
 
+add_subdirectory(execution)
+
 # LLM runtime utilities (text generation, interactive REPL).
 add_subdirectory(llm)

--- a/runtime/execution/CMakeLists.txt
+++ b/runtime/execution/CMakeLists.txt
@@ -1,0 +1,31 @@
+add_library(buddy_runtime_execution STATIC
+  RaxExecutionSession.cpp
+  RaxExecutor.cpp
+)
+target_link_libraries(buddy_runtime_execution PUBLIC
+  buddy_runtime_core
+  ${CMAKE_DL_LIBS}
+)
+target_compile_features(buddy_runtime_execution PUBLIC cxx_std_17)
+
+install(TARGETS buddy_runtime_execution
+        EXPORT BuddyMLIRTargets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT buddy_runtime)
+
+if(BUDDY_RUNTIME_ENABLE_MPI)
+  find_package(MPI REQUIRED COMPONENTS CXX)
+  add_library(buddy_runtime_mpi STATIC
+    MpiCommunicator.cpp
+  )
+  target_link_libraries(buddy_runtime_mpi PUBLIC
+    buddy_runtime_core
+    MPI::MPI_CXX
+  )
+  target_compile_features(buddy_runtime_mpi PUBLIC cxx_std_17)
+
+  install(TARGETS buddy_runtime_mpi
+          EXPORT BuddyMLIRTargets
+          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          COMPONENT buddy_runtime)
+endif()

--- a/runtime/execution/MpiCommunicator.cpp
+++ b/runtime/execution/MpiCommunicator.cpp
@@ -1,0 +1,113 @@
+//===- MpiCommunicator.cpp - MPI collective backend ----------------------===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/communication/MpiCommunicator.h"
+
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace buddy {
+namespace runtime {
+
+static void checkMpi(int status, const char *operation) {
+  if (status != MPI_SUCCESS)
+    throw std::runtime_error(std::string("MpiCommunicator: ") + operation +
+                             " failed");
+}
+
+static std::vector<int> convertMpiValues(const std::vector<int64_t> &values,
+                                         const char *description) {
+  std::vector<int> result;
+  result.reserve(values.size());
+  for (int64_t value : values) {
+    if (value < 0 || value > std::numeric_limits<int>::max())
+      throw std::runtime_error(std::string("MpiCommunicator: ") + description +
+                               " exceeds MPI int range");
+    result.push_back(static_cast<int>(value));
+  }
+  return result;
+}
+
+MpiCommunicator::MpiCommunicator(MPI_Comm communicator)
+    : communicator_(communicator) {}
+
+int MpiCommunicator::rank() const {
+  int value = 0;
+  checkMpi(MPI_Comm_rank(communicator_, &value), "MPI_Comm_rank");
+  return value;
+}
+
+int MpiCommunicator::size() const {
+  int value = 0;
+  checkMpi(MPI_Comm_size(communicator_, &value), "MPI_Comm_size");
+  return value;
+}
+
+void MpiCommunicator::broadcast(void *buffer, size_t bytes, int root) {
+  if (bytes > static_cast<size_t>(std::numeric_limits<int>::max()))
+    throw std::runtime_error(
+        "MpiCommunicator: Broadcast count exceeds MPI int");
+  checkMpi(
+      MPI_Bcast(buffer, static_cast<int>(bytes), MPI_BYTE, root, communicator_),
+      "MPI_Bcast");
+}
+
+void MpiCommunicator::allReduce(const void *sendBuffer, void *recvBuffer,
+                                size_t count, DataType dataType,
+                                ReductionOp reduction) {
+  if (dataType != DataType::F32 || reduction != ReductionOp::Sum)
+    throw std::runtime_error(
+        "MpiCommunicator: unsupported AllReduce datatype or reduction");
+  if (count > static_cast<size_t>(std::numeric_limits<int>::max()))
+    throw std::runtime_error(
+        "MpiCommunicator: AllReduce count exceeds MPI int");
+  const void *mpiSendBuffer =
+      sendBuffer == recvBuffer ? MPI_IN_PLACE : sendBuffer;
+  checkMpi(MPI_Allreduce(mpiSendBuffer, recvBuffer, static_cast<int>(count),
+                         MPI_FLOAT, MPI_SUM, communicator_),
+           "MPI_Allreduce");
+}
+
+void MpiCommunicator::allGatherV(const void *sendBuffer, size_t sendCount,
+                                 void *recvBuffer,
+                                 const std::vector<int64_t> &recvCounts,
+                                 const std::vector<int64_t> &displacements,
+                                 DataType dataType) {
+  if (dataType != DataType::F32)
+    throw std::runtime_error(
+        "MpiCommunicator: unsupported AllGatherV datatype");
+  if (sendCount > static_cast<size_t>(std::numeric_limits<int>::max()))
+    throw std::runtime_error(
+        "MpiCommunicator: AllGatherV send count exceeds MPI int");
+  const std::vector<int> mpiRecvCounts =
+      convertMpiValues(recvCounts, "AllGatherV receive count");
+  const std::vector<int> mpiDisplacements =
+      convertMpiValues(displacements, "AllGatherV displacement");
+  checkMpi(MPI_Allgatherv(sendBuffer, static_cast<int>(sendCount), MPI_FLOAT,
+                          recvBuffer, mpiRecvCounts.data(),
+                          mpiDisplacements.data(), MPI_FLOAT, communicator_),
+           "MPI_Allgatherv");
+}
+
+void MpiCommunicator::reduceScatter(const void *sendBuffer, void *recvBuffer,
+                                    const std::vector<int64_t> &recvCounts,
+                                    DataType dataType, ReductionOp reduction) {
+  if (dataType != DataType::F32 || reduction != ReductionOp::Sum)
+    throw std::runtime_error(
+        "MpiCommunicator: unsupported ReduceScatter datatype or reduction");
+  const std::vector<int> mpiRecvCounts =
+      convertMpiValues(recvCounts, "ReduceScatter receive count");
+  checkMpi(MPI_Reduce_scatter(sendBuffer, recvBuffer, mpiRecvCounts.data(),
+                              MPI_FLOAT, MPI_SUM, communicator_),
+           "MPI_Reduce_scatter");
+}
+
+} // namespace runtime
+} // namespace buddy

--- a/runtime/execution/RaxExecutionSession.cpp
+++ b/runtime/execution/RaxExecutionSession.cpp
@@ -1,0 +1,35 @@
+//===- RaxExecutionSession.cpp - Own a RAX execution context --------------===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/core/RaxExecutionSession.h"
+
+namespace buddy {
+namespace runtime {
+
+RaxExecutionSession::RaxExecutionSession(const std::string &raxPath)
+    : manifest_(ModelManifest::loadFromRax(raxPath)), executor_(manifest_) {}
+
+RaxExecutionSession::RaxExecutionSession(const std::string &raxPath,
+                                         Communicator &communicator)
+    : manifest_(ModelManifest::loadFromRax(raxPath)),
+      executor_(manifest_, communicator) {}
+
+void RaxExecutionSession::bindBuffer(uint32_t id, void *ptr) {
+  executor_.bindBuffer(id, ptr);
+}
+
+void RaxExecutionSession::bindConstant(uint32_t id, void *ptr) {
+  executor_.bindConstant(id, ptr);
+}
+
+void RaxExecutionSession::execute(const std::string &function) {
+  executor_.execute(function);
+}
+
+} // namespace runtime
+} // namespace buddy

--- a/runtime/execution/RaxExecutor.cpp
+++ b/runtime/execution/RaxExecutor.cpp
@@ -170,9 +170,19 @@ RaxExecutor::resolveHostBuffer(uint32_t bufferId) const {
         buffer->strides[dim] != static_cast<int64_t>(expectedStride))
       throw std::runtime_error("RaxExecutor: non-contiguous buffer " +
                                std::to_string(bufferId));
-    elementCount *= static_cast<size_t>(staticSize);
+    const size_t dimension = static_cast<size_t>(staticSize);
+    if (dimension != 0 &&
+        elementCount > std::numeric_limits<size_t>::max() / dimension)
+      throw std::runtime_error("RaxExecutor: element count overflows size_t "
+                               "for buffer " +
+                               std::to_string(bufferId));
+    elementCount *= dimension;
     expectedStride = elementCount;
   }
+  if (elementCount > std::numeric_limits<size_t>::max() / elementBytes)
+    throw std::runtime_error("RaxExecutor: byte size overflows size_t for "
+                             "buffer " +
+                             std::to_string(bufferId));
   const size_t bytes = elementCount * elementBytes;
   return {binding->second, elementCount, bytes, buffer->dtype};
 }

--- a/runtime/execution/RaxExecutor.cpp
+++ b/runtime/execution/RaxExecutor.cpp
@@ -1,0 +1,348 @@
+//===- RaxExecutor.cpp - Execute host RAX functions -----------------------===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "buddy/runtime/core/RaxExecutor.h"
+
+#include <dlfcn.h>
+
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+namespace buddy {
+namespace runtime {
+
+struct RaxExecutor::HostBufferView {
+  void *data = nullptr;
+  size_t elementCount = 0;
+  size_t bytes = 0;
+  rhal::rax::DType dtype = rhal::rax::DType_Invalid;
+};
+
+RaxExecutor::RaxExecutor(const ModelManifest &manifest) : manifest_(manifest) {}
+
+RaxExecutor::RaxExecutor(const ModelManifest &manifest,
+                         Communicator &communicator)
+    : manifest_(manifest), communicator_(&communicator) {}
+
+RaxExecutor::~RaxExecutor() {
+  for (const auto &library : libraryHandles_)
+    dlclose(library.second);
+}
+
+void RaxExecutor::bindBuffer(uint32_t id, void *data) { buffers_[id] = data; }
+
+void RaxExecutor::bindConstant(uint32_t id, void *abiPtr) {
+  constants_[id] = abiPtr;
+}
+
+RaxHostEntryFn RaxExecutor::resolveEntry(uint32_t codeObjectId) {
+  auto cachedEntry = entries_.find(codeObjectId);
+  if (cachedEntry != entries_.end())
+    return cachedEntry->second;
+
+  const ModelManifest::ResolvedCodeObject *codeObject = nullptr;
+  for (const auto &candidate : manifest_.codeObjects) {
+    if (candidate.id == codeObjectId) {
+      codeObject = &candidate;
+      break;
+    }
+  }
+  if (!codeObject)
+    throw std::runtime_error("RaxExecutor: unknown code object ID " +
+                             std::to_string(codeObjectId));
+  if (codeObject->kind != rhal::rax::CodeObjectKind_HostSharedLib)
+    throw std::runtime_error("RaxExecutor: code object " +
+                             std::to_string(codeObjectId) +
+                             " is not a HostSharedLib");
+  if (codeObject->path.empty())
+    throw std::runtime_error("RaxExecutor: code object " +
+                             std::to_string(codeObjectId) +
+                             " has no shared-library path");
+  if (codeObject->entrySymbol.empty())
+    throw std::runtime_error("RaxExecutor: code object " +
+                             std::to_string(codeObjectId) +
+                             " has no entry symbol");
+
+  void *handle = nullptr;
+  auto cachedLibrary = libraryHandles_.find(codeObject->path);
+  if (cachedLibrary != libraryHandles_.end()) {
+    handle = cachedLibrary->second;
+  } else {
+    handle = dlopen(codeObject->path.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (!handle) {
+      const char *error = dlerror();
+      throw std::runtime_error("RaxExecutor: dlopen failed for " +
+                               codeObject->path + ": " +
+                               (error ? error : "unknown error"));
+    }
+    libraryHandles_.emplace(codeObject->path, handle);
+  }
+
+  dlerror();
+  void *symbol = dlsym(handle, codeObject->entrySymbol.c_str());
+  const char *error = dlerror();
+  if (error || !symbol)
+    throw std::runtime_error("RaxExecutor: dlsym failed for " +
+                             codeObject->entrySymbol + ": " +
+                             (error ? error : "symbol is null"));
+
+  auto entry = reinterpret_cast<RaxHostEntryFn>(symbol);
+  entries_.emplace(codeObjectId, entry);
+  return entry;
+}
+
+RaxExecutor::HostBufferView
+RaxExecutor::resolveHostBuffer(uint32_t bufferId) const {
+  const ModelManifest::RaxBuffer *buffer = nullptr;
+  for (const auto &candidate : manifest_.buffers) {
+    if (candidate.id == bufferId) {
+      buffer = &candidate;
+      break;
+    }
+  }
+  if (!buffer)
+    throw std::runtime_error("RaxExecutor: unknown buffer ID " +
+                             std::to_string(bufferId));
+  if (buffer->memorySpace != rhal::rax::MemorySpace_Host &&
+      buffer->memorySpace != rhal::rax::MemorySpace_Any)
+    throw std::runtime_error("RaxExecutor: collective buffer " +
+                             std::to_string(bufferId) + " is not host memory");
+  if (buffer->layout != rhal::rax::Layout_RowMajor &&
+      buffer->layout != rhal::rax::Layout_Any)
+    throw std::runtime_error("RaxExecutor: collective buffer " +
+                             std::to_string(bufferId) + " is not row-major");
+
+  size_t elementBytes = 0;
+  switch (buffer->dtype) {
+  case rhal::rax::DType_I8:
+  case rhal::rax::DType_U8:
+    elementBytes = 1;
+    break;
+  case rhal::rax::DType_I16:
+  case rhal::rax::DType_U16:
+  case rhal::rax::DType_F16:
+  case rhal::rax::DType_BF16:
+    elementBytes = 2;
+    break;
+  case rhal::rax::DType_I32:
+  case rhal::rax::DType_U32:
+  case rhal::rax::DType_F32:
+    elementBytes = 4;
+    break;
+  case rhal::rax::DType_I64:
+  case rhal::rax::DType_U64:
+  case rhal::rax::DType_F64:
+    elementBytes = 8;
+    break;
+  default:
+    throw std::runtime_error("RaxExecutor: unsupported dtype for buffer " +
+                             std::to_string(bufferId));
+  }
+
+  auto binding = buffers_.find(bufferId);
+  if (binding == buffers_.end())
+    throw std::runtime_error("RaxExecutor: unbound buffer ID " +
+                             std::to_string(bufferId));
+  if (!binding->second)
+    throw std::runtime_error("RaxExecutor: null data pointer for buffer " +
+                             std::to_string(bufferId));
+
+  const size_t rank = buffer->shape.size();
+  if (!buffer->strides.empty() && buffer->strides.size() != rank)
+    throw std::runtime_error("RaxExecutor: invalid strides for buffer " +
+                             std::to_string(bufferId));
+  size_t elementCount = 1;
+  size_t expectedStride = 1;
+  for (size_t reverseIndex = 0; reverseIndex < rank; ++reverseIndex) {
+    const size_t dim = rank - reverseIndex - 1;
+    const int64_t staticSize = buffer->shape[dim];
+    if (staticSize < 0)
+      throw std::runtime_error("RaxExecutor: dynamic collective buffer " +
+                               std::to_string(bufferId));
+    if (!buffer->strides.empty() &&
+        buffer->strides[dim] != static_cast<int64_t>(expectedStride))
+      throw std::runtime_error("RaxExecutor: non-contiguous buffer " +
+                               std::to_string(bufferId));
+    elementCount *= static_cast<size_t>(staticSize);
+    expectedStride = elementCount;
+  }
+  const size_t bytes = elementCount * elementBytes;
+  return {binding->second, elementCount, bytes, buffer->dtype};
+}
+
+void RaxExecutor::executeDispatch(const ModelManifest::RaxOperation &op) {
+  std::vector<void *> callArgs;
+  callArgs.reserve(op.arguments.size());
+  for (const auto &argument : op.arguments) {
+    if (argument.kind == ModelManifest::RaxDispatchArgument::Kind::Buffer) {
+      auto binding = buffers_.find(argument.resourceId);
+      if (binding == buffers_.end())
+        throw std::runtime_error("RaxExecutor: unbound buffer ID " +
+                                 std::to_string(argument.resourceId));
+      callArgs.push_back(binding->second);
+    } else {
+      auto binding = constants_.find(argument.resourceId);
+      if (binding == constants_.end())
+        throw std::runtime_error("RaxExecutor: unbound constant ID " +
+                                 std::to_string(argument.resourceId));
+      callArgs.push_back(binding->second);
+    }
+  }
+  resolveEntry(op.codeObjectId)(callArgs.data());
+}
+
+void RaxExecutor::executeCollective(const ModelManifest::RaxOperation &op) {
+  if (!communicator_)
+    throw std::runtime_error("RaxExecutor: Collective requires a communicator");
+
+  if (op.collectiveKind == rhal::rax::CollectiveKind_AllGatherV ||
+      op.collectiveKind == rhal::rax::CollectiveKind_ReduceScatter) {
+    if (op.collectiveOperands.size() != 1)
+      throw std::runtime_error(
+          "RaxExecutor: variable Collective requires exactly one operand");
+
+    const auto &operand = op.collectiveOperands.front();
+    const HostBufferView input = resolveHostBuffer(operand.inputBufferId);
+    const HostBufferView output = resolveHostBuffer(operand.outputBufferId);
+    if (input.dtype != rhal::rax::DType_F32 ||
+        output.dtype != rhal::rax::DType_F32)
+      throw std::runtime_error(
+          "RaxExecutor: variable Collective requires F32 buffers");
+
+    const int communicatorSize = communicator_->size();
+    const int communicatorRank = communicator_->rank();
+    if (operand.recvCounts.size() != static_cast<size_t>(communicatorSize))
+      throw std::runtime_error(
+          "RaxExecutor: receive counts do not match communicator size");
+
+    if (op.collectiveKind == rhal::rax::CollectiveKind_AllGatherV) {
+      if (operand.displacements.size() != static_cast<size_t>(communicatorSize))
+        throw std::runtime_error(
+            "RaxExecutor: displacements do not match communicator size");
+
+      size_t requiredOutputElements = 0;
+      for (size_t i = 0; i < operand.recvCounts.size(); ++i) {
+        if (operand.recvCounts[i] < 0 || operand.displacements[i] < 0)
+          throw std::runtime_error(
+              "RaxExecutor: negative AllGatherV count or displacement");
+        const size_t count = static_cast<size_t>(operand.recvCounts[i]);
+        const size_t displacement =
+            static_cast<size_t>(operand.displacements[i]);
+        if (displacement > std::numeric_limits<size_t>::max() - count)
+          throw std::runtime_error(
+              "RaxExecutor: AllGatherV output extent overflows size_t");
+        requiredOutputElements =
+            std::max(requiredOutputElements, displacement + count);
+      }
+      if (input.elementCount !=
+          static_cast<size_t>(operand.recvCounts[communicatorRank]))
+        throw std::runtime_error(
+            "RaxExecutor: AllGatherV input element count mismatch");
+      if (output.elementCount < requiredOutputElements)
+        throw std::runtime_error(
+            "RaxExecutor: AllGatherV output buffer is too small");
+
+      communicator_->allGatherV(input.data, input.elementCount, output.data,
+                                operand.recvCounts, operand.displacements,
+                                DataType::F32);
+      return;
+    }
+
+    if (op.reductionKind != rhal::rax::ReductionKind_Sum)
+      throw std::runtime_error(
+          "RaxExecutor: ReduceScatter requires Sum reduction");
+    size_t totalInputElements = 0;
+    for (int64_t recvCount : operand.recvCounts) {
+      if (recvCount < 0)
+        throw std::runtime_error(
+            "RaxExecutor: negative ReduceScatter receive count");
+      const size_t count = static_cast<size_t>(recvCount);
+      if (totalInputElements > std::numeric_limits<size_t>::max() - count)
+        throw std::runtime_error(
+            "RaxExecutor: ReduceScatter input extent overflows size_t");
+      totalInputElements += count;
+    }
+    if (input.elementCount != totalInputElements)
+      throw std::runtime_error(
+          "RaxExecutor: ReduceScatter input element count mismatch");
+    if (output.elementCount !=
+        static_cast<size_t>(operand.recvCounts[communicatorRank]))
+      throw std::runtime_error(
+          "RaxExecutor: ReduceScatter output element count mismatch");
+
+    communicator_->reduceScatter(input.data, output.data, operand.recvCounts,
+                                 DataType::F32, ReductionOp::Sum);
+    return;
+  }
+
+  if (op.collectiveKind == rhal::rax::CollectiveKind_Broadcast &&
+      (op.root < 0 || op.root >= communicator_->size()))
+    throw std::runtime_error("RaxExecutor: invalid Broadcast root " +
+                             std::to_string(op.root));
+
+  std::vector<HostBufferView> operands;
+  operands.reserve(op.collectiveOperands.size());
+  for (const auto &operand : op.collectiveOperands) {
+    if (operand.inputBufferId != operand.outputBufferId)
+      throw std::runtime_error(
+          "RaxExecutor: only in-place Collective operands are supported");
+    operands.push_back(resolveHostBuffer(operand.inputBufferId));
+  }
+
+  for (const auto &operand : operands) {
+    if (op.collectiveKind == rhal::rax::CollectiveKind_AllReduce &&
+        (operand.dtype != rhal::rax::DType_F32 ||
+         op.reductionKind != rhal::rax::ReductionKind_Sum))
+      throw std::runtime_error(
+          "RaxExecutor: unsupported Collective datatype or reduction");
+  }
+  if (op.collectiveKind != rhal::rax::CollectiveKind_Broadcast &&
+      op.collectiveKind != rhal::rax::CollectiveKind_AllReduce)
+    throw std::runtime_error("RaxExecutor: unsupported Collective kind");
+
+  for (const auto &operand : operands) {
+    if (op.collectiveKind == rhal::rax::CollectiveKind_Broadcast) {
+      communicator_->broadcast(operand.data, operand.bytes, op.root);
+      continue;
+    }
+    communicator_->allReduce(operand.data, operand.data, operand.elementCount,
+                             DataType::F32, ReductionOp::Sum);
+  }
+}
+
+void RaxExecutor::execute(const std::string &functionName) {
+  const ModelManifest::RaxFunction *function = nullptr;
+  for (const auto &candidate : manifest_.functions) {
+    if (candidate.name == functionName) {
+      function = &candidate;
+      break;
+    }
+  }
+  if (!function)
+    throw std::runtime_error("RaxExecutor: unknown function " + functionName);
+
+  for (const auto &op : function->ops) {
+    if (op.kind == rhal::rax::OpKind_Dispatch) {
+      executeDispatch(op);
+      continue;
+    }
+    if (op.kind == rhal::rax::OpKind_Collective) {
+      executeCollective(op);
+      continue;
+    }
+    if (op.kind == rhal::rax::OpKind_Barrier)
+      continue;
+    throw std::runtime_error("RaxExecutor: unsupported operation kind " +
+                             std::to_string(static_cast<int>(op.kind)));
+  }
+}
+
+} // namespace runtime
+} // namespace buddy

--- a/runtime/include/buddy/runtime/communication/Communicator.h
+++ b/runtime/include/buddy/runtime/communication/Communicator.h
@@ -1,0 +1,44 @@
+//===- Communicator.h - Runtime collective interface -----------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_COMMUNICATION_COMMUNICATOR_H
+#define BUDDY_RUNTIME_COMMUNICATION_COMMUNICATOR_H
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace buddy {
+namespace runtime {
+
+enum class DataType { F32 };
+enum class ReductionOp { Sum };
+
+class Communicator {
+public:
+  virtual ~Communicator() = default;
+
+  virtual int rank() const = 0;
+  virtual int size() const = 0;
+  virtual void broadcast(void *buffer, size_t bytes, int root) = 0;
+  virtual void allReduce(const void *sendBuffer, void *recvBuffer, size_t count,
+                         DataType dataType, ReductionOp reduction) = 0;
+  virtual void allGatherV(const void *sendBuffer, size_t sendCount,
+                          void *recvBuffer,
+                          const std::vector<int64_t> &recvCounts,
+                          const std::vector<int64_t> &displacements,
+                          DataType dataType) = 0;
+  virtual void reduceScatter(const void *sendBuffer, void *recvBuffer,
+                             const std::vector<int64_t> &recvCounts,
+                             DataType dataType, ReductionOp reduction) = 0;
+};
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_COMMUNICATION_COMMUNICATOR_H

--- a/runtime/include/buddy/runtime/communication/MpiCommunicator.h
+++ b/runtime/include/buddy/runtime/communication/MpiCommunicator.h
@@ -1,0 +1,43 @@
+//===- MpiCommunicator.h - MPI collective backend --------------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_COMMUNICATION_MPICOMMUNICATOR_H
+#define BUDDY_RUNTIME_COMMUNICATION_MPICOMMUNICATOR_H
+
+#include "buddy/runtime/communication/Communicator.h"
+
+#include <mpi.h>
+
+namespace buddy {
+namespace runtime {
+
+class MpiCommunicator final : public Communicator {
+public:
+  explicit MpiCommunicator(MPI_Comm communicator);
+
+  int rank() const override;
+  int size() const override;
+  void broadcast(void *buffer, size_t bytes, int root) override;
+  void allReduce(const void *sendBuffer, void *recvBuffer, size_t count,
+                 DataType dataType, ReductionOp reduction) override;
+  void allGatherV(const void *sendBuffer, size_t sendCount, void *recvBuffer,
+                  const std::vector<int64_t> &recvCounts,
+                  const std::vector<int64_t> &displacements,
+                  DataType dataType) override;
+  void reduceScatter(const void *sendBuffer, void *recvBuffer,
+                     const std::vector<int64_t> &recvCounts, DataType dataType,
+                     ReductionOp reduction) override;
+
+private:
+  MPI_Comm communicator_;
+};
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_COMMUNICATION_MPICOMMUNICATOR_H

--- a/runtime/include/buddy/runtime/core/ModelManifest.h
+++ b/runtime/include/buddy/runtime/core/ModelManifest.h
@@ -77,6 +77,50 @@ inline std::filesystem::path buddyRaxPayloadBaseDir() {
 } // namespace detail
 
 struct ModelManifest {
+  struct RaxBuffer {
+    uint32_t id = 0;
+    std::string name;
+    rhal::rax::DType dtype = rhal::rax::DType_Invalid;
+    std::vector<int64_t> shape;
+    std::vector<int64_t> strides;
+    rhal::rax::Layout layout = rhal::rax::Layout_Any;
+    rhal::rax::MemorySpace memorySpace = rhal::rax::MemorySpace_Any;
+    std::unordered_map<std::string, std::string> attrs;
+  };
+
+  struct RaxDispatchArgument {
+    enum class Kind { Buffer, Constant };
+
+    Kind kind;
+    uint32_t resourceId = 0;
+  };
+
+  struct RaxCollectiveOperand {
+    uint32_t inputBufferId = 0;
+    uint32_t outputBufferId = 0;
+    std::vector<int64_t> recvCounts;
+    std::vector<int64_t> displacements;
+  };
+
+  struct RaxOperation {
+    rhal::rax::OpKind kind = rhal::rax::OpKind_Invalid;
+    uint32_t codeObjectId = 0;
+    std::vector<RaxDispatchArgument> arguments;
+    rhal::rax::CollectiveKind collectiveKind =
+        rhal::rax::CollectiveKind_Invalid;
+    rhal::rax::ReductionKind reductionKind = rhal::rax::ReductionKind_Invalid;
+    int32_t root = -1;
+    std::vector<RaxCollectiveOperand> collectiveOperands;
+  };
+
+  struct RaxFunction {
+    std::string name;
+    std::vector<uint32_t> inputs;
+    std::vector<uint32_t> outputs;
+    std::vector<uint32_t> temps;
+    std::vector<RaxOperation> ops;
+  };
+
   struct ResolvedCodeObject {
     uint32_t id = 0;
     std::string name;
@@ -124,8 +168,10 @@ struct ModelManifest {
   std::unordered_map<std::string, std::string> resolvedModuleAttrs;
   // All manifest resources, including non-CPU backends such as TTNN
   // flatbuffers.
+  std::vector<RaxBuffer> buffers;
   std::vector<ResolvedCodeObject> codeObjects;
   std::vector<ResolvedConstant> constants;
+  std::vector<RaxFunction> functions;
 
   // Load and resolve from a .rax manifest file.
   // Throws std::runtime_error on any parse / missing-field error.
@@ -490,6 +536,32 @@ struct ModelManifest {
       return out;
     };
 
+    // --- Buffers -> owned tensor metadata ---------------------------------
+    if (mod->buffers()) {
+      for (auto buffer : *mod->buffers()) {
+        if (!buffer)
+          continue;
+
+        RaxBuffer rec;
+        rec.id = buffer->id();
+        if (buffer->name())
+          rec.name = buffer->name()->str();
+        rec.memorySpace = buffer->space();
+        rec.attrs = attrsToMap(buffer->attrs());
+        if (const auto *type = buffer->type()) {
+          rec.dtype = type->dtype();
+          rec.layout = type->layout();
+          if (type->shape() && type->shape()->dims())
+            rec.shape.assign(type->shape()->dims()->begin(),
+                             type->shape()->dims()->end());
+          if (type->strides())
+            rec.strides.assign(type->strides()->begin(),
+                               type->strides()->end());
+        }
+        out.buffers.push_back(std::move(rec));
+      }
+    }
+
     // --- Code objects -> generic list + legacy soPath fields ---------------
     if (!mod->code_objects() || mod->code_objects()->size() == 0)
       throw std::runtime_error("ModelManifest: no code_objects in " +
@@ -541,6 +613,104 @@ struct ModelManifest {
 
         if (c->storage() == rhal::rax::ConstantStorage_External)
           out.weightPaths.push_back(rec.path);
+      }
+    }
+
+    // --- Functions -> owned, linear execution metadata --------------------
+    if (mod->functions()) {
+      for (auto function : *mod->functions()) {
+        if (!function || !function->name() || function->name()->size() == 0)
+          throw std::runtime_error("ModelManifest: function has no name");
+
+        RaxFunction functionRecord;
+        functionRecord.name = function->name()->str();
+        if (function->inputs())
+          functionRecord.inputs.assign(function->inputs()->begin(),
+                                       function->inputs()->end());
+        if (function->outputs())
+          functionRecord.outputs.assign(function->outputs()->begin(),
+                                        function->outputs()->end());
+        if (function->temps())
+          functionRecord.temps.assign(function->temps()->begin(),
+                                      function->temps()->end());
+
+        if (function->ops()) {
+          for (auto op : *function->ops()) {
+            if (!op)
+              throw std::runtime_error("ModelManifest: null op in function " +
+                                       functionRecord.name);
+
+            RaxOperation operation;
+            operation.kind = op->kind();
+            if (operation.kind == rhal::rax::OpKind_Dispatch) {
+              const auto *dispatch = op->dispatch();
+              if (!dispatch || dispatch->code_object_id() == 0)
+                throw std::runtime_error(
+                    "ModelManifest: malformed Dispatch in function " +
+                    functionRecord.name);
+              operation.codeObjectId = dispatch->code_object_id();
+
+              if (dispatch->args()) {
+                for (auto arg : *dispatch->args()) {
+                  if (!arg)
+                    throw std::runtime_error(
+                        "ModelManifest: null Dispatch argument in function " +
+                        functionRecord.name);
+
+                  const bool hasBuffer = arg->buffer_id() != 0;
+                  const bool hasConstant = arg->constant_id() != 0;
+                  if (arg->scalar() || hasBuffer == hasConstant)
+                    throw std::runtime_error(
+                        "ModelManifest: unsupported or malformed Dispatch "
+                        "argument in function " +
+                        functionRecord.name);
+
+                  operation.arguments.push_back(
+                      {hasBuffer ? RaxDispatchArgument::Kind::Buffer
+                                 : RaxDispatchArgument::Kind::Constant,
+                       hasBuffer ? arg->buffer_id() : arg->constant_id()});
+                }
+              }
+            } else if (operation.kind == rhal::rax::OpKind_Collective) {
+              const auto *collective = op->collective();
+              if (!collective)
+                throw std::runtime_error(
+                    "ModelManifest: malformed Collective in function " +
+                    functionRecord.name);
+              operation.collectiveKind = collective->kind();
+              operation.reductionKind = collective->reduction();
+              operation.root = collective->root();
+              if (collective->operands()) {
+                for (auto operand : *collective->operands()) {
+                  if (!operand)
+                    throw std::runtime_error(
+                        "ModelManifest: null Collective operand in function " +
+                        functionRecord.name);
+                  RaxCollectiveOperand operandRecord;
+                  operandRecord.inputBufferId = operand->input_buffer_id();
+                  operandRecord.outputBufferId = operand->output_buffer_id();
+                  if (operand->recv_counts())
+                    operandRecord.recvCounts.assign(
+                        operand->recv_counts()->begin(),
+                        operand->recv_counts()->end());
+                  if (operand->displacements())
+                    operandRecord.displacements.assign(
+                        operand->displacements()->begin(),
+                        operand->displacements()->end());
+                  operation.collectiveOperands.push_back(
+                      std::move(operandRecord));
+                }
+              }
+            } else if (operation.kind == rhal::rax::OpKind_Barrier &&
+                       !op->barrier()) {
+              throw std::runtime_error(
+                  "ModelManifest: malformed Barrier in function " +
+                  functionRecord.name);
+            }
+            functionRecord.ops.push_back(std::move(operation));
+          }
+        }
+        out.functions.push_back(std::move(functionRecord));
       }
     }
 

--- a/runtime/include/buddy/runtime/core/RaxExecutionSession.h
+++ b/runtime/include/buddy/runtime/core/RaxExecutionSession.h
@@ -1,0 +1,48 @@
+//===- RaxExecutionSession.h - Own a RAX execution context ------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_CORE_RAXEXECUTIONSESSION_H
+#define BUDDY_RUNTIME_CORE_RAXEXECUTIONSESSION_H
+
+#include "buddy/runtime/core/ModelManifest.h"
+#include "buddy/runtime/core/RaxExecutor.h"
+
+#include <cstdint>
+#include <string>
+
+namespace buddy {
+namespace runtime {
+
+/// Owns the manifest and low-level executor for one RAX artifact.
+///
+/// Resource storage is deliberately left to model-specific sessions. The
+/// generic session only keeps the resolved artifact metadata alive and
+/// forwards bindings and ordered execution to RaxExecutor.
+class RaxExecutionSession {
+public:
+  explicit RaxExecutionSession(const std::string &raxPath);
+  RaxExecutionSession(const std::string &raxPath, Communicator &communicator);
+
+  RaxExecutionSession(const RaxExecutionSession &) = delete;
+  RaxExecutionSession &operator=(const RaxExecutionSession &) = delete;
+
+  void bindBuffer(uint32_t id, void *ptr);
+  void bindConstant(uint32_t id, void *ptr);
+  void execute(const std::string &function);
+
+  const ModelManifest &manifest() const { return manifest_; }
+
+private:
+  ModelManifest manifest_;
+  RaxExecutor executor_;
+};
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_CORE_RAXEXECUTIONSESSION_H

--- a/runtime/include/buddy/runtime/core/RaxExecutor.h
+++ b/runtime/include/buddy/runtime/core/RaxExecutor.h
@@ -1,0 +1,56 @@
+//===- RaxExecutor.h - Execute host RAX functions --------------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BUDDY_RUNTIME_CORE_RAXEXECUTOR_H
+#define BUDDY_RUNTIME_CORE_RAXEXECUTOR_H
+
+#include "buddy/runtime/communication/Communicator.h"
+#include "buddy/runtime/core/ModelManifest.h"
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+namespace buddy {
+namespace runtime {
+
+using RaxHostEntryFn = void (*)(void **args);
+
+class RaxExecutor {
+public:
+  explicit RaxExecutor(const ModelManifest &manifest);
+  RaxExecutor(const ModelManifest &manifest, Communicator &communicator);
+  ~RaxExecutor();
+
+  RaxExecutor(const RaxExecutor &) = delete;
+  RaxExecutor &operator=(const RaxExecutor &) = delete;
+
+  void bindBuffer(uint32_t id, void *data);
+  void bindConstant(uint32_t id, void *abiPtr);
+  void execute(const std::string &functionName);
+
+private:
+  struct HostBufferView;
+
+  RaxHostEntryFn resolveEntry(uint32_t codeObjectId);
+  HostBufferView resolveHostBuffer(uint32_t bufferId) const;
+  void executeDispatch(const ModelManifest::RaxOperation &op);
+  void executeCollective(const ModelManifest::RaxOperation &op);
+
+  const ModelManifest &manifest_;
+  Communicator *communicator_ = nullptr;
+  std::unordered_map<uint32_t, void *> buffers_;
+  std::unordered_map<uint32_t, void *> constants_;
+  std::unordered_map<std::string, void *> libraryHandles_;
+  std::unordered_map<uint32_t, RaxHostEntryFn> entries_;
+};
+
+} // namespace runtime
+} // namespace buddy
+
+#endif // BUDDY_RUNTIME_CORE_RAXEXECUTOR_H

--- a/runtime/include/buddy/runtime/llm/TextGeneration.h
+++ b/runtime/include/buddy/runtime/llm/TextGeneration.h
@@ -113,11 +113,13 @@ void printStats(const GenerationResult &result, bool verbose = false);
 /// Run a single generation pass: tokenize → prefill → decode loop.
 /// Resets session position before prefill (safe for multi-turn reuse).
 /// Weights must already be loaded into the session via loadWeights().
+/// When emitOutput is false, generation still runs but stdout stays silent.
 GenerationResult runGeneration(const std::string &prompt, LLMSession &session,
                                const std::string &vocabPath, int maxNewTokens,
                                const std::vector<long long> &stopTokenIds,
                                buddy::Sampler &sampler, const TextCodec &codec,
-                               bool suppress, bool streamJsonl = false);
+                               bool suppress, bool streamJsonl = false,
+                               bool emitOutput = true);
 
 /// Run a single generation pass and deliver newly decoded text through
 /// @p callback. Unlike the legacy overload above, this does not write to

--- a/runtime/llm/TextGeneration.cpp
+++ b/runtime/llm/TextGeneration.cpp
@@ -160,7 +160,8 @@ GenerationResult runGeneration(const std::string &prompt, LLMSession &session,
                                const std::string &vocabPath, int maxNewTokens,
                                const std::vector<long long> &stopTokenIds,
                                buddy::Sampler &sampler, const TextCodec &codec,
-                               bool suppress, bool streamJsonl) {
+                               bool suppress, bool streamJsonl,
+                               bool emitOutput) {
   GenerationResult result;
 
   const int keepTokenNum = codec.maxTokenLen / 4;
@@ -197,10 +198,10 @@ GenerationResult runGeneration(const std::string &prompt, LLMSession &session,
   recentTokens.push_back(firstToken);
 
   if (isStopToken(firstToken)) {
-    if (streamJsonl) {
+    if (streamJsonl && emitOutput) {
       writeStreamJsonTokenEvent("prefill", 0, firstToken, "", true);
       writeStreamJsonDoneEvent("");
-    } else {
+    } else if (emitOutput) {
       std::cout << std::endl;
     }
     return result;
@@ -209,9 +210,9 @@ GenerationResult runGeneration(const std::string &prompt, LLMSession &session,
   outputTokens.appendTokenIdx(firstToken);
   std::string lastPrinted;
   std::string delta = takeNewText(outputTokens, lastPrinted, codec);
-  if (streamJsonl)
+  if (streamJsonl && emitOutput)
     writeStreamJsonTokenEvent("prefill", 0, firstToken, delta, false);
-  else
+  else if (emitOutput)
     writeStdoutDelta(delta);
 
   // ── Decode loop ─────────────────────────────────────────────────────────
@@ -266,29 +267,29 @@ GenerationResult runGeneration(const std::string &prompt, LLMSession &session,
                          recentTokens.end() - sampler.config().repeatLastN);
 
     if (isStopToken(nextToken)) {
-      if (streamJsonl)
+      if (streamJsonl && emitOutput)
         writeStreamJsonTokenEvent("decode", step, nextToken, "", true);
       break;
     }
 
     outputTokens.appendTokenIdx(nextToken);
     delta = takeNewText(outputTokens, lastPrinted, codec);
-    if (streamJsonl)
+    if (streamJsonl && emitOutput)
       writeStreamJsonTokenEvent("decode", step, nextToken, delta, false);
-    else
+    else if (emitOutput)
       writeStdoutDelta(delta);
     curToken = nextToken;
     if (step == maxSteps)
       result.hitTokenLimit = true;
   }
 
-  if (!streamJsonl)
+  if (!streamJsonl && emitOutput)
     std::cout << std::endl;
 
   result.generatedTokens = decodeCount;
   result.decodeSecs = decodeAccumMs / 1000.0;
   result.text = codec.detokenize(outputTokens);
-  if (streamJsonl)
+  if (streamJsonl && emitOutput)
     writeStreamJsonDoneEvent(result.text);
   return result;
 }

--- a/runtime/rax/rax.fbs
+++ b/runtime/rax/rax.fbs
@@ -149,7 +149,22 @@ enum OpKind : byte {
   // Memory operations
   Memcpy = 2,      // buffer-to-buffer copy
   Fill = 3,        // fill a buffer with a scalar pattern (optional)
-  Barrier = 4      // synchronization point
+  Barrier = 4,     // synchronization point
+
+  Collective = 5
+}
+
+enum CollectiveKind : byte {
+  Invalid = 0,
+  AllReduce = 1,
+  Broadcast = 2,
+  AllGatherV = 3,
+  ReduceScatter = 4
+}
+
+enum ReductionKind : byte {
+  Invalid = 0,
+  Sum = 1
 }
 
 enum MemcpyKind : byte {
@@ -222,6 +237,21 @@ table BarrierOp {
   attrs:[KV];
 }
 
+table CollectiveOperand {
+  input_buffer_id:uint32;
+  output_buffer_id:uint32;
+  recv_counts:[int64];
+  displacements:[int64];
+}
+
+table CollectiveOp {
+  kind:CollectiveKind = Invalid;
+  operands:[CollectiveOperand];
+  reduction:ReductionKind = Invalid;
+  root:int32 = -1;
+  attrs:[KV];
+}
+
 table Op {
   kind:OpKind = Invalid;
 
@@ -233,6 +263,8 @@ table Op {
   // Useful for debugging/profiling.
   name:string;
   attrs:[KV];
+
+  collective:CollectiveOp;
 }
 
 // -----------------------------

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(BUDDY_TEST_DEPENDS
   buddy-container-test
   buddy-audio-container-test
   buddy-text-container-test
+  buddy-rax-executor-test
   rax-inspect
   rax-pack
   mlir-runner

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,8 @@ set(BUDDY_TEST_DEPENDS
   buddy-container-test
   buddy-audio-container-test
   buddy-text-container-test
+  rax-inspect
+  rax-pack
   mlir-runner
   )
 

--- a/tests/Dialect/RHAL/rax-pack.mlir
+++ b/tests/Dialect/RHAL/rax-pack.mlir
@@ -1,0 +1,88 @@
+// RUN: rax-pack %s -o %t.rax
+// RUN: rax-inspect %t.rax | FileCheck %s
+
+rhal.module @stage1a attributes {version = "0.1.0"} {
+  rhal.constant @weights {id = 7 : i32, storage = "external",
+                          type = tensor<4xf32>, uri = "file:weights.bin"}
+
+  rhal.codeobj @stage0 {id = 10 : i32, kind = "host_shared_lib",
+                        backend = "cpu", uri = "file:kernels.so",
+                        entry_symbol = "kernel_a"}
+  rhal.codeobj @stage1 {id = 11 : i32, kind = "host_shared_lib",
+                        backend = "cpu", uri = "file:kernels.so",
+                        entry_symbol = "kernel_b"}
+  rhal.codeobj @stage2 {id = 12 : i32, kind = "host_shared_lib",
+                        backend = "cpu", uri = "file:kernels.so"}
+
+  rhal.buffer @input {space = "host", type = tensor<4xf32>}
+  rhal.buffer @scratch {space = "dram", type = tensor<4xf32>}
+  rhal.buffer @output {space = "host", type = tensor<4xf32>}
+  rhal.buffer @cos {space = "dram", type = tensor<4xf32>}
+  rhal.buffer @sin {space = "dram", type = tensor<4xf32>}
+
+  rhal.func @legacy {inputs = ["input"], outputs = ["output"],
+                     dispatch = "stage0", args = ["input", "output"]}
+
+  rhal.func @pipeline {inputs = ["input"], outputs = ["output"]} body {
+    rhal.dispatch @stage0 [@weights, @input, @scratch]
+    rhal.dispatch @stage1 [@scratch, @weights, @output]
+  }
+
+  rhal.func @ordered {inputs = ["input"], outputs = ["scratch"]} body {
+    rhal.dispatch @stage0 [@input]
+    rhal.dispatch @stage1 [@scratch]
+    rhal.collective [@input, @scratch] {
+      kind = "all_reduce",
+      reduction = "sum"
+    }
+    rhal.dispatch @stage2 [@scratch]
+  }
+
+  rhal.func @broadcast {inputs = ["output", "cos"], outputs = ["sin"]} body {
+    rhal.collective [@output, @cos, @sin] {
+      kind = "broadcast",
+      root = 2 : i32
+    }
+  }
+
+  rhal.func @all_gatherv {inputs = ["input"], outputs = ["scratch"]} body {
+    rhal.collective [@input] {
+      kind = "all_gatherv",
+      output_buffers = [@scratch],
+      recv_counts = array<i64: 2, 3>,
+      displacements = array<i64: 0, 2>
+    }
+  }
+
+  rhal.func @reduce_scatter {inputs = ["output"], outputs = ["cos"]} body {
+    rhal.collective [@output] {
+      kind = "reduce_scatter",
+      output_buffers = [@cos],
+      recv_counts = array<i64: 2, 2>,
+      reduction = "sum"
+    }
+  }
+}
+
+// CHECK: code_objects: 3
+// CHECK-NEXT: [10] @stage0  kind=HostSharedLib  uri=file:kernels.so  entry_symbol=kernel_a
+// CHECK-NEXT: [11] @stage1  kind=HostSharedLib  uri=file:kernels.so  entry_symbol=kernel_b
+// CHECK-NEXT: [12] @stage2  kind=HostSharedLib  uri=file:kernels.so
+// CHECK: functions: 6
+// CHECK-NEXT: @legacy
+// CHECK-NEXT: [0] Dispatch code_object_id=10 args=[buffer:1, buffer:3]
+// CHECK-NEXT: [1] Barrier
+// CHECK-NEXT: @pipeline
+// CHECK-NEXT: [0] Dispatch code_object_id=10 args=[constant:7, buffer:1, buffer:2]
+// CHECK-NEXT: [1] Dispatch code_object_id=11 args=[buffer:2, constant:7, buffer:3]
+// CHECK-NEXT: @ordered
+// CHECK-NEXT: [0] Dispatch code_object_id=10 args=[buffer:1]
+// CHECK-NEXT: [1] Dispatch code_object_id=11 args=[buffer:2]
+// CHECK-NEXT: [2] Collective kind=AllReduce reduction=Sum operands=[1->1, 2->2]
+// CHECK-NEXT: [3] Dispatch code_object_id=12 args=[buffer:2]
+// CHECK-NEXT: @broadcast
+// CHECK-NEXT: [0] Collective kind=Broadcast root=2 operands=[3->3, 4->4, 5->5]
+// CHECK-NEXT: @all_gatherv
+// CHECK-NEXT: [0] Collective kind=AllGatherV operands=[1->2 recv_counts=[2,3] displacements=[0,2]]
+// CHECK-NEXT: @reduce_scatter
+// CHECK-NEXT: [0] Collective kind=ReduceScatter reduction=Sum operands=[3->4 recv_counts=[2,2]]

--- a/tests/Interface/core/CMakeLists.txt
+++ b/tests/Interface/core/CMakeLists.txt
@@ -41,3 +41,17 @@ _add_test_executable(buddy-audio-container-test
 _add_test_executable(buddy-text-container-test
   TextContainerTest.cpp
 )
+
+add_library(buddy-rax-executor-test-kernels SHARED
+  Inputs/RaxExecutorTestKernels.cpp
+)
+
+_add_test_executable(buddy-rax-executor-test
+  RaxExecutorTest.cpp
+  LINK_LIBS
+    buddy_runtime_execution
+)
+target_compile_definitions(buddy-rax-executor-test PRIVATE
+  RAX_EXECUTOR_TEST_LIBRARY="$<TARGET_FILE:buddy-rax-executor-test-kernels>"
+)
+add_dependencies(buddy-rax-executor-test buddy-rax-executor-test-kernels)

--- a/tests/Interface/core/Inputs/RaxExecutorTestKernels.cpp
+++ b/tests/Interface/core/Inputs/RaxExecutorTestKernels.cpp
@@ -1,0 +1,112 @@
+#include <cstdio>
+
+extern "C" void kernel_a(void **args) {
+  auto *value = static_cast<int *>(args[0]);
+  auto *increment = static_cast<int *>(args[1]);
+  *value += *increment;
+}
+
+extern "C" void kernel_b(void **args) {
+  auto *factor = static_cast<int *>(args[0]);
+  auto *value = static_cast<int *>(args[1]);
+  *value *= *factor;
+}
+
+extern "C" void collective_producer(void **args) {
+  auto *data = static_cast<float *>(args[0]);
+  data[0] = 1.0f;
+  data[1] = 2.0f;
+  data[2] = 3.0f;
+  data[3] = 4.0f;
+}
+
+extern "C" void collective_consumer(void **args) {
+  auto *data = static_cast<float *>(args[0]);
+  data[0] += data[3];
+}
+
+extern "C" void deepseek_session_kernel(void **args) {
+  auto *parameters = static_cast<int *>(args[0]);
+  auto *input = static_cast<int *>(args[1]);
+  auto *kvCache = static_cast<int *>(args[2]);
+  auto *output = static_cast<int *>(args[3]);
+  *output = *parameters + *input + *kvCache;
+}
+
+extern "C" void stage5d_rank0_prefill(void **args) {
+  *static_cast<float *>(args[1]) = 1.0f;
+  *static_cast<float *>(args[2]) = 10.0f;
+  auto *logits = static_cast<float *>(args[3]);
+  for (int i = 0; i < 2048; ++i)
+    logits[i] = 0.0f;
+  logits[5 * 2] = 10.0f;
+}
+
+extern "C" void stage5d_rank1_prefill(void **args) {
+  *static_cast<float *>(args[1]) = 2.0f;
+  *static_cast<float *>(args[2]) = 20.0f;
+  auto *logits = static_cast<float *>(args[3]);
+  for (int i = 0; i < 2048; ++i)
+    logits[i] = 0.0f;
+  logits[5 * 2] = 10.0f;
+}
+
+extern "C" void stage5d_rank0_decode(void **args) {
+  const auto token = *static_cast<long long *>(args[0]);
+  const auto position = *static_cast<long long *>(args[1]);
+  const auto key = *static_cast<float *>(args[2]);
+  *static_cast<long long *>(args[4]) = position;
+  *static_cast<float *>(args[5]) = key;
+  *static_cast<float *>(args[6]) = *static_cast<float *>(args[3]);
+  static_cast<float *>(args[7])[1] = 1.0f;
+  if (key == 1.0f)
+    std::puts("Stage 5D.1 rank0 prefill/decode passed");
+  if (key == 1.0f && token == 0 && position == 6)
+    std::puts("Stage 5D.2 rank0 generation passed");
+}
+
+extern "C" void stage5d_rank1_decode(void **args) {
+  const auto token = *static_cast<long long *>(args[0]);
+  const auto position = *static_cast<long long *>(args[1]);
+  const auto key = *static_cast<float *>(args[2]);
+  *static_cast<long long *>(args[4]) = position;
+  *static_cast<float *>(args[5]) = key;
+  *static_cast<float *>(args[6]) = *static_cast<float *>(args[3]);
+  static_cast<float *>(args[7])[1] = 1.0f;
+  if (key == 2.0f)
+    std::puts("Stage 5D.1 rank1 prefill/decode passed");
+  if (key == 2.0f && token == 0 && position == 6)
+    std::puts("Stage 5D.2 rank1 generation passed");
+}
+
+extern "C" void stage5d2_generation_prefill(void **args) {
+  auto *tokens = static_cast<long long *>(args[0]);
+  auto *key = static_cast<int *>(args[1]);
+  auto *value = static_cast<int *>(args[2]);
+  auto *logits = static_cast<float *>(args[3]);
+  *key = static_cast<int>(tokens[0]);
+  *value = static_cast<int>(tokens[1]);
+  for (int i = 0; i < 40; ++i)
+    logits[i] = 0.0f;
+  logits[5 * 4 + 2] = 10.0f;
+}
+
+extern "C" void stage5d2_generation_decode(void **args) {
+  const auto token = *static_cast<long long *>(args[0]);
+  const auto position = *static_cast<long long *>(args[1]);
+  const auto key = *static_cast<int *>(args[2]);
+  const auto value = *static_cast<int *>(args[3]);
+  auto *positionOut = static_cast<long long *>(args[4]);
+  auto *keyOut = static_cast<int *>(args[5]);
+  auto *valueOut = static_cast<int *>(args[6]);
+  auto *logits = static_cast<float *>(args[7]);
+  *positionOut = position;
+  *keyOut = key + static_cast<int>(token);
+  *valueOut = value;
+  for (int i = 0; i < 4; ++i)
+    logits[i] = 0.0f;
+  if (position == 6 && token == 2 && key == 151646)
+    logits[1] = 10.0f;
+  else if (position == 7 && token == 1 && key == 151648)
+    logits[3] = 10.0f;
+}

--- a/tests/Interface/core/RaxExecutorTest.cpp
+++ b/tests/Interface/core/RaxExecutorTest.cpp
@@ -1,0 +1,100 @@
+// RUN: buddy-rax-executor-test %t.rax
+
+#include "buddy/runtime/core/RaxExecutor.h"
+#include "buddy/runtime/core/ModelManifest.h"
+#include "buddy/runtime/rax/RAX.h"
+
+#include "flatbuffers/flatbuffers.h"
+
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace rhal::rax;
+
+static void writeTestRax(const std::string &path) {
+  flatbuffers::FlatBufferBuilder builder;
+  const std::string uri = "file:" RAX_EXECUTOR_TEST_LIBRARY;
+
+  auto codeObjectA = CreateCodeObject(
+      builder, 10, builder.CreateString("stage_a"),
+      CodeObjectKind_HostSharedLib, 0, builder.CreateString(uri),
+      builder.CreateString("kernel_a"), builder.CreateString("cpu"), 0);
+  auto codeObjectB = CreateCodeObject(
+      builder, 11, builder.CreateString("stage_b"),
+      CodeObjectKind_HostSharedLib, 0, builder.CreateString(uri),
+      builder.CreateString("kernel_b"), builder.CreateString("cpu"), 0);
+
+  std::vector<flatbuffers::Offset<Arg>> firstArgs = {
+      CreateArg(builder, 1, 0, 0, 0), CreateArg(builder, 0, 7, 0, 0)};
+  auto firstDispatch =
+      CreateDispatchOp(builder, 10, builder.CreateVector(firstArgs), 0, 0);
+  std::vector<flatbuffers::Offset<Arg>> secondArgs = {
+      CreateArg(builder, 0, 8, 0, 0), CreateArg(builder, 1, 0, 0, 0)};
+  auto secondDispatch =
+      CreateDispatchOp(builder, 11, builder.CreateVector(secondArgs), 0, 0);
+
+  std::vector<flatbuffers::Offset<Op>> ops = {
+      CreateOp(builder, OpKind_Dispatch, firstDispatch, 0, 0, 0, 0, 0),
+      CreateOp(builder, OpKind_Barrier, 0, 0, 0, CreateBarrierOp(builder, 0), 0,
+               0),
+      CreateOp(builder, OpKind_Dispatch, secondDispatch, 0, 0, 0, 0, 0)};
+  std::vector<uint32_t> inputs = {1};
+  std::vector<uint32_t> outputs = {1};
+  std::vector<uint32_t> temps = {2};
+  auto function = CreateFunction(
+      builder, builder.CreateString("pipeline"), builder.CreateVector(inputs),
+      builder.CreateVector(outputs), builder.CreateVector(temps),
+      builder.CreateVector(ops), 0);
+
+  std::vector<flatbuffers::Offset<CodeObject>> codeObjects = {codeObjectA,
+                                                              codeObjectB};
+  std::vector<flatbuffers::Offset<Function>> functions = {function};
+  auto module = CreateModule(builder, builder.CreateString("RAX"),
+                             CreateVersion(builder, 0, 1, 0), Endianness_Little,
+                             0, 0, 0, 0, builder.CreateVector(codeObjects),
+                             builder.CreateVector(functions));
+  builder.Finish(module, "RAX0");
+
+  std::ofstream output(path, std::ios::binary);
+  output.write(reinterpret_cast<const char *>(builder.GetBufferPointer()),
+               builder.GetSize());
+  if (!output)
+    throw std::runtime_error("failed to write test RAX file");
+}
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::cerr << "usage: buddy-rax-executor-test <output.rax>\n";
+    return 1;
+  }
+
+  try {
+    writeTestRax(argv[1]);
+    auto manifest = buddy::runtime::ModelManifest::loadFromRax(argv[1]);
+    if (manifest.functions.size() != 1 ||
+        manifest.functions[0].inputs != std::vector<uint32_t>{1} ||
+        manifest.functions[0].outputs != std::vector<uint32_t>{1} ||
+        manifest.functions[0].temps != std::vector<uint32_t>{2} ||
+        manifest.functions[0].ops.size() != 3)
+      throw std::runtime_error("function metadata was not preserved");
+
+    int value = 3;
+    int increment = 2;
+    int factor = 4;
+    buddy::runtime::RaxExecutor executor(manifest);
+    executor.bindBuffer(1, &value);
+    executor.bindConstant(7, &increment);
+    executor.bindConstant(8, &factor);
+    executor.execute("pipeline");
+    if (value != 20)
+      throw std::runtime_error("dispatches did not execute in RAX order");
+  } catch (const std::exception &error) {
+    std::cerr << error.what() << '\n';
+    return 1;
+  }
+  return 0;
+}

--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -87,6 +87,8 @@ tools = [
     "buddy-container-test",
     "buddy-audio-container-test",
     "buddy-text-container-test",
+    "rax-inspect",
+    "rax-pack",
     "mlir-runner",
 ]
 

--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -87,6 +87,7 @@ tools = [
     "buddy-container-test",
     "buddy-audio-container-test",
     "buddy-text-container-test",
+    "buddy-rax-executor-test",
     "rax-inspect",
     "rax-pack",
     "mlir-runner",

--- a/tools/buddy-cli/buddy-cli.cpp
+++ b/tools/buddy-cli/buddy-cli.cpp
@@ -490,7 +490,16 @@ int main(int argc, char **argv) {
                    "--model contains {rank}, but PMI_RANK is not set.\n";
       return 2;
     }
-    const std::string rank(rankEnv);
+    errno = 0;
+    char *rankEnd = nullptr;
+    const long parsedRank = std::strtol(rankEnv, &rankEnd, 10);
+    if (errno == ERANGE || rankEnd == rankEnv || *rankEnd != '\0' ||
+        parsedRank < 0) {
+      std::cerr << "\033[31;1m[Error]\033[0m "
+                   "PMI_RANK must be a non-negative integer.\n";
+      return 2;
+    }
+    const std::string rank = std::to_string(parsedRank);
     do {
       raxPath.replace(rankPosition, rankPlaceholder.size(), rank);
       rankPosition = raxPath.find(rankPlaceholder, rankPosition + rank.size());

--- a/tools/buddy-cli/buddy-cli.cpp
+++ b/tools/buddy-cli/buddy-cli.cpp
@@ -36,6 +36,7 @@
 #endif
 
 #include <cerrno>
+#include <cstdlib>
 #include <cstring>
 #include <dlfcn.h>
 #include <filesystem>
@@ -271,6 +272,7 @@ static void usage(const char *prog) {
       << "\n"
       << "Model source (one required):\n"
       << "  --model      <path.rax>  Model manifest (recommended)\n"
+      << "                           {rank} resolves from PMI_RANK\n"
       << "  --model-so   <path.so>   Model shared library  (legacy mode)\n"
       << "  --weights    <path>      Weights file           (legacy mode)\n"
       << "  --vocab      <path>      Vocabulary file        (legacy mode)\n"
@@ -478,6 +480,23 @@ int main(int argc, char **argv) {
     return 2;
   }
 
+  const std::string rankPlaceholder = "{rank}";
+  size_t rankPosition = raxPath.find(rankPlaceholder);
+  const bool rankLocalModel = rankPosition != std::string::npos;
+  if (rankLocalModel) {
+    const char *rankEnv = std::getenv("PMI_RANK");
+    if (!rankEnv || rankEnv[0] == '\0') {
+      std::cerr << "\033[31;1m[Error]\033[0m "
+                   "--model contains {rank}, but PMI_RANK is not set.\n";
+      return 2;
+    }
+    const std::string rank(rankEnv);
+    do {
+      raxPath.replace(rankPosition, rankPlaceholder.size(), rank);
+      rankPosition = raxPath.find(rankPlaceholder, rankPosition + rank.size());
+    } while (rankPosition != std::string::npos);
+  }
+
   std::vector<std::string> prompts;
   if (!promptFile.empty()) {
     std::ifstream input(promptFile);
@@ -501,7 +520,7 @@ int main(int argc, char **argv) {
 
   // Speech and vision-language runs are driven by media inputs.
   if (prompt.empty() && prompts.empty() && audioPath.empty() &&
-      imagePath.empty() && !interactive) {
+      imagePath.empty() && !interactive && !rankLocalModel) {
     std::cout << "Prompt: ";
     std::getline(std::cin, prompt);
     std::cout << "\n";

--- a/tools/buddy-codegen/build_model.py
+++ b/tools/buddy-codegen/build_model.py
@@ -92,8 +92,9 @@ def main() -> int:
         type=Path,
         default=None,
         help="Local HuggingFace-format model directory for PyTorch import. "
-        "For deepseek_r1, this sets BUDDY_DSR1_LOCAL_MODEL and may provide "
-        "config.json. For qwen3_vl and bge_m3, this is required and sets "
+        "For deepseek_r1, this sets the selected TP1/TP2 package's local-model "
+        "cache variable and may provide config.json. For qwen3_vl and bge_m3, "
+        "this is required and sets "
         "BUDDY_QWEN3_VL_MODEL_PATH / BUDDY_BGE_M3_MODEL_PATH.",
     )
     ap.add_argument(
@@ -111,6 +112,12 @@ def main() -> int:
         "--target",
         default=None,
         help="Semicolon-separated CMake targets (default: inferred from spec model_family)",
+    )
+    ap.add_argument(
+        "--tensor-parallel-size",
+        type=int,
+        default=1,
+        help="Tensor-parallel world size (DeepSeek: 1 or validated size 2; default: 1)",
     )
     ap.add_argument(
         "--jobs",
@@ -198,6 +205,21 @@ def main() -> int:
         )
         return 1
 
+    if args.tensor_parallel_size not in {1, 2}:
+        print(
+            "error: --tensor-parallel-size currently supports only 1 or 2; "
+            f"got {args.tensor_parallel_size}",
+            file=sys.stderr,
+        )
+        return 1
+    if args.tensor_parallel_size == 2 and model_family != "deepseek_r1":
+        print(
+            "error: --tensor-parallel-size 2 is currently validated only "
+            "for model_family=deepseek_r1",
+            file=sys.stderr,
+        )
+        return 1
+
     build_dir = resolve_from_cwd(args.build_dir)
 
     rvv_toolchain: Path | None = None
@@ -270,22 +292,33 @@ def main() -> int:
         "-DBUDDY_MLIR_ENABLE_PYTHON_PACKAGES=ON",
     ]
     if model_family == "deepseek_r1":
-        cmake_args.extend(
-            [
-                f"-DBUDDY_DSR1_SPEC={spec}",
-                "-DBUDDY_BUILD_DEEPSEEK_R1_MODEL=ON",
-            ]
-        )
+        if args.tensor_parallel_size == 2:
+            cmake_args.extend(
+                [
+                    f"-DBUDDY_DSR1_TP2_SPEC={spec}",
+                    "-DBUDDY_BUILD_DEEPSEEK_R1_TP2_MODEL=ON",
+                    "-DBUDDY_RUNTIME_ENABLE_MPI=ON",
+                ]
+            )
+            model_prefix = "BUDDY_DSR1_TP2"
+        else:
+            cmake_args.extend(
+                [
+                    f"-DBUDDY_DSR1_SPEC={spec}",
+                    "-DBUDDY_BUILD_DEEPSEEK_R1_MODEL=ON",
+                ]
+            )
+            model_prefix = "BUDDY_DSR1"
         if local_model is not None:
-            cmake_args.append(f"-DBUDDY_DSR1_LOCAL_MODEL={local_model}")
+            cmake_args.append(f"-D{model_prefix}_LOCAL_MODEL={local_model}")
 
         if args.hf_config is not None:
             hf = resolve_from_cwd(args.hf_config)
-            cmake_args.append(f"-DBUDDY_DSR1_HF_CONFIG={hf}")
+            cmake_args.append(f"-D{model_prefix}_HF_CONFIG={hf}")
         elif local_model is not None:
             auto_cfg = local_model / "config.json"
             if auto_cfg.is_file():
-                cmake_args.append(f"-DBUDDY_DSR1_HF_CONFIG={auto_cfg}")
+                cmake_args.append(f"-D{model_prefix}_HF_CONFIG={auto_cfg}")
     elif model_family == "whisper":
         cmake_args.extend(
             [
@@ -393,7 +426,12 @@ def main() -> int:
         if rc != 0:
             return rc
 
-    target = args.target or f"{model_family}_rax"
+    if args.target:
+        target = args.target
+    elif model_family == "deepseek_r1" and args.tensor_parallel_size == 2:
+        target = "deepseek_r1_tp2_rax"
+    else:
+        target = f"{model_family}_rax"
     build_cmd = ["cmake", "--build", str(build_dir), "--target"]
     build_cmd.extend(target.split(";"))
     if args.jobs > 0:

--- a/tools/buddy-codegen/compile_pipeline.py
+++ b/tools/buddy-codegen/compile_pipeline.py
@@ -80,6 +80,7 @@ def build_stages(
     variant: str = "f32",
     tiered: bool = False,
     decode_pack: dict | None = None,
+    tp_wrapper_out_params: bool = False,
 ):
     """
     Build the list of (tool_name, [args]) stages for a given pipeline type.
@@ -98,10 +99,20 @@ def build_stages(
         llc_base_args.append("-code-model=large")
 
     if pipeline_type == "forward":
+        out_param_opts = []
+        if tp_wrapper_out_params:
+            out_param_opts = [
+                "-buffer-results-to-out-params=hoist-static-allocs",
+                (
+                    "-buffer-results-to-out-params="
+                    "hoist-static-allocs modify-public-functions"
+                ),
+            ]
         stages.append(
             (
                 "buddy-opt",
-                [
+                out_param_opts
+                + [
                     "-expand-strided-metadata",
                     "-canonicalize",
                     "-cse",
@@ -144,6 +155,17 @@ def build_stages(
     opts.extend(
         [
             "-one-shot-bufferize=bufferize-function-boundaries",
+            *(
+                [
+                    "-buffer-results-to-out-params=hoist-static-allocs",
+                    (
+                        "-buffer-results-to-out-params="
+                        "hoist-static-allocs modify-public-functions"
+                    ),
+                ]
+                if tp_wrapper_out_params
+                else []
+            ),
             "-expand-strided-metadata",
             "-ownership-based-buffer-deallocation",
             "-canonicalize",
@@ -402,6 +424,7 @@ def _compile_one(task: dict) -> str:
         task.get("variant", "f32"),
         task.get("tiered", False),
         task.get("decode_pack"),
+        task.get("tp_wrapper_out_params", False),
     )
     run_pipeline(
         stages,
@@ -609,6 +632,139 @@ def partitioned_compile_entries(
     ]
 
 
+def tp_runtime_compile_entries(
+    mlir_dir: str, runtime_plan_paths: list[str]
+) -> list[tuple[str, str, str, str, bool]]:
+    """Resolve the exact rank-local wrapper/subgraph sources in runtime plans."""
+    mlir_dir = os.path.abspath(mlir_dir)
+    plans = []
+    for path in runtime_plan_paths:
+        with open(path) as file:
+            plan = json.load(file)
+        rank = plan.get("rank")
+        graph = plan.get("graph")
+        if type(rank) is not int or rank < 0:
+            raise ValueError(f"{path}: invalid runtime-plan rank {rank!r}")
+        if not isinstance(graph, str) or not re.fullmatch(
+            r"[A-Za-z_][A-Za-z0-9_]*", graph
+        ):
+            raise ValueError(f"{path}: invalid runtime-plan graph {graph!r}")
+        plans.append((path, rank, graph, plan))
+
+    ranks = sorted({rank for _, rank, _, _ in plans})
+    if not ranks:
+        raise ValueError("TP wrapper compilation requires runtime plans")
+    canonical_rank = ranks[0]
+    canonical_plans = [item for item in plans if item[1] == canonical_rank]
+    other_plans = {(rank, graph): plan for _, rank, graph, plan in plans}
+
+    def dispatch_symbols(plan):
+        return {
+            (operation.get("wrapper"), operation.get("function"))
+            for operation in plan.get("operations", [])
+            if isinstance(operation, dict)
+            and operation.get("kind") == "dispatch"
+        }
+
+    for _, _, graph, canonical_plan in canonical_plans:
+        canonical_symbols = dispatch_symbols(canonical_plan)
+        for rank in ranks[1:]:
+            other_plan = other_plans.get((rank, graph))
+            if (
+                other_plan is None
+                or dispatch_symbols(other_plan) != canonical_symbols
+            ):
+                raise ValueError(
+                    f"rank-local dispatch set differs for {graph}; "
+                    "pass one rank's runtime plans per rank-specific library"
+                )
+
+    sources = {}
+    wrappers = {}
+    for path, _, graph, plan in canonical_plans:
+        operations = plan.get("operations")
+        if not isinstance(operations, list):
+            raise ValueError(f"{path}: 'operations' must be an array")
+        phase_dir = os.path.join(mlir_dir, f"rank{canonical_rank}", graph)
+        for operation in operations:
+            if operation.get("kind") != "dispatch":
+                continue
+            wrapper = operation.get("wrapper")
+            function = operation.get("function")
+            for label, symbol in (("wrapper", wrapper), ("function", function)):
+                if not isinstance(symbol, str) or not re.fullmatch(
+                    r"[A-Za-z_][A-Za-z0-9_]*", symbol
+                ):
+                    raise ValueError(
+                        f"{path}: dispatch has invalid {label} symbol {symbol!r}"
+                    )
+            previous = wrappers.setdefault(wrapper, function)
+            if previous != function:
+                raise ValueError(
+                    f"{path}: wrapper {wrapper!r} references inconsistent functions"
+                )
+            sources[(graph, wrapper, True)] = os.path.join(
+                phase_dir, f"{wrapper}.mlir"
+            )
+            sources[(graph, function, False)] = os.path.join(
+                phase_dir, f"{function}.mlir"
+            )
+
+    for key, canonical_source in sources.items():
+        graph, symbol, _ = key
+        if not os.path.isfile(canonical_source):
+            raise FileNotFoundError(
+                f"Missing TP runtime MLIR source: {canonical_source}"
+            )
+        with open(canonical_source, "rb") as file:
+            canonical_contents = file.read()
+        for rank in ranks[1:]:
+            if (rank, graph) not in other_plans:
+                raise ValueError(
+                    f"rank {rank} has no {graph!r} runtime plan; "
+                    "pass one rank only to build a rank-specific library"
+                )
+            other_source = os.path.join(
+                mlir_dir, f"rank{rank}", graph, f"{symbol}.mlir"
+            )
+            try:
+                with open(other_source, "rb") as file:
+                    other_contents = file.read()
+            except OSError as error:
+                raise FileNotFoundError(
+                    f"Missing TP runtime MLIR source: {other_source}"
+                ) from error
+            if other_contents != canonical_contents:
+                raise ValueError(
+                    f"rank-local source differs for {graph}/{symbol}; "
+                    "pass one rank's runtime plans per rank-specific library"
+                )
+
+    entries = []
+    for (graph, symbol, is_wrapper), source in sorted(sources.items()):
+        if is_wrapper:
+            pipeline = "forward"
+            kind = "wrapper"
+        else:
+            pipeline = "subgraph_decode" if "decode" in graph else "subgraph"
+            kind = "subgraph"
+        # An external declaration in a separately compiled wrapper is not
+        # rewritten by buffer-results-to-out-params. Keep reusable subgraph
+        # definitions on the returned-descriptor ABI that declaration uses.
+        entries.append(
+            (
+                f"{graph}_{kind}_{symbol}",
+                source,
+                f"tp_{graph}_{kind}_{symbol}.o",
+                pipeline,
+                is_wrapper,
+            )
+        )
+    if not entries:
+        raise RuntimeError("Runtime plans contain no TP dispatch sources")
+    return entries
+
+
 def compile_partitioned(
     config: dict,
     mlir_dir: str,
@@ -619,14 +775,21 @@ def compile_partitioned(
     jobs: int = 1,
     prefill_only: bool = False,
     full_mlir_dir: str | None = None,
-) -> None:
+    runtime_plan_paths: list[str] | None = None,
+) -> list[str]:
     """Compile all per-layer MLIR files from a layer_partitioned directory."""
-    entries = partitioned_compile_entries(
-        mlir_dir,
-        prefill_only=prefill_only,
-        full_mlir_dir=full_mlir_dir,
-        tiered=is_tiered_kv_cache(config),
-    )
+    if runtime_plan_paths:
+        entries = tp_runtime_compile_entries(mlir_dir, runtime_plan_paths)
+    else:
+        entries = [
+            (*entry, False)
+            for entry in partitioned_compile_entries(
+                mlir_dir,
+                prefill_only=prefill_only,
+                full_mlir_dir=full_mlir_dir,
+                tiered=is_tiered_kv_cache(config),
+            )
+        ]
     if not entries:
         raise RuntimeError(f"No partitioned MLIR files found in {mlir_dir}")
 
@@ -636,7 +799,7 @@ def compile_partitioned(
     os.makedirs(output_dir, exist_ok=True)
 
     tasks = []
-    for key, mlir_name, obj_name, pipeline_type in entries:
+    for key, mlir_name, obj_name, pipeline_type, tp_out_params in entries:
         tasks.append(
             {
                 "name": key,
@@ -652,6 +815,7 @@ def compile_partitioned(
                 "output": os.path.join(output_dir, obj_name),
                 "buddy_opt": buddy_opt,
                 "llvm_dir": llvm_dir,
+                "tp_wrapper_out_params": tp_out_params,
             }
         )
 
@@ -673,6 +837,7 @@ def compile_partitioned(
 
     elapsed = time.perf_counter() - started
     print(f"[compile] All done in {elapsed:.2f}s.", file=sys.stderr)
+    return [task["output"] for task in tasks]
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -733,6 +898,14 @@ def link_shared_lib(
 
     print(f"[link] {os.path.basename(output_so)}", file=sys.stderr)
     subprocess.check_call(cmd)
+
+
+def compile_cpp(source: str, output: str, cxx: str = "c++") -> None:
+    """Compile the generated RAX shim translation unit."""
+    print(f"[compile] {os.path.basename(source)}", file=sys.stderr)
+    subprocess.check_call(
+        [cxx, "-std=c++17", "-fPIC", "-c", source, "-o", output]
+    )
 
 
 def partitioned_runtime_objects(
@@ -824,6 +997,27 @@ def main():
         help="Pipeline type (single-file mode)",
     )
     parser.add_argument(
+        "--tp-wrapper-out-params",
+        action="store_true",
+        help=(
+            "Convert public TP wrapper memref results to caller-provided "
+            "output arguments (single-file forward mode)"
+        ),
+    )
+    parser.add_argument(
+        "--runtime-plan",
+        action="append",
+        default=[],
+        help=(
+            "Stage 4 runtime-plan JSON used to select and compile exact TP "
+            "wrappers (repeatable)"
+        ),
+    )
+    parser.add_argument(
+        "--rax-shims",
+        help="Generated RaxShims.cpp to compile into a TP kernel library",
+    )
+    parser.add_argument(
         "--mlir-dir", help="Directory with MLIR files (compile-all)"
     )
     parser.add_argument(
@@ -880,6 +1074,21 @@ def main():
 
     args = parser.parse_args()
 
+    if args.tp_wrapper_out_params and (
+        args.compile_all
+        or args.compile_partitioned
+        or args.pipeline != "forward"
+    ):
+        parser.error(
+            "--tp-wrapper-out-params requires single-file --pipeline forward"
+        )
+    if args.runtime_plan and not args.compile_partitioned:
+        parser.error("--runtime-plan requires --compile-partitioned")
+    if args.rax_shims and not args.runtime_plan:
+        parser.error("--rax-shims requires --runtime-plan")
+    if args.runtime_plan and args.link and not args.rax_shims:
+        parser.error("linked TP runtime-plan compilation requires --rax-shims")
+
     with open(args.config) as f:
         config = json.load(f)
 
@@ -919,7 +1128,7 @@ def main():
                 "--compile-partitioned requires --mlir-dir and --output-dir"
             )
 
-        compile_partitioned(
+        compiled_objects = compile_partitioned(
             config=config,
             mlir_dir=args.mlir_dir,
             output_dir=args.output_dir,
@@ -929,17 +1138,27 @@ def main():
             jobs=args.jobs,
             prefill_only=args.partitioned_prefill_only,
             full_mlir_dir=args.full_mlir_dir,
+            runtime_plan_paths=args.runtime_plan,
         )
         if args.link:
             output_so = args.output_so or os.path.join(
                 args.output_dir, config["compilation"]["so_name"]
             )
-            link_shared_lib(
-                obj_files=partitioned_runtime_objects(
+            obj_files = (
+                compiled_objects
+                if args.runtime_plan
+                else partitioned_runtime_objects(
                     args.output_dir,
                     config,
                     prefill_only=args.partitioned_prefill_only,
-                ),
+                )
+            )
+            if args.rax_shims:
+                shim_object = os.path.join(args.output_dir, "RaxShims.o")
+                compile_cpp(args.rax_shims, shim_object, args.cxx)
+                obj_files.append(shim_object)
+            link_shared_lib(
+                obj_files=obj_files,
                 output_so=output_so,
                 cxx=args.cxx,
                 llvm_lib_dir=args.llvm_lib_dir,
@@ -958,6 +1177,7 @@ def main():
             variant,
             is_tiered_kv_cache(config),
             config.get("decode_pack"),
+            args.tp_wrapper_out_params,
         )
 
         print(

--- a/tools/buddy-codegen/gen_manifest.py
+++ b/tools/buddy-codegen/gen_manifest.py
@@ -231,6 +231,325 @@ def gen_manifest(
     return out.getvalue()
 
 
+_RUNTIME_DTYPE_TO_MLIR = {
+    "int8": "i8",
+    "int32": "i32",
+    "int64": "i64",
+    "float16": "f16",
+    "bfloat16": "bf16",
+    "float32": "f32",
+    "float64": "f64",
+    "bool": "i1",
+    "complex64": "complex<f32>",
+    "complex128": "complex<f64>",
+}
+
+
+def _runtime_tensor_type(resource: str, metadata: dict) -> str:
+    dtype = metadata["dtype"]
+    try:
+        element_type = _RUNTIME_DTYPE_TO_MLIR[dtype]
+    except KeyError:
+        raise ValueError(
+            f"unsupported dtype {dtype!r} for resource {resource!r}"
+        ) from None
+    dimensions = "x".join(str(dimension) for dimension in metadata["shape"])
+    if dimensions:
+        dimensions += "x"
+    return f"tensor<{dimensions}{element_type}>"
+
+
+def gen_parallel_manifest(
+    config: dict,
+    runtime_plans: dict[str, dict],
+    dep_shared_libs: list[str] | None = None,
+    runner_library: str | None = None,
+    kernel_library: str | None = None,
+) -> str:
+    """Generate one rank-local body-form RHAL manifest from Stage 4A plans."""
+    if not runtime_plans:
+        raise ValueError("at least one runtime plan is required")
+
+    plans = list(runtime_plans.items())
+    rank = plans[0][1]["rank"]
+    world_size = plans[0][1]["world_size"]
+    for function_name, plan in plans[1:]:
+        if plan["rank"] != rank:
+            raise ValueError(
+                f"runtime plan {function_name!r} has rank {plan['rank']}; "
+                f"expected {rank}"
+            )
+        if plan["world_size"] != world_size:
+            raise ValueError(
+                f"runtime plan {function_name!r} has world_size "
+                f"{plan['world_size']}; expected {world_size}"
+            )
+
+    parameter_packs = {}
+    parameter_metadata = {}
+    for function_name, plan in plans:
+        resources = plan["resources"]
+        for pack in plan["parameter_packs"]:
+            resource = pack["resource"]
+            if resource not in resources:
+                raise ValueError(
+                    f"parameter pack {resource!r} in {function_name!r} has "
+                    "no resource metadata"
+                )
+            metadata = resources[resource]
+            if metadata["role"] != "parameter":
+                raise ValueError(
+                    f"parameter pack {resource!r} in {function_name!r} "
+                    "does not reference a parameter resource"
+                )
+            signature = (pack["dtype"], pack["numel"])
+            resource_signature = (metadata["dtype"], tuple(metadata["shape"]))
+            if resource in parameter_packs:
+                if parameter_packs[resource] != signature:
+                    raise ValueError(
+                        f"parameter pack {resource!r} has inconsistent "
+                        "dtype/size metadata"
+                    )
+                if parameter_metadata[resource] != resource_signature:
+                    raise ValueError(
+                        f"parameter resource {resource!r} has inconsistent "
+                        "dtype/size metadata"
+                    )
+                continue
+            if signature != (metadata["dtype"], metadata["shape"][0]):
+                raise ValueError(
+                    f"parameter pack {resource!r} metadata does not match "
+                    "its resource"
+                )
+            parameter_packs[resource] = signature
+            parameter_metadata[resource] = resource_signature
+
+    wrappers = []
+    seen_wrappers = set()
+    for function_name, plan in plans:
+        for operation in plan["operations"]:
+            if operation["kind"] == "dispatch":
+                wrapper = operation["wrapper"]
+                if wrapper not in seen_wrappers:
+                    seen_wrappers.add(wrapper)
+                    wrappers.append(wrapper)
+            elif operation["kind"] != "collective":
+                raise ValueError(
+                    f"unsupported operation kind {operation['kind']!r} "
+                    f"in {function_name!r}"
+                )
+
+    model_id = config["model_id"]
+    model_family = config["model_family"]
+    vocab_file = config["tokens"]["vocab_file"]
+    runner_uri = _normalize_dep_uri(
+        runner_library or f"{model_family}_runner.so"
+    )
+    kernel_uri = _normalize_dep_uri(
+        kernel_library or config["compilation"]["so_name"]
+    )
+    dep_uris = [_normalize_dep_uri(item) for item in dep_shared_libs or []]
+
+    def buffer_symbol(function_name: str, resource: str) -> str:
+        return f"{function_name}__{resource}"
+
+    def operand_symbol(function_name: str, plan: dict, resource: str) -> str:
+        metadata = plan["resources"].get(resource)
+        if metadata is None:
+            raise ValueError(
+                f"operation in {function_name!r} references unknown "
+                f"resource {resource!r}"
+            )
+        if metadata["role"] == "parameter":
+            if resource not in parameter_packs:
+                raise ValueError(
+                    f"parameter resource {resource!r} in {function_name!r} "
+                    "has no parameter-pack metadata"
+                )
+            return resource
+        return buffer_symbol(function_name, resource)
+
+    def quoted_resources(function_name: str, plan: dict, resources) -> str:
+        return ", ".join(
+            f'"{operand_symbol(function_name, plan, resource)}"'
+            for resource in resources
+        )
+
+    def at_resources(function_name: str, plan: dict, resources) -> str:
+        return ", ".join(
+            f"@{operand_symbol(function_name, plan, resource)}"
+            for resource in resources
+        )
+
+    out = StringIO()
+
+    def p(*args, **kwargs):
+        print(*args, file=out, **kwargs)
+
+    p(f"rhal.module @{model_family}_rank{rank} attributes {{")
+    p('    version = "0.1.0",')
+    p(f'    model_name = "{model_id}",')
+    p(f'    vocab_uri = "file:{vocab_file}",')
+    p(f'    runner_library = "{runner_uri}"}} {{')
+    p()
+
+    for constant_id, resource in enumerate(parameter_packs, start=1):
+        metadata = None
+        for _, plan in plans:
+            if resource in plan["resources"]:
+                metadata = plan["resources"][resource]
+                break
+        tensor_type = _runtime_tensor_type(resource, metadata)
+        p(
+            f"  rhal.constant @{resource} {{id = {constant_id} : i32, "
+            'storage = "external",'
+        )
+        p(f"                         type = {tensor_type},")
+        p(f'                         uri = "file:{resource}.data"}}')
+    if parameter_packs:
+        p()
+
+    code_object_symbols = {}
+    for code_object_id, wrapper in enumerate(wrappers, start=1):
+        symbol = f"scheduled_codeobj__{wrapper}"
+        code_object_symbols[wrapper] = symbol
+        p(
+            f"  rhal.codeobj @{symbol} {{id = {code_object_id} : i32, "
+            'kind = "host_shared_lib",'
+        )
+        p('                                backend = "cpu",')
+        p(f'                                uri = "{kernel_uri}",')
+        p(f'                                entry_symbol = "rax_{wrapper}"}}')
+    for dependency_index, dep_uri in enumerate(dep_uris, start=1):
+        code_object_id = len(wrappers) + dependency_index
+        symbol = f"scheduled_runtime_dep_{dependency_index}"
+        p(
+            f"  rhal.codeobj @{symbol} {{id = {code_object_id} : i32, "
+            'kind = "host_shared_lib",'
+        )
+        p('                                backend = "cpu",')
+        p(f'                                uri = "{dep_uri}"}}')
+    if wrappers or dep_uris:
+        p()
+
+    for function_name, plan in plans:
+        for resource, metadata in plan["resources"].items():
+            if metadata["role"] == "parameter":
+                continue
+            symbol = buffer_symbol(function_name, resource)
+            tensor_type = _runtime_tensor_type(resource, metadata)
+            p(
+                f'  rhal.buffer @{symbol} {{space = "host", '
+                f"type = {tensor_type}}}"
+            )
+    p()
+
+    for function_index, (function_name, plan) in enumerate(plans):
+        inputs = quoted_resources(function_name, plan, plan["runtime_inputs"])
+        outputs = quoted_resources(function_name, plan, plan["runtime_outputs"])
+        p(
+            f"  rhal.func @{function_name} {{inputs = [{inputs}], "
+            f"outputs = [{outputs}]}} body {{"
+        )
+        for operation in plan["operations"]:
+            if operation["kind"] == "dispatch":
+                arguments = at_resources(
+                    function_name, plan, operation["arguments"]
+                )
+                code_object = code_object_symbols[operation["wrapper"]]
+                p(f"    rhal.dispatch @{code_object} [{arguments}]")
+                continue
+
+            collective = operation["collective"]
+            input_symbol = at_resources(
+                function_name, plan, (operation["input"],)
+            )
+            output_symbol = at_resources(
+                function_name, plan, (operation["output"],)
+            )
+            if collective == "all_reduce":
+                if operation["input"] != operation["output"]:
+                    raise ValueError(
+                        f"all_reduce in {function_name!r} must be in-place"
+                    )
+                if operation.get("reduction") != "sum":
+                    raise ValueError(
+                        f"all_reduce in {function_name!r} requires sum "
+                        "reduction"
+                    )
+                p(f"    rhal.collective [{input_symbol}] {{")
+                p('      kind = "all_reduce",')
+                p('      reduction = "sum"')
+            elif collective == "all_gatherv":
+                if operation["input"] == operation["output"]:
+                    raise ValueError(
+                        f"all_gatherv in {function_name!r} must be out-of-place"
+                    )
+                counts = ", ".join(
+                    str(item) for item in operation["recv_counts"]
+                )
+                displacements = ", ".join(
+                    str(item) for item in operation["displacements"]
+                )
+                p(f"    rhal.collective [{input_symbol}] {{")
+                p('      kind = "all_gatherv",')
+                p(f"      output_buffers = [{output_symbol}],")
+                p(f"      recv_counts = array<i64: {counts}>,")
+                p(f"      displacements = array<i64: {displacements}>")
+            elif collective == "reduce_scatter":
+                if operation["input"] == operation["output"]:
+                    raise ValueError(
+                        f"reduce_scatter in {function_name!r} must be "
+                        "out-of-place"
+                    )
+                if operation.get("reduction") != "sum":
+                    raise ValueError(
+                        f"reduce_scatter in {function_name!r} requires sum "
+                        "reduction"
+                    )
+                counts = ", ".join(
+                    str(item) for item in operation["recv_counts"]
+                )
+                p(f"    rhal.collective [{input_symbol}] {{")
+                p('      kind = "reduce_scatter",')
+                p(f"      output_buffers = [{output_symbol}],")
+                p(f"      recv_counts = array<i64: {counts}>,")
+                p('      reduction = "sum"')
+            else:
+                raise ValueError(
+                    f"unsupported collective {collective!r} in "
+                    f"{function_name!r}"
+                )
+            p("    }")
+        p("  }")
+        if function_index + 1 != len(plans):
+            p()
+
+    p("}")
+    return out.getvalue()
+
+
+def _load_runtime_plans(items: list[str]) -> dict[str, dict]:
+    runtime_plans = {}
+    for item in items:
+        if "=" not in item:
+            raise ValueError(
+                f"malformed --runtime-plan {item!r}; expected FUNCTION=PATH"
+            )
+        function_name, path = item.split("=", 1)
+        if not function_name or not path:
+            raise ValueError(
+                f"malformed --runtime-plan {item!r}; expected FUNCTION=PATH"
+            )
+        if function_name in runtime_plans:
+            raise ValueError(
+                f"duplicate --runtime-plan function {function_name!r}"
+            )
+        with open(path) as file:
+            runtime_plans[function_name] = json.load(file)
+    return runtime_plans
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Generate RHAL .mlir manifest from a full model config."
@@ -292,21 +611,47 @@ def main():
             "Audio transcription plugin URI/name to place into module attrs."
         ),
     )
+    parser.add_argument(
+        "--runtime-plan",
+        action="append",
+        default=[],
+        metavar="FUNCTION=PATH",
+        help=(
+            "Stage 4A rank-local runtime plan JSON for a body-form function "
+            "(repeatable)"
+        ),
+    )
+    parser.add_argument(
+        "--kernel-library",
+        default=None,
+        metavar="URI_OR_NAME",
+        help="Shared library used by scheduled dispatch code objects",
+    )
     args = parser.parse_args()
 
     with open(args.config) as f:
         config = json.load(f)
 
     try:
-        mlir_text = gen_manifest(
-            config,
-            dep_shared_libs=args.dep_shared_lib,
-            runner_library=args.runner_library,
-            serving_library=args.serving_library,
-            embedding_library=args.embedding_library,
-            masked_lm_library=args.masked_lm_library,
-            transcription_library=args.transcription_library,
-        )
+        if args.runtime_plan:
+            runtime_plans = _load_runtime_plans(args.runtime_plan)
+            mlir_text = gen_parallel_manifest(
+                config,
+                runtime_plans,
+                dep_shared_libs=args.dep_shared_lib,
+                runner_library=args.runner_library,
+                kernel_library=args.kernel_library,
+            )
+        else:
+            mlir_text = gen_manifest(
+                config,
+                dep_shared_libs=args.dep_shared_lib,
+                runner_library=args.runner_library,
+                serving_library=args.serving_library,
+                embedding_library=args.embedding_library,
+                masked_lm_library=args.masked_lm_library,
+                transcription_library=args.transcription_library,
+            )
     except (ValueError, RuntimeError, OSError) as e:
         print(f"error: {e}", file=sys.stderr)
         return 1

--- a/tools/buddy-codegen/gen_rax_shims.py
+++ b/tools/buddy-codegen/gen_rax_shims.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+# ===- gen_rax_shims.py - Generate RAX-to-MLIR ABI shims -----------------===//
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===----------------------------------------------------------------------===//
+
+"""Generate raw-payload RAX entry points for scheduled TP wrappers."""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_SYMBOL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_DTYPES = {
+    "bool": ("i1", "bool", "I1"),
+    "f32": ("f32", "float", "F32"),
+    "float32": ("f32", "float", "F32"),
+    "i64": ("i64", "int64_t", "I64"),
+    "int64": ("i64", "int64_t", "I64"),
+}
+
+
+@dataclass(frozen=True)
+class MemRef:
+    dtype: str
+    shape: tuple[int, ...]
+
+
+def _fail(path: Path, message: str) -> ValueError:
+    return ValueError(f"{path}: {message}")
+
+
+def load_wrapper_abis(paths: list[Path]) -> dict[str, tuple[MemRef, ...]]:
+    """Load and validate wrapper ABIs from Stage 4 runtime plans."""
+    if not paths:
+        raise ValueError("at least one runtime plan is required")
+
+    wrappers: dict[str, tuple[MemRef, ...]] = {}
+    for path in paths:
+        try:
+            plan = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as error:
+            raise _fail(path, f"cannot load runtime plan: {error}") from error
+
+        if not isinstance(plan, dict):
+            raise _fail(path, "runtime plan must be a JSON object")
+        resources = plan.get("resources")
+        operations = plan.get("operations")
+        if not isinstance(resources, dict):
+            raise _fail(path, "'resources' must be an object")
+        if not isinstance(operations, list):
+            raise _fail(path, "'operations' must be an array")
+
+        for operation_index, operation in enumerate(operations):
+            where = f"operation {operation_index}"
+            if not isinstance(operation, dict):
+                raise _fail(path, f"{where} must be an object")
+            if operation.get("kind") != "dispatch":
+                continue
+
+            wrapper = operation.get("wrapper")
+            if not isinstance(wrapper, str) or not _SYMBOL_RE.fullmatch(
+                wrapper
+            ):
+                raise _fail(
+                    path, f"{where} has invalid wrapper symbol {wrapper!r}"
+                )
+
+            arguments = operation.get("arguments")
+            if not isinstance(arguments, list):
+                raise _fail(path, f"dispatch {wrapper!r} has no argument array")
+            argument_groups = []
+            for field in ("parameter_packs", "inputs", "outputs"):
+                group = operation.get(field)
+                if not isinstance(group, list):
+                    raise _fail(
+                        path,
+                        f"dispatch {wrapper!r} field {field!r} must be an array",
+                    )
+                argument_groups.extend(group)
+            expected_arguments = argument_groups
+            if arguments != expected_arguments:
+                raise _fail(
+                    path,
+                    f"dispatch {wrapper!r} arguments do not equal "
+                    "parameter_packs + inputs + outputs",
+                )
+
+            signature = []
+            for argument_index, resource in enumerate(arguments):
+                if not isinstance(resource, str) or resource not in resources:
+                    raise _fail(
+                        path,
+                        f"dispatch {wrapper!r} argument {argument_index} "
+                        f"references unknown resource {resource!r}",
+                    )
+                metadata = resources[resource]
+                if not isinstance(metadata, dict):
+                    raise _fail(
+                        path, f"resource {resource!r} must be an object"
+                    )
+                dtype = metadata.get("dtype")
+                if dtype not in _DTYPES:
+                    raise _fail(
+                        path,
+                        f"resource {resource!r} has unsupported dtype {dtype!r}; "
+                        "the TP shim path supports f32 plus the i64/i1 control "
+                        "tensors present in Stage 4 plans",
+                    )
+                shape = metadata.get("shape")
+                if (
+                    not isinstance(shape, list)
+                    or not shape
+                    or any(
+                        type(dimension) is not int or dimension <= 0
+                        for dimension in shape
+                    )
+                ):
+                    raise _fail(
+                        path,
+                        f"resource {resource!r} must have a non-empty static shape",
+                    )
+                signature.append(MemRef(_DTYPES[dtype][0], tuple(shape)))
+
+            signature_tuple = tuple(signature)
+            previous = wrappers.setdefault(wrapper, signature_tuple)
+            if previous != signature_tuple:
+                raise _fail(
+                    path,
+                    f"wrapper {wrapper!r} has inconsistent ABI across runtime plans",
+                )
+
+    if not wrappers:
+        raise ValueError("runtime plans contain no dispatch wrappers")
+    return wrappers
+
+
+def required_symbols(wrappers: dict[str, tuple[MemRef, ...]]) -> list[str]:
+    return [f"rax_{wrapper}" for wrapper in sorted(wrappers)]
+
+
+def _strides(shape: tuple[int, ...]) -> tuple[int, ...]:
+    strides = []
+    running = 1
+    for dimension in reversed(shape):
+        strides.append(running)
+        running *= dimension
+    return tuple(reversed(strides))
+
+
+def generate_cpp(wrappers: dict[str, tuple[MemRef, ...]]) -> str:
+    out = [
+        "// Generated by tools/buddy-codegen/gen_rax_shims.py. Do not edit.",
+        "#include <cstdint>",
+        "",
+        "template <typename T, int Rank> struct MemRefDescriptor {",
+        "  T *allocated;",
+        "  T *aligned;",
+        "  int64_t offset;",
+        "  int64_t sizes[Rank];",
+        "  int64_t strides[Rank];",
+        "};",
+        "",
+    ]
+    descriptor_types = sorted(
+        {
+            (memref.dtype, len(memref.shape))
+            for abi in wrappers.values()
+            for memref in abi
+        }
+    )
+    dtype_info = {value[0]: value[1:] for value in _DTYPES.values()}
+    for dtype, rank in descriptor_types:
+        c_type, suffix = dtype_info[dtype]
+        out.append(
+            f"using MemRef{rank}D{suffix} = MemRefDescriptor<{c_type}, {rank}>;"
+        )
+    out.append("")
+
+    for wrapper in sorted(wrappers):
+        abi = wrappers[wrapper]
+        parameters = ", ".join(
+            f"MemRef{len(memref.shape)}D{dtype_info[memref.dtype][1]} *arg{index}"
+            for index, memref in enumerate(abi)
+        )
+        out.append(f'extern "C" void _mlir_ciface_{wrapper}({parameters});')
+    out.append("")
+
+    for wrapper in sorted(wrappers):
+        abi = wrappers[wrapper]
+        out.append(f'extern "C" void rax_{wrapper}(void **args) {{')
+        for index, memref in enumerate(abi):
+            rank = len(memref.shape)
+            c_type, suffix = dtype_info[memref.dtype]
+            sizes = ", ".join(str(dimension) for dimension in memref.shape)
+            strides = ", ".join(
+                str(stride) for stride in _strides(memref.shape)
+            )
+            out.extend(
+                [
+                    f"  auto *data{index} = static_cast<{c_type} *>(args[{index}]);",
+                    f"  MemRef{rank}D{suffix} arg{index} = "
+                    f"{{data{index}, data{index}, 0, {{{sizes}}}, {{{strides}}}}};",
+                ]
+            )
+        arguments = ", ".join(f"&arg{index}" for index in range(len(abi)))
+        out.append(f"  _mlir_ciface_{wrapper}({arguments});")
+        out.append("}")
+        out.append("")
+    return "\n".join(out)
+
+
+def exported_symbols(library: Path, nm: str = "nm") -> set[str]:
+    try:
+        result = subprocess.run(
+            [nm, "-D", "--defined-only", str(library)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise ValueError(
+            f"failed to inspect {library} with {nm}: {error}"
+        ) from error
+    return {
+        line.split()[-1] for line in result.stdout.splitlines() if line.split()
+    }
+
+
+def validate_library(
+    wrappers: dict[str, tuple[MemRef, ...]], library: Path, nm: str = "nm"
+) -> None:
+    required = set(required_symbols(wrappers))
+    missing = sorted(required - exported_symbols(library, nm))
+    if missing:
+        raise ValueError(
+            f"{library}: missing {len(missing)} required RAX symbols: "
+            + ", ".join(missing)
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate RAX-to-MLIR shims from Stage 4 runtime plans"
+    )
+    parser.add_argument(
+        "--runtime-plan",
+        action="append",
+        required=True,
+        type=Path,
+        help="Stage 4 rank runtime-plan JSON (repeatable)",
+    )
+    parser.add_argument(
+        "-o", "--output", type=Path, help="Generated RaxShims.cpp"
+    )
+    parser.add_argument(
+        "--validate-library",
+        type=Path,
+        help="Check that the shared library exports every required rax_* symbol",
+    )
+    parser.add_argument(
+        "--nm", default="nm", help="nm executable for validation"
+    )
+    args = parser.parse_args()
+    if args.output is None and args.validate_library is None:
+        parser.error(
+            "at least one of --output or --validate-library is required"
+        )
+
+    try:
+        wrappers = load_wrapper_abis(args.runtime_plan)
+        if args.output is not None:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(generate_cpp(wrappers))
+            print(
+                f"[gen_rax_shims] Written: {args.output} "
+                f"({len(wrappers)} wrappers)",
+                file=sys.stderr,
+            )
+        if args.validate_library is not None:
+            validate_library(wrappers, args.validate_library, args.nm)
+            print(
+                f"[gen_rax_shims] Validated {len(wrappers)} RAX symbols in "
+                f"{args.validate_library} (missing=0)",
+                file=sys.stderr,
+            )
+    except ValueError as error:
+        parser.error(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/buddy-codegen/import_model.py
+++ b/tools/buddy-codegen/import_model.py
@@ -71,8 +71,11 @@ try:
     from buddy.compiler.frontend import DynamoCompiler
     from buddy.compiler.graph import (
         GraphDriver,
+        ParallelTemplatePartitionedGraphDriver,
         PartitionedGraphDriver,
         TemplatePartitionedGraphDriver,
+        TransformerParallelConfig,
+        build_transformer_parallel_plan,
         build_transformer_partition_plan,
     )
     from buddy.compiler.graph.operation import *
@@ -697,9 +700,258 @@ def export_layer_partitioned_mlir(
     return manifest
 
 
+def _lower_parallel_driver_artifacts(driver, phase_dir: str) -> None:
+    """Write one rank/phase's reusable segments and concrete wrappers."""
+    subgraphs = driver.build_parallel_template_subgraphs()
+    for subgraph in subgraphs:
+        subgraph.lower_to_top_level_ir()
+
+    os.makedirs(phase_dir, exist_ok=True)
+    for template in driver._parallel_plan.templates:
+        for segment in template.segments:
+            key = (template.template_id, segment.segment_index)
+            subgraph = driver._subgraphs[key]
+            name = f"{driver.parallel_template_symbol(*key)}.mlir"
+            with open(os.path.join(phase_dir, name), "w") as f:
+                print(subgraph._imported_module, file=f)
+
+    driver.construct_parallel_segment_wrappers()
+    pack_sizes = {}
+    for layout in driver._rank_parameter_layout.values():
+        dtype = layout["dtype"]
+        pack_sizes[dtype] = max(
+            pack_sizes.get(dtype, 0), layout["offset"] + layout["numel"]
+        )
+    for key, wrapper in driver._parallel_segment_wrappers.items():
+        bindings = driver._wrapper_parameter_bindings[key]
+        offsets = {
+            name: driver._rank_parameter_layout[parameter_index]["offset"]
+            for name, parameter_index in bindings.items()
+        }
+        wrapper_pack_sizes = {
+            layout["dtype"]: pack_sizes[layout["dtype"]]
+            for parameter_index in bindings.values()
+            for layout in (driver._rank_parameter_layout[parameter_index],)
+        }
+        wrapper.lower_to_top_level_ir(
+            do_param_pack=True,
+            param_pack_sizes=wrapper_pack_sizes,
+            param_pack_offsets=offsets,
+        )
+        with open(
+            os.path.join(phase_dir, f"{wrapper._func_name}.mlir"), "w"
+        ) as f:
+            print(wrapper._imported_module, file=f)
+
+
+def _write_runtime_plan(path: str, runtime_plan: dict) -> None:
+    with open(path, "w") as f:
+        json.dump(runtime_plan, f, indent=2)
+        f.write("\n")
+
+
+def _parallel_plan_provenance(
+    graph, partition_plan, parallel_plan, output_remap
+):
+    """Serialize the real frontend instance/template coverage for validation."""
+    excluded = set(graph.inputs) | set(graph.params)
+    eligible = {
+        op
+        for op in graph.body
+        if op not in excluded
+        and not isinstance(op, (TensorConstantOp, OutputOp))
+    }
+    covered = [
+        op
+        for region in partition_plan.partition_sequence
+        for op in region.nodes
+    ]
+    if len(covered) != len(set(covered)) or set(covered) != eligible:
+        raise ValueError("parallel artifact provenance has incomplete coverage")
+
+    suffix = graph._func_name.removeprefix("forward_")
+    separator = "" if suffix in ("prefill", "decode") else "_"
+    templates = {item.template_id: item for item in parallel_plan.templates}
+    template_records = []
+    for template in parallel_plan.templates:
+        base = f"subgraph0_{suffix}{separator}{template.template_id}"
+        template_records.append(
+            {
+                "template_id": template.template_id,
+                "segment_indices": [
+                    segment.segment_index for segment in template.segments
+                ],
+                "reusable_subgraphs": [
+                    f"{base}_seg{segment.segment_index}.mlir"
+                    for segment in template.segments
+                ],
+            }
+        )
+
+    instances = []
+    for instance_index, binding in enumerate(partition_plan.instance_bindings):
+        is_layer = hasattr(binding.region, "layer_index")
+        region_index = (
+            binding.region.layer_index if is_layer else instance_index
+        )
+        instances.append(
+            {
+                "instance_index": instance_index,
+                "region_type": type(binding.region).__name__,
+                "region_kind": binding.region.kind.name.lower(),
+                "region_label": "layer" if is_layer else "region",
+                "region_index": region_index,
+                "template_id": binding.template_id,
+                "segment_indices": [
+                    segment.segment_index
+                    for segment in templates[binding.template_id].segments
+                ],
+                "node_count": len(binding.region.nodes),
+            }
+        )
+
+    layer_count = sum(item["region_label"] == "layer" for item in instances)
+    return {
+        "graph": graph._func_name,
+        "eligible_node_count": len(eligible),
+        "covered_node_count": len(covered),
+        "region_instance_count": len(instances),
+        "layer_region_count": layer_count,
+        "non_layer_region_count": len(instances) - layer_count,
+        "template_ids": [item.template_id for item in parallel_plan.templates],
+        "templates": template_records,
+        "instances": instances,
+        "output_remap": output_remap,
+        "rank_schedules": {},
+    }
+
+
+def _export_parallel_template_runtime_artifacts(
+    graph_plans: list[tuple[object, object, list[int] | None]],
+    params: list,
+    output_dir: str,
+    partition_dir: str,
+    world_size: int,
+) -> dict:
+    """Materialize and serialize the existing TP plan for every rank."""
+    if not graph_plans:
+        raise ValueError("parallel template export requires at least one graph")
+    if params is None:
+        raise ValueError("parallel template export requires model parameters")
+
+    runtime_dir = os.path.join(partition_dir, "runtime")
+    os.makedirs(runtime_dir, exist_ok=True)
+    for filename in os.listdir(runtime_dir):
+        if re.fullmatch(r"rank\d+_forward_[A-Za-z0-9_]+\.json", filename):
+            os.remove(os.path.join(runtime_dir, filename))
+
+    parallel_config = TransformerParallelConfig(tp_size=world_size)
+    parallel_plans = [
+        build_transformer_parallel_plan(graph, partition_plan, parallel_config)
+        for graph, partition_plan, _ in graph_plans
+    ]
+    plan_artifacts = {
+        graph._func_name: _parallel_plan_provenance(
+            graph, partition_plan, parallel_plan, output_remap
+        )
+        for (graph, partition_plan, output_remap), parallel_plan in zip(
+            graph_plans, parallel_plans, strict=True
+        )
+    }
+    rank_artifacts = []
+    for rank in range(world_size):
+        rank_dir = os.path.join(partition_dir, f"rank{rank}")
+        os.makedirs(rank_dir, exist_ok=True)
+        for root, _, filenames in os.walk(rank_dir):
+            for filename in filenames:
+                if filename.endswith(".mlir"):
+                    os.remove(os.path.join(root, filename))
+
+        drivers = []
+        for (graph, partition_plan, _), parallel_plan in zip(
+            graph_plans, parallel_plans, strict=True
+        ):
+            driver = ParallelTemplatePartitionedGraphDriver(
+                graph, partition_plan, parallel_plan, rank=rank
+            )
+            phase_dir = os.path.join(rank_dir, graph._func_name)
+            _lower_parallel_driver_artifacts(driver, phase_dir)
+            drivers.append(driver)
+
+        expected_layout = drivers[0]._rank_parameter_layout
+        for driver in drivers[1:]:
+            if driver._rank_parameter_layout != expected_layout:
+                raise ValueError(
+                    f"rank {rank} Prefill/Decode parameter-pack metadata is "
+                    "inconsistent"
+                )
+
+        for filename in os.listdir(output_dir):
+            if re.fullmatch(
+                rf"rank{rank}_params_[A-Za-z0-9_]+\.data", filename
+            ):
+                os.remove(os.path.join(output_dir, filename))
+        drivers[0].build_rank_parameter_pack(params, output_dir)
+
+        function_artifacts = {"rank": rank}
+        expected_packs = None
+        for (graph, _, output_remap), driver in zip(
+            graph_plans, drivers, strict=True
+        ):
+            runtime_plan = driver.build_parallel_runtime_plan(
+                output_remap=output_remap
+            )
+            plan_artifacts[graph._func_name]["rank_schedules"][str(rank)] = {
+                "operations": [
+                    {
+                        "kind": operation["kind"],
+                        **(
+                            {"wrapper": operation["wrapper"]}
+                            if operation["kind"] == "dispatch"
+                            else {"collective": operation["collective"]}
+                        ),
+                    }
+                    for operation in runtime_plan["operations"]
+                ],
+                "runtime_outputs": list(runtime_plan["runtime_outputs"]),
+            }
+            packs = runtime_plan["parameter_packs"]
+            if expected_packs is None:
+                expected_packs = packs
+            elif packs != expected_packs:
+                raise ValueError(
+                    f"rank {rank} Prefill/Decode parameter-pack metadata is "
+                    "inconsistent"
+                )
+            filename = f"rank{rank}_{graph._func_name}.json"
+            _write_runtime_plan(
+                os.path.join(runtime_dir, filename), runtime_plan
+            )
+            function_artifacts[graph._func_name] = f"runtime/{filename}"
+            print(
+                f"[import] Written: layer_partitioned/runtime/{filename}",
+                file=sys.stderr,
+            )
+        function_artifacts["parameter_packs"] = [
+            f"../{pack['resource']}.data" for pack in expected_packs or ()
+        ]
+        function_artifacts["materialized_mlir"] = f"rank{rank}"
+        rank_artifacts.append(function_artifacts)
+
+    return {
+        "world_size": world_size,
+        "plans": plan_artifacts,
+        "ranks": rank_artifacts,
+    }
+
+
 def export_template_partitioned_mlir(
-    graph_prefill, graph_decode, output_dir: str
-) -> dict[str, int | bool]:
+    graph_prefill,
+    graph_decode,
+    output_dir: str,
+    params: list | None = None,
+    tensor_parallel_size: int = 1,
+) -> dict:
     """Export unique prefill/decode templates and complete static wrappers."""
     prefill_plan = build_transformer_partition_plan(graph_prefill)
     prefill_driver = TemplatePartitionedGraphDriver(graph_prefill, prefill_plan)
@@ -775,6 +1027,21 @@ def export_template_partitioned_mlir(
         "debug_wrappers": False,
         "template_materialization": True,
     }
+    if tensor_parallel_size > 1:
+        manifest["runtime"] = _export_parallel_template_runtime_artifacts(
+            [
+                (
+                    graph_prefill,
+                    prefill_plan,
+                    _prefill_output_remap(graph_prefill),
+                ),
+                (graph_decode, decode_plan, None),
+            ],
+            params,
+            output_dir,
+            partition_dir,
+            tensor_parallel_size,
+        )
     with open(os.path.join(partition_dir, "partition_manifest.json"), "w") as f:
         json.dump(manifest, f, indent=2)
         f.write("\n")
@@ -1216,15 +1483,36 @@ def import_model(
     direct_plain_weight_export: bool = True,
     reuse_existing_weights: bool = False,
     skip_weights: bool = False,
+    tensor_parallel_size: int = 1,
 ):
     """Full import pipeline: load → compile → transform → export."""
     if export_layer_partitioned and export_template_partitioned:
         raise ValueError(
             "layer and template partitioned exports are mutually exclusive"
         )
+    if tensor_parallel_size < 1:
+        raise ValueError("tensor parallel size must be positive")
+    if tensor_parallel_size > 1 and not export_template_partitioned:
+        raise ValueError(
+            "tensor parallel export requires --experimental-template-partitioned"
+        )
     os.makedirs(output_dir, exist_ok=True)
     variant = config["variant"]
     is_quantized = variant.startswith("w")
+    if tensor_parallel_size > 1 and is_tiered_kv_cache(config):
+        raise ValueError(
+            "tensor parallel runtime artifacts do not support tiered KV cache"
+        )
+    if tensor_parallel_size > 1 and is_quantized:
+        raise ValueError(
+            "tensor parallel runtime artifacts currently require plain weights"
+        )
+    if tensor_parallel_size > 1 and config.get("decode_pack", {}).get(
+        "enabled"
+    ):
+        raise ValueError(
+            "tensor parallel runtime artifacts do not support decode_pack"
+        )
 
     # 1. Load model
     with timed_import_step("load_model"):
@@ -1339,7 +1627,11 @@ def import_model(
     if export_template_partitioned:
         with timed_import_step("export_template_partitioned_mlir"):
             export_template_partitioned_mlir(
-                graphs_prefill[0], graphs_decode[0], output_dir
+                graphs_prefill[0],
+                graphs_decode[0],
+                output_dir,
+                params=original_params,
+                tensor_parallel_size=tensor_parallel_size,
             )
 
     # 7. Export whole-graph MLIR when requested. Partitioned runtime builds
@@ -1443,6 +1735,16 @@ def main():
         ),
     )
     parser.add_argument(
+        "--tensor-parallel-size",
+        type=int,
+        default=1,
+        help=(
+            "Experimental template tensor-parallel world size. The current "
+            "frontend planner supports 2; runtime plans are generated "
+            "automatically."
+        ),
+    )
+    parser.add_argument(
         "--layer-partition-debug-wrappers",
         action="store_true",
         help=(
@@ -1488,6 +1790,11 @@ def main():
 
     try:
         if config.get("model_family") == "qwen3_vl":
+            if args.tensor_parallel_size > 1:
+                raise ValueError(
+                    "tensor parallel runtime artifacts are limited to the "
+                    "DeepSeek template path"
+                )
             import_qwen3_vl_model(
                 config,
                 args.output_dir,
@@ -1510,8 +1817,9 @@ def main():
                 direct_plain_weight_export=not args.no_direct_plain_weight_export,
                 reuse_existing_weights=args.reuse_existing_weights,
                 skip_weights=args.skip_weights,
+                tensor_parallel_size=args.tensor_parallel_size,
             )
-    except RuntimeError as e:
+    except (RuntimeError, ValueError) as e:
         print(f"error: {e}", file=sys.stderr)
         return 1
 

--- a/tools/rax-inspect/rax-inspect.cpp
+++ b/tools/rax-inspect/rax-inspect.cpp
@@ -226,7 +226,10 @@ int main(int argc, char **argv) {
       std::cout << "  [" << co->id() << "] @"
                 << (co->name() ? co->name()->c_str() : "?")
                 << "  kind=" << rhal::rax::EnumNameCodeObjectKind(co->kind())
-                << "  uri=" << (co->uri() ? co->uri()->c_str() : "") << "\n";
+                << "  uri=" << (co->uri() ? co->uri()->c_str() : "");
+      if (co->entry_symbol() && co->entry_symbol()->size() != 0)
+        std::cout << "  entry_symbol=" << co->entry_symbol()->c_str();
+      std::cout << "\n";
     }
 
     // Functions
@@ -235,6 +238,71 @@ int main(int argc, char **argv) {
     for (uint32_t i = 0; i < nFunc; ++i) {
       auto f = m->functions()->Get(i);
       std::cout << "  @" << (f->name() ? f->name()->c_str() : "?") << "\n";
+      const auto nOps = f->ops() ? f->ops()->size() : 0;
+      for (uint32_t j = 0; j < nOps; ++j) {
+        auto op = f->ops()->Get(j);
+        std::cout << "    [" << j << "] "
+                  << rhal::rax::EnumNameOpKind(op->kind());
+        if (op->kind() == rhal::rax::OpKind_Dispatch) {
+          auto dispatch = op->dispatch();
+          std::cout << " code_object_id=" << dispatch->code_object_id()
+                    << " args=[";
+          const auto nArgs = dispatch->args() ? dispatch->args()->size() : 0;
+          for (uint32_t k = 0; k < nArgs; ++k) {
+            if (k != 0)
+              std::cout << ", ";
+            auto arg = dispatch->args()->Get(k);
+            if (arg->buffer_id() != 0)
+              std::cout << "buffer:" << arg->buffer_id();
+            else if (arg->constant_id() != 0)
+              std::cout << "constant:" << arg->constant_id();
+            else
+              std::cout << "scalar";
+          }
+          std::cout << "]";
+        } else if (op->kind() == rhal::rax::OpKind_Collective) {
+          auto collective = op->collective();
+          std::cout << " kind="
+                    << rhal::rax::EnumNameCollectiveKind(collective->kind());
+          if (collective->kind() == rhal::rax::CollectiveKind_AllReduce ||
+              collective->kind() == rhal::rax::CollectiveKind_ReduceScatter)
+            std::cout << " reduction="
+                      << rhal::rax::EnumNameReductionKind(
+                             collective->reduction());
+          else if (collective->kind() == rhal::rax::CollectiveKind_Broadcast)
+            std::cout << " root=" << collective->root();
+          std::cout << " operands=[";
+          const auto nOperands =
+              collective->operands() ? collective->operands()->size() : 0;
+          for (uint32_t k = 0; k < nOperands; ++k) {
+            if (k != 0)
+              std::cout << ", ";
+            auto operand = collective->operands()->Get(k);
+            std::cout << operand->input_buffer_id() << "->"
+                      << operand->output_buffer_id();
+            if (auto recvCounts = operand->recv_counts()) {
+              std::cout << " recv_counts=[";
+              for (uint32_t l = 0; l < recvCounts->size(); ++l) {
+                if (l != 0)
+                  std::cout << ",";
+                std::cout << recvCounts->Get(l);
+              }
+              std::cout << "]";
+            }
+            if (auto displacements = operand->displacements()) {
+              std::cout << " displacements=[";
+              for (uint32_t l = 0; l < displacements->size(); ++l) {
+                if (l != 0)
+                  std::cout << ",";
+                std::cout << displacements->Get(l);
+              }
+              std::cout << "]";
+            }
+          }
+          std::cout << "]";
+        }
+        std::cout << "\n";
+      }
     }
 
     if (hasPayload) {

--- a/tools/rax-pack/rax-pack.cpp
+++ b/tools/rax-pack/rax-pack.cpp
@@ -31,6 +31,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 
 #include "buddy/runtime/rax/RAX.h"
@@ -444,13 +445,28 @@ int main(int argc, char **argv) {
       CodeObjectKind kind;
       std::string backend;
       std::string uri;
+      std::string entrySymbol;
     };
+    struct DispatchRec {
+      std::string codeObject;
+      std::vector<std::string> args;
+    };
+    struct CollectiveRec {
+      CollectiveKind kind = CollectiveKind_Invalid;
+      std::vector<std::string> inputBuffers;
+      std::vector<std::string> outputBuffers;
+      ReductionKind reduction = ReductionKind_Invalid;
+      int32_t root = -1;
+      std::vector<int64_t> recvCounts;
+      std::vector<int64_t> displacements;
+    };
+    using FuncOpRec = std::variant<DispatchRec, CollectiveRec>;
     struct FuncRec {
       std::string name;
       std::vector<std::string> inputs;
       std::vector<std::string> outputs;
-      std::string dispatch;
-      std::vector<std::string> args;
+      bool hasBody;
+      std::vector<FuncOpRec> ops;
     };
 
     std::vector<BufRec> buffers;
@@ -461,6 +477,7 @@ int main(int argc, char **argv) {
     // Walk the rhal.module body (single block)
     uint32_t nextBufId = 1;
     std::unordered_map<std::string, uint32_t> bufNameToId;
+    std::unordered_map<std::string, uint32_t> constNameToId;
 
     for (auto &op : rhalMod.getBody().front()) {
       if (auto co = mlir::dyn_cast<buddy::rhal::ConstantOp>(&op)) {
@@ -472,6 +489,7 @@ int main(int argc, char **argv) {
         r.storage = (co.getStorage() == "inline") ? ConstantStorage_Inline
                                                   : ConstantStorage_External;
         r.uri = co.getUri().str();
+        constNameToId[r.name] = r.id;
         constants.push_back(std::move(r));
 
       } else if (auto co = mlir::dyn_cast<buddy::rhal::CodeobjOp>(&op)) {
@@ -481,6 +499,8 @@ int main(int argc, char **argv) {
         r.kind = parseCodeKind(co.getKind());
         r.backend = co.getBackend().str();
         r.uri = co.getUri().str();
+        if (auto entry = co.getEntrySymbol())
+          r.entrySymbol = entry->str();
         codeobjs.push_back(std::move(r));
 
       } else if (auto bo = mlir::dyn_cast<buddy::rhal::BufferOp>(&op)) {
@@ -496,13 +516,79 @@ int main(int argc, char **argv) {
       } else if (auto fo = mlir::dyn_cast<buddy::rhal::FuncOp>(&op)) {
         FuncRec r;
         r.name = fo.getSymName().str();
-        r.dispatch = fo.getDispatch().str();
+        r.hasBody = !fo.getBody().empty();
         for (auto a : fo.getInputs())
           r.inputs.push_back(mlir::cast<mlir::StringAttr>(a).getValue().str());
         for (auto a : fo.getOutputs())
           r.outputs.push_back(mlir::cast<mlir::StringAttr>(a).getValue().str());
-        for (auto a : fo.getArgs())
-          r.args.push_back(mlir::cast<mlir::StringAttr>(a).getValue().str());
+
+        if (!r.hasBody) {
+          DispatchRec dispatch;
+          dispatch.codeObject =
+              fo->getAttrOfType<mlir::StringAttr>("dispatch").getValue().str();
+          for (auto a : fo->getAttrOfType<mlir::ArrayAttr>("args"))
+            dispatch.args.push_back(
+                mlir::cast<mlir::StringAttr>(a).getValue().str());
+          r.ops.push_back(std::move(dispatch));
+        } else {
+          for (auto &bodyOp : fo.getBody().front()) {
+            if (auto dispatch =
+                    mlir::dyn_cast<buddy::rhal::DispatchOp>(&bodyOp)) {
+              DispatchRec record;
+              record.codeObject = dispatch.getCodeObject().str();
+              for (auto a : dispatch.getArgs())
+                record.args.push_back(
+                    mlir::cast<mlir::FlatSymbolRefAttr>(a).getValue().str());
+              r.ops.push_back(std::move(record));
+              continue;
+            }
+
+            if (auto collective =
+                    mlir::dyn_cast<buddy::rhal::CollectiveOp>(&bodyOp)) {
+              CollectiveRec record;
+              if (collective.getKind() == "all_reduce") {
+                record.kind = CollectiveKind_AllReduce;
+                record.reduction = ReductionKind_Sum;
+              } else if (collective.getKind() == "broadcast") {
+                record.kind = CollectiveKind_Broadcast;
+                record.root = *collective.getRoot();
+              } else if (collective.getKind() == "all_gatherv") {
+                record.kind = CollectiveKind_AllGatherV;
+              } else if (collective.getKind() == "reduce_scatter") {
+                record.kind = CollectiveKind_ReduceScatter;
+                record.reduction = ReductionKind_Sum;
+              } else {
+                throw std::runtime_error("rhal.func @" + r.name +
+                                         ": unsupported collective kind '" +
+                                         collective.getKind().str() + "'");
+              }
+              for (auto buffer : collective.getBuffers())
+                record.inputBuffers.push_back(
+                    mlir::cast<mlir::FlatSymbolRefAttr>(buffer)
+                        .getValue()
+                        .str());
+              if (record.kind == CollectiveKind_AllGatherV ||
+                  record.kind == CollectiveKind_ReduceScatter) {
+                for (auto buffer : *collective.getOutputBuffers())
+                  record.outputBuffers.push_back(
+                      mlir::cast<mlir::FlatSymbolRefAttr>(buffer)
+                          .getValue()
+                          .str());
+                auto recvCounts = *collective.getRecvCounts();
+                record.recvCounts.assign(recvCounts.begin(), recvCounts.end());
+                if (auto displacements = collective.getDisplacements())
+                  record.displacements.assign(displacements->begin(),
+                                              displacements->end());
+              }
+              r.ops.push_back(std::move(record));
+              continue;
+            }
+
+            throw std::runtime_error(
+                "rhal.func @" + r.name + ": unsupported body operation '" +
+                bodyOp.getName().getStringRef().str() + "'");
+          }
+        }
         funcs.push_back(std::move(r));
       }
     }
@@ -640,47 +726,103 @@ int main(int argc, char **argv) {
     std::unordered_map<std::string, uint32_t> codeNameToId;
     for (auto &r : codeobjs) {
       codeNameToId[r.name] = r.id;
-      fbCodes.push_back(CreateCodeObject(b, r.id, b.CreateString(r.name),
-                                         r.kind,
-                                         0, // inline data
-                                         b.CreateString(r.uri),
-                                         b.CreateString(""), // entry
-                                         b.CreateString(r.backend), 0));
+      fbCodes.push_back(
+          CreateCodeObject(b, r.id, b.CreateString(r.name), r.kind,
+                           0, // inline data
+                           b.CreateString(r.uri), b.CreateString(r.entrySymbol),
+                           b.CreateString(r.backend), 0));
     }
 
     // Functions
     std::vector<flatbuffers::Offset<Function>> fbFuncs;
     for (auto &fr : funcs) {
-      auto codeIt = codeNameToId.find(fr.dispatch);
-      if (codeIt == codeNameToId.end())
-        throw std::runtime_error("rhal.func @" + fr.name +
-                                 ": unknown dispatch target '" + fr.dispatch +
-                                 "'");
-      uint32_t codeId = codeIt->second;
+      std::vector<flatbuffers::Offset<Op>> ops;
+      for (auto &op : fr.ops) {
+        if (auto *collective = std::get_if<CollectiveRec>(&op)) {
+          std::vector<flatbuffers::Offset<CollectiveOperand>> operands;
+          if (collective->kind == CollectiveKind_AllGatherV ||
+              collective->kind == CollectiveKind_ReduceScatter) {
+            auto inputIt = bufNameToId.find(collective->inputBuffers.front());
+            if (inputIt == bufNameToId.end())
+              throw std::runtime_error("rhal.func @" + fr.name +
+                                       ": unknown buffer '" +
+                                       collective->inputBuffers.front() +
+                                       "' in collective operands");
+            auto outputIt = bufNameToId.find(collective->outputBuffers.front());
+            if (outputIt == bufNameToId.end())
+              throw std::runtime_error("rhal.func @" + fr.name +
+                                       ": unknown buffer '" +
+                                       collective->outputBuffers.front() +
+                                       "' in collective operands");
+            auto recvCounts = b.CreateVector(collective->recvCounts);
+            flatbuffers::Offset<flatbuffers::Vector<int64_t>> displacements;
+            if (collective->kind == CollectiveKind_AllGatherV)
+              displacements = b.CreateVector(collective->displacements);
+            operands.push_back(
+                CreateCollectiveOperand(b, inputIt->second, outputIt->second,
+                                        recvCounts, displacements));
+          } else {
+            for (auto &name : collective->inputBuffers) {
+              auto bufferIt = bufNameToId.find(name);
+              if (bufferIt == bufNameToId.end())
+                throw std::runtime_error("rhal.func @" + fr.name +
+                                         ": unknown buffer '" + name +
+                                         "' in collective operands");
+              operands.push_back(CreateCollectiveOperand(b, bufferIt->second,
+                                                         bufferIt->second));
+            }
+          }
+          auto collectiveOp =
+              CreateCollectiveOp(b, collective->kind, b.CreateVector(operands),
+                                 collective->reduction, collective->root, 0);
+          ops.push_back(
+              CreateOp(b, OpKind_Collective, 0, 0, 0, 0, 0, 0, collectiveOp));
+          continue;
+        }
 
-      // Build dispatch arg list (buffer name → id)
-      std::vector<flatbuffers::Offset<Arg>> dispArgs;
-      for (auto &name : fr.args) {
-        auto it = bufNameToId.find(name);
-        if (it == bufNameToId.end())
+        auto &dispatch = std::get<DispatchRec>(op);
+        auto codeIt = codeNameToId.find(dispatch.codeObject);
+        if (codeIt == codeNameToId.end())
+          throw std::runtime_error("rhal.func @" + fr.name +
+                                   ": unknown dispatch target '" +
+                                   dispatch.codeObject + "'");
+
+        std::vector<flatbuffers::Offset<Arg>> dispArgs;
+        for (auto &name : dispatch.args) {
+          auto bufferIt = bufNameToId.find(name);
+          if (bufferIt != bufNameToId.end()) {
+            dispArgs.push_back(CreateArg(b, bufferIt->second, 0, 0, 0));
+            continue;
+          }
+
+          if (fr.hasBody) {
+            auto constantIt = constNameToId.find(name);
+            if (constantIt != constNameToId.end()) {
+              dispArgs.push_back(CreateArg(b, 0, constantIt->second, 0, 0));
+              continue;
+            }
+          }
+
+          if (fr.hasBody)
+            throw std::runtime_error("rhal.func @" + fr.name +
+                                     ": unknown resource '" + name +
+                                     "' in dispatch args");
           throw std::runtime_error("rhal.func @" + fr.name +
                                    ": unknown buffer '" + name + "' in args");
-        dispArgs.push_back(CreateArg(b, it->second, 0, 0, 0));
+        }
+
+        // grid/block: (1,1,1) for CPU kernels
+        std::vector<uint32_t> g{1, 1, 1}, blk{1, 1, 1};
+        auto dims =
+            CreateLaunchDims(b, b.CreateVector(g), b.CreateVector(blk), 0);
+        auto disp = CreateDispatchOp(b, codeIt->second,
+                                     b.CreateVector(dispArgs), dims, 0);
+        ops.push_back(CreateOp(b, OpKind_Dispatch, disp, 0, 0, 0, 0, 0));
       }
 
-      // grid/block: (1,1,1) for CPU kernels
-      std::vector<uint32_t> g{1, 1, 1}, blk{1, 1, 1};
-      auto dims =
-          CreateLaunchDims(b, b.CreateVector(g), b.CreateVector(blk), 0);
-
-      auto disp =
-          CreateDispatchOp(b, codeId, b.CreateVector(dispArgs), dims, 0);
-      auto dispOp = CreateOp(b, OpKind_Dispatch, disp, 0, 0, 0, 0, 0);
-
-      auto barrierOp =
-          CreateOp(b, OpKind_Barrier, 0, 0, 0, CreateBarrierOp(b, 0), 0, 0);
-
-      std::vector<flatbuffers::Offset<Op>> ops = {dispOp, barrierOp};
+      if (!fr.hasBody)
+        ops.push_back(
+            CreateOp(b, OpKind_Barrier, 0, 0, 0, CreateBarrierOp(b, 0), 0, 0));
 
       // input/output buffer id lists
       std::vector<uint32_t> inputIds, outputIds;


### PR DESCRIPTION
## Summary

This PR adds distributed execution support to RAX and integrates an end-to-end DeepSeek R1 tensor-parallel path with TP=2.

The main changes include:

* add ordered `rhal.dispatch` and `rhal.collective` execution in RHAL/RAX;
* add collective communication support to the RAX runtime through an abstract `Communicator` interface and an MPI backend;
* add Transformer parallel planning, rank-local materialization, runtime-plan generation, and RAX kernel shim generation in the frontend/codegen pipeline;
* add an independent DeepSeek R1 TP=2 build and inference path using rank-local RAX packages;
* add generic `{rank}` model-path resolution in `buddy-cli` for MPI-launched rank-local RAX execution.

The complete design, build instructions, MPI/MPICH setup, generated artifacts, and DeepSeek TP=2 usage are documented in:

`docs/RaxDistributedExecution.md`

## Dependency

This PR depends on #878 (`[frontend] Preserve template output order`).


